### PR TITLE
feat: auto-append co-author trailer to git commits

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -32,6 +32,7 @@ export interface AgentTurnOpts {
   temperature?: number;
   maxCompletionTokens?: number;
   reasoningEffort?: "low" | "medium" | "high";
+  coauthor?: { name: string; email: string };
 }
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
@@ -106,7 +107,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       const result = await opts.executor.run(
         { id: tc.id, name: tc.function.name, arguments: tc.function.arguments },
         opts.callbacks.askPermission,
-        { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks },
+        { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor },
       );
       opts.messages.push({
         role: "tool",

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -69,7 +69,8 @@ How to work:
 - If a tool returns an error, read it carefully and adjust; do not retry the same call blindly.
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.
 - If a request is ambiguous, ask one focused question instead of making large assumptions.
-- When you finish a task, stop. Do not add a closing summary.`;
+- When you finish a task, stop. Do not add a closing summary.
+- When creating git commits, you may include \`Co-authored-by: kimiflare <sinameraji@users.noreply.github.com>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects \`git commit\` commands.`;
 
   const ctx = loadContextFile(opts.cwd);
   const contextBlock = ctx

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -44,6 +44,9 @@ interface Cfg {
   model: string;
   theme?: string;
   reasoningEffort?: ReasoningEffort;
+  coauthor?: boolean;
+  coauthorName?: string;
+  coauthorEmail?: string;
 }
 
 interface PendingPermission {
@@ -305,6 +308,10 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         cwd,
         signal: controller.signal,
         reasoningEffort: effortRef.current,
+        coauthor:
+          cfg.coauthor !== false
+            ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "sinameraji@users.noreply.github.com" }
+            : undefined,
         callbacks: {
           onAssistantStart: () => {
             const id = nextAssistantId++;
@@ -680,6 +687,10 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
           cwd: process.cwd(),
           signal: controller.signal,
           reasoningEffort: effortRef.current,
+          coauthor:
+            cfg.coauthor !== false
+              ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "sinameraji@users.noreply.github.com" }
+              : undefined,
           callbacks: {
             onAssistantStart: () => {
               const id = nextAssistantId++;

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,9 @@ export interface KimiConfig {
   model: string;
   theme?: string;
   reasoningEffort?: ReasoningEffort;
+  coauthor?: boolean;
+  coauthorName?: string;
+  coauthorEmail?: string;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
@@ -26,12 +29,21 @@ function readReasoningEffortEnv(): ReasoningEffort | undefined {
   return undefined;
 }
 
+function readCoauthorEnv(): { enabled: boolean; name: string; email: string } | undefined {
+  const enabled = process.env.KIMIFLARE_COAUTHOR;
+  if (enabled === "0" || enabled === "false") return undefined;
+  const name = process.env.KIMIFLARE_COAUTHOR_NAME || "kimiflare";
+  const email = process.env.KIMIFLARE_COAUTHOR_EMAIL || "sinameraji@users.noreply.github.com";
+  return { enabled: true, name, email };
+}
+
 export async function loadConfig(): Promise<KimiConfig | null> {
   const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
   const envToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
   const envModel = process.env.KIMI_MODEL ?? DEFAULT_MODEL;
   const envEffort = readReasoningEffortEnv();
   const envTheme = process.env.KIMI_THEME;
+  const envCoauthor = readCoauthorEnv();
 
   if (envAccount && envToken) {
     return {
@@ -40,6 +52,9 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       model: envModel,
       theme: envTheme,
       reasoningEffort: envEffort,
+      coauthor: envCoauthor?.enabled ?? true,
+      coauthorName: envCoauthor?.name,
+      coauthorEmail: envCoauthor?.email,
     };
   }
 
@@ -53,6 +68,9 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         model: envModel ?? parsed.model ?? DEFAULT_MODEL,
         theme: envTheme ?? parsed.theme,
         reasoningEffort: envEffort ?? parsed.reasoningEffort,
+        coauthor: envCoauthor?.enabled ?? parsed.coauthor ?? true,
+        coauthorName: envCoauthor?.name ?? parsed.coauthorName,
+        coauthorEmail: envCoauthor?.email ?? parsed.coauthorEmail,
       };
     }
   } catch {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,6 +85,9 @@ interface PrintOpts {
   prompt: string;
   allowAll: boolean;
   showReasoning: boolean;
+  coauthor?: boolean;
+  coauthorName?: string;
+  coauthorEmail?: string;
 }
 
 async function runPrintMode(opts: PrintOpts): Promise<void> {
@@ -110,6 +113,10 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
     executor,
     cwd,
     signal: controller.signal,
+    coauthor:
+      opts.coauthor !== false
+        ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "sinameraji@users.noreply.github.com" }
+        : undefined,
     callbacks: {
       onReasoningDelta: opts.showReasoning
         ? (delta) => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -41,10 +41,27 @@ function formatBashTitle(raw: string): string {
   return `$ ${cmd}`.slice(0, 120);
 }
 
+function injectCoauthor(command: string, coauthor?: { name: string; email: string }): string {
+  if (!coauthor) return command;
+  const trailer = `Co-authored-by: ${coauthor.name} <${coauthor.email}>`;
+
+  const trimmed = command.trim();
+  if (!/\bgit\s+commit\b/.test(trimmed)) return command;
+  if (command.includes(trailer)) return command;
+  // Skip dry-run or rebase-continue style invocations
+  if (/\b(--dry-run|-n)\b/.test(trimmed) && !/-m\b|--message\b/.test(trimmed)) return command;
+
+  const tmpFile = `/tmp/kf-coauthor-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const check = `! git log -1 --pretty=%B 2>/dev/null | grep -qF "${trailer}"`;
+  const append = `git log -1 --pretty=%B | git interpret-trailers --trailer "${trailer}" > "${tmpFile}" && git commit --amend -F "${tmpFile}" --no-edit && rm -f "${tmpFile}"`;
+  return `(${command}) && ${check} && ${append}`;
+}
+
 function runBash(args: Args, ctx: ToolContext): Promise<string> {
   const timeout = Math.min(Math.max(1000, args.timeout_ms ?? DEFAULT_TIMEOUT), MAX_TIMEOUT);
+  const command = injectCoauthor(args.command, ctx.coauthor);
   return new Promise<string>((resolve, reject) => {
-    const child = spawn("bash", ["-lc", args.command], {
+    const child = spawn("bash", ["-lc", command], {
       cwd: ctx.cwd,
       signal: ctx.signal,
     });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -5,6 +5,7 @@ export interface ToolContext {
   cwd: string;
   signal?: AbortSignal;
   onTasks?: (tasks: Task[]) => void;
+  coauthor?: { name: string; email: string };
 }
 
 export interface ToolRender {


### PR DESCRIPTION
## What

Claude Code gets added as a GitHub contributor when users commit code it wrote. This PR brings the same mechanic to kimiflare.

<img src="https://raw.githubusercontent.com/sinameraji/kimiflare/main/docs/logo.png" width="80" alt="kimiflare logo">

## How it works

GitHub recognizes "Co-authored-by: Name <email>" trailers in commit messages and attributes contribution to that identity. This PR:

1. **Auto-injects the trailer** — When the bash tool detects a "git commit" command, it now automatically amends the commit to append:
   ```
   Co-authored-by: kimiflare <sinameraji@gmail.com>
   ```
   GitHub links this to the @sinameraji account.

2. **Configurability** — Users can control this via:
   - Config file: `coauthor`, `coauthorName`, `coauthorEmail`
   - Env vars: `KIMIFLARE_COAUTHOR`, `KIMIFLARE_COAUTHOR_NAME`, `KIMIFLARE_COAUTHOR_EMAIL`
   - Set `KIMIFLARE_COAUTHOR=false` to disable

3. **System prompt** — The agent is now instructed to include the trailer in commit messages it writes manually.

## Demo

This commit itself was made with the co-author trailer included — check the commit message!