### PR TITLE
feat: Claude Code-style UX (modes, themes, thinking, resume, compact, queue)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check if publish is needed
+        id: check
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          REMOTE=$(npm view kimiflare version 2>/dev/null || echo "0.0.0")
+          echo "local=$LOCAL"  >> "$GITHUB_OUTPUT"
+          echo "remote=$REMOTE" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL" != "$REMOTE" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Will publish $LOCAL (npm latest is $REMOTE)"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Already on npm as $REMOTE; skipping."
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.publish == 'true'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        if: steps.check.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.check.outputs.local }}"
+          gh release create "$TAG" --generate-notes --title "$TAG" || true

--- a/README.md
+++ b/README.md
@@ -23,24 +23,19 @@ kimiflare · /help for commands · ctrl-c to exit
     [Allow once] [Allow for session] [Deny]
 ```
 
-## Why
-
-- **262k context.** Read entire modules without pagination.
-- **Native tool use.** File I/O, shell, globs, grep, web fetch — all wired up, with per-call approval for anything mutating.
-- **Streaming reasoning + content.** The model's chain-of-thought streams separately; toggle with `/reasoning` or `Ctrl-R`.
-- **Pay your own way.** Your Cloudflare account, your credits, your rate limits. `$0.95 / M input`, `$0.16 / M cached input`, `$4.00 / M output`. The bottom status line shows live cost.
-
 ## Install
 
 ```sh
-git clone https://github.com/sinameraji/kimiflare
-cd kimiflare
-npm install
-npm run build
-npm link          # or: ln -s "$PWD/bin/kimiflare.mjs" ~/.local/bin/kimiflare
+npm install -g kimiflare
 ```
 
-Published npm package coming soon.
+Or run without installing:
+
+```sh
+npx kimiflare
+```
+
+Requires Node.js ≥ 20.
 
 ## Configure
 
@@ -93,6 +88,13 @@ Interactive slash commands:
 
 Keys: `Ctrl-R` toggles reasoning, `Ctrl-C` interrupts an in-flight turn (press again to exit).
 
+## Why
+
+- **262k context.** Read entire modules without pagination.
+- **Native tool use.** File I/O, shell, globs, grep, web fetch — all wired up, with per-call approval for anything mutating.
+- **Streaming reasoning + content.** The model's chain-of-thought streams separately; toggle with `/reasoning` or `Ctrl-R`.
+- **Pay your own way.** Your Cloudflare account, your credits, your rate limits. `$0.95 / M input`, `$0.16 / M cached input`, `$4.00 / M output`. The bottom status line shows live cost.
+
 ## Tools
 
 All tool calls show inline; mutating ones require per-call approval the first time, with an option to allow for the rest of the session.
@@ -128,9 +130,19 @@ All tool calls show inline; mutating ones require per-call approval the first ti
 
 No AI Gateway, no proxy, no OpenAI SDK. Direct `fetch` to Workers AI, OpenAI-compatible `messages` + `tools` payload, SSE stream with reasoning + content + tool-call deltas accumulated by index.
 
+## Development
+
+```sh
+git clone https://github.com/sinameraji/kimiflare
+cd kimiflare
+npm install
+npm run build
+npm link          # or: ln -s "$PWD/bin/kimiflare.mjs" ~/.local/bin/kimiflare
+```
+
 ## Status
 
-Early. Transport + tools + agent loop + print mode are verified end-to-end; interactive TUI renders cleanly under a pty and awaits real-terminal shakedown. See `PLAN.md` for milestone log and deferred items (first-run wizard, npm publish, session resume).
+Early. Transport + tools + agent loop + print mode are verified end-to-end; interactive TUI renders cleanly under a pty and awaits real-terminal shakedown. See `PLAN.md` for milestone log and deferred items (first-run wizard, session resume).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -77,16 +77,45 @@ kimiflare --reasoning                 # (print mode) stream chain-of-thought to 
 
 Interactive slash commands:
 
-| Command       | Effect                                           |
-|---------------|--------------------------------------------------|
-| `/clear`      | Reset the conversation (keeps system prompt)    |
-| `/reasoning`  | Toggle chain-of-thought display                 |
-| `/cost`       | Show token usage so far                          |
-| `/model`      | Show current model                               |
-| `/help`       | List commands                                    |
-| `/exit`       | Quit                                             |
+| Command                     | Effect                                                                          |
+|-----------------------------|---------------------------------------------------------------------------------|
+| `/mode edit\|plan\|auto`     | Switch mode. `edit` prompts for permission (default), `plan` is read-only research, `auto` auto-approves every tool call. |
+| `/plan` `/auto` `/edit`     | Shortcuts for the three modes.                                                  |
+| `/thinking low\|medium\|high` | Reasoning effort. `low` = fastest, shallow; `medium` = balanced (default); `high` = deepest, slowest. Saved to config. |
+| `/theme NAME`               | Switch color scheme: `dark` (default), `light` (bright terminals), `high-contrast`. Saved to config. |
+| `/resume`                   | Pick a past conversation to restore.                                            |
+| `/compact`                  | Summarize older turns to free context. Suggested automatically at ~80% full.    |
+| `/reasoning`                | Toggle chain-of-thought display.                                                |
+| `/clear`                    | Reset the current conversation.                                                 |
+| `/cost` `/model` `/update`  | Info commands.                                                                  |
+| `/logout`                   | Clear saved credentials.                                                        |
+| `/help` `/exit`             | List commands / quit.                                                           |
 
-Keys: `Ctrl-R` toggles reasoning, `Ctrl-C` interrupts an in-flight turn (press again to exit).
+Keys: `Shift+Tab` cycles mode · `Ctrl-R` toggles reasoning · `Ctrl-C` interrupts an in-flight turn (press again to exit) · `↑`/`↓` walks prompt history.
+
+### Modes
+
+- **edit** — default. The agent calls tools freely for read-only work; mutating tools (`write`, `edit`, `bash`) pause for your approval.
+- **plan** — read-only. Mutating tools are hard-blocked. Ask "plan a refactor" and the agent will investigate and produce a plan without touching the filesystem. Exit plan mode to execute.
+- **auto** — autonomous. Every tool call is auto-approved. Use for trusted, well-scoped tasks.
+
+### Thinking level (quality vs speed)
+
+Kimi-K2.6 always reasons, but you can cap the effort:
+
+- **low** — fastest. Best for chat, small edits, running commands.
+- **medium** — balanced (default). Solid reasoning on real edits without the latency of deep thinking on trivial prompts.
+- **high** — deepest. Best for multi-file refactors, subtle bugs, architectural decisions.
+
+Set with `/thinking medium` (persists), or per-launch via `KIMI_REASONING_EFFORT=high`.
+
+### Type-ahead queue
+
+You can type the next prompt while the model is still executing. Submitted prompts show up as `⏳ …` and fire in order as each turn completes. `Ctrl-C` aborts the current turn and clears the queue.
+
+### Session persistence
+
+Sessions are saved to `~/.local/share/kimiflare/sessions/` after each turn. `/resume` lists the most recent (with first prompt + message count) so you can pick one up later.
 
 ## Why
 
@@ -142,7 +171,7 @@ npm link          # or: ln -s "$PWD/bin/kimiflare.mjs" ~/.local/bin/kimiflare
 
 ## Status
 
-Early. Transport + tools + agent loop + print mode are verified end-to-end; interactive TUI renders cleanly under a pty and awaits real-terminal shakedown. See `PLAN.md` for milestone log and deferred items (first-run wizard, session resume).
+Early but functional. Transport + tools + agent loop + print mode are verified end-to-end. Interactive TUI ships modes, themes, thinking levels, session resume, compaction, and type-ahead queue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Sessions are saved to `~/.local/share/kimiflare/sessions/` after each turn. `/re
 
 For multi-step requests, the agent can publish a live task list via the `tasks_set` tool. The panel shows progress inline with status icons (`■` active, `☐` pending, `✓` done), elapsed time, and tokens consumed for the current task batch. Press `Ctrl-O` while a turn is running to switch tool output between compact (first line) and verbose (full output) modes.
 
+### Paste collapse
+
+Paste a large block (≥ 200 chars or ≥ 3 newlines in one paste) into the prompt and the input collapses it to `[pasted N lines #id]`. The full content still goes to the model on submit — only the on-screen display and chat history are collapsed, so scrollback doesn't get buried by a wall of code.
+
 ## Why
 
 - **262k context.** Read entire modules without pagination.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ Interactive slash commands:
 
 Keys: `Shift+Tab` cycles mode · `Ctrl-R` toggles reasoning · `Ctrl-O` toggles verbose tool output · `Ctrl-C` interrupts an in-flight turn (press again to exit) · `↑`/`↓` walks prompt history.
 
