### PR TITLE
feat: paginate /resume picker and add interactive theme picker with live preview

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,7 @@ import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
 import { ResumePicker } from "./ui/resume-picker.js";
+import { ThemePicker } from "./ui/theme-picker.js";
 import { TaskList } from "./ui/task-list.js";
 import type { Task } from "./tasks-state.js";
 import { existsSync } from "node:fs";
@@ -29,7 +30,7 @@ import {
   saveConfig,
   type ReasoningEffort,
 } from "./config.js";
-import { resolveTheme, themeNames, type Theme } from "./ui/theme.js";
+import { resolveTheme, themeNames, themeList, type Theme } from "./ui/theme.js";
 import { nextMode, type Mode, isBlockedInPlanMode } from "./mode.js";
 import {
   listSessions,
@@ -90,6 +91,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   );
   const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
   const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
+  const [showThemePicker, setShowThemePicker] = useState(false);
+  const [originalTheme, setOriginalTheme] = useState<Theme | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
   const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
@@ -284,6 +287,11 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       setVerbose((v) => !v);
       return;
     }
+    if (key.ctrl && inputChar === "t") {
+      setOriginalTheme(theme);
+      setShowThemePicker(true);
+      return;
+    }
   });
 
   const updateAssistant = useCallback(
@@ -358,7 +366,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   }, [cfg, busy, saveSessionSafe]);
 
   const openResumePicker = useCallback(async () => {
-    const sessions = await listSessions(30);
+    const sessions = await listSessions(200);
     setResumeSessions(sessions);
   }, []);
 
@@ -539,6 +547,28 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     [],
   );
 
+  const handleThemePick = useCallback(
+    (picked: Theme | null) => {
+      if (!picked) {
+        // cancel — revert to original
+        if (originalTheme) setTheme(originalTheme);
+        setShowThemePicker(false);
+        setOriginalTheme(null);
+        return;
+      }
+      setTheme(picked);
+      setCfg((c) => (c ? { ...c, theme: picked.name } : c));
+      if (cfg) void saveConfig({ ...cfg, theme: picked.name }).catch(() => {});
+      setShowThemePicker(false);
+      setOriginalTheme(null);
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: `theme: ${picked.label}` },
+      ]);
+    },
+    [cfg, originalTheme],
+  );
+
   const handleSlash = useCallback(
     (cmd: string): boolean => {
       const raw = cmd.trim();
@@ -626,14 +656,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       }
       if (c === "/theme") {
         if (!arg) {
-          setEvents((e) => [
-            ...e,
-            {
-              kind: "info",
-              key: mkKey(),
-              text: `current: ${theme.name}  ·  available: ${themeNames().join(", ")}`,
-            },
-          ]);
+          setOriginalTheme(theme);
+          setShowThemePicker(true);
           return true;
         }
         const next = resolveTheme(arg);
@@ -758,14 +782,15 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
               "  /mode edit|plan|auto    switch mode (or shift+tab to cycle)\n" +
               "  /plan /auto /edit       shortcuts for /mode\n" +
               "  /thinking low|med|high  set reasoning effort (quality vs speed)\n" +
-              "  /theme NAME             dark, light, high-contrast\n" +
+              "  /theme                  interactive theme picker (or ctrl+t)\n" +
+              "  /theme NAME             set theme by name\n" +
               "  /resume                 pick a past conversation\n" +
               "  /compact                summarize old turns to free context\n" +
               "  /init                   scan this repo and write a KIMI.md for future agents\n" +
               "  /reasoning              toggle show/hide model reasoning\n" +
               "  /clear                  clear current conversation\n" +
               "  /cost /model /update /logout /help /exit\n" +
-              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o toggle verbose output · shift+tab cycle mode · ↑/↓ history",
+              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o verbose · ctrl+t theme · shift+tab cycle mode · ↑/↓ history",
           },
         ]);
         return true;
@@ -981,6 +1006,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     return (
       <Box flexDirection="column">
         <ResumePicker sessions={resumeSessions} onPick={handleResumePick} theme={theme} />
+      </Box>
+    );
+  }
+
+  if (showThemePicker) {
+    return (
+      <Box flexDirection="column">
+        <ThemePicker themes={themeList()} current={theme} onPick={handleThemePick} />
       </Box>
     );
   }

