### PR TITLE
chore: bump to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Ships the Claude Code-style UX bundle merged in #8 to npm.

Why 0.2.0 and not 0.1.4:

- Config file gained new fields (`theme`, `reasoningEffort`). Existing configs are forward-compat but new defaults ship with the bump.
- Several user-visible behaviors change: reasoning effort defaults to `medium` instead of model-default, the spinner no longer hides the input, long pastes now collapse in the UI.
- Six new features exposed via slash commands.

When this merges, `.github/workflows/publish.yml` will see `0.2.0` ≠ npm's `0.1.3` and publish. It'll also create a `v0.2.0` GitHub release.

## Test plan

- [ ] Merge triggers `Publish to npm` workflow
- [ ] Workflow's "Check if publish is needed" step prints `publish=true`
- [ ] `npm view kimiflare version` returns `0.2.0` a minute after merge
- [ ] `v0.2.0` release appears on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)