### PR TITLE
fix: --version reads from package.json (was hardcoded 0.1.0)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,30 @@
 import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { loadConfig, DEFAULT_MODEL } from "./config.js";
 import { runAgentTurn } from "./agent/loop.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ChatMessage } from "./agent/messages.js";
 
+function readPackageVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as {
+      version?: string;
+    };
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
 const program = new Command();
 program
   .name("kimiflare")
   .description("Terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.")
-  .version("0.1.0")
+  .version(readPackageVersion())
   .option("-p, --print <prompt>", "one-shot mode: send prompt, stream reply to stdout, exit")
   .option("-m, --model <id>", "model id (defaults to @cf/moonshotai/kimi-k2.6)")
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")


### PR DESCRIPTION
\`kimiflare --version\` was hardcoded to \`"0.1.0"\` in \`src/index.tsx\` since the first commit, so every published version reported itself as \`0.1.0\` regardless of what was in \`package.json\`. That's why \`kimiflare --version\` returned \`0.1.0\` even after installing \`0.3.0\` from npm.

Fix reads the version at runtime from \`package.json\` (same technique as \`update-check.ts\`).

Verified locally: built tarball now prints \`0.3.0\`.

Once merged, release-please will bump to \`0.3.1\` (patch bump because it's a \`fix:\` commit), and the publish workflow will ship it.

## Test plan

- [ ] \`kimiflare --version\` returns the actual installed version (not \`0.1.0\`)
- [ ] After release-please + publish, \`npm view kimiflare version\` returns \`0.3.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)