### PR TITLE
fix: prevent memory leaks from unbounded events and timer churn

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -77,7 +77,16 @@ const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
 function App({ initialCfg }: { initialCfg: Cfg | null }) {
   const { exit } = useApp();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
-  const [events, setEvents] = useState<ChatEvent[]>([]);
+  const [events, setRawEvents] = useState<ChatEvent[]>([]);
+  const setEvents = useCallback(
+    (updater: React.SetStateAction<ChatEvent[]>) => {
+      setRawEvents((prev) => {
+        const next = typeof updater === "function" ? (updater as (prev: ChatEvent[]) => ChatEvent[])(prev) : updater;
+        return capEvents(next);
+      });
+    },
+    [],
+  );
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [usage, setUsage] = useState<Usage | null>(null);
@@ -403,7 +412,6 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
       setBusy(false);
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
-      setEvents((prev) => capEvents(prev));
     }
   }, [cfg, busy, updateAssistant, updateTool]);
 
@@ -801,7 +809,6 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         setBusy(false);
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
-        setEvents((prev) => capEvents(prev));
       }
     },
     [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -57,10 +57,16 @@ interface PendingPermission {
 
 const CONTEXT_LIMIT = 262_000;
 const AUTO_COMPACT_SUGGEST_PCT = 0.8;
+const MAX_EVENTS = 500;
 
 let nextAssistantId = 1;
 let nextKey = 1;
 const mkKey = () => `evt_${nextKey++}`;
+
+function capEvents(prev: ChatEvent[]): ChatEvent[] {
+  if (prev.length <= MAX_EVENTS) return prev;
+  return prev.slice(prev.length - MAX_EVENTS);
+}
 
 const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
   low: "low — fastest; lightest reasoning. Best for simple Q&A, small edits, quick coordination.",
@@ -397,6 +403,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
       setBusy(false);
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
+      setEvents((prev) => capEvents(prev));
     }
   }, [cfg, busy, updateAssistant, updateTool]);
 
@@ -794,6 +801,7 @@ function App({ initialCfg }: { initialCfg: Cfg | null }) {
         setBusy(false);
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
+        setEvents((prev) => capEvents(prev));
       }
     },
     [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -25,7 +25,7 @@ interface Props {
   verbose?: boolean;
 }
 
-export function ChatView({ events, showReasoning, theme, verbose }: Props) {
+export const ChatView = React.memo(function ChatView({ events, showReasoning, theme, verbose }: Props) {
   return (
     <Box flexDirection="column">
       {events.map((e, i) => {
@@ -47,7 +47,7 @@ export function ChatView({ events, showReasoning, theme, verbose }: Props) {
       })}
     </Box>
   );
-}
+});
 
 function EventView({
   evt,

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Box, Text } from "ink";
 import type { Theme } from "./theme.js";
 
@@ -13,7 +13,7 @@ interface InlineSegment {
 }
 
 export function MD({ text, theme }: Props) {
-  const blocks = parseBlocks(text);
+  const blocks = useMemo(() => parseBlocks(text), [text]);
   return (
     <Box flexDirection="column">
       {blocks.map((b, i) => (

--- a/src/ui/task-list.tsx
+++ b/src/ui/task-list.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Box, Text } from "ink";
 import type { Task } from "../tasks-state.js";
 import type { Theme } from "./theme.js";
@@ -14,14 +14,20 @@ const MAX_VISIBLE = 6;
 
 export function TaskList({ tasks, theme, startedAt, tokensDelta }: Props) {
   const [now, setNow] = useState(Date.now());
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
 
   useEffect(() => {
     if (startedAt === null) return;
-    const allDone = tasks.length > 0 && tasks.every((t) => t.status === "completed");
-    if (allDone) return;
-    const id = setInterval(() => setNow(Date.now()), 1000);
+    const id = setInterval(() => {
+      setNow(Date.now());
+      const current = tasksRef.current;
+      if (current.length > 0 && current.every((t) => t.status === "completed")) {
+        clearInterval(id);
+      }
+    }, 1000);
     return () => clearInterval(id);
-  }, [startedAt, tasks]);
+  }, [startedAt]);
 
   if (tasks.length === 0) return null;
 


### PR DESCRIPTION
- TaskList: remove tasks from useEffect deps so setInterval isn't recreated on every tasks_set call; self-clear when all done
- MD: wrap parseBlocks in useMemo to avoid re-parsing markdown on every parent re-render
- ChatView: wrap in React.memo so history doesn't re-render on unrelated keystrokes
- App: cap events array at 500 items to prevent unbounded growth, and make capping automatic for all setEvents calls