### PR TITLE
feat: UI polish, /init + KIMI.md, release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,17 @@
+name: release-please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Interactive slash commands:
 | `/theme NAME`               | Switch color scheme: `dark` (default), `light` (bright terminals), `high-contrast`. Saved to config. |
 | `/resume`                   | Pick a past conversation to restore.                                            |
 | `/compact`                  | Summarize older turns to free context. Suggested automatically at ~80% full.    |
+| `/init`                     | Scan the repo and write a `KIMI.md` so future agents have project context.      |
 | `/reasoning`                | Toggle chain-of-thought display.                                                |
 | `/clear`                    | Reset the current conversation.                                                 |
 | `/cost` `/model` `/update`  | Info commands.                                                                  |
@@ -134,6 +135,10 @@ For multi-step requests, the agent can publish a live task list via the `tasks_s
 ### Paste collapse
 
 Paste a large block (≥ 200 chars or ≥ 3 newlines in one paste) into the prompt and the input collapses it to `[pasted N lines #id]`. The full content still goes to the model on submit — only the on-screen display and chat history are collapsed, so scrollback doesn't get buried by a wall of code.
+
+### Project context (KIMI.md)
+
+Run `/init` inside a repo and kimiflare scans the project (reads `package.json`, `README`, source layout, etc.) and writes a concise `KIMI.md` at the repo root — project overview, build/test commands, conventions, quirks. On every subsequent launch in that directory, `KIMI.md` (or `KIMIFLARE.md` or `AGENT.md`, whichever exists) is auto-loaded into the system prompt so the agent already "knows" the project. If the file already exists, `/init` refuses so you don't overwrite hand-edited context.
 
 ## Why
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,5 +1,6 @@
 import { platform, release, homedir } from "node:os";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
+import { readFileSync, statSync } from "node:fs";
 import type { ToolSpec } from "../tools/registry.js";
 import { systemPromptForMode, type Mode } from "../mode.js";
 
@@ -9,6 +10,31 @@ export interface SystemPromptOpts {
   model: string;
   now?: Date;
   mode?: Mode;
+}
+
+const CONTEXT_FILENAMES = ["KIMI.md", "KIMIFLARE.md", "AGENT.md"];
+const MAX_CONTEXT_BYTES = 20 * 1024;
+
+export interface ContextFile {
+  name: string;
+  path: string;
+  content: string;
+  lineCount: number;
+}
+
+export function loadContextFile(cwd: string): ContextFile | null {
+  for (const name of CONTEXT_FILENAMES) {
+    const path = join(cwd, name);
+    try {
+      const s = statSync(path);
+      if (!s.isFile() || s.size > MAX_CONTEXT_BYTES) continue;
+      const content = readFileSync(path, "utf8");
+      return { name, path, content, lineCount: content.split("\n").length };
+    } catch {
+      /* not present */
+    }
+  }
+  return null;
 }
 
 export function buildSystemPrompt(opts: SystemPromptOpts): string {
@@ -22,7 +48,7 @@ export function buildSystemPrompt(opts: SystemPromptOpts): string {
     })
     .join("\n");
 
-  return `You are kimiflare, an interactive coding assistant running in the user's terminal. You act on the user's local filesystem through the tools listed below. You are powered by the ${opts.model} model on Cloudflare Workers AI.
+  const base = `You are kimiflare, an interactive coding assistant running in the user's terminal. You act on the user's local filesystem through the tools listed below. You are powered by the ${opts.model} model on Cloudflare Workers AI.
 
 Environment:
 - Working directory: ${opts.cwd}
@@ -43,5 +69,13 @@ How to work:
 - If a tool returns an error, read it carefully and adjust; do not retry the same call blindly.
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.
 - If a request is ambiguous, ask one focused question instead of making large assumptions.
-- When you finish a task, stop. Do not add a closing summary.${opts.mode ? systemPromptForMode(opts.mode) : ""}`;
+- When you finish a task, stop. Do not add a closing summary.`;
+
+  const ctx = loadContextFile(opts.cwd);
+  const contextBlock = ctx
+    ? `\n\nProject context from ${ctx.name} (${ctx.lineCount} lines, treat as authoritative):\n${ctx.content.trim()}`
+    : "";
+  const modeBlock = opts.mode ? systemPromptForMode(opts.mode) : "";
+
+  return base + contextBlock + modeBlock;
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,6 +13,9 @@ import { PermissionModal } from "./ui/permission.js";
 import { ResumePicker } from "./ui/resume-picker.js";
 import { TaskList } from "./ui/task-list.js";
 import type { Task } from "./tasks-state.js";
+import { loadContextFile } from "./agent/system-prompt.js";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
 import { checkForUpdate, isGitRepo, type UpdateCheckResult } from "./util/update-check.js";
@@ -65,9 +68,20 @@ const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
 function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const { exit } = useApp();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
-  const [events, setEvents] = useState<ChatEvent[]>([
-    { kind: "info", key: mkKey(), text: "kimiflare · /help for commands · ctrl-c to exit · shift+tab to cycle modes" },
-  ]);
+  const [events, setEvents] = useState<ChatEvent[]>(() => {
+    const initial: ChatEvent[] = [
+      { kind: "info", key: mkKey(), text: "kimiflare · /help for commands · ctrl-c to exit · shift+tab to cycle modes" },
+    ];
+    const ctxFile = loadContextFile(process.cwd());
+    if (ctxFile) {
+      initial.push({
+        kind: "info",
+        key: mkKey(),
+        text: `loaded project context from ${ctxFile.name} (${ctxFile.lineCount} lines)`,
+      });
+    }
+    return initial;
+  });
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [usage, setUsage] = useState<Usage | null>(null);
@@ -106,6 +120,8 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const sessionIdRef = useRef<string | null>(null);
   const modeRef = useRef<Mode>(mode);
   const effortRef = useRef<ReasoningEffort>(effort);
+  const tasksRef = useRef<Task[]>([]);
+  const usageRef = useRef<Usage | null>(null);
 
   useEffect(() => {
     modeRef.current = mode;
@@ -262,6 +278,147 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
     const sessions = await listSessions(30);
     setResumeSessions(sessions);
   }, []);
+
+  const runInit = useCallback(async () => {
+    if (!cfg) return;
+    if (busy) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /init while model is running" }]);
+      return;
+    }
+    const cwd = process.cwd();
+    for (const name of ["KIMI.md", "KIMIFLARE.md", "AGENT.md"]) {
+      if (existsSync(join(cwd, name))) {
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `${name} already exists at ${join(cwd, name)} — delete it first if you want to regenerate`,
+          },
+        ]);
+        return;
+      }
+    }
+    const prompt = [
+      "Generate a KIMI.md at the repository root so future agents have project context.",
+      "",
+      "First, use the `glob`, `read`, and `grep` tools to understand the project: read `package.json`, the top-level `README.md` if present, the tsconfig / build config, and skim the top-level source directory structure.",
+      "",
+      "Then call the `write` tool to create `KIMI.md` at the repo root with these sections, terse (aim ≤ 100 lines total):",
+      "",
+      "- **Project** — one-line description + primary language/runtime.",
+      "- **Build / test / run** — exact shell commands an agent should use.",
+      "- **Layout** — key directories and what lives in each.",
+      "- **Conventions** — naming, import style, file structure, commit style, anything surprising.",
+      "- **Do / Don't** — quirks or rules future agents should know.",
+      "",
+      "Do not call `tasks_set` for this. Just read what you need, then write the file.",
+    ].join("\n");
+
+    setEvents((e) => [...e, { kind: "user", key: mkKey(), text: "/init" }]);
+    messagesRef.current.push({ role: "user", content: prompt });
+    setBusy(true);
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+
+    try {
+      await runAgentTurn({
+        accountId: cfg.accountId,
+        apiToken: cfg.apiToken,
+        model: cfg.model,
+        messages: messagesRef.current,
+        tools: ALL_TOOLS,
+        executor: executorRef.current,
+        cwd,
+        signal: controller.signal,
+        reasoningEffort: effortRef.current,
+        callbacks: {
+          onAssistantStart: () => {
+            const id = nextAssistantId++;
+            activeAsstIdRef.current = id;
+            setEvents((e) => [
+              ...e,
+              { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true },
+            ]);
+          },
+          onReasoningDelta: (d) => {
+            const id = activeAsstIdRef.current;
+            if (id !== null) updateAssistant(id, (e) => ({ reasoning: e.reasoning + d }));
+          },
+          onTextDelta: (d) => {
+            const id = activeAsstIdRef.current;
+            if (id !== null) updateAssistant(id, (e) => ({ text: e.text + d }));
+          },
+          onAssistantFinal: () => {
+            const id = activeAsstIdRef.current;
+            if (id !== null) updateAssistant(id, () => ({ streaming: false }));
+          },
+          onToolCallFinalized: (call) => {
+            const spec = executorRef.current.list().find((t) => t.name === call.function.name);
+            let renderMeta: ToolRender | undefined;
+            try {
+              const args = call.function.arguments ? JSON.parse(call.function.arguments) : {};
+              renderMeta = spec?.render?.(args);
+            } catch {
+              /* ignore */
+            }
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "tool",
+                key: `tool_${call.id}`,
+                id: call.id,
+                name: call.function.name,
+                args: call.function.arguments,
+                status: "running",
+                render: renderMeta,
+                expanded: false,
+              },
+            ]);
+          },
+          onToolResult: (r) => {
+            updateTool(r.tool_call_id, { status: r.ok ? "done" : "error", result: r.content });
+          },
+          onUsage: (u) => {
+            usageRef.current = u;
+            setUsage(u);
+          },
+          askPermission: (req) =>
+            new Promise<PermissionDecision>((resolve) => {
+              if (modeRef.current === "auto") return resolve("allow");
+              setPerm({ tool: req.tool, args: req.args, resolve });
+            }),
+        },
+      });
+
+      if (existsSync(join(cwd, "KIMI.md"))) {
+        messagesRef.current[0] = {
+          role: "system",
+          content: buildSystemPrompt({
+            cwd,
+            tools: ALL_TOOLS,
+            model: cfg.model,
+            mode: modeRef.current,
+          }),
+        };
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "KIMI.md generated; context loaded for future turns" },
+        ]);
+      }
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") {
+        setEvents((es) => [
+          ...es,
+          { kind: "error", key: mkKey(), text: `init failed: ${(e as Error).message}` },
+        ]);
+      }
+    } finally {
+      setBusy(false);
+      activeAsstIdRef.current = null;
+      activeControllerRef.current = null;
+    }
+  }, [cfg, busy, updateAssistant, updateTool]);
 
   const handleResumePick = useCallback(
     async (picked: SessionSummary | null) => {
@@ -450,6 +607,10 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         void runCompact();
         return true;
       }
+      if (c === "/init") {
+        void runInit();
+        return true;
+      }
       if (c === "/update") {
         if (updateInfo?.hasUpdate) {
           setEvents((e) => [
@@ -512,6 +673,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
               "  /theme NAME             dark, light, high-contrast\n" +
               "  /resume                 pick a past conversation\n" +
               "  /compact                summarize old turns to free context\n" +
+              "  /init                   scan this repo and write a KIMI.md for future agents\n" +
               "  /reasoning              toggle show/hide model reasoning\n" +
               "  /clear                  clear current conversation\n" +
               "  /cost /model /update /logout /help /exit\n" +
@@ -522,7 +684,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
       }
       return false;
     },
-    [cfg, exit, usage, updateInfo, effort, theme, mode, openResumePicker, runCompact],
+    [cfg, exit, usage, updateInfo, effort, theme, mode, openResumePicker, runCompact, runInit],
   );
 
   const processMessage = useCallback(
@@ -602,19 +764,22 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
                 result: r.content,
               });
             },
