### PR TITLE
fix: validate tool_call arguments JSON to prevent 400 BadRequest loops

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -43,7 +43,7 @@ function isRetryable(err: KimiApiError, attempt: number): boolean {
 export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, void, void> {
   const url = `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${opts.model}`;
   const body: Record<string, unknown> = {
-    messages: opts.messages,
+    messages: sanitizeMessagesForApi(opts.messages),
     ...(opts.tools && opts.tools.length
       ? { tools: opts.tools, tool_choice: "auto", parallel_tool_calls: true }
       : {}),
@@ -208,6 +208,32 @@ interface StreamToolCall {
   id?: string | null;
   type?: string | null;
   function?: { name?: string | null; arguments?: string | null };
+}
+
+function sanitizeMessagesForApi(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((m) => {
+    if (!m.tool_calls || m.tool_calls.length === 0) return m;
+    return {
+      ...m,
+      tool_calls: m.tool_calls.map((tc) => ({
+        ...tc,
+        function: {
+          name: tc.function.name,
+          arguments: validateJsonArguments(tc.function.arguments),
+        },
+      })),
+    };
+  });
+}
+
+function validateJsonArguments(raw: string): string {
+  if (!raw || !raw.trim()) return "{}";
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {
+    return "{}";
+  }
 }
 
 function extractCloudflareError(parsed: unknown): { code?: number; message?: string } | null {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -75,10 +75,11 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           opts.callbacks.onToolCallArgs?.(ev.index, ev.argsDelta);
           break;
         case "tool_call_complete": {
+          const safeArgs = validateToolArguments(ev.arguments);
           const call: ToolCall = {
             id: ev.id,
             type: "function",
-            function: { name: ev.name, arguments: ev.arguments },
+            function: { name: ev.name, arguments: safeArgs },
           };
           toolCalls.push(call);
           opts.callbacks.onToolCallFinalized?.(call);
@@ -131,4 +132,14 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   }
 
   throw new Error(`kimiflare: tool iteration limit reached (${opts.maxToolIterations ?? 50})`);
+}
+
+function validateToolArguments(raw: string): string {
+  if (!raw || !raw.trim()) return "{}";
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {
+    return "{}";
+  }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/execut
 import type { ToolSpec } from "./tools/registry.js";
 import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, Usage } from "./agent/messages.js";
+import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
@@ -926,10 +927,26 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         if ((e as Error).name === "AbortError") {
           setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(aborted)" }]);
         } else {
-          setEvents((es) => [
-            ...es,
-            { kind: "error", key: mkKey(), text: (e as Error).message ?? String(e) },
-          ]);
+          const isInvalidJson400 =
+            e instanceof KimiApiError &&
+            e.httpStatus === 400 &&
+            e.message.includes("invalid escaped character");
+          if (isInvalidJson400) {
+            messagesRef.current.pop();
+            setEvents((es) => [
+              ...es,
+              {
+                kind: "error",
+                key: mkKey(),
+                text: "API rejected request (invalid JSON in conversation history). Retrying may work; run /clear to reset if it persists.",
+              },
+            ]);
+          } else {
+            setEvents((es) => [
+              ...es,
+              { kind: "error", key: mkKey(), text: (e as Error).message ?? String(e) },
+            ]);
+          }
         }
       } finally {
         setBusy(false);


### PR DESCRIPTION
Cloudflare Workers AI rejects requests when tool_calls[].function.arguments contains invalid JSON escapes (e.g. \v, \x, unescaped newlines). Previous fixes only stripped lone UTF-16 surrogates, which didn't catch these cases.

This PR adds three layers of defense:

1. **loop.ts**: Validate arguments at ingestion. If JSON.parse fails on a tool_call_complete event, replace arguments with '{}' before it enters conversation history.

2. **client.ts**: Defense-in-depth before sending. Walk all messages and validate tool_calls[].function.arguments right before JSON.stringify. Replace invalid JSON with '{}' so the API never sees it.

3. **app.tsx**: Graceful 400 recovery. Detect KimiApiError with httpStatus 400 and 'invalid escaped character' message. Pop the user message so the user can retry without accumulating dead turns.