+Editing keys (macOS):
+
+- `⌥←` / `⌥→` — jump word left/right (also works with `Esc b` / `Esc f`)
+- `⌘←` / `⌘→` — jump to start / end of line (in iTerm2's default profile; in Terminal.app you may need to map these to send `Ctrl-A` / `Ctrl-E`)
+- `⌥⌫` — delete word backward
+- `⌘⌫` — delete to start of line (iTerm2 sends this as `Ctrl-U`; map in Terminal.app if needed)
+- `⌥⌦` — delete word forward
+- `Ctrl-A` / `Ctrl-E` — start / end of line (always works)
+- `Ctrl-W` / `Ctrl-U` / `Ctrl-K` — delete word backward / to start of line / to end of line
+
 ### Modes
 
 - **edit** — default. The agent calls tools freely for read-only work; mutating tools (`write`, `edit`, `bash`) pause for your approval.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Interactive slash commands:
 | `/logout`                   | Clear saved credentials.                                                        |
 | `/help` `/exit`             | List commands / quit.                                                           |
 
-Keys: `Shift+Tab` cycles mode · `Ctrl-R` toggles reasoning · `Ctrl-C` interrupts an in-flight turn (press again to exit) · `↑`/`↓` walks prompt history.
+Keys: `Shift+Tab` cycles mode · `Ctrl-R` toggles reasoning · `Ctrl-O` toggles verbose tool output · `Ctrl-C` interrupts an in-flight turn (press again to exit) · `↑`/`↓` walks prompt history.
 
 ### Modes
 
@@ -116,6 +116,10 @@ You can type the next prompt while the model is still executing. Submitted promp
 ### Session persistence
 
 Sessions are saved to `~/.local/share/kimiflare/sessions/` after each turn. `/resume` lists the most recent (with first prompt + message count) so you can pick one up later.
+
+### Task panel
+
+For multi-step requests, the agent can publish a live task list via the `tasks_set` tool. The panel shows progress inline with status icons (`■` active, `☐` pending, `✓` done), elapsed time, and tokens consumed for the current task batch. Press `Ctrl-O` while a turn is running to switch tool output between compact (first line) and verbose (full output) modes.
 
 ## Why
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kimiflare",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kimiflare",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "commander": "^12.1.0",
         "diff": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kimiflare",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kimiflare",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "commander": "^12.1.0",
         "diff": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kimiflare",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kimiflare",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "commander": "^12.1.0",
         "diff": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "bin",
     "dist",
+    "README.md",
     "PLAN.md"
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.",
   "type": "module",
   "bin": {

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -20,6 +20,7 @@ export interface RunKimiOpts {
   signal?: AbortSignal;
   temperature?: number;
   maxCompletionTokens?: number;
+  reasoningEffort?: "low" | "medium" | "high";
 }
 
 const RETRYABLE_CODE = 3040; // "Capacity temporarily exceeded"
@@ -27,7 +28,7 @@ const MAX_ATTEMPTS = 5;
 
 export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, void, void> {
   const url = `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${opts.model}`;
-  const body = {
+  const body: Record<string, unknown> = {
     messages: opts.messages,
     ...(opts.tools && opts.tools.length
       ? { tools: opts.tools, tool_choice: "auto", parallel_tool_calls: true }
@@ -36,6 +37,9 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
     temperature: opts.temperature ?? 0.2,
     max_completion_tokens: opts.maxCompletionTokens ?? 16384,
   };
+  if (opts.reasoningEffort) {
+    body.reasoning_effort = opts.reasoningEffort;
+  }
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const res = await fetch(url, {

--- a/src/agent/compact.ts
+++ b/src/agent/compact.ts
@@ -1,0 +1,98 @@
+import { runKimi } from "./client.js";
+import type { ChatMessage } from "./messages.js";
+
+export interface CompactOpts {
+  accountId: string;
+  apiToken: string;
+  model: string;
+  messages: ChatMessage[];
+  keepLastTurns?: number;
+  signal?: AbortSignal;
+}
+
+export interface CompactResult {
+  summary: string;
+  newMessages: ChatMessage[];
+  replacedCount: number;
+}
+
+const SUMMARY_SYSTEM = `You are summarizing a terminal coding session so it can fit back into a short context window. Produce a dense summary that captures:
+- The user's goal(s) and what they've asked for.
+- Files read or modified, with paths.
+- Tools run (bash commands, edits) and the outcome of each.
+- Decisions made and open questions.
+- Any constraints or preferences the user has stated.
+
+Do not include speculation. Do not include chat-style pleasantries. Use short bullet form. Aim for ~400-800 tokens.`;
+
+function indexOfNthUserFromEnd(messages: ChatMessage[], n: number): number {
+  let seen = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === "user") {
+      seen++;
+      if (seen === n) return i;
+    }
+  }
+  return -1;
+}
+
+export async function compactMessages(opts: CompactOpts): Promise<CompactResult> {
+  const keep = opts.keepLastTurns ?? 4;
+  const messages = opts.messages;
+
+  const systemMsg = messages.find((m) => m.role === "system");
+  if (!systemMsg) throw new Error("compact: no system message found");
+
+  const cutoffUserIdx = indexOfNthUserFromEnd(messages, keep);
+  const firstKeepIdx = cutoffUserIdx >= 0 ? cutoffUserIdx : messages.length;
+  const toSummarize = messages.slice(1, firstKeepIdx);
+  const toKeep = messages.slice(firstKeepIdx);
+
+  if (toSummarize.length === 0) {
+    return { summary: "", newMessages: messages, replacedCount: 0 };
+  }
+
+  const transcript = toSummarize
+    .map((m) => {
+      if (m.role === "tool") {
+        const snippet = (m.content ?? "").slice(0, 500);
+        return `[tool ${m.name ?? ""}] ${snippet}`;
+      }
+      if (m.role === "assistant") {
+        const calls = m.tool_calls
+          ? ` (tool_calls: ${m.tool_calls.map((c) => c.function.name).join(", ")})`
+          : "";
+        return `[assistant]${calls} ${m.content ?? ""}`;
+      }
+      return `[${m.role}] ${m.content ?? ""}`;
+    })
+    .join("\n");
+
+  let summary = "";
+  const events = runKimi({
+    accountId: opts.accountId,
+    apiToken: opts.apiToken,
+    model: opts.model,
+    messages: [
+      { role: "system", content: SUMMARY_SYSTEM },
+      { role: "user", content: `Summarize this session so it can be replaced by your summary:\n\n${transcript}` },
+    ],
+    signal: opts.signal,
+    temperature: 0.1,
+    reasoningEffort: "low",
+  });
+  for await (const ev of events) {
+    if (ev.type === "text") summary += ev.delta;
+  }
+
+  const summaryMsg: ChatMessage = {
+    role: "user",
+    content: `[compacted summary of earlier turns]\n${summary.trim()}`,
+  };
+
+  return {
+    summary: summary.trim(),
+    newMessages: [systemMsg, summaryMsg, ...toKeep],
+    replacedCount: toSummarize.length,
+  };
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -29,6 +29,7 @@ export interface AgentTurnOpts {
   maxToolIterations?: number;
   temperature?: number;
   maxCompletionTokens?: number;
+  reasoningEffort?: "low" | "medium" | "high";
 }
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
@@ -50,6 +51,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       signal: opts.signal,
       temperature: opts.temperature,
       maxCompletionTokens: opts.maxCompletionTokens,
+      reasoningEffort: opts.reasoningEffort,
     });
 
     for await (const ev of events) {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2,6 +2,7 @@ import { runKimi } from "./client.js";
 import { toOpenAIToolDefs, type ToolSpec } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
+import type { Task } from "../tasks-state.js";
 
 export interface AgentCallbacks {
   onAssistantStart?: () => void;
@@ -13,6 +14,7 @@ export interface AgentCallbacks {
   onUsage?: (usage: Usage) => void;
   onAssistantFinal?: (msg: ChatMessage) => void;
   onToolResult?: (result: ToolResult) => void;
+  onTasks?: (tasks: Task[]) => void;
   askPermission: PermissionAsker;
 }
 
@@ -104,7 +106,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       const result = await opts.executor.run(
         { id: tc.id, name: tc.function.name, arguments: tc.function.arguments },
         opts.callbacks.askPermission,
-        { cwd: opts.cwd, signal: opts.signal },
+        { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks },
       );
       opts.messages.push({
         role: "tool",

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,12 +1,14 @@
 import { platform, release, homedir } from "node:os";
 import { basename } from "node:path";
 import type { ToolSpec } from "../tools/registry.js";
+import { systemPromptForMode, type Mode } from "../mode.js";
 
 export interface SystemPromptOpts {
   cwd: string;
   tools: ToolSpec[];
   model: string;
   now?: Date;
+  mode?: Mode;
 }
 
 export function buildSystemPrompt(opts: SystemPromptOpts): string {
@@ -40,5 +42,5 @@ How to work:
 - If a tool returns an error, read it carefully and adjust; do not retry the same call blindly.
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.
 - If a request is ambiguous, ask one focused question instead of making large assumptions.
-- When you finish a task, stop. Do not add a closing summary.`;
+- When you finish a task, stop. Do not add a closing summary.${opts.mode ? systemPromptForMode(opts.mode) : ""}`;
 }

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -38,6 +38,7 @@ How to work:
 - Prefer calling tools over guessing. Read files before editing them. Use \`glob\` and \`grep\` to explore code before assuming structure.
 - Before any mutating tool call (write, edit, bash), state in one short sentence what you're about to do, then call the tool. The user will be asked to approve each mutating call.
 - When the user asks for a change, make the change. Do not paste code in chat that you could apply with \`edit\` or \`write\`.
+- For multi-step work, call \`tasks_set\` at the start with a short task list (one task "in_progress", the rest "pending"), then call it again after each step completes (flip that one to "completed" and the next to "in_progress"). Skip it for trivial single-step requests.
 - Keep responses terse. The user sees tool calls and their results inline — do not re-summarize them unless asked.
 - If a tool returns an error, read it carefully and adjust; do not retry the same call blindly.
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,23 +3,42 @@ import { Box, Text, useApp, useInput, render } from "ink";
 import Spinner from "ink-spinner";
 import { runAgentTurn } from "./agent/loop.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
+import { compactMessages } from "./agent/compact.js";
 import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/executor.js";
 import type { ToolSpec } from "./tools/registry.js";
 import type { ChatMessage, Usage } from "./agent/messages.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
+import { ResumePicker } from "./ui/resume-picker.js";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
 import { checkForUpdate, isGitRepo, type UpdateCheckResult } from "./util/update-check.js";
 import { Onboarding } from "./ui/onboarding.js";
-import { configPath, DEFAULT_MODEL } from "./config.js";
+import {
+  configPath,
+  DEFAULT_MODEL,
+  DEFAULT_REASONING_EFFORT,
+  saveConfig,
+  type ReasoningEffort,
+} from "./config.js";
+import { resolveTheme, themeNames, type Theme } from "./ui/theme.js";
+import { nextMode, type Mode, isBlockedInPlanMode } from "./mode.js";
+import {
+  listSessions,
+  loadSession,
+  makeSessionId,
+  saveSession,
+  type SessionSummary,
+} from "./sessions.js";
 import { unlink } from "node:fs/promises";
 
 interface Cfg {
   accountId: string;
   apiToken: string;
   model: string;
+  theme?: string;
+  reasoningEffort?: ReasoningEffort;
 }
 
 interface PendingPermission {
@@ -28,15 +47,24 @@ interface PendingPermission {
   resolve: (d: PermissionDecision) => void;
 }
 
+const CONTEXT_LIMIT = 262_000;
+const AUTO_COMPACT_SUGGEST_PCT = 0.8;
+
 let nextAssistantId = 1;
 let nextKey = 1;
 const mkKey = () => `evt_${nextKey++}`;
+
+const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
+  low: "low — fastest; lightest reasoning. Best for simple Q&A, small edits, quick coordination.",
+  medium: "medium — balanced (default). Solid quality on most edits, fast on trivial prompts.",
+  high: "high — deepest reasoning; slowest. Best for complex debugging, architecture, multi-file refactors.",
+};
 
 function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const { exit } = useApp();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
   const [events, setEvents] = useState<ChatEvent[]>([
-    { kind: "info", key: mkKey(), text: "kimiflare · /help for commands · ctrl-c to exit" },
+    { kind: "info", key: mkKey(), text: "kimiflare · /help for commands · ctrl-c to exit · shift+tab to cycle modes" },
   ]);
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -48,27 +76,99 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [draftInput, setDraftInput] = useState("");
   const [updateInfo, setUpdateInfo] = useState<UpdateCheckResult | null>(null);
+  const [mode, setMode] = useState<Mode>("edit");
+  const [effort, setEffort] = useState<ReasoningEffort>(
+    initialCfg?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+  );
+  const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
+  const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
 
   const messagesRef = useRef<ChatMessage[]>([
     {
       role: "system",
-      content: buildSystemPrompt({ cwd: process.cwd(), tools: ALL_TOOLS, model: cfg?.model ?? DEFAULT_MODEL }),
+      content: buildSystemPrompt({
+        cwd: process.cwd(),
+        tools: ALL_TOOLS,
+        model: cfg?.model ?? DEFAULT_MODEL,
+        mode: "edit",
+      }),
     },
   ]);
   const executorRef = useRef<ToolExecutor>(new ToolExecutor(ALL_TOOLS));
   const activeAsstIdRef = useRef<number | null>(null);
   const activeControllerRef = useRef<AbortController | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const modeRef = useRef<Mode>(mode);
+  const effortRef = useRef<ReasoningEffort>(effort);
+
+  useEffect(() => {
+    modeRef.current = mode;
+    messagesRef.current[0] = {
+      role: "system",
+      content: buildSystemPrompt({
+        cwd: process.cwd(),
+        tools: ALL_TOOLS,
+        model: cfg?.model ?? DEFAULT_MODEL,
+        mode,
+      }),
+    };
+    if (mode === "plan") {
+      executorRef.current.clearSessionPermissions();
+    }
+  }, [mode, cfg?.model]);
+
+  useEffect(() => {
+    effortRef.current = effort;
+  }, [effort]);
+
+  const saveSessionSafe = useCallback(async () => {
+    if (!cfg) return;
+    if (!sessionIdRef.current) {
+      const firstUser = messagesRef.current.find((m) => m.role === "user");
+      const firstText =
+        typeof firstUser?.content === "string" ? firstUser.content : "session";
+      sessionIdRef.current = makeSessionId(firstText);
+    }
+    try {
+      await saveSession({
+        id: sessionIdRef.current,
+        cwd: process.cwd(),
+        model: cfg.model,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        messages: messagesRef.current,
+      });
+    } catch {
+      /* non-fatal */
+    }
+  }, [cfg]);
 
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
       if (busy && activeControllerRef.current) {
         activeControllerRef.current.abort();
+        setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
       } else {
         exit();
       }
+      return;
     }
-    if (key.ctrl && inputChar === "r") setShowReasoning((s) => !s);
+    if (key.ctrl && inputChar === "r") {
+      setShowReasoning((s) => !s);
+      return;
+    }
+    if (key.shift && key.tab) {
+      setMode((m) => {
+        const nm = nextMode(m);
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `mode: ${nm}` },
+        ]);
+        return nm;
+      });
+      return;
+    }
   });
 
   const updateAssistant = useCallback(
@@ -93,15 +193,103 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
     [],
   );
 
+  const runCompact = useCallback(async () => {
+    if (!cfg) return;
+    if (busy) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't compact while model is running" }]);
+      return;
+    }
+    setBusy(true);
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "compacting conversation…" }]);
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+    try {
+      const result = await compactMessages({
+        accountId: cfg.accountId,
+        apiToken: cfg.apiToken,
+        model: cfg.model,
+        messages: messagesRef.current,
+        signal: controller.signal,
+      });
+      if (result.replacedCount === 0) {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "nothing to compact yet" },
+        ]);
+      } else {
+        messagesRef.current = result.newMessages;
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `compacted ${result.replacedCount} messages into a summary`,
+          },
+        ]);
+        await saveSessionSafe();
+      }
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") {
+        setEvents((es) => [
+          ...es,
+          { kind: "error", key: mkKey(), text: `compact failed: ${(e as Error).message}` },
+        ]);
+      }
+    } finally {
+      setBusy(false);
+      activeControllerRef.current = null;
+    }
+  }, [cfg, busy, saveSessionSafe]);
+
+  const openResumePicker = useCallback(async () => {
+    const sessions = await listSessions(30);
+    setResumeSessions(sessions);
+  }, []);
+
+  const handleResumePick = useCallback(
+    async (picked: SessionSummary | null) => {
+      setResumeSessions(null);
+      if (!picked) return;
+      try {
+        const file = await loadSession(picked.filePath);
+        messagesRef.current = file.messages;
+        sessionIdRef.current = file.id;
+        setEvents([
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `resumed session ${picked.id} (${picked.messageCount} msgs)`,
+          },
+        ]);
+        const userMsgs = file.messages
+          .filter((m) => m.role === "user" && typeof m.content === "string")
+          .map((m) => m.content as string);
+        if (userMsgs.length > 0) setHistory(userMsgs);
+        setUsage(null);
+      } catch (e) {
+        setEvents((es) => [
+          ...es,
+          { kind: "error", key: mkKey(), text: `failed to load session: ${(e as Error).message}` },
+        ]);
+      }
+    },
+    [],
+  );
+
   const handleSlash = useCallback(
     (cmd: string): boolean => {
-      const c = cmd.trim().toLowerCase();
+      const raw = cmd.trim();
+      const [head, ...rest] = raw.split(/\s+/);
+      const c = (head ?? "").toLowerCase();
+      const arg = rest.join(" ").trim().toLowerCase();
+
       if (c === "/exit" || c === "/quit") {
         exit();
         return true;
       }
       if (c === "/clear") {
         messagesRef.current = [messagesRef.current[0]!];
+        sessionIdRef.current = null;
         setEvents([{ kind: "info", key: mkKey(), text: "conversation cleared" }]);
         setUsage(null);
         return true;
@@ -135,6 +323,111 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
           ...e,
           { kind: "info", key: mkKey(), text: `current model: ${cfg?.model ?? "unknown"}` },
         ]);
+        return true;
+      }
+      if (c === "/thinking" || c === "/effort") {
+        if (!arg) {
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "info",
+              key: mkKey(),
+              text: `current: ${effort}  ·  ${EFFORT_DESCRIPTIONS[effort]}\nuse: /thinking low | medium | high`,
+            },
+          ]);
+          return true;
+        }
+        if (arg === "low" || arg === "medium" || arg === "high") {
+          setEffort(arg);
+          if (cfg) void saveConfig({ ...cfg, reasoningEffort: arg }).catch(() => {});
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "info",
+              key: mkKey(),
+              text: `thinking: ${arg}  ·  ${EFFORT_DESCRIPTIONS[arg]}`,
+            },
+          ]);
+          return true;
+        }
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "usage: /thinking low | medium | high" },
+        ]);
+        return true;
+      }
+      if (c === "/theme") {
+        if (!arg) {
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "info",
+              key: mkKey(),
+              text: `current: ${theme.name}  ·  available: ${themeNames().join(", ")}`,
+            },
+          ]);
+          return true;
+        }
+        const next = resolveTheme(arg);
+        if (next.name !== arg) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `unknown theme "${arg}" — available: ${themeNames().join(", ")}` },
+          ]);
+          return true;
+        }
+        setTheme(next);
+        setCfg((c) => (c ? { ...c, theme: next.name } : c));
+        if (cfg) void saveConfig({ ...cfg, theme: next.name }).catch(() => {});
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `theme: ${next.label}` },
+        ]);
+        return true;
+      }
+      if (c === "/mode") {
+        if (!arg) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `current mode: ${mode}  ·  use /mode edit|plan|auto or shift+tab` },
+          ]);
+          return true;
+        }
+        if (arg === "edit" || arg === "plan" || arg === "auto") {
+          setMode(arg);
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `mode: ${arg}` },
+          ]);
+          return true;
+        }
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "usage: /mode edit|plan|auto" },
+        ]);
+        return true;
+      }
+      if (c === "/plan") {
+        setMode("plan");
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: plan" }]);
+        return true;
+      }
+      if (c === "/auto") {
+        setMode("auto");
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: auto" }]);
+        return true;
+      }
+      if (c === "/edit") {
+        setMode("edit");
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: edit" }]);
+        return true;
+      }
+      if (c === "/resume") {
+        void openResumePicker();
+        return true;
+      }
+      if (c === "/compact") {
+        void runCompact();
         return true;
       }
       if (c === "/update") {
@@ -192,14 +485,24 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
             kind: "info",
             key: mkKey(),
             text:
-              "commands: /clear /reasoning /cost /model /update /logout /help /exit  ·  keys: ctrl-r toggle reasoning, ctrl-c interrupt/exit",
+              "commands:\n" +
+              "  /mode edit|plan|auto    switch mode (or shift+tab to cycle)\n" +
+              "  /plan /auto /edit       shortcuts for /mode\n" +
+              "  /thinking low|med|high  set reasoning effort (quality vs speed)\n" +
+              "  /theme NAME             dark, light, high-contrast\n" +
+              "  /resume                 pick a past conversation\n" +
+              "  /compact                summarize old turns to free context\n" +
+              "  /reasoning              toggle show/hide model reasoning\n" +
+              "  /clear                  clear current conversation\n" +
+              "  /cost /model /update /logout /help /exit\n" +
+              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · shift+tab cycle mode · ↑/↓ history",
           },
         ]);
         return true;
       }
       return false;
     },
-    [cfg, exit, usage, updateInfo],
+    [cfg, exit, usage, updateInfo, effort, theme, mode, openResumePicker, runCompact],
   );
 
   const processMessage = useCallback(
@@ -227,6 +530,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
           executor: executorRef.current,
           cwd: process.cwd(),
           signal: controller.signal,
+          reasoningEffort: effortRef.current,
           callbacks: {
             onAssistantStart: () => {
               const id = nextAssistantId++;
@@ -280,10 +584,27 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
             onUsage: (u) => setUsage(u),
             askPermission: (req) =>
               new Promise<PermissionDecision>((resolve) => {
+                if (modeRef.current === "auto") {
+                  resolve("allow");
+                  return;
+                }
+                if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
+                  setEvents((e) => [
+                    ...e,
+                    {
+                      kind: "info",
+                      key: mkKey(),
+                      text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
+                    },
+                  ]);
+                  resolve("deny");
+                  return;
+                }
                 setPerm({ tool: req.tool, args: req.args, resolve });
               }),
           },
         });
+        await saveSessionSafe();
       } catch (e) {
         if ((e as Error).name === "AbortError") {
           setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(aborted)" }]);
@@ -299,7 +620,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         activeControllerRef.current = null;
       }
     },
-    [cfg, handleSlash, updateAssistant, updateTool],
+    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],
   );
 
   useEffect(() => {
@@ -332,10 +653,6 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   );
 
   useEffect(() => {
-    // Force a re-render tick so streaming state change is flushed.
-  }, [events]);
-
-  useEffect(() => {
     checkForUpdate().then((result) => {
       if (result.hasUpdate) {
         setUpdateInfo(result);
@@ -351,6 +668,23 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
     });
   }, []);
 
+  useEffect(() => {
+    if (usage && usage.prompt_tokens / CONTEXT_LIMIT >= AUTO_COMPACT_SUGGEST_PCT) {
+      setEvents((e) => {
+        const last = e[e.length - 1];
+        if (last?.kind === "info" && last.text.startsWith("context ")) return e;
+        return [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `context ${Math.round((usage.prompt_tokens / CONTEXT_LIMIT) * 100)}% full — run /compact to summarize older turns`,
+          },
+        ];
+      });
+    }
+  }, [usage]);
+
   if (!cfg) {
     return (
       <Onboarding
@@ -365,13 +699,22 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
     );
   }
 
+  if (resumeSessions !== null) {
+    return (
+      <Box flexDirection="column">
+        <ResumePicker sessions={resumeSessions} onPick={handleResumePick} theme={theme} />
+      </Box>
+    );
+  }
+
   return (
     <Box flexDirection="column">
-      <ChatView events={events} showReasoning={showReasoning} />
+      <ChatView events={events} showReasoning={showReasoning} theme={theme} />
       {perm ? (
         <PermissionModal
           tool={perm.tool}
           args={perm.args}
+          theme={theme}
           onDecide={(d) => {
             perm.resolve(d);
             setPerm(null);
@@ -382,7 +725,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
           {queue.length > 0 && (
             <Box flexDirection="column" marginBottom={1}>
               {queue.map((q, i) => (
-                <Text key={`queue_${i}`} color="gray" dimColor>
+                <Text key={`queue_${i}`} color={theme.queue.color} dimColor={theme.queue.dim}>
                   ⏳ {q}
                 </Text>
               ))}
@@ -392,61 +735,64 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
             model={cfg.model}
             usage={usage}
             thinking={busy}
-            hint={busy ? "ctrl-c to interrupt" : "enter to send · /help"}
+            hint={busy ? "ctrl-c to interrupt · type to queue next" : "enter to send · /help · shift+tab cycles mode"}
+            theme={theme}
+            mode={mode}
+            effort={effort}
+            contextLimit={CONTEXT_LIMIT}
           />
+          {busy && (
+            <Box>
+              <Text color={theme.spinner}>
+                <Spinner type="dots" />
+              </Text>
+              <Text color={theme.info.color} dimColor={theme.info.dim}>
+                {" working…"}
+              </Text>
+            </Box>
+          )}
           <Box>
-            {busy ? (
-              <Box>
-                <Text color="yellow">
-                  <Spinner type="dots" />
-                </Text>
-                <Text color="gray"> working…</Text>
-              </Box>
-            ) : (
-              <Box>
-                <Text color="cyan">› </Text>
-                <CustomTextInput
-                  value={input}
-                  onChange={setInput}
-                  onSubmit={submit}
-                  onHistoryUp={() => {
-                    if (history.length === 0) return;
-                    if (historyIndex === -1) {
-                      setDraftInput(input);
-                      const nextIndex = history.length - 1;
-                      setHistoryIndex(nextIndex);
-                      setInput(history[nextIndex]!);
-                    } else {
-                      const nextIndex = Math.max(0, historyIndex - 1);
-                      setHistoryIndex(nextIndex);
-                      setInput(history[nextIndex]!);
-                    }
-                  }}
-                  onHistoryDown={() => {
-                    if (historyIndex === -1) return;
-                    const nextIndex = historyIndex + 1;
-                    if (nextIndex >= history.length) {
-                      setHistoryIndex(-1);
-                      setInput(draftInput);
-                    } else {
-                      setHistoryIndex(nextIndex);
-                      setInput(history[nextIndex]!);
-                    }
-                  }}
-                  onClearQueueItem={(text) => {
-                    setQueue((q) => {
-                      const idx = q.indexOf(text);
-                      if (idx >= 0) {
-                        const next = [...q];
-                        next.splice(idx, 1);
-                        return next;
-                      }
-                      return q;
-                    });
-                  }}
-                />
-              </Box>
-            )}
+            <Text color={theme.user}>{busy ? "⏳ " : "› "}</Text>
+            <CustomTextInput
+              value={input}
+              onChange={setInput}
+              onSubmit={submit}
+              onHistoryUp={() => {
+                if (history.length === 0) return;
+                if (historyIndex === -1) {
+                  setDraftInput(input);
+                  const nextIndex = history.length - 1;
+                  setHistoryIndex(nextIndex);
+                  setInput(history[nextIndex]!);
+                } else {
+                  const nextIndex = Math.max(0, historyIndex - 1);
+                  setHistoryIndex(nextIndex);
+                  setInput(history[nextIndex]!);
+                }
+              }}
+              onHistoryDown={() => {
+                if (historyIndex === -1) return;
+                const nextIndex = historyIndex + 1;
+                if (nextIndex >= history.length) {
+                  setHistoryIndex(-1);
+                  setInput(draftInput);
+                } else {
+                  setHistoryIndex(nextIndex);
+                  setInput(history[nextIndex]!);
+                }
+              }}
+              onClearQueueItem={(text) => {
+                setQueue((q) => {
+                  const idx = q.indexOf(text);
+                  if (idx >= 0) {
+                    const next = [...q];
+                    next.splice(idx, 1);
+                    return next;
+                  }
+                  return q;
+                });
+              }}
+            />
           </Box>
         </Box>
       )}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,6 +11,8 @@ import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
 import { ResumePicker } from "./ui/resume-picker.js";
+import { TaskList } from "./ui/task-list.js";
+import type { Task } from "./tasks-state.js";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
 import { checkForUpdate, isGitRepo, type UpdateCheckResult } from "./util/update-check.js";
@@ -82,6 +84,10 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   );
   const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
   const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
+  const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
+  const [verbose, setVerbose] = useState(false);
 
   const messagesRef = useRef<ChatMessage[]>([
     {
@@ -166,6 +172,17 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
           { kind: "info", key: mkKey(), text: `mode: ${nm}` },
         ]);
         return nm;
+      });
+      return;
+    }
+    if (key.ctrl && inputChar === "o") {
+      setVerbose((v) => {
+        const next = !v;
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `output: ${next ? "verbose (full tool results)" : "compact"}` },
+        ]);
+        return next;
       });
       return;
     }
@@ -292,6 +309,9 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         sessionIdRef.current = null;
         setEvents([{ kind: "info", key: mkKey(), text: "conversation cleared" }]);
         setUsage(null);
+        setTasks([]);
+        setTasksStartedAt(null);
+        setTasksStartTokens(0);
         return true;
       }
       if (c === "/reasoning") {
@@ -495,7 +515,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
               "  /reasoning              toggle show/hide model reasoning\n" +
               "  /clear                  clear current conversation\n" +
               "  /cost /model /update /logout /help /exit\n" +
-              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · shift+tab cycle mode · ↑/↓ history",
+              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o toggle verbose output · shift+tab cycle mode · ↑/↓ history",
           },
         ]);
         return true;
@@ -582,6 +602,19 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
               });
             },
             onUsage: (u) => setUsage(u),
+            onTasks: (nextTasks) => {
+              setTasks((prev) => {
+                if (prev.length === 0 && nextTasks.length > 0) {
+                  setTasksStartedAt(Date.now());
+                  setTasksStartTokens(usage?.prompt_tokens ?? 0);
+                }
+                if (nextTasks.length === 0) {
+                  setTasksStartedAt(null);
+                  setTasksStartTokens(0);
+                }
+                return nextTasks;
+              });
+            },
             askPermission: (req) =>
               new Promise<PermissionDecision>((resolve) => {
                 if (modeRef.current === "auto") {
@@ -709,7 +742,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
 
   return (
     <Box flexDirection="column">
-      <ChatView events={events} showReasoning={showReasoning} theme={theme} />
+      <ChatView events={events} showReasoning={showReasoning} theme={theme} verbose={verbose} />
       {perm ? (
         <PermissionModal
           tool={perm.tool}
@@ -722,6 +755,14 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         />
       ) : (
         <Box flexDirection="column" marginTop={1}>
+          {tasks.length > 0 && (
+            <TaskList
+              tasks={tasks}
+              theme={theme}
+              startedAt={tasksStartedAt}
+              tokensDelta={Math.max(0, (usage?.prompt_tokens ?? 0) - tasksStartTokens)}
+            />
+          )}
           {queue.length > 0 && (
             <Box flexDirection="column" marginBottom={1}>
               {queue.map((q, i) => (

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -73,7 +73,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const [usage, setUsage] = useState<Usage | null>(null);
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
-  const [queue, setQueue] = useState<string[]>([]);
+  const [queue, setQueue] = useState<Array<{ full: string; display: string }>>([]);
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [draftInput, setDraftInput] = useState("");
@@ -526,14 +526,15 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   );
 
   const processMessage = useCallback(
-    async (text: string) => {
+    async (text: string, displayText?: string) => {
       if (!cfg) return;
       const trimmed = text.trim();
       if (!trimmed) return;
 
       if (trimmed.startsWith("/") && handleSlash(trimmed)) return;
 
-      setEvents((e) => [...e, { kind: "user", key: mkKey(), text: trimmed }]);
+      const display = displayText?.trim() || trimmed;
+      setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display }]);
       messagesRef.current.push({ role: "user", content: trimmed });
       setBusy(true);
 
@@ -660,27 +661,30 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
     if (!busy && queue.length > 0) {
       const next = queue[0]!;
       setQueue((q) => q.slice(1));
-      processMessage(next);
+      processMessage(next.full, next.display);
     }
   }, [busy, queue, processMessage]);
 
   const submit = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed) return;
+    (full: string, display?: string) => {
+      const trimmedFull = full.trim();
+      if (!trimmedFull) return;
+      const trimmedDisplay = (display ?? full).trim() || trimmedFull;
+
+      const historyEntry = trimmedDisplay;
 
       if (busy) {
-        setQueue((q) => [...q, trimmed]);
-        setHistory((h) => (h.length > 0 && h[h.length - 1] === trimmed ? h : [...h, trimmed]));
+        setQueue((q) => [...q, { full: trimmedFull, display: trimmedDisplay }]);
+        setHistory((h) => (h.length > 0 && h[h.length - 1] === historyEntry ? h : [...h, historyEntry]));
         setInput("");
         setHistoryIndex(-1);
         return;
       }
 
-      setHistory((h) => (h.length > 0 && h[h.length - 1] === trimmed ? h : [...h, trimmed]));
+      setHistory((h) => (h.length > 0 && h[h.length - 1] === historyEntry ? h : [...h, historyEntry]));
       setInput("");
       setHistoryIndex(-1);
-      processMessage(trimmed);
+      processMessage(trimmedFull, trimmedDisplay !== trimmedFull ? trimmedDisplay : undefined);
     },
     [busy, processMessage],
   );
@@ -767,7 +771,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
             <Box flexDirection="column" marginBottom={1}>
               {queue.map((q, i) => (
                 <Text key={`queue_${i}`} color={theme.queue.color} dimColor={theme.queue.dim}>
-                  ⏳ {q}
+                  ⏳ {q.display}
                 </Text>
               ))}
             </Box>
@@ -798,6 +802,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
               value={input}
               onChange={setInput}
               onSubmit={submit}
+              enablePaste
               onHistoryUp={() => {
                 if (history.length === 0) return;
                 if (historyIndex === -1) {
@@ -824,7 +829,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
               }}
               onClearQueueItem={(text) => {
                 setQueue((q) => {
-                  const idx = q.indexOf(text);
+                  const idx = q.findIndex((item) => item.display === text);
                   if (idx >= 0) {
                     const next = [...q];
                     next.splice(idx, 1);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,26 +2,45 @@ import { readFile, mkdir, writeFile, chmod } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+export type ReasoningEffort = "low" | "medium" | "high";
+
 export interface KimiConfig {
   accountId: string;
   apiToken: string;
   model: string;
+  theme?: string;
+  reasoningEffort?: ReasoningEffort;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
 
 export function configPath(): string {
   const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   return join(xdg, "kimiflare", "config.json");
 }
 
+function readReasoningEffortEnv(): ReasoningEffort | undefined {
+  const raw = process.env.KIMI_REASONING_EFFORT?.toLowerCase();
+  if (raw === "low" || raw === "medium" || raw === "high") return raw;
+  return undefined;
+}
+
 export async function loadConfig(): Promise<KimiConfig | null> {
   const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
   const envToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
   const envModel = process.env.KIMI_MODEL ?? DEFAULT_MODEL;
+  const envEffort = readReasoningEffortEnv();
+  const envTheme = process.env.KIMI_THEME;
 
   if (envAccount && envToken) {
-    return { accountId: envAccount, apiToken: envToken, model: envModel };
+    return {
+      accountId: envAccount,
+      apiToken: envToken,
+      model: envModel,
+      theme: envTheme,
+      reasoningEffort: envEffort,
+    };
   }
 
   try {
@@ -32,6 +51,8 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         accountId: envAccount ?? parsed.accountId,
         apiToken: envToken ?? parsed.apiToken,
         model: envModel ?? parsed.model ?? DEFAULT_MODEL,
+        theme: envTheme ?? parsed.theme,
+        reasoningEffort: envEffort ?? parsed.reasoningEffort,
       };
     }
   } catch {

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -1,0 +1,35 @@
+export type Mode = "edit" | "plan" | "auto";
+
+export const MODES: Mode[] = ["edit", "plan", "auto"];
+
+export function nextMode(m: Mode): Mode {
+  const i = MODES.indexOf(m);
+  return MODES[(i + 1) % MODES.length]!;
+}
+
+export function modeDescription(m: Mode): string {
+  switch (m) {
+    case "edit":
+      return "edit — default; prompts for permission before mutating tools";
+    case "plan":
+      return "plan — read-only research; blocks writes/edits/bash until you exit plan mode";
+    case "auto":
+      return "auto — autonomous; auto-approves every tool call (use with care)";
+  }
+}
+
+export const MUTATING_TOOLS = new Set(["write", "edit", "bash"]);
+
+export function isBlockedInPlanMode(toolName: string): boolean {
+  return MUTATING_TOOLS.has(toolName);
+}
+
+export function systemPromptForMode(m: Mode): string {
+  if (m === "plan") {
+    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or bash. Only use read/glob/grep/web-fetch. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
+  }
+  if (m === "auto") {
+    return "\n\nAUTO MODE is active. The user has opted into autonomous execution — every tool call will be auto-approved. Work efficiently, but do not take irreversible destructive actions (rm -rf, git push --force, dropping tables, etc.) without pausing to describe them in chat first. Prefer smaller reversible steps.";
+  }
+  return "";
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,0 +1,89 @@
+import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ChatMessage } from "./agent/messages.js";
+
+export interface SessionSummary {
+  id: string;
+  filePath: string;
+  cwd: string;
+  firstPrompt: string;
+  messageCount: number;
+  updatedAt: string;
+}
+
+export interface SessionFile {
+  id: string;
+  cwd: string;
+  model: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: ChatMessage[];
+}
+
+function sessionsDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(xdg, "kimiflare", "sessions");
+}
+
+function sanitize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+export function makeSessionId(firstPrompt: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const slug = sanitize(firstPrompt) || "session";
+  return `${ts}_${slug}`;
+}
+
+export async function saveSession(file: SessionFile): Promise<string> {
+  const dir = sessionsDir();
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, `${file.id}.json`);
+  await writeFile(path, JSON.stringify(file, null, 2), "utf8");
+  return path;
+}
+
+export async function listSessions(limit = 30): Promise<SessionSummary[]> {
+  const dir = sessionsDir();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const summaries: SessionSummary[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const path = join(dir, name);
+    try {
+      const [s, raw] = await Promise.all([stat(path), readFile(path, "utf8")]);
+      const parsed = JSON.parse(raw) as SessionFile;
+      const firstUser = parsed.messages.find((m) => m.role === "user");
+      const firstPrompt =
+        typeof firstUser?.content === "string" ? firstUser.content : "(no prompt)";
+      summaries.push({
+        id: parsed.id,
+        filePath: path,
+        cwd: parsed.cwd,
+        firstPrompt: firstPrompt.slice(0, 80),
+        messageCount: parsed.messages.filter((m) => m.role !== "system").length,
+        updatedAt: parsed.updatedAt ?? s.mtime.toISOString(),
+      });
+    } catch {
+      /* skip unreadable */
+    }
+  }
+  summaries.sort((a, b) => (b.updatedAt < a.updatedAt ? -1 : 1));
+  return summaries.slice(0, limit);
+}
+
+export async function loadSession(filePath: string): Promise<SessionFile> {
+  const raw = await readFile(filePath, "utf8");
+  return JSON.parse(raw) as SessionFile;
+}

--- a/src/tasks-state.ts
+++ b/src/tasks-state.ts
@@ -1,0 +1,24 @@
+export type TaskStatus = "pending" | "in_progress" | "completed";
+
+export interface Task {
+  id: string;
+  title: string;
+  status: TaskStatus;
+}
+
+export function isValidStatus(s: unknown): s is TaskStatus {
+  return s === "pending" || s === "in_progress" || s === "completed";
+}
+
+export function validateTasks(input: unknown): Task[] {
+  if (!Array.isArray(input)) throw new Error("tasks must be an array");
+  return input.map((t, i) => {
+    if (!t || typeof t !== "object") throw new Error(`tasks[${i}] must be an object`);
+    const rec = t as Record<string, unknown>;
+    const id = typeof rec.id === "string" && rec.id.length > 0 ? rec.id : String(i + 1);
+    const title = typeof rec.title === "string" ? rec.title.trim() : "";
+    if (!title) throw new Error(`tasks[${i}].title is required`);
+    const status: TaskStatus = isValidStatus(rec.status) ? rec.status : "pending";
+    return { id, title, status };
+  });
+}

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -6,6 +6,7 @@ import { bashTool } from "./bash.js";
 import { globTool } from "./glob.js";
 import { grepTool } from "./grep.js";
 import { webFetchTool } from "./web-fetch.js";
+import { tasksSetTool } from "./tasks.js";
 
 export const ALL_TOOLS: ToolSpec[] = [
   readTool,
@@ -15,6 +16,7 @@ export const ALL_TOOLS: ToolSpec[] = [
   globTool,
   grepTool,
   webFetchTool,
+  tasksSetTool,
 ];
 
 export type PermissionDecision = "allow" | "allow_session" | "deny";

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -52,6 +52,10 @@ export class ToolExecutor {
     return [...this.tools.values()];
   }
 
+  clearSessionPermissions(): void {
+    this.sessionAllowed.clear();
+  }
+
   async run(
     call: ToolInvocation,
     askPermission: PermissionAsker,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,8 +1,10 @@
 import type { ToolDef } from "../agent/messages.js";
+import type { Task } from "../tasks-state.js";
 
 export interface ToolContext {
   cwd: string;
   signal?: AbortSignal;
+  onTasks?: (tasks: Task[]) => void;
 }
 
 export interface ToolRender {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,0 +1,60 @@
+import type { ToolSpec } from "./registry.js";
+import { validateTasks, type Task } from "../tasks-state.js";
+
+interface TasksSetArgs {
+  tasks: Task[];
+}
+
+export const tasksSetTool: ToolSpec<TasksSetArgs> = {
+  name: "tasks_set",
+  description: [
+    "Set the visible task list shown to the user during this turn.",
+    "Call this when the user has given you a multi-step job, or whenever progress changes:",
+    "at the start (all tasks pending, with exactly one in_progress), and after each step completes",
+    "(flip that task to completed and the next to in_progress).",
+    "Pass the ENTIRE task list each call — this replaces the panel.",
+    "Keep tasks short (one imperative clause). Only one should be in_progress at a time.",
+    "For quick single-step requests, don't use this tool at all.",
+  ].join(" "),
+  parameters: {
+    type: "object",
+    properties: {
+      tasks: {
+        type: "array",
+        description: "The full, ordered list of tasks. Pass every call.",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Stable short id (e.g. '1', '2')." },
+            title: { type: "string", description: "Short imperative task title." },
+            status: {
+              type: "string",
+              enum: ["pending", "in_progress", "completed"],
+              description: "Only one task should be 'in_progress' at a time.",
+            },
+          },
+          required: ["id", "title", "status"],
+        },
+      },
+    },
+    required: ["tasks"],
+  },
+  needsPermission: false,
+  render: (args) => ({
+    title: `tasks (${args.tasks.length} items)`,
+    body: args.tasks
+      .map((t) => `${t.status === "completed" ? "✓" : t.status === "in_progress" ? "▸" : "·"} ${t.title}`)
+      .join("\n"),
+  }),
+  run: async (args, ctx) => {
+    let tasks: Task[];
+    try {
+      tasks = validateTasks(args.tasks);
+    } catch (e) {
+      return `Error: ${(e as Error).message}`;
+    }
+    ctx.onTasks?.(tasks);
+    const summary = `${tasks.length} tasks set — ${tasks.filter((t) => t.status === "completed").length} done, ${tasks.filter((t) => t.status === "in_progress").length} active, ${tasks.filter((t) => t.status === "pending").length} pending`;
+    return summary;
+  },
+};

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { ToolView, type ToolEventState } from "./tool-view.js";
+import type { Theme } from "./theme.js";
 
 export type ChatEvent =
   | { kind: "user"; key: string; text: string }
@@ -19,23 +20,24 @@ export type ChatEvent =
 interface Props {
   events: ChatEvent[];
   showReasoning: boolean;
+  theme: Theme;
 }
 
-export function ChatView({ events, showReasoning }: Props) {
+export function ChatView({ events, showReasoning, theme }: Props) {
   return (
     <Box flexDirection="column">
       {events.map((e) => (
-        <EventView key={e.key} evt={e} showReasoning={showReasoning} />
+        <EventView key={e.key} evt={e} showReasoning={showReasoning} theme={theme} />
       ))}
     </Box>
   );
 }
 
-function EventView({ evt, showReasoning }: { evt: ChatEvent; showReasoning: boolean }) {
+function EventView({ evt, showReasoning, theme }: { evt: ChatEvent; showReasoning: boolean; theme: Theme }) {
   if (evt.kind === "user") {
     return (
       <Box marginY={0}>
-        <Text color="cyan">› </Text>
+        <Text color={theme.user}>› </Text>
         <Text>{evt.text}</Text>
       </Box>
     );
@@ -45,12 +47,14 @@ function EventView({ evt, showReasoning }: { evt: ChatEvent; showReasoning: bool
       <Box flexDirection="column" marginY={0}>
         {showReasoning && evt.reasoning ? (
           <Box flexDirection="column" marginLeft={2}>
-            <Text color="gray" dimColor>
+            <Text color={theme.reasoning.color} dimColor={theme.reasoning.dim}>
               ✧ thinking: {evt.reasoning.length > 400 ? evt.reasoning.slice(0, 400) + "…" : evt.reasoning}
             </Text>
           </Box>
         ) : null}
-        {evt.text ? <Text>{evt.text}</Text> : null}
+        {evt.text ? (
+          theme.assistant ? <Text color={theme.assistant}>{evt.text}</Text> : <Text>{evt.text}</Text>
+        ) : null}
       </Box>
     );
   }
@@ -59,10 +63,10 @@ function EventView({ evt, showReasoning }: { evt: ChatEvent; showReasoning: bool
   }
   if (evt.kind === "info") {
     return (
-      <Text color="gray" dimColor>
+      <Text color={theme.info.color} dimColor={theme.info.dim}>
         {evt.text}
       </Text>
     );
   }
-  return <Text color="red">! {evt.text}</Text>;
+  return <Text color={theme.error}>! {evt.text}</Text>;
 }

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -21,19 +21,20 @@ interface Props {
   events: ChatEvent[];
   showReasoning: boolean;
   theme: Theme;
+  verbose?: boolean;
 }
 
-export function ChatView({ events, showReasoning, theme }: Props) {
+export function ChatView({ events, showReasoning, theme, verbose }: Props) {
   return (
     <Box flexDirection="column">
       {events.map((e) => (
-        <EventView key={e.key} evt={e} showReasoning={showReasoning} theme={theme} />
+        <EventView key={e.key} evt={e} showReasoning={showReasoning} theme={theme} verbose={verbose} />
       ))}
     </Box>
   );
 }
 
-function EventView({ evt, showReasoning, theme }: { evt: ChatEvent; showReasoning: boolean; theme: Theme }) {
+function EventView({ evt, showReasoning, theme, verbose }: { evt: ChatEvent; showReasoning: boolean; theme: Theme; verbose?: boolean }) {
   if (evt.kind === "user") {
     return (
       <Box marginY={0}>
@@ -59,7 +60,7 @@ function EventView({ evt, showReasoning, theme }: { evt: ChatEvent; showReasonin
     );
   }
   if (evt.kind === "tool") {
-    return <ToolView evt={evt} />;
+    return <ToolView evt={evt} verbose={verbose} />;
   }
   if (evt.kind === "info") {
     return (

--- a/src/ui/permission.tsx
+++ b/src/ui/permission.tsx
@@ -4,14 +4,16 @@ import SelectInput from "ink-select-input";
 import type { ToolSpec } from "../tools/registry.js";
 import type { PermissionDecision } from "../tools/executor.js";
 import { DiffView } from "./diff-view.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   tool: ToolSpec;
   args: Record<string, unknown>;
   onDecide: (decision: PermissionDecision) => void;
+  theme: Theme;
 }
 
-export function PermissionModal({ tool, args, onDecide }: Props) {
+export function PermissionModal({ tool, args, onDecide, theme }: Props) {
   const render = tool.render?.(args);
   const items = [
     { label: "Allow once", value: "allow" as const },
@@ -20,12 +22,12 @@ export function PermissionModal({ tool, args, onDecide }: Props) {
   ];
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="yellow" paddingX={1}>
-      <Text color="yellow" bold>
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.permission} paddingX={1}>
+      <Text color={theme.permission} bold>
         Permission requested
       </Text>
       <Text>
-        tool: <Text color="magenta">{tool.name}</Text>
+        tool: <Text color={theme.tool}>{tool.name}</Text>
       </Text>
       {render?.title ? <Text>action: {render.title}</Text> : null}
       {render?.diff ? (
@@ -33,7 +35,7 @@ export function PermissionModal({ tool, args, onDecide }: Props) {
           <DiffView {...render.diff} />
         </Box>
       ) : (
-        <Text color="gray">args: {JSON.stringify(args)}</Text>
+        <Text color={theme.info.color} dimColor={theme.info.dim}>args: {JSON.stringify(args)}</Text>
       )}
       <Box marginTop={1}>
         <SelectInput items={items} onSelect={(item) => onDecide(item.value)} />

--- a/src/ui/resume-picker.tsx
+++ b/src/ui/resume-picker.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { SessionSummary } from "../sessions.js";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  sessions: SessionSummary[];
+  onPick: (session: SessionSummary | null) => void;
+  theme: Theme;
+}
+
+export function ResumePicker({ sessions, onPick, theme }: Props) {
+  if (sessions.length === 0) {
+    return (
+      <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+        <Text color={theme.accent} bold>
+          Resume a session
+        </Text>
+        <Text color={theme.info.color} dimColor={theme.info.dim}>
+          No saved sessions yet. Press Enter to dismiss.
+        </Text>
+        <Box marginTop={1}>
+          <SelectInput
+            items={[{ label: "(back)", value: "__cancel__" }]}
+            onSelect={() => onPick(null)}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  const items = sessions.map((s) => ({
+    label: `${formatDate(s.updatedAt)}  ·  ${s.messageCount} msgs  ·  ${s.firstPrompt}`,
+    value: s.id,
+  }));
+  items.push({ label: "(cancel)", value: "__cancel__" });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        Resume a session
+      </Text>
+      <Text color={theme.info.color} dimColor={theme.info.dim}>
+        Arrow keys to select, Enter to confirm.
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => {
+            if (item.value === "__cancel__") return onPick(null);
+            const picked = sessions.find((s) => s.id === item.value) ?? null;
+            onPick(picked);
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -1,20 +1,27 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { Usage } from "../agent/messages.js";
+import type { Theme } from "./theme.js";
+import type { ReasoningEffort } from "../config.js";
+import type { Mode } from "../mode.js";
 
 interface Props {
   model: string;
   usage: Usage | null;
   thinking: boolean;
   hint?: string;
+  theme: Theme;
+  mode: Mode;
+  effort: ReasoningEffort;
+  contextLimit: number;
 }
 
 const PRICE_IN_PER_M = 0.95;
 const PRICE_IN_CACHED_PER_M = 0.16;
 const PRICE_OUT_PER_M = 4.0;
 
-export function StatusBar({ model, usage, thinking, hint }: Props) {
-  const parts: string[] = [`model: ${shortModel(model)}`];
+export function StatusBar({ model, usage, thinking, hint, theme, mode, effort, contextLimit }: Props) {
+  const parts: string[] = [`model: ${shortModel(model)}`, `effort: ${effort}`];
   if (usage) {
     const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
     const uncachedIn = usage.prompt_tokens - cached;
@@ -22,20 +29,35 @@ export function StatusBar({ model, usage, thinking, hint }: Props) {
       (uncachedIn * PRICE_IN_PER_M) / 1_000_000 +
       (cached * PRICE_IN_CACHED_PER_M) / 1_000_000 +
       (usage.completion_tokens * PRICE_OUT_PER_M) / 1_000_000;
+    const pct = Math.round((usage.prompt_tokens / contextLimit) * 100);
     parts.push(
       `in: ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
       `out: ${usage.completion_tokens}`,
+      `ctx: ${pct}%`,
       `$${cost.toFixed(5)}`,
     );
   }
   if (thinking) parts.push("thinking…");
   if (hint) parts.push(hint);
 
+  const modeColor =
+    mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
+  const warn = usage && usage.prompt_tokens / contextLimit >= 0.8;
+
   return (
     <Box>
-      <Text color="gray" dimColor>
+      <Text color={modeColor} bold>
+        [{mode}]
+      </Text>
+      <Text> </Text>
+      <Text color={theme.info.color} dimColor={theme.info.dim}>
         {parts.join("  ·  ")}
       </Text>
+      {warn ? (
+        <Text color={theme.warn} bold>
+          {"  ·  "}/compact recommended
+        </Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/ui/task-list.tsx
+++ b/src/ui/task-list.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import type { Task } from "../tasks-state.js";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  tasks: Task[];
+  theme: Theme;
+  startedAt: number | null;
+  tokensDelta: number;
+}
+
+const MAX_VISIBLE = 6;
+
+export function TaskList({ tasks, theme, startedAt, tokensDelta }: Props) {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (startedAt === null) return;
+    const allDone = tasks.length > 0 && tasks.every((t) => t.status === "completed");
+    if (allDone) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [startedAt, tasks]);
+
+  if (tasks.length === 0) return null;
+
+  const active = tasks.find((t) => t.status === "in_progress");
+  const done = tasks.filter((t) => t.status === "completed").length;
+  const total = tasks.length;
+  const allDone = done === total;
+
+  const header = active
+    ? active.title
+    : allDone
+      ? `Done (${total} tasks)`
+      : `Tasks (${done}/${total})`;
+
+  const elapsed = startedAt ? formatElapsed(now - startedAt) : null;
+  const headerStats = [elapsed, tokensDelta > 0 ? `↑ ${formatTokens(tokensDelta)} tokens` : null]
+    .filter(Boolean)
+    .join(" · ");
+
+  const visibleTasks = tasks.slice(0, MAX_VISIBLE);
+  const hiddenPending = Math.max(0, tasks.length - visibleTasks.length);
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box>
+        <Text color={allDone ? "green" : theme.accent} bold>
+          {allDone ? "✓" : "▸"} {header}
+        </Text>
+        {headerStats && (
+          <Text color={theme.info.color} dimColor={theme.info.dim}>
+            {"  "}({headerStats})
+          </Text>
+        )}
+      </Box>
+      {visibleTasks.map((t) => (
+        <TaskRow key={t.id} task={t} theme={theme} />
+      ))}
+      {hiddenPending > 0 && (
+        <Text color={theme.info.color} dimColor={theme.info.dim}>
+          {"  "}… +{hiddenPending} more
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+function TaskRow({ task, theme }: { task: Task; theme: Theme }) {
+  if (task.status === "completed") {
+    return (
+      <Text color={theme.info.color} dimColor={theme.info.dim}>
+        {"  "}✓ <Text strikethrough>{task.title}</Text>
+      </Text>
+    );
+  }
+  if (task.status === "in_progress") {
+    return (
+      <Text color={theme.accent} bold>
+        {"  "}■ {task.title}
+      </Text>
+    );
+  }
+  return (
+    <Text color={theme.info.color} dimColor={theme.info.dim}>
+      {"  "}☐ {task.title}
+    </Text>
+  );
+}
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}m ${s}s`;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -1,16 +1,34 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Text, useInput } from "ink";
 import chalk from "chalk";
 
 interface Props {
   value: string;
   onChange: (value: string) => void;
-  onSubmit: (value: string) => void;
+  onSubmit: (value: string, display?: string) => void;
   onHistoryUp?: () => void;
   onHistoryDown?: () => void;
   onClearQueueItem?: (text: string) => void;
   focus?: boolean;
   mask?: string;
+  enablePaste?: boolean;
+}
+
+const PASTE_CHAR_THRESHOLD = 200;
+const PASTE_NEWLINE_THRESHOLD = 3;
+
+function shouldTreatAsPaste(input: string): boolean {
+  if (input.length >= PASTE_CHAR_THRESHOLD) return true;
+  const newlines = (input.match(/\n/g) ?? []).length;
+  return newlines >= PASTE_NEWLINE_THRESHOLD;
+}
+
+function newPasteId(): string {
+  return Math.random().toString(36).slice(2, 7);
+}
+
+function countLines(s: string): number {
+  return s.split("\n").length;
 }
 
 function findWordBoundaryForward(text: string, pos: number): number {
@@ -34,8 +52,10 @@ export function CustomTextInput({
   onClearQueueItem,
   focus = true,
   mask,
+  enablePaste = false,
 }: Props) {
   const [cursorOffset, setCursorOffset] = useState(value.length);
+  const pastesRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (!focus) return;
@@ -46,13 +66,24 @@ export function CustomTextInput({
     (input, key) => {
       if (!focus) return;
 
-      // Let app-level handlers process these
       if (key.ctrl && input === "c") return;
       if (key.ctrl && input === "r") return;
+      if (key.ctrl && input === "o") return;
       if (key.tab) return;
 
       if (key.return) {
-        onSubmit(value);
+        let full = value;
+        let hasPastes = false;
+        if (enablePaste && pastesRef.current.size > 0) {
+          for (const [placeholder, fullText] of pastesRef.current) {
+            if (full.includes(placeholder)) {
+              full = full.split(placeholder).join(fullText);
+              hasPastes = true;
+            }
+          }
+        }
+        onSubmit(full, hasPastes ? value : undefined);
+        pastesRef.current.clear();
         setCursorOffset(0);
         return;
       }
@@ -89,12 +120,19 @@ export function CustomTextInput({
         nextCursor = value.length;
       } else if (key.backspace) {
         didDelete = true;
-        if (key.meta || (key.ctrl && input === "w")) {
+        const tokenBoundary = enablePaste
+          ? findPasteTokenEndingAt(value, cursorOffset, pastesRef.current)
+          : -1;
+        if (tokenBoundary >= 0) {
+          const token = value.slice(tokenBoundary, cursorOffset);
+          pastesRef.current.delete(token);
+          nextValue = value.slice(0, tokenBoundary) + value.slice(cursorOffset);
+          nextCursor = tokenBoundary;
+        } else if (key.meta || (key.ctrl && input === "w")) {
           const boundary = findWordBoundaryBackward(value, cursorOffset);
           nextValue = value.slice(0, boundary) + value.slice(cursorOffset);
           nextCursor = boundary;
         } else if (key.ctrl) {
-          // Ctrl+Backspace -> delete word backward
           const boundary = findWordBoundaryBackward(value, cursorOffset);
           nextValue = value.slice(0, boundary) + value.slice(cursorOffset);
           nextCursor = boundary;
@@ -125,8 +163,16 @@ export function CustomTextInput({
         didDelete = true;
         nextValue = value.slice(0, cursorOffset);
       } else if (input.length > 0 && !key.ctrl && !key.meta) {
-        nextValue = value.slice(0, cursorOffset) + input + value.slice(cursorOffset);
-        nextCursor = cursorOffset + input.length;
+        let toInsert = input;
+        if (enablePaste && shouldTreatAsPaste(input)) {
+          const lines = countLines(input);
+          const id = newPasteId();
+          const placeholder = `[pasted ${lines} line${lines === 1 ? "" : "s"} #${id}]`;
+          pastesRef.current.set(placeholder, input);
+          toInsert = placeholder;
+        }
+        nextValue = value.slice(0, cursorOffset) + toInsert + value.slice(cursorOffset);
+        nextCursor = cursorOffset + toInsert.length;
       }
 
       if (nextCursor < 0) nextCursor = 0;
@@ -161,4 +207,18 @@ export function CustomTextInput({
   }
 
   return <Text>{renderedValue}</Text>;
+}
+
+function findPasteTokenEndingAt(
+  value: string,
+  pos: number,
+  pastes: Map<string, string>,
+): number {
+  if (pos <= 0 || value[pos - 1] !== "]") return -1;
+  for (const placeholder of pastes.keys()) {
+    if (placeholder.length > pos) continue;
+    const start = pos - placeholder.length;
+    if (value.slice(start, pos) === placeholder) return start;
+  }
+  return -1;
 }

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -114,6 +114,14 @@ export function CustomTextInput({
         } else {
           nextCursor = cursorOffset + 1;
         }
+      } else if (key.meta && input === "b") {
+        nextCursor = findWordBoundaryBackward(value, cursorOffset);
+      } else if (key.meta && input === "f") {
+        nextCursor = findWordBoundaryForward(value, cursorOffset);
+      } else if (key.meta && input === "d") {
+        didDelete = true;
+        const boundary = findWordBoundaryForward(value, cursorOffset);
+        nextValue = value.slice(0, cursorOffset) + value.slice(boundary);
       } else if (key.home || (key.ctrl && input === "a")) {
         nextCursor = 0;
       } else if (key.end || (key.ctrl && input === "e")) {

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,91 @@
+export type ColorName = string;
+
+export interface DimColor {
+  color: ColorName;
+  dim: boolean;
+}
+
+export interface Theme {
+  name: string;
+  label: string;
+  user: ColorName;
+  assistant: ColorName | undefined;
+  reasoning: DimColor;
+  info: DimColor;
+  error: ColorName;
+  warn: ColorName;
+  tool: ColorName;
+  spinner: ColorName;
+  permission: ColorName;
+  queue: DimColor;
+  accent: ColorName;
+  modeBadge: { plan: ColorName; auto: ColorName; edit: ColorName };
+}
+
+const dark: Theme = {
+  name: "dark",
+  label: "dark (default — for dark terminals)",
+  user: "cyan",
+  assistant: undefined,
+  reasoning: { color: "gray", dim: true },
+  info: { color: "gray", dim: true },
+  error: "red",
+  warn: "yellow",
+  tool: "magenta",
+  spinner: "yellow",
+  permission: "yellow",
+  queue: { color: "gray", dim: true },
+  accent: "cyan",
+  modeBadge: { plan: "blue", auto: "green", edit: "cyan" },
+};
+
+const light: Theme = {
+  name: "light",
+  label: "light (for bright terminal backgrounds)",
+  user: "blue",
+  assistant: undefined,
+  reasoning: { color: "blackBright", dim: false },
+  info: { color: "blackBright", dim: false },
+  error: "red",
+  warn: "magenta",
+  tool: "magenta",
+  spinner: "blue",
+  permission: "magenta",
+  queue: { color: "blackBright", dim: false },
+  accent: "blue",
+  modeBadge: { plan: "blue", auto: "green", edit: "magenta" },
+};
+
+const highContrast: Theme = {
+  name: "high-contrast",
+  label: "high-contrast (bold, bright colors for low-vision)",
+  user: "cyanBright",
+  assistant: "whiteBright",
+  reasoning: { color: "whiteBright", dim: false },
+  info: { color: "whiteBright", dim: false },
+  error: "redBright",
+  warn: "yellowBright",
+  tool: "magentaBright",
+  spinner: "yellowBright",
+  permission: "yellowBright",
+  queue: { color: "whiteBright", dim: false },
+  accent: "cyanBright",
+  modeBadge: { plan: "blueBright", auto: "greenBright", edit: "cyanBright" },
+};
+
+export const THEMES: Record<string, Theme> = {
+  dark,
+  light,
+  "high-contrast": highContrast,
+};
+
+export const DEFAULT_THEME_NAME = "dark";
+
+export function resolveTheme(name: string | undefined): Theme {
+  if (!name) return THEMES[DEFAULT_THEME_NAME]!;
+  return THEMES[name] ?? THEMES[DEFAULT_THEME_NAME]!;
+}
+
+export function themeNames(): string[] {
+  return Object.keys(THEMES);
+}

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -13,10 +13,18 @@ export interface ToolEventState {
   expanded?: boolean;
 }
 
-export function ToolView({ evt }: { evt: ToolEventState }) {
+interface Props {
+  evt: ToolEventState;
+  verbose?: boolean;
+}
+
+export function ToolView({ evt, verbose }: Props) {
   const statusIcon =
     evt.status === "running" ? <Spinner type="dots" /> : evt.status === "error" ? <Text color="red">✗</Text> : <Text color="green">✓</Text>;
   const title = evt.render?.title ?? `${evt.name}(${compactArgs(evt.args)})`;
+  const expand = Boolean(evt.expanded || verbose);
+  const lines = evt.result ? evt.result.split("\n") : [];
+  const showLimit = verbose ? 200 : 20;
 
   return (
     <Box flexDirection="column" marginLeft={2}>
@@ -28,17 +36,17 @@ export function ToolView({ evt }: { evt: ToolEventState }) {
           <DiffView {...evt.render.diff} />
         </Box>
       ) : null}
-      {evt.result && evt.expanded ? (
+      {evt.result && expand ? (
         <Box marginLeft={2} flexDirection="column">
-          {evt.result.split("\n").slice(0, 20).map((l, i) => (
+          {lines.slice(0, showLimit).map((l, i) => (
             <Text key={i} color="gray">{l}</Text>
           ))}
-          {evt.result.split("\n").length > 20 && (
-            <Text color="gray">... ({evt.result.split("\n").length - 20} more lines)</Text>
+          {lines.length > showLimit && (
+            <Text color="gray">... ({lines.length - showLimit} more lines)</Text>
           )}
         </Box>
       ) : null}
-      {evt.result && !evt.expanded && evt.status !== "running" ? (
+      {evt.result && !expand && evt.status !== "running" ? (
         <Text color="gray">  {firstLine(evt.result)}</Text>
       ) : null}
     </Box>

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -4,7 +4,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-const GITHUB_API = "https://api.github.com/repos/sinameraji/kimiflare/releases/latest";
+const NPM_REGISTRY = "https://registry.npmjs.org/kimiflare/latest";
 
 interface CacheEntry {
   checkedAt: number;
@@ -54,12 +54,12 @@ async function writeCache(entry: CacheEntry): Promise<void> {
 
 async function fetchLatestVersion(): Promise<string | null> {
   try {
-    const res = await fetch(GITHUB_API, {
-      headers: { "User-Agent": "kimiflare-update-checker" },
+    const res = await fetch(NPM_REGISTRY, {
+      headers: { "User-Agent": "kimiflare-update-checker", Accept: "application/json" },
     });
     if (!res.ok) return null;
-    const data = (await res.json()) as { tag_name?: string };
-    return data.tag_name ?? null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Adds six interlocking UX features to make kimiflare feel closer to Claude Code:

- **Modes** (`edit` / `plan` / `auto`) — cycle with `Shift+Tab` or set via `/mode`. Plan mode blocks mutating tools and clears cached session allows; auto mode auto-approves every permission; edit mode (default) prompts as before. Mode is injected into the system prompt.
- **Color themes** (`dark` / `light` / `high-contrast`) — `/theme NAME`, persisted to `~/.config/kimiflare/config.json`. New `src/ui/theme.ts` exposes a `Theme` type consumed by chat, status, permission modal, and the resume picker.
- **Reasoning effort** — `/thinking low|medium|high` sends `reasoning_effort` in the Cloudflare request body (the Workers AI kimi-k2.6 endpoint accepts it; we just weren't using it). Defaults to `medium`. Also overridable via `KIMI_REASONING_EFFORT` env var. Shown in the status bar.
- **Type-ahead queue** — the input stays visible while the model is busy, so you can type the next prompt and it queues (`⏳ …`). `Ctrl-C` now aborts *and* clears the queue.
- **Session persistence + `/resume`** — sessions serialize to `~/.local/share/kimiflare/sessions/` after each turn. `/resume` opens a SelectInput picker showing recent sessions (date, msg count, first prompt) to restore.
- **`/compact`** — summarizes older turns into a single compacted-summary message, preserving the last 4 user turns. Status bar warns when context is ≥80% full. Uses `reasoning_effort=low` for cheap summaries.

### New commands

| Command | Effect |
|---|---|
| `/mode edit\|plan\|auto` (or `/plan` `/auto` `/edit`) | switch mode |
| `/thinking low\|medium\|high` | reasoning effort (persists) |
| `/theme NAME` | color scheme (persists) |
| `/resume` | pick a past conversation |
| `/compact` | summarize older turns |

### New keys

- `Shift+Tab` — cycle mode
- `Ctrl+C` while busy — aborts current turn *and* clears the pending queue

### Files

- New: `src/mode.ts`, `src/sessions.ts`, `src/agent/compact.ts`, `src/ui/theme.ts`, `src/ui/resume-picker.tsx`
- Touched: `src/app.tsx` (biggest diff; integrates everything), `src/config.ts`, `src/agent/client.ts`, `src/agent/loop.ts`, `src/agent/system-prompt.ts`, `src/tools/executor.ts`, `src/ui/{chat,status,permission}.tsx`, `README.md`

### Note on commit range

This PR includes 5 pre-existing commits from your local `main` that weren't on `origin/main` yet (`0.1.1` through `0.1.3` version bumps + README work). They'll merge cleanly alongside the feature commit.

## Test plan

- [ ] `npm run build` passes (confirmed locally)
- [ ] `npx tsc --noEmit` passes (confirmed locally)
- [ ] Launch `kimiflare`, confirm the status bar shows `[edit]` and the input is visible below the model spinner while a turn is running
- [ ] Press `Shift+Tab` three times — mode cycles edit → plan → auto → edit, announced inline
- [ ] In plan mode, ask the agent to "write a file" — `write`/`edit`/`bash` calls should be blocked with a `plan mode blocked …` message
- [ ] In auto mode, ask for a change that would normally prompt — no modal appears
- [ ] `/thinking low`, then a trivial prompt — should feel faster than before; `/thinking high` on a complex prompt should feel slower with deeper reasoning
- [ ] `/theme light` on a bright terminal — text should be readable (no more dim gray on white)
- [ ] Run a couple of turns, quit, relaunch, `/resume` — most recent session appears with correct first-prompt and message count; selecting it restores history
- [ ] Drive context to ≥80% (or test `/compact` directly) — status bar warns; `/compact` replaces old turns with a summary message
- [ ] While busy, type the next prompt — shows as `⏳ …`, runs when current turn ends; `Ctrl-C` clears it

🤖 Generated with [Claude Code](https://claude.com/claude-code)