### PR TITLE
feat: runtime update nudge on startup + periodic checks

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
 import { checkForUpdate, isGitRepo } from "./util/update-check.js";
+import type { UpdateCheckResult } from "./util/update-check.js";
 import { Onboarding } from "./ui/onboarding.js";
 import { Welcome } from "./ui/welcome.js";
 import {
@@ -68,7 +69,7 @@ const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
   high: "high — deepest reasoning; slowest. Best for complex debugging, architecture, multi-file refactors.",
 };
 
-function App({ initialCfg }: { initialCfg: Cfg | null }) {
+function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; initialUpdateResult?: UpdateCheckResult }) {
   const { exit } = useApp();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
   const [events, setEvents] = useState<ChatEvent[]>([]);
@@ -93,6 +94,8 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
   const [turnStartedAt, setTurnStartedAt] = useState<number | null>(null);
   const [verbose, setVerbose] = useState(false);
+  const [hasUpdate, setHasUpdate] = useState(initialUpdateResult?.hasUpdate ?? false);
+  const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
 
   const messagesRef = useRef<ChatMessage[]>([
     {
@@ -114,13 +117,47 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const tasksRef = useRef<Task[]>([]);
   const usageRef = useRef<Usage | null>(null);
   const updateCheckedRef = useRef(false);
+  const updateNudgedRef = useRef(false);
   const compactSuggestedRef = useRef(false);
 
   useEffect(() => {
     if (!cfg || updateCheckedRef.current) return;
     updateCheckedRef.current = true;
+
+    if (initialUpdateResult) {
+      if (initialUpdateResult.hasUpdate && !updateNudgedRef.current) {
+        updateNudgedRef.current = true;
+        setHasUpdate(true);
+        setLatestVersion(initialUpdateResult.latestVersion);
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `update available: ${initialUpdateResult.localVersion} → ${initialUpdateResult.latestVersion}`,
+          },
+        ]);
+        void isGitRepo().then((git) => {
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "info",
+              key: mkKey(),
+              text: git
+                ? "run:  git pull && npm install && npm run build  then restart kimiflare"
+                : "run:  npm update -g kimiflare  then restart",
+            },
+          ]);
+        });
+      }
+      return;
+    }
+
     void checkForUpdate().then((result) => {
-      if (result.hasUpdate) {
+      if (result.hasUpdate && !updateNudgedRef.current) {
+        updateNudgedRef.current = true;
+        setHasUpdate(true);
+        setLatestVersion(result.latestVersion);
         setEvents((e) => [
           ...e,
           {
@@ -143,7 +180,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         });
       }
     });
-  }, [cfg]);
+  }, [cfg, initialUpdateResult]);
 
   useEffect(() => {
     modeRef.current = mode;
@@ -164,6 +201,42 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   useEffect(() => {
     effortRef.current = effort;
   }, [effort]);
+
+  useEffect(() => {
+    if (!cfg) return;
+    const id = setInterval(() => {
+      void checkForUpdate().then((result) => {
+        if (result.hasUpdate) {
+          setHasUpdate(true);
+          setLatestVersion(result.latestVersion);
+          if (!updateNudgedRef.current) {
+            updateNudgedRef.current = true;
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "info",
+                key: mkKey(),
+                text: `update available: ${result.localVersion} → ${result.latestVersion}`,
+              },
+            ]);
+            void isGitRepo().then((git) => {
+              setEvents((e) => [
+                ...e,
+                {
+                  kind: "info",
+                  key: mkKey(),
+                  text: git
+                    ? "run:  git pull && npm install && npm run build  then restart kimiflare"
+                    : "run:  npm update -g kimiflare  then restart",
+                },
+              ]);
+            });
+          }
+        }
+      });
+    }, 30 * 60 * 1000); // 30 minutes
+    return () => clearInterval(id);
+  }, [cfg]);
 
   const saveSessionSafe = useCallback(async () => {
     if (!cfg) return;
@@ -485,6 +558,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         setTasksStartedAt(null);
         setTasksStartTokens(0);
         compactSuggestedRef.current = false;
+        updateNudgedRef.current = false;
         return true;
       }
       if (c === "/reasoning") {
@@ -628,8 +702,10 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         return true;
       }
       if (c === "/update") {
-        void checkForUpdate().then((result) => {
+        void checkForUpdate(true).then((result) => {
           if (result.hasUpdate) {
+            setHasUpdate(true);
+            setLatestVersion(result.latestVersion);
             setEvents((e) => [
               ...e,
               {
@@ -651,6 +727,8 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
               ]);
             });
           } else {
+            setHasUpdate(false);
+            setLatestVersion(null);
             setEvents((e) => [
               ...e,
               { kind: "info", key: mkKey(), text: "no update available" },
@@ -953,6 +1031,8 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
             mode={mode}
             effort={effort}
             contextLimit={CONTEXT_LIMIT}
+            hasUpdate={hasUpdate}
+            latestVersion={latestVersion}
           />
           <Box marginTop={1}>
             <Text color={theme.accent}>› </Text>
@@ -1004,7 +1084,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
   );
 }
 
-export async function renderApp(cfg: Cfg | null) {
-  const instance = render(<App initialCfg={cfg} />);
+export async function renderApp(cfg: Cfg | null, updateResult?: UpdateCheckResult) {
+  const instance = render(<App initialCfg={cfg} initialUpdateResult={updateResult} />);
   await instance.waitUntilExit();
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { runAgentTurn } from "./agent/loop.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ChatMessage } from "./agent/messages.js";
+import { checkForUpdate, isGitRepo } from "./util/update-check.js";
+import type { UpdateCheckResult } from "./util/update-check.js";
 
 function readPackageVersion(): string {
   try {
@@ -40,6 +42,7 @@ const opts = program.opts<{
 
 async function main() {
   const cfg = await loadConfig();
+  const updateResult = await checkForUpdate();
 
   if (opts.print !== undefined) {
     if (!cfg) {
@@ -58,6 +61,7 @@ async function main() {
       prompt: opts.print,
       allowAll: !!opts.dangerouslyAllowAll,
       showReasoning: !!opts.reasoning,
+      updateResult,
     });
     return;
   }
@@ -72,9 +76,9 @@ async function main() {
   const { renderApp } = await import("./app.js");
   if (cfg) {
     const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;
-    await renderApp({ ...cfg, model });
+    await renderApp({ ...cfg, model }, updateResult);
   } else {
-    await renderApp(null);
+    await renderApp(null, updateResult);
   }
 }
 
@@ -88,9 +92,18 @@ interface PrintOpts {
   coauthor?: boolean;
   coauthorName?: string;
   coauthorEmail?: string;
+  updateResult: UpdateCheckResult;
 }
 
 async function runPrintMode(opts: PrintOpts): Promise<void> {
+  if (opts.updateResult.hasUpdate) {
+    const git = await isGitRepo();
+    process.stderr.write(
+      `\x1b[33mkimiflare update available: ${opts.updateResult.localVersion} → ${opts.updateResult.latestVersion}\x1b[0m\n` +
+        `\x1b[33m  ${git ? "git pull && npm install && npm run build" : "npm update -g kimiflare"}  then restart\x1b[0m\n\n`,
+    );
+  }
+
   const cwd = process.cwd();
   const executor = new ToolExecutor(ALL_TOOLS);
   const messages: ChatMessage[] = [

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -15,13 +15,15 @@ interface Props {
   mode: Mode;
   effort: ReasoningEffort;
   contextLimit: number;
+  hasUpdate?: boolean;
+  latestVersion?: string | null;
 }
 
 const PRICE_IN_PER_M = 0.95;
 const PRICE_IN_CACHED_PER_M = 0.16;
 const PRICE_OUT_PER_M = 4.0;
 
-export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit }: Props) {
+export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion }: Props) {
   const [now, setNow] = useState(Date.now());
   const modeColor =
     mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
@@ -63,6 +65,11 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
           {warn ? (
             <Text color={theme.warn} bold>
               {"  ·  "}/compact recommended
+            </Text>
+          ) : null}
+          {hasUpdate ? (
+            <Text color={theme.warn} bold>
+              {"  ·  "}update available{latestVersion ? ` → ${latestVersion}` : ""} · run /update
             </Text>
           ) : null}
         </Box>

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -97,13 +97,15 @@ export interface UpdateCheckResult {
   latestVersion: string | null;
 }
 
-export async function checkForUpdate(): Promise<UpdateCheckResult> {
+export async function checkForUpdate(force = false): Promise<UpdateCheckResult> {
   const localVersion = await readLocalVersion();
   if (!localVersion) return { hasUpdate: false, localVersion: null, latestVersion: null };
 
-  const cached = await readCache();
-  if (cached) {
-    return { hasUpdate: cached.hasUpdate, localVersion, latestVersion: cached.latestVersion };
+  if (!force) {
+    const cached = await readCache();
+    if (cached) {
+      return { hasUpdate: cached.hasUpdate, localVersion, latestVersion: cached.latestVersion };
+    }
   }
 
   const latestVersion = await fetchLatestVersion();


### PR DESCRIPTION
- checkForUpdate() now accepts optional force flag to bypass cache
- index.tsx awaits update check before launching TUI/print mode
- app.tsx receives startup result, shows chat info + status-bar badge immediately
- periodic recheck every 30 min during session
- /update forces fresh check; /clear resets nudge gate
- StatusBar renders persistent update badge when available