### PR TITLE
fix: sanitize lone surrogates and improve AI error handling

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -1,5 +1,6 @@
 import { readSSE } from "../util/sse.js";
 import { KimiApiError } from "../util/errors.js";
+import { jsonReplacer } from "./messages.js";
 import type { ChatMessage, ToolDef, Usage } from "./messages.js";
 
 export type KimiEvent =
@@ -23,8 +24,21 @@ export interface RunKimiOpts {
   reasoningEffort?: "low" | "medium" | "high";
 }
 
-const RETRYABLE_CODE = 3040; // "Capacity temporarily exceeded"
+const RETRYABLE_CODES = new Set([3040]); // "Capacity temporarily exceeded"
 const MAX_ATTEMPTS = 5;
+
+function cleanErrorMessage(msg: string): string {
+  // Cloudflare Workers AI sometimes prefixes messages with redundant "AiError: "
+  return msg.replace(/^(AiError:\s*)+/, "").trim();
+}
+
+function isRetryable(err: KimiApiError, attempt: number): boolean {
+  if (attempt >= MAX_ATTEMPTS - 1) return false;
+  if (err.code !== undefined && RETRYABLE_CODES.has(err.code)) return true;
+  if (err.httpStatus !== undefined && err.httpStatus >= 500 && err.httpStatus < 600) return true;
+  if (err.message.includes("Internal server error")) return true;
+  return false;
+}
 
 export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, void, void> {
   const url = `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${opts.model}`;
@@ -42,20 +56,32 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   }
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${opts.apiToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-      signal: opts.signal,
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${opts.apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body, jsonReplacer),
+        signal: opts.signal,
+      });
+    } catch (fetchErr) {
+      const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+      if (attempt < MAX_ATTEMPTS - 1) {
+        const delay = 500 * 2 ** attempt + Math.random() * 250;
+        await sleep(delay, opts.signal);
+        continue;
+      }
+      throw new KimiApiError(`kimiflare: network error: ${msg}`, undefined, undefined);
+    }
 
     const contentType = res.headers.get("content-type") ?? "";
 
     // Cloudflare returns HTTP 200 + application/json with {success:false,errors:[{code:3040}]}
-    // for transient capacity errors. Retry those; surface everything else.
+    // for transient capacity errors. It also returns HTTP 5xx or OpenAI-style error objects
+    // for transient internal failures. Retry those; surface everything else.
     if (!contentType.includes("text/event-stream")) {
       const text = await res.text();
       let parsed: unknown = null;
@@ -65,13 +91,15 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
         /* ignore */
       }
       const err = extractCloudflareError(parsed);
-      if (err?.code === RETRYABLE_CODE && attempt < MAX_ATTEMPTS - 1) {
+      const rawMsg = err?.message ?? `HTTP ${res.status}: ${text.slice(0, 300)}`;
+      const msg = cleanErrorMessage(rawMsg);
+      const apiErr = new KimiApiError(`kimiflare: ${msg}`, err?.code, res.status);
+      if (isRetryable(apiErr, attempt)) {
         const delay = 500 * 2 ** attempt + Math.random() * 250;
         await sleep(delay, opts.signal);
         continue;
       }
-      const msg = err?.message ?? `HTTP ${res.status}: ${text.slice(0, 300)}`;
-      throw new KimiApiError(`kimiflare: ${msg}`, err?.code, res.status);
+      throw apiErr;
     }
 
     if (!res.body) throw new KimiApiError("kimiflare: empty response body", undefined, res.status);