-            onUsage: (u) => setUsage(u),
+            onUsage: (u) => {
+              usageRef.current = u;
+              setUsage(u);
+            },
             onTasks: (nextTasks) => {
-              setTasks((prev) => {
-                if (prev.length === 0 && nextTasks.length > 0) {
-                  setTasksStartedAt(Date.now());
-                  setTasksStartTokens(usage?.prompt_tokens ?? 0);
-                }
-                if (nextTasks.length === 0) {
-                  setTasksStartedAt(null);
-                  setTasksStartTokens(0);
-                }
-                return nextTasks;
-              });
+              const prevEmpty = tasksRef.current.length === 0;
+              tasksRef.current = nextTasks;
+              setTasks(nextTasks);
+              if (prevEmpty && nextTasks.length > 0) {
+                setTasksStartedAt(Date.now());
+                setTasksStartTokens(usageRef.current?.prompt_tokens ?? 0);
+              }
+              if (nextTasks.length === 0) {
+                setTasksStartedAt(null);
+                setTasksStartTokens(0);
+              }
             },
             askPermission: (req) =>
               new Promise<PermissionDecision>((resolve) => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import type { ToolSpec } from "./registry.js";
+import type { ToolSpec, ToolContext } from "./registry.js";
 import { truncate } from "../util/paths.js";
 
 interface Args {
@@ -30,42 +30,51 @@ export const bashTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: true,
-  render: (args) => ({ title: `bash: ${args.command}`.slice(0, 120) }),
-  run(args, ctx) {
-    const timeout = Math.min(Math.max(1000, args.timeout_ms ?? DEFAULT_TIMEOUT), MAX_TIMEOUT);
-    return new Promise<string>((resolve, reject) => {
-      const child = spawn("bash", ["-lc", args.command], {
-        cwd: ctx.cwd,
-        signal: ctx.signal,
-      });
-      let stdout = "";
-      let stderr = "";
-      let killedByTimeout = false;
-      const timer = setTimeout(() => {
-        killedByTimeout = true;
-        child.kill("SIGKILL");
-      }, timeout);
-      child.stdout.on("data", (d: Buffer) => {
-        stdout += d.toString("utf8");
-      });
-      child.stderr.on("data", (d: Buffer) => {
-        stderr += d.toString("utf8");
-      });
-      child.on("error", (e) => {
-        clearTimeout(timer);
-        reject(e);
-      });
-      child.on("close", (code, signal) => {
-        clearTimeout(timer);
-        const header = killedByTimeout
-          ? `(timed out after ${timeout}ms)`
-          : `exit=${code ?? "?"}${signal ? ` signal=${signal}` : ""}`;
-        const parts: string[] = [header];
-        if (stdout) parts.push(`--- stdout ---\n${stdout.trimEnd()}`);
-        if (stderr) parts.push(`--- stderr ---\n${stderr.trimEnd()}`);
-        if (!stdout && !stderr) parts.push("(no output)");
-        resolve(truncate(parts.join("\n"), OUTPUT_CAP));
-      });
-    });
-  },
+  render: (args) => ({ title: formatBashTitle(args.command) }),
+  run: (args, ctx) => runBash(args, ctx),
 };
+
+function formatBashTitle(raw: string): string {
+  let cmd = (raw ?? "").trim();
+  const m = cmd.match(/^cd\s+([^\s&;]+)\s*(?:&&|;)\s*(.*)$/);
+  if (m) cmd = m[2]!.trim();
+  return `$ ${cmd}`.slice(0, 120);
+}
+
+function runBash(args: Args, ctx: ToolContext): Promise<string> {
+  const timeout = Math.min(Math.max(1000, args.timeout_ms ?? DEFAULT_TIMEOUT), MAX_TIMEOUT);
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn("bash", ["-lc", args.command], {
+      cwd: ctx.cwd,
+      signal: ctx.signal,
+    });
+    let stdout = "";
+    let stderr = "";
+    let killedByTimeout = false;
+    const timer = setTimeout(() => {
+      killedByTimeout = true;
+      child.kill("SIGKILL");
+    }, timeout);
+    child.stdout.on("data", (d: Buffer) => {
+      stdout += d.toString("utf8");
+    });
+    child.stderr.on("data", (d: Buffer) => {
+      stderr += d.toString("utf8");
+    });
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      const header = killedByTimeout
+        ? `(timed out after ${timeout}ms)`
+        : `exit=${code ?? "?"}${signal ? ` signal=${signal}` : ""}`;
+      const parts: string[] = [header];
+      if (stdout) parts.push(`--- stdout ---\n${stdout.trimEnd()}`);
+      if (stderr) parts.push(`--- stderr ---\n${stderr.trimEnd()}`);
+      if (!stdout && !stderr) parts.push("(no output)");
+      resolve(truncate(parts.join("\n"), OUTPUT_CAP));
+    });
+  });
+}

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import type { ToolSpec } from "./registry.js";
-import { resolvePath } from "../util/paths.js";
+import { resolvePath, collapsePath } from "../util/paths.js";
 
 interface Args {
   path: string;
@@ -26,7 +26,7 @@ export const editTool: ToolSpec<Args> = {
   },
   needsPermission: true,
   render: (args) => ({
-    title: `edit ${args.path}${args.replace_all ? " (replace_all)" : ""}`,
+    title: `edit ${collapsePath(args.path, process.cwd())}${args.replace_all ? " (replace_all)" : ""}`,
     diff: { path: args.path, before: args.old_string, after: args.new_string },
   }),
   async run(args, ctx) {

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,6 +1,6 @@
 import fg from "fast-glob";
 import type { ToolSpec } from "./registry.js";
-import { resolvePath } from "../util/paths.js";
+import { resolvePath, collapsePath } from "../util/paths.js";
 
 interface Args {
   pattern: string;
@@ -21,7 +21,7 @@ export const globTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `glob ${args.pattern}${args.path ? ` in ${args.path}` : ""}` }),
+  render: (args) => ({ title: `glob ${args.pattern}${args.path ? ` in ${collapsePath(args.path, process.cwd())}` : ""}` }),
   async run(args, ctx) {
     const root = args.path ? resolvePath(ctx.cwd, args.path) : ctx.cwd;
     const entries = (await fg(args.pattern, {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises";
 import type { ToolSpec } from "./registry.js";
-import { resolvePath } from "../util/paths.js";
+import { resolvePath, collapsePath } from "../util/paths.js";
 
 const MAX_BYTES = 2 * 1024 * 1024;
 
@@ -25,7 +25,7 @@ export const readTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: ({ path }) => ({ title: `read ${path}` }),
+  render: ({ path }) => ({ title: `read ${collapsePath(path, process.cwd())}` }),
   async run(args, ctx) {
     const abs = resolvePath(ctx.cwd, args.path);
     const st = await stat(abs);

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { ToolSpec } from "./registry.js";
-import { resolvePath } from "../util/paths.js";
+import { resolvePath, collapsePath } from "../util/paths.js";
 
 interface Args {
   path: string;
@@ -23,7 +23,7 @@ export const writeTool: ToolSpec<Args> = {
   },
   needsPermission: true,
   render: (args) => ({
-    title: `write ${args.path} (${args.content.length} chars)`,
+    title: `write ${collapsePath(args.path, process.cwd())} (${args.content.length} chars)`,
     diff: { path: args.path, before: "", after: args.content },
   }),
   async run(args, ctx) {

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { ToolView, type ToolEventState } from "./tool-view.js";
+import { MD } from "./markdown.js";
 import type { Theme } from "./theme.js";
 
 export type ChatEvent =
@@ -37,7 +38,7 @@ export function ChatView({ events, showReasoning, theme, verbose }: Props) {
 function EventView({ evt, showReasoning, theme, verbose }: { evt: ChatEvent; showReasoning: boolean; theme: Theme; verbose?: boolean }) {
   if (evt.kind === "user") {
     return (
-      <Box marginY={0}>
+      <Box marginTop={1}>
         <Text color={theme.user}>› </Text>
         <Text>{evt.text}</Text>
       </Box>
@@ -45,7 +46,7 @@ function EventView({ evt, showReasoning, theme, verbose }: { evt: ChatEvent; sho
   }
   if (evt.kind === "assistant") {
     return (
-      <Box flexDirection="column" marginY={0}>
+      <Box flexDirection="column" marginTop={1} paddingLeft={1}>
         {showReasoning && evt.reasoning ? (
           <Box flexDirection="column" marginLeft={2}>
             <Text color={theme.reasoning.color} dimColor={theme.reasoning.dim}>
@@ -53,9 +54,7 @@ function EventView({ evt, showReasoning, theme, verbose }: { evt: ChatEvent; sho
             </Text>
           </Box>
         ) : null}
-        {evt.text ? (
-          theme.assistant ? <Text color={theme.assistant}>{evt.text}</Text> : <Text>{evt.text}</Text>
-        ) : null}
+        {evt.text ? <MD text={evt.text} theme={theme} /> : null}
       </Box>
     );
   }

--- a/src/ui/diff-view.tsx
+++ b/src/ui/diff-view.tsx
@@ -11,28 +11,47 @@ interface Props {
 
 export function DiffView({ path, before, after, maxLines = 40 }: Props) {
   const patch = createTwoFilesPatch(path, path, before, after, "", "", { context: 2 });
-  const lines = patch.split("\n").slice(4); // drop the `Index:` + header block
-  const truncated = lines.length > maxLines ? lines.slice(0, maxLines) : lines;
+  const raw = patch.split("\n").slice(4);
+  const lines = raw.filter((l) => {
+    if (l.startsWith("--- ") || l.startsWith("+++ ")) return false;
+    if (l.startsWith("\\ No newline at end of file")) return false;
+    return true;
+  });
+
+  const diffStats = countChanges(lines);
+  const hideHeader =
+    diffStats.changed <= 3 && diffStats.context <= 3 && diffStats.hunks <= 1;
+  const filtered = hideHeader
+    ? lines.filter((l) => !l.startsWith("@@"))
+    : lines;
+
+  const truncated = filtered.length > maxLines ? filtered.slice(0, maxLines) : filtered;
 
   return (
     <Box flexDirection="column">
       {truncated.map((line, i) => <DiffLine key={i} line={line} />)}
-      {lines.length > maxLines && (
-        <Text color="gray">... ({lines.length - maxLines} more lines)</Text>
+      {filtered.length > maxLines && (
+        <Text color="gray">... ({filtered.length - maxLines} more lines)</Text>
       )}
     </Box>
   );
 }
 
+function countChanges(lines: string[]): { changed: number; context: number; hunks: number } {
+  let changed = 0;
+  let context = 0;
+  let hunks = 0;
+  for (const l of lines) {
+    if (l.startsWith("@@")) hunks++;
+    else if (l.startsWith("+") || l.startsWith("-")) changed++;
+    else if (l.trim().length > 0) context++;
+  }
+  return { changed, context, hunks };
+}
+
 function DiffLine({ line }: { line: string }) {
-  if (line.startsWith("+") && !line.startsWith("+++")) {
-    return <Text color="green">{line}</Text>;
-  }
-  if (line.startsWith("-") && !line.startsWith("---")) {
-    return <Text color="red">{line}</Text>;
-  }
-  if (line.startsWith("@@")) {
-    return <Text color="cyan">{line}</Text>;
-  }
+  if (line.startsWith("+")) return <Text color="green">{line}</Text>;
+  if (line.startsWith("-")) return <Text color="red">{line}</Text>;
+  if (line.startsWith("@@")) return <Text color="cyan">{line}</Text>;
   return <Text color="gray">{line}</Text>;
 }

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -1,0 +1,215 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  text: string;
+  theme: Theme;
+}
+
+interface InlineSegment {
+  kind: "plain" | "bold" | "italic" | "code";
+  text: string;
+}
+
+export function MD({ text, theme }: Props) {
+  const blocks = parseBlocks(text);
+  return (
+    <Box flexDirection="column">
+      {blocks.map((b, i) => (
+        <Block key={i} block={b} theme={theme} />
+      ))}
+    </Box>
+  );
+}
+
+type Block =
+  | { kind: "paragraph"; text: string }
+  | { kind: "heading"; level: 1 | 2 | 3; text: string }
+  | { kind: "bullet"; items: string[] }
+  | { kind: "quote"; text: string }
+  | { kind: "code"; lang?: string; text: string }
+  | { kind: "blank" };
+
+function parseBlocks(src: string): Block[] {
+  const out: Block[] = [];
+  const lines = src.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (line.trim() === "") {
+      out.push({ kind: "blank" });
+      i++;
+      continue;
+    }
+    const fence = line.match(/^```(\w*)\s*$/);
+    if (fence) {
+      const lang = fence[1] || undefined;
+      const start = i + 1;
+      let end = start;
+      while (end < lines.length && !/^```\s*$/.test(lines[end]!)) end++;
+      out.push({ kind: "code", lang, text: lines.slice(start, end).join("\n") });
+      i = end + 1;
+      continue;
+    }
+    const heading = line.match(/^(#{1,3})\s+(.*)$/);
+    if (heading) {
+      out.push({ kind: "heading", level: heading[1]!.length as 1 | 2 | 3, text: heading[2]! });
+      i++;
+      continue;
+    }
+    if (/^\s*>\s?/.test(line)) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && /^\s*>\s?/.test(lines[i]!)) {
+        quoteLines.push(lines[i]!.replace(/^\s*>\s?/, ""));
+        i++;
+      }
+      out.push({ kind: "quote", text: quoteLines.join("\n") });
+      continue;
+    }
+    if (/^\s*[-*]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*[-*]\s+/.test(lines[i]!)) {
+        items.push(lines[i]!.replace(/^\s*[-*]\s+/, ""));
+        i++;
+      }
+      out.push({ kind: "bullet", items });
+      continue;
+    }
+    const paraLines: string[] = [line];
+    i++;
+    while (
+      i < lines.length &&
+      lines[i]!.trim() !== "" &&
+      !/^(#{1,3})\s+/.test(lines[i]!) &&
+      !/^\s*[-*]\s+/.test(lines[i]!) &&
+      !/^\s*>\s?/.test(lines[i]!) &&
+      !/^```/.test(lines[i]!)
+    ) {
+      paraLines.push(lines[i]!);
+      i++;
+    }
+    out.push({ kind: "paragraph", text: paraLines.join("\n") });
+  }
+  return out;
+}
+
+function Block({ block, theme }: { block: Block; theme: Theme }) {
+  if (block.kind === "blank") return <Text> </Text>;
+  if (block.kind === "heading") {
+    return (
+      <Box marginTop={block.level === 1 ? 1 : 0}>
+        <Text bold color={theme.accent}>
+          {renderInline(block.text, theme)}
+        </Text>
+      </Box>
+    );
+  }
+  if (block.kind === "bullet") {
+    return (
+      <Box flexDirection="column">
+        {block.items.map((item, i) => (
+          <Box key={i}>
+            <Text color={theme.accent}>  • </Text>
+            <Text>{renderInline(item, theme)}</Text>
+          </Box>
+        ))}
+      </Box>
+    );
+  }
+  if (block.kind === "quote") {
+    return (
+      <Box marginLeft={2}>
+        <Text color={theme.info.color} dimColor={theme.info.dim} italic>
+          {renderInline(block.text, theme)}
+        </Text>
+      </Box>
+    );
+  }
+  if (block.kind === "code") {
+    return (
+      <Box flexDirection="column" marginLeft={2}>
+        {block.text.split("\n").map((l, i) => (
+          <Text key={i} color={theme.tool}>
+            {l}
+          </Text>
+        ))}
+      </Box>
+    );
+  }
+  return <Text>{renderInline(block.text, theme)}</Text>;
+}
+
+function renderInline(src: string, theme: Theme): React.ReactNode {
+  const segments = parseInline(src);
+  return segments.map((seg, i) => {
+    if (seg.kind === "bold") return <Text key={i} bold>{seg.text}</Text>;
+    if (seg.kind === "italic") return <Text key={i} italic>{seg.text}</Text>;
+    if (seg.kind === "code") return <Text key={i} color={theme.tool}>{seg.text}</Text>;
+    return <Text key={i}>{seg.text}</Text>;
+  });
+}
+
+function parseInline(src: string): InlineSegment[] {
+  const out: InlineSegment[] = [];
+  let i = 0;
+  let buf = "";
+  const flush = () => {
+    if (buf) {
+      out.push({ kind: "plain", text: buf });
+      buf = "";
+    }
+  };
+  while (i < src.length) {
+    const ch = src[i]!;
+    if (ch === "`") {
+      const end = src.indexOf("`", i + 1);
+      if (end > i) {
+        flush();
+        out.push({ kind: "code", text: src.slice(i + 1, end) });
+        i = end + 1;
+        continue;
+      }
+    }
+    if (ch === "*" && src[i + 1] === "*") {
+      const end = src.indexOf("**", i + 2);
+      if (end > i + 1) {
+        flush();
+        out.push({ kind: "bold", text: src.slice(i + 2, end) });
+        i = end + 2;
+        continue;
+      }
+    }
+    if (ch === "_" && src[i + 1] === "_") {
+      const end = src.indexOf("__", i + 2);
+      if (end > i + 1) {
+        flush();
+        out.push({ kind: "bold", text: src.slice(i + 2, end) });
+        i = end + 2;
+        continue;
+      }
+    }
+    if (ch === "*" && src[i + 1] !== "*") {
+      const end = src.indexOf("*", i + 1);
+      if (end > i) {
+        flush();
+        out.push({ kind: "italic", text: src.slice(i + 1, end) });
+        i = end + 1;
+        continue;
+      }
+    }
+    if (ch === "_" && !/\w/.test(src[i - 1] ?? "") && src[i + 1] !== "_") {
+      const end = src.indexOf("_", i + 1);
+      if (end > i && !/\w/.test(src[end + 1] ?? "")) {
+        flush();
+        out.push({ kind: "italic", text: src.slice(i + 1, end) });
+        i = end + 1;
+        continue;
+      }
+    }
+    buf += ch;
+    i++;
+  }
+  flush();
+  return out;
+}

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import { DiffView } from "./diff-view.js";
+import { collapsePathsInText } from "../util/paths.js";
 
 export interface ToolEventState {
   id: string;
@@ -54,7 +55,8 @@ export function ToolView({ evt, verbose }: Props) {
 }
 
 function compactArgs(raw: string): string {
-  const s = raw.replace(/\s+/g, " ");
+  const collapsed = collapsePathsInText(raw, process.cwd());
+  const s = collapsed.replace(/\s+/g, " ");
   return s.length <= 80 ? s : s.slice(0, 80) + "…";
 }
 

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -1,4 +1,4 @@
-import { resolve, isAbsolute } from "node:path";
+import { resolve, isAbsolute, relative, sep } from "node:path";
 import { homedir } from "node:os";
 
 export function resolvePath(cwd: string, input: string): string {
@@ -11,4 +11,36 @@ export function resolvePath(cwd: string, input: string): string {
 export function truncate(s: string, n: number): string {
   if (s.length <= n) return s;
   return s.slice(0, n) + `\n... [truncated, ${s.length - n} chars omitted]`;
+}
+
+/**
+ * Collapse a path for display:
+ *   - If inside cwd, return the path relative to cwd.
+ *   - If not inside cwd and length > maxLen, return `…/last-two-segments`.
+ *   - Otherwise return the path unchanged.
+ */
+export function collapsePath(input: string, cwd: string, maxLen = 40): string {
+  if (!input) return input;
+  let abs: string;
+  try {
+    abs = resolvePath(cwd, input);
+  } catch {
+    return input;
+  }
+  const rel = relative(cwd, abs);
+  if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+    return rel === "" ? "." : rel;
+  }
+  if (input.length <= maxLen) return input;
+  const parts = input.split(sep).filter(Boolean);
+  if (parts.length <= 2) return input;
+  return `…/${parts.slice(-2).join(sep)}`;
+}
+
+/**
+ * Replace any long absolute-looking path (starting with `/` or `~`) inside `s`
+ * with a collapsed form. Useful for compacting tool argument previews.
+ */
+export function collapsePathsInText(s: string, cwd: string, maxLen = 40): string {
+  return s.replace(/([~/][^\s"',)}\]]+)/g, (match) => collapsePath(match, cwd, maxLen));
 }


### PR DESCRIPTION
Bundle addressing the "UI is a mess", manual version bumps, and lack of per-repo agent context.

## Part A — UI polish

- **Markdown renderer** (`src/ui/markdown.tsx`, new). Kimi's replies use **bold**, *italic*, `code`, `#` headers, and `- ` bullets — all previously rendered as literal syntax. Now styled via a ~180-line parser wired into `ChatView`'s assistant branch.
- **Diff view**: drop `--- path` / `+++ path` headers (tool title has the path already) and `\ No newline at end of file` markers. For small edits (≤ 3 changed lines, single hunk) hide the `@@` header too.
- **Visual rhythm**: `marginTop={1}` on user events + `paddingLeft={1}` on assistant replies. No more wall-of-text.
- **Tool titles**: `bash: cd /long/path && git status` → `$ git status`. Paths inside cwd show as relative, paths outside collapse to `…/last-two`.
- **Tool-view compact args**: absolute paths in fallback previews collapse via the same helper.

## Part B — `/init` + `KIMI.md`

Matches Claude Code's `CLAUDE.md` pattern but named `KIMI.md` (`KIMIFLARE.md` and `AGENT.md` also accepted). 

- `/init` slash command scans the repo and has the model `write` a concise `KIMI.md` at the root.
- On every subsequent launch, `buildSystemPrompt` auto-loads the file into the system prompt as authoritative project context.
- A one-line info event confirms when a context file was picked up.

## Part C — release-please for auto-version bumps

`.github/workflows/release-please.yml` (new):

1. Feature PR merges to main → release-please opens/updates a single "release PR" that bumps `package.json` + writes `CHANGELOG.md` entries based on Conventional Commit subjects.
2. Merging the release PR tags `v*.*.*` and creates a GitHub release.
3. The existing `publish.yml` sees the version change and publishes to npm automatically.

No more hand-edited `package.json` version bumps per PR.

## Part D — defensive

`onTasks` callback no longer nests `setTasksStartedAt` inside a `setTasks` updater function (React anti-pattern; state updaters should be pure). Unlikely to be the welcome-flood cause but worth cleaning up.

## Test plan

- [ ] `npm run build` + `npx tsc --noEmit` clean (confirmed locally)
- [ ] Ask a question that returns markdown (`**bold**`, bullets) — assistant reply shows styled, not literal
- [ ] Run `bash: cd $(pwd) && git status` — tool title shows `$ git status`
- [ ] One-line edit — diff shows just `- old / + new`, no `---`/`+++` headers or `@@`
- [ ] Delete `KIMI.md`, run `/init` in the kimiflare repo itself — model writes `KIMI.md`
- [ ] Re-launch kimiflare — `loaded project context from KIMI.md (N lines)` info appears
- [ ] Merge this PR — release-please bot opens a release PR within ~1 min
- [ ] Merge the release PR — version bumps, `publish.yml` publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)