### PR TITLE
fix: stale update cache and double arrow in theme picker

### DIFF
--- a/src/ui/theme-picker.tsx
+++ b/src/ui/theme-picker.tsx
@@ -45,7 +45,6 @@ export function ThemePicker({ themes, current, onPick }: Props) {
             return (
               <Box>
                 <Text color={color} bold={isSelected} dimColor={!isSelected}>
-                  {isSelected ? "› " : "  "}
                   {label}
                 </Text>
               </Box>

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -9,7 +9,6 @@ const NPM_REGISTRY = "https://registry.npmjs.org/kimiflare/latest";
 interface CacheEntry {
   checkedAt: number;
   latestVersion: string;
-  hasUpdate: boolean;
 }
 
 function cachePath(): string {
@@ -104,7 +103,8 @@ export async function checkForUpdate(force = false): Promise<UpdateCheckResult> 
   if (!force) {
     const cached = await readCache();
     if (cached) {
-      return { hasUpdate: cached.hasUpdate, localVersion, latestVersion: cached.latestVersion };
+      const hasUpdate = isNewer(localVersion, cached.latestVersion);
+      return { hasUpdate, localVersion, latestVersion: cached.latestVersion };
     }
   }
 
@@ -114,7 +114,7 @@ export async function checkForUpdate(force = false): Promise<UpdateCheckResult> 
   }
 
   const hasUpdate = isNewer(localVersion, latestVersion);
-  await writeCache({ checkedAt: Date.now(), latestVersion, hasUpdate });
+  await writeCache({ checkedAt: Date.now(), latestVersion });
   return { hasUpdate, localVersion, latestVersion };
 }
 


### PR DESCRIPTION
## Fixes

### Update check false-positive after upgrading
The cache stored a stale `hasUpdate: true` boolean with a 1-hour TTL. After upgrading kimiflare, the cached boolean was still `true`, so the app kept nagging about an update that was already installed. Also, if npm ever regressed (or the cache was written when local was older), it could show backwards versions like `0.8.0 → 0.6.0`.

**Fix:** Remove `hasUpdate` from the cache entirely. Only cache `latestVersion`. On every read, recompute `hasUpdate` by comparing the *current* local version against the cached latest. After upgrading, local ≥ cached latest → `hasUpdate: false`.

### Double arrow in theme picker
`ink-select-input` already renders its own `›` indicator via the default `Indicator` component. The custom `itemComponent` also prefixed `› `, causing two arrows.

**Fix:** Remove the manual `› ` prefix from `ThemePicker`'s `itemComponent`.