### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "kimiflare",
   "version": "0.2.0",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sinameraji/kimiflare.git"
+  },
+  "homepage": "https://github.com/sinameraji/kimiflare#readme",
+  "bugs": "https://github.com/sinameraji/kimiflare/issues",
   "type": "module",
   "bin": {
     "kimiflare": "bin/kimiflare.mjs"


### PR DESCRIPTION
The 0.2.0 publish from #9 failed with:

\`\`\`
npm error 422 — Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json:
"repository.url" is "", expected to match
"https://github.com/sinameraji/kimiflare"
\`\`\`

\`npm publish --provenance\` requires \`package.json\` to declare the GitHub repo URL so sigstore can verify the build's origin. Adding \`repository\`, \`homepage\`, and \`bugs\` fields.

When this merges, the publish workflow re-runs with \`0.2.0\` still not on npm, and should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)