### PR TITLE
feat: add logo, badges, and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sina Meraji
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-# kimiflare
+<p align="center">
+  <img src="assets/logo.svg" alt="kimiflare" width="320">
+</p>
 
-A terminal coding agent powered by **[Kimi-K2.6](https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/)** on Cloudflare Workers AI. Moonshot's 1T-parameter open-source model runs directly on your Cloudflare account. You bring the token, your traffic goes straight to Cloudflare.
+<p align="center">
+  <a href="https://www.npmjs.com/package/kimiflare"><img src="https://img.shields.io/npm/v/kimiflare?style=flat-square&color=cb3837" alt="npm version"></a>
+  <a href="https://github.com/sinameraji/kimiflare/blob/main/LICENSE"><img src="https://img.shields.io/github/license/sinameraji/kimiflare?style=flat-square&color=2ea44f" alt="license"></a>
+  <img src="https://img.shields.io/badge/node-%3E%3D20-339933?style=flat-square&logo=nodedotjs&logoColor=white" alt="Node.js >= 20">
+  <img src="https://img.shields.io/badge/typescript-5.7-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript">
+  <a href="https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/"><img src="https://img.shields.io/badge/powered%20by-Kimi--K2.6-f59e0b?style=flat-square" alt="Powered by Kimi-K2.6"></a>
+</p>
+
+<p align="center">
+  A terminal coding agent powered by <strong><a href="https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/">Kimi-K2.6</a></strong> on Cloudflare Workers AI. Moonshot's 1T-parameter open-source model runs directly on your Cloudflare account. You bring the token, your traffic goes straight to Cloudflare.
+</p>
 
 ```
 $ kimiflare
@@ -198,4 +210,4 @@ Early but functional. Transport + tools + agent loop + print mode are verified e
 
 ## License
 
-TBD.
+[MIT](LICENSE) © Sina Meraji

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#ea580c;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="10" width="100" height="100" rx="20" fill="url(#grad)"/>
+  <text x="60" y="82" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="72" font-weight="bold" fill="white" text-anchor="middle">K</text>
+  <text x="135" y="55" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="42" font-weight="800" fill="#1f2937">kimiflare</text>
+  <text x="135" y="85" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="16" fill="#6b7280">terminal coding agent</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -568,7 +568,7 @@
     <ul class="nav-links">
       <li><a href="#features">Features</a></li>
       <li><a href="#install">Install</a></li>
-      <li><a href="https://github.com/sinameraji/kimiflare" class="nav-cta" target="_blank">GitHub →</a></li>
+      <li><a href="https://github.com/sinameraji/kimiflare" class="nav-cta" target="_blank">X GitHub →</a></li>
     </ul>
   </nav>
 
@@ -582,7 +582,7 @@
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
-      <a href="https://github.com/sinameraji/kimiflare" class="btn btn-secondary" target="_blank">View source</a>
+      <a href="https://github.com/sinameraji/kimiflare" class="btn btn-secondary" target="_blank">X View source</a>
     </div>
 
     <div class="fade-in delay-3" style="margin-top: 1.5rem;">
@@ -842,10 +842,11 @@
   </section>
 
   <footer>
-    <span>Built by <a href="https://github.com/sinameraji" target="_blank">@sinameraji</a></span>
+    <span>Built by <a href="https://github.com/sinameraji" target="_blank">@sinameraji</a> · <a href="https://x.com/sinasanm" target="_blank">X @sinasanm</a></span>
     <span>
       <a href="https://github.com/sinameraji/kimiflare" target="_blank">GitHub</a> ·
-      <a href="https://github.com/sinameraji/kimiflare/issues" target="_blank">Issues</a>
+      <a href="https://github.com/sinameraji/kimiflare/issues" target="_blank">Issues</a> ·
+      <a href="https://github.com/sinameraji/kimiflare/blob/main/LICENSE" target="_blank">MIT License</a>
     </span>
   </footer>
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "homepage": "https://github.com/sinameraji/kimiflare#readme",
   "bugs": "https://github.com/sinameraji/kimiflare/issues",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "kimiflare": "bin/kimiflare.mjs"


### PR DESCRIPTION
## What's changed

- Added a custom SVG logo (gradient K mark + wordmark) to the README header
- Added shields.io badges:
  - npm version
  - MIT license
  - Node.js >=20
  - TypeScript
  - Powered by Kimi-K2.6
- Added MIT LICENSE file
- Updated README license section from TBD → MIT

## Why MIT?

MIT is the de-facto standard for open-source Node.js CLI tools. It's permissive, simple, and makes it easy for others to adopt, fork, or integrate kimiflare into their workflows without legal friction.