### PR TITLE
fix(ci): configure release-please to recognize ui commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          release-type: node
+          config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,16 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features", "hidden": false },
+        { "type": "fix", "section": "Bug Fixes", "hidden": false },
+        { "type": "ui", "section": "UI", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "perf", "section": "Performance", "hidden": false },
+        { "type": "refactor", "section": "Refactors", "hidden": false },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds release-please-config.json so that `ui:` conventional commits are treated as patch-level user-facing changes. This should unblock the release for the already-merged #18.