### PR TITLE
fix: prevent theme picker from closing on arrow keys

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1013,7 +1013,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   if (showThemePicker) {
     return (
       <Box flexDirection="column">
-        <ThemePicker themes={themeList()} current={theme} onPick={handleThemePick} />
+        <ThemePicker themes={themeList()} current={theme} onPick={handleThemePick} onPreview={(t) => setTheme(t)} />
       </Box>
     );
   }

--- a/src/ui/theme-picker.tsx
+++ b/src/ui/theme-picker.tsx
@@ -7,9 +7,10 @@ interface Props {
   themes: Theme[];
   current: Theme;
   onPick: (theme: Theme | null) => void;
+  onPreview?: (theme: Theme) => void;
 }
 
-export function ThemePicker({ themes, current, onPick }: Props) {
+export function ThemePicker({ themes, current, onPick, onPreview }: Props) {
   const items = themes.map((t) => ({
     label: t.label,
     value: t.name,
@@ -31,7 +32,7 @@ export function ThemePicker({ themes, current, onPick }: Props) {
           onHighlight={(item) => {
             if (item.value !== "__cancel__") {
               const highlighted = themes.find((t) => t.name === item.value);
-              if (highlighted) onPick(highlighted);
+              if (highlighted) onPreview?.(highlighted);
             }
           }}
           onSelect={(item) => {


### PR DESCRIPTION
## Problem

`/theme` shows a list of themes, but using arrow up/down exits the menu immediately. This happens because `ink-select-input`'s `onHighlight` (fired on arrow keys) was wired to `onPick`, which calls `setShowThemePicker(false)` — closing the picker on the very first arrow keypress.

This clashes with the text input's own arrow up/down handling for walking through previous/next sent messages.

## Fix

- Add an `onPreview` prop to `ThemePicker` for live preview without closing
- Wire `onHighlight` to `onPreview` instead of `onPick`
- Pass `onPreview={(t) => setTheme(t)}` from `app.tsx`

Arrow keys now preview themes live; Enter still confirms the selection and closes the picker. Cancel reverts to the original theme as before.

## Files changed

- `src/ui/theme-picker.tsx`
- `src/app.tsx`