--- a/src/ui/resume-picker.tsx
+++ b/src/ui/resume-picker.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Box, Text } from "ink";
+import React, { useState } from "react";
+import { Box, Text, useWindowSize } from "ink";
 import SelectInput from "ink-select-input";
 import type { SessionSummary } from "../sessions.js";
 import type { Theme } from "./theme.js";
@@ -10,7 +10,18 @@ interface Props {
   theme: Theme;
 }
 
+const HEADER_ROWS = 5; // title + subtitle + border padding + margin
+const FOOTER_ROWS = 2; // cancel + bottom padding
+const MIN_PAGE_SIZE = 5;
+
 export function ResumePicker({ sessions, onPick, theme }: Props) {
+  const { rows } = useWindowSize();
+  const [page, setPage] = useState(0);
+
+  const pageSize = Math.max(MIN_PAGE_SIZE, rows - HEADER_ROWS - FOOTER_ROWS);
+  const totalPages = Math.max(1, Math.ceil(sessions.length / pageSize));
+  const safePage = Math.min(page, totalPages - 1);
+
   if (sessions.length === 0) {
     return (
       <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
@@ -30,10 +41,21 @@ export function ResumePicker({ sessions, onPick, theme }: Props) {
     );
   }
 
-  const items = sessions.map((s) => ({
+  const start = safePage * pageSize;
+  const end = Math.min(start + pageSize, sessions.length);
+  const pageSessions = sessions.slice(start, end);
+
+  const items = pageSessions.map((s) => ({
     label: `${formatDate(s.updatedAt)}  ·  ${s.messageCount} msgs  ·  ${s.firstPrompt}`,
     value: s.id,
   }));
+
+  if (safePage > 0) {
+    items.push({ label: "← previous page", value: "__prev__" });
+  }
+  if (safePage < totalPages - 1) {
+    items.push({ label: "→ next page", value: "__next__" });
+  }
   items.push({ label: "(cancel)", value: "__cancel__" });
 
   return (
@@ -42,13 +64,15 @@ export function ResumePicker({ sessions, onPick, theme }: Props) {
         Resume a session
       </Text>
       <Text color={theme.info.color} dimColor={theme.info.dim}>
-        Arrow keys to select, Enter to confirm.
+        Arrow keys to select, Enter to confirm. Page {safePage + 1} of {totalPages} ({sessions.length} total)
       </Text>
       <Box marginTop={1}>
         <SelectInput
           items={items}
           onSelect={(item) => {
             if (item.value === "__cancel__") return onPick(null);
+            if (item.value === "__prev__") return setPage((p) => Math.max(0, p - 1));
+            if (item.value === "__next__") return setPage((p) => Math.min(totalPages - 1, p + 1));
             const picked = sessions.find((s) => s.id === item.value) ?? null;
             onPick(picked);
           }}

--- a/src/ui/theme-picker.tsx
+++ b/src/ui/theme-picker.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  themes: Theme[];
+  current: Theme;
+  onPick: (theme: Theme | null) => void;
+}
+
+export function ThemePicker({ themes, current, onPick }: Props) {
+  const items = themes.map((t) => ({
+    label: t.label,
+    value: t.name,
+    key: t.name,
+  }));
+  items.push({ label: "(cancel)", value: "__cancel__", key: "__cancel__" });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={current.accent} paddingX={1}>
+      <Text color={current.accent} bold>
+        Pick a theme
+      </Text>
+      <Text color={current.info.color} dimColor={current.info.dim}>
+        Arrow keys to preview, Enter to confirm.
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onHighlight={(item) => {
+            if (item.value !== "__cancel__") {
+              const highlighted = themes.find((t) => t.name === item.value);
+              if (highlighted) onPick(highlighted);
+            }
+          }}
+          onSelect={(item) => {
+            if (item.value === "__cancel__") return onPick(null);
+            const picked = themes.find((t) => t.name === item.value) ?? null;
+            onPick(picked);
+          }}
+          itemComponent={({ label, isSelected }) => {
+            const theme = themes.find((t) => t.label === label);
+            const color = theme?.accent ?? current.accent;
+            return (
+              <Box>
+                <Text color={color} bold={isSelected} dimColor={!isSelected}>
+                  {isSelected ? "› " : "  "}
+                  {label}
+                </Text>
+              </Box>
+            );
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -73,10 +73,208 @@ const highContrast: Theme = {
   modeBadge: { plan: "blueBright", auto: "greenBright", edit: "cyanBright" },
 };
 
+const dracula: Theme = {
+  name: "dracula",
+  label: "dracula (purple & cyan, popular dark)",
+  user: "cyanBright",
+  assistant: undefined,
+  reasoning: { color: "magenta", dim: true },
+  info: { color: "gray", dim: true },
+  error: "redBright",
+  warn: "yellowBright",
+  tool: "magentaBright",
+  spinner: "cyanBright",
+  permission: "yellowBright",
+  queue: { color: "gray", dim: true },
+  accent: "magentaBright",
+  modeBadge: { plan: "blueBright", auto: "greenBright", edit: "magentaBright" },
+};
+
+const nord: Theme = {
+  name: "nord",
+  label: "nord (arctic blue & frost, calm dark)",
+  user: "cyan",
+  assistant: undefined,
+  reasoning: { color: "blue", dim: true },
+  info: { color: "blue", dim: true },
+  error: "red",
+  warn: "yellow",
+  tool: "cyan",
+  spinner: "cyan",
+  permission: "yellow",
+  queue: { color: "blue", dim: true },
+  accent: "cyan",
+  modeBadge: { plan: "blue", auto: "green", edit: "cyan" },
+};
+
+const oneDark: Theme = {
+  name: "one-dark",
+  label: "one-dark (Atom's classic dark)",
+  user: "cyan",
+  assistant: undefined,
+  reasoning: { color: "gray", dim: true },
+  info: { color: "gray", dim: true },
+  error: "red",
+  warn: "yellow",
+  tool: "blue",
+  spinner: "cyan",
+  permission: "yellow",
+  queue: { color: "gray", dim: true },
+  accent: "blue",
+  modeBadge: { plan: "blue", auto: "green", edit: "cyan" },
+};
+
+const monokai: Theme = {
+  name: "monokai",
+  label: "monokai (vibrant magenta & yellow)",
+  user: "magentaBright",
+  assistant: undefined,
+  reasoning: { color: "gray", dim: true },
+  info: { color: "gray", dim: true },
+  error: "redBright",
+  warn: "yellowBright",
+  tool: "cyanBright",
+  spinner: "yellowBright",
+  permission: "yellowBright",
+  queue: { color: "gray", dim: true },
+  accent: "magentaBright",
+  modeBadge: { plan: "blueBright", auto: "greenBright", edit: "magentaBright" },
+};
+
+const solarizedDark: Theme = {
+  name: "solarized-dark",
+  label: "solarized-dark (muted blue & yellow)",
+  user: "cyan",
+  assistant: undefined,
+  reasoning: { color: "blue", dim: true },
+  info: { color: "blue", dim: true },
+  error: "red",
+  warn: "yellow",
+  tool: "cyan",
+  spinner: "yellow",
+  permission: "yellow",
+  queue: { color: "blue", dim: true },
+  accent: "cyan",
+  modeBadge: { plan: "blue", auto: "green", edit: "cyan" },
+};
+
+const solarizedLight: Theme = {
+  name: "solarized-light",
+  label: "solarized-light (light beige & cyan)",
+  user: "blue",
+  assistant: undefined,
+  reasoning: { color: "cyan", dim: false },
+  info: { color: "cyan", dim: false },
+  error: "red",
+  warn: "yellow",
+  tool: "blue",
+  spinner: "blue",
+  permission: "yellow",
+  queue: { color: "cyan", dim: false },
+  accent: "blue",
+  modeBadge: { plan: "blue", auto: "green", edit: "blue" },
+};
+
+const tokyoNight: Theme = {
+  name: "tokyo-night",
+  label: "tokyo-night (deep blue & purple)",
+  user: "cyanBright",
+  assistant: undefined,
+  reasoning: { color: "blue", dim: true },
+  info: { color: "blue", dim: true },
+  error: "redBright",
+  warn: "yellow",
+  tool: "magentaBright",
+  spinner: "cyanBright",
+  permission: "yellow",
+  queue: { color: "blue", dim: true },
+  accent: "magentaBright",
+  modeBadge: { plan: "blueBright", auto: "greenBright", edit: "magentaBright" },
+};
+
+const gruvboxDark: Theme = {
+  name: "gruvbox-dark",
+  label: "gruvbox-dark (warm retro dark)",
+  user: "yellow",
+  assistant: undefined,
+  reasoning: { color: "gray", dim: true },
+  info: { color: "gray", dim: true },
+  error: "red",
+  warn: "yellowBright",
+  tool: "cyan",
+  spinner: "yellow",
+  permission: "yellowBright",
+  queue: { color: "gray", dim: true },
+  accent: "yellow",
+  modeBadge: { plan: "blue", auto: "green", edit: "yellow" },
+};
+
+const gruvboxLight: Theme = {
+  name: "gruvbox-light",
+  label: "gruvbox-light (warm retro light)",
+  user: "blue",
+  assistant: undefined,
+  reasoning: { color: "blackBright", dim: false },
+  info: { color: "blackBright", dim: false },
+  error: "red",
+  warn: "yellow",
+  tool: "cyan",
+  spinner: "blue",
+  permission: "yellow",
+  queue: { color: "blackBright", dim: false },
+  accent: "blue",
+  modeBadge: { plan: "blue", auto: "green", edit: "blue" },
+};
+
+const catppuccinMocha: Theme = {
+  name: "catppuccin-mocha",
+  label: "catppuccin-mocha (pastel pink & lavender)",
+  user: "magentaBright",
+  assistant: undefined,
+  reasoning: { color: "gray", dim: true },
+  info: { color: "gray", dim: true },
+  error: "redBright",
+  warn: "yellow",
+  tool: "cyanBright",
+  spinner: "cyanBright",
+  permission: "yellow",
+  queue: { color: "gray", dim: true },
+  accent: "magentaBright",
+  modeBadge: { plan: "blueBright", auto: "greenBright", edit: "magentaBright" },
+};
+
+const rosePine: Theme = {
+  name: "rose-pine",
+  label: "rose-pine (soft rose & foam)",
+  user: "magenta",
+  assistant: undefined,
+  reasoning: { color: "gray", dim: true },
+  info: { color: "gray", dim: true },
+  error: "red",
+  warn: "yellow",
+  tool: "cyan",
+  spinner: "magenta",
+  permission: "yellow",
+  queue: { color: "gray", dim: true },
+  accent: "magenta",
+  modeBadge: { plan: "blue", auto: "green", edit: "magenta" },
+};
+
 export const THEMES: Record<string, Theme> = {
   dark,
   light,
   "high-contrast": highContrast,
+  dracula,
+  nord,
+  "one-dark": oneDark,
+  monokai,
+  "solarized-dark": solarizedDark,
+  "solarized-light": solarizedLight,
+  "tokyo-night": tokyoNight,
+  "gruvbox-dark": gruvboxDark,
+  "gruvbox-light": gruvboxLight,
+  "catppuccin-mocha": catppuccinMocha,
+  "rose-pine": rosePine,
 };
 
 export const DEFAULT_THEME_NAME = "dark";
@@ -88,4 +286,8 @@ export function resolveTheme(name: string | undefined): Theme {
 
 export function themeNames(): string[] {
   return Object.keys(THEMES);
+}
+
+export function themeList(): Theme[] {
+  return Object.values(THEMES);
 }


### PR DESCRIPTION
## Changes

### /resume UX
- Resume picker now uses terminal height (via `useWindowSize`) to compute a dynamic page size, preventing the list from growing beyond the terminal viewport.
- Added prev/next page navigation with page counter (e.g. "Page 1 of 3 (45 total)").
- Increased session list limit from 30 → 200 so pagination is actually useful.

### Themes
- Expanded from 3 themes to **14 popular editor palettes**:
  - dark, light, high-contrast (existing)
  - dracula, nord, one-dark, monokai
  - solarized-dark, solarized-light
  - tokyo-night, gruvbox-dark, gruvbox-light
  - catppuccin-mocha, rose-pine
- New `ThemePicker` component uses `ink-select-input`'s `onHighlight` for **real-time arrow-key preview** — the entire TUI updates instantly as you arrow through themes.
- `/theme` without an argument now opens the interactive picker instead of just listing names.
- Added `ctrl+t` shortcut to open the theme picker directly.
- Updated `/help` text to reflect new shortcuts.