@@ -184,10 +212,20 @@ interface StreamToolCall {
 
 function extractCloudflareError(parsed: unknown): { code?: number; message?: string } | null {
   if (!parsed || typeof parsed !== "object") return null;
-  const p = parsed as { success?: boolean; errors?: Array<{ code?: number; message?: string }> };
-  if (p.success === false && Array.isArray(p.errors) && p.errors.length > 0) {
-    return { code: p.errors[0]?.code, message: p.errors[0]?.message };
+
+  // Cloudflare native format: { success: false, errors: [...] }
+  const cf = parsed as { success?: boolean; errors?: Array<{ code?: number; message?: string }> };
+  if (cf.success === false && Array.isArray(cf.errors) && cf.errors.length > 0) {
+    return { code: cf.errors[0]?.code, message: cf.errors[0]?.message };
   }
+
+  // OpenAI-compatible format: { object: "error", message, code }
+  const oai = parsed as { object?: string; message?: string; code?: string | number };
+  if (oai.object === "error" && typeof oai.message === "string") {
+    const codeNum = typeof oai.code === "number" ? oai.code : undefined;
+    return { code: codeNum, message: oai.message };
+  }
+
   return null;
 }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,6 +1,7 @@
 import { runKimi } from "./client.js";
 import { toOpenAIToolDefs, type ToolSpec } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
+import { sanitizeString } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tasks-state.js";
 
@@ -93,9 +94,19 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
     const assistantMsg: ChatMessage = {
       role: "assistant",
-      content: content || null,
-      ...(reasoning ? { reasoning_content: reasoning } : {}),
-      ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+      content: content ? sanitizeString(content) : null,
+      ...(reasoning ? { reasoning_content: sanitizeString(reasoning) } : {}),
+      ...(toolCalls.length
+        ? {
+            tool_calls: toolCalls.map((tc) => ({
+              ...tc,
+              function: {
+                name: tc.function.name,
+                arguments: sanitizeString(tc.function.arguments),
+              },
+            })),
+          }
+        : {}),
     };
     opts.messages.push(assistantMsg);
     opts.callbacks.onAssistantFinal?.(assistantMsg);
@@ -112,7 +123,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       opts.messages.push({
         role: "tool",
         tool_call_id: result.tool_call_id,
-        content: result.content,
+        content: sanitizeString(result.content),
         name: result.name,
       });
       opts.callbacks.onToolResult?.(result);

--- a/src/agent/messages.ts
+++ b/src/agent/messages.ts
@@ -30,3 +30,39 @@ export interface Usage {
   total_tokens: number;
   prompt_tokens_details?: { cached_tokens?: number } | null;
 }
+
+/** Replace lone UTF-16 surrogates with the replacement character (U+FFFD).
+ *  JSON.stringify preserves lone surrogates as \uD800..\uDFFF escapes, which
+ *  JavaScript accepts but many strict parsers (Cloudflare AI Gateway, Python,
+ *  Rust serde_json) reject. Stripping them at the boundary prevents a single
+ *  bad model token from permanently poisoning the conversation history. */
+export function sanitizeString(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/[\uD800-\uDFFF]/g, "\uFFFD");
+}
+
+/** Recursively sanitize every string value in an object/array. */
+export function sanitizeForJson<T>(value: T): T {
+  if (typeof value === "string") {
+    return sanitizeString(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeForJson) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = sanitizeForJson(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
+/** JSON.stringify replacer that sanitizes strings in-place without a deep copy. */
+export function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "string") {
+    return sanitizeString(value);
+  }
+  return value;
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { compactMessages } from "./agent/compact.js";
 import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/executor.js";
 import type { ToolSpec } from "./tools/registry.js";
+import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, Usage } from "./agent/messages.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
@@ -325,7 +326,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
     ].join("\n");
 
     setEvents((e) => [...e, { kind: "user", key: mkKey(), text: "/init" }]);
-    messagesRef.current.push({ role: "user", content: prompt });
+    messagesRef.current.push({ role: "user", content: sanitizeString(prompt) });
     setBusy(true);
     setTurnStartedAt(Date.now());
     const controller = new AbortController();
@@ -706,7 +707,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
 
       const display = displayText?.trim() || trimmed;
       setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display }]);
-      messagesRef.current.push({ role: "user", content: trimmed });
+      messagesRef.current.push({ role: "user", content: sanitizeString(trimmed) });
       setBusy(true);
       setTurnStartedAt(Date.now());
 


### PR DESCRIPTION
- Add `sanitizeString()` and `jsonReplacer()` to strip lone UTF-16 surrogates before JSON.stringify. Cloudflare's stricter parser rejects \uD800..\uDFFF escapes that JavaScript's JSON.stringify preserves, causing permanent 400 BadRequest once a bad token enters conversation history.

- Sanitize assistant messages, tool arguments, tool results, and user input before pushing to history.

- Replace deep-copy `sanitizeForJson` with zero-copy `jsonReplacer` in `client.ts` to reduce memory pressure on large message arrays.

- Improve error extraction to handle OpenAI-style errors (`{object: error}`).

- Clean up redundant `AiError: ` prefixes from Cloudflare error messages.

- Retry on HTTP 5xx and internal server errors, not just code 3040. Also retry transient network errors from `fetch()`.