### PR TITLE
fix: use sinameraji@gmail.com as default co-author email

### DIFF
--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -70,7 +70,7 @@ How to work:
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.
 - If a request is ambiguous, ask one focused question instead of making large assumptions.
 - When you finish a task, stop. Do not add a closing summary.
-- When creating git commits, you may include \`Co-authored-by: kimiflare <sinameraji@users.noreply.github.com>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects \`git commit\` commands.`;
+- When creating git commits, you may include \`Co-authored-by: kimiflare <sinameraji@gmail.com>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects \`git commit\` commands.`;
 
   const ctx = loadContextFile(opts.cwd);
   const contextBlock = ctx

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -310,7 +310,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         reasoningEffort: effortRef.current,
         coauthor:
           cfg.coauthor !== false
-            ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "sinameraji@users.noreply.github.com" }
+            ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "sinameraji@gmail.com" }
             : undefined,
         callbacks: {
           onAssistantStart: () => {
@@ -689,7 +689,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
           reasoningEffort: effortRef.current,
           coauthor:
             cfg.coauthor !== false
-              ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "sinameraji@users.noreply.github.com" }
+              ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "sinameraji@gmail.com" }
               : undefined,
           callbacks: {
             onAssistantStart: () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ function readCoauthorEnv(): { enabled: boolean; name: string; email: string } | 
   const enabled = process.env.KIMIFLARE_COAUTHOR;
   if (enabled === "0" || enabled === "false") return undefined;
   const name = process.env.KIMIFLARE_COAUTHOR_NAME || "kimiflare";
-  const email = process.env.KIMIFLARE_COAUTHOR_EMAIL || "sinameraji@users.noreply.github.com";
+  const email = process.env.KIMIFLARE_COAUTHOR_EMAIL || "sinameraji@gmail.com";
   return { enabled: true, name, email };
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -115,7 +115,7 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
     signal: controller.signal,
     coauthor:
       opts.coauthor !== false
-        ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "sinameraji@users.noreply.github.com" }
+        ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "sinameraji@gmail.com" }
         : undefined,
     callbacks: {
       onReasoningDelta: opts.showReasoning


### PR DESCRIPTION
Updates the default co-author email from the GitHub noreply address to `sinameraji@gmail.com` so GitHub properly links co-authored commits to the @sinameraji account.