### PR TITLE
feat: allow read-only bash commands in plan mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,7 @@ import {
   type ReasoningEffort,
 } from "./config.js";
 import { resolveTheme, themeNames, themeList, type Theme } from "./ui/theme.js";
-import { nextMode, type Mode, isBlockedInPlanMode } from "./mode.js";
+import { nextMode, type Mode, isBlockedInPlanMode, isReadOnlyBash } from "./mode.js";
 import {
   listSessions,
   loadSession,
@@ -497,7 +497,26 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           },
           askPermission: (req) =>
             new Promise<PermissionDecision>((resolve) => {
-              if (modeRef.current === "auto") return resolve("allow");
+              if (modeRef.current === "auto") {
+                resolve("allow");
+                return;
+              }
+              if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
+                if (req.tool.name === "bash" && typeof req.args.command === "string" && isReadOnlyBash(req.args.command)) {
+                  resolve("allow");
+                  return;
+                }
+                setEvents((e) => [
+                  ...e,
+                  {
+                    kind: "info",
+                    key: mkKey(),
+                    text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
+                  },
+                ]);
+                resolve("deny");
+                return;
+              }
               setPerm({ tool: req.tool, args: req.args, resolve });
             }),
         },
@@ -922,6 +941,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                   return;
                 }
                 if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
+                  if (req.tool.name === "bash" && typeof req.args.command === "string" && isReadOnlyBash(req.args.command)) {
+                    resolve("allow");
+                    return;
+                  }
                   setEvents((e) => [
                     ...e,
                     {

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -12,7 +12,7 @@ export function modeDescription(m: Mode): string {
     case "edit":
       return "edit — default; prompts for permission before mutating tools";
     case "plan":
-      return "plan — read-only research; blocks writes/edits/bash until you exit plan mode";
+      return "plan — read-only research; blocks writes/edits/mutating bash until you exit plan mode";
     case "auto":
       return "auto — autonomous; auto-approves every tool call (use with care)";
   }
@@ -24,9 +24,179 @@ export function isBlockedInPlanMode(toolName: string): boolean {
   return MUTATING_TOOLS.has(toolName);
 }
 
+// Dangerous shell patterns that disqualify any command from read-only status
+const DANGEROUS_PATTERNS = /[<>|;&`$]|\$\(|\$\{|&&|\|\||\b&\s*$/;
+
+// Git subcommands that are read-only (value = true means always safe, false means needs arg check)
+const GIT_READONLY_SUBCOMMANDS: Record<string, boolean> = {
+  log: true,
+  diff: true,
+  status: true,
+  show: true,
+  blame: true,
+  describe: true,
+  "rev-parse": true,
+  "ls-files": true,
+  reflog: true,
+  shortlog: true,
+  whatchanged: true,
+  grep: true,
+  branch: false, // needs check: block -d/-D/-m/-M/-c/-C
+  stash: false, // needs check: only allow "list"
+  remote: false, // needs check: only allow -v
+  tag: false, // needs check: only allow -l
+  config: false, // needs check: only allow --list/--get
+};
+
+// Whitelisted non-git commands (must be exact first token)
+const READONLY_COMMANDS = new Set([
+  // File system
+  "ls", "cat", "head", "tail", "pwd", "echo",
+  "file", "stat", "readlink", "realpath", "dirname", "basename",
+  "wc", "sort", "uniq", "diff", "cmp",
+  // Search
+  "grep", "rg", "ag", "fd",
+  // System info
+  "ps", "df", "du", "env", "printenv", "which", "whereis",
+  "uname", "hostname", "uptime", "free", "date", "id", "whoami", "groups",
+  // Dev tools (version/info only)
+  "node", "npx", "python3", "ruby", "perl",
+  // Utilities
+  "jq", "yq", "awk", "cut", "tr",
+  "base64", "sha256sum", "md5sum", "shasum", "hexdump", "xxd", "strings",
+  "less", "more", "man", "clear", "history",
+  // Archive inspection
+  "zipinfo",
+  // Network
+  "ping", "netstat", "ss", "lsof",
+]);
+
+// Commands that need argument validation
+const COMMANDS_NEEDING_ARG_CHECK: Record<string, (args: string[]) => boolean> = {
+  find: (args) => !args.some((a) => a === "-delete" || a === "-exec"),
+  sed: (args) => !args.some((a) => a === "-i" || a.startsWith("-i")),
+  tar: (args) => args[0] === "-tf" || args[0] === "--list",
+  unzip: (args) => args[0] === "-l",
+  curl: (args) =>
+    !args.some((a) => a === "-o" || a === "-O" || a === "-d" || a === "--data" || a.startsWith("-X")),
+  wget: (args) =>
+    !args.some((a) => a === "-O" || a === "--output-document" || a.startsWith("--post")),
+  npm: (args) =>
+    ["list", "view", "config"].includes(args[0] ?? "") &&
+    !(args[0] === "config" && args[1] && !args[1].startsWith("get") && args[1] !== "list"),
+  tsc: (args) =>
+    args.every((a) =>
+      ["--noEmit", "--version", "--showConfig", "--help", "-h", "--init"].includes(a),
+    ),
+  eslint: (args) =>
+    args.every((a) =>
+      ["--version", "--print-config", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  prettier: (args) =>
+    args.every((a) =>
+      ["--version", "--check", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  jest: (args) =>
+    args.every((a) =>
+      ["--version", "--listTests", "--showConfig", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  vitest: (args) =>
+    args.every((a) =>
+      ["--version", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  go: (args) =>
+    ["version", "env", "list", "mod"].includes(args[0] ?? "") &&
+    !(args[0] === "mod" && args[1] && !["graph", "download", "why", "verify"].includes(args[1])),
+  cargo: (args) =>
+    ["--version", "-V", "check", "test", "metadata"].includes(args[0] ?? "") &&
+    !(args[0] === "test" && args.includes("--no-run") === false),
+};
+
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+  for (const ch of command) {
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+export function isReadOnlyBash(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+
+  // Reject any command with dangerous shell patterns
+  if (DANGEROUS_PATTERNS.test(trimmed)) return false;
+
+  const tokens = tokenizeCommand(trimmed);
+  if (tokens.length === 0) return false;
+
+  const first = tokens[0]!;
+
+  // Handle cd prefix: cd somewhere && real_command
+  let cmdIndex = 0;
+  if (first === "cd" && tokens.length >= 3 && tokens[1] && tokens[2] === "&&") {
+    cmdIndex = 3;
+  }
+
+  const cmd = tokens[cmdIndex];
+  if (!cmd) return false;
+  const args = tokens.slice(cmdIndex + 1);
+
+  // Git commands
+  if (cmd === "git") {
+    const sub = args[0] ?? "";
+    const allowed = GIT_READONLY_SUBCOMMANDS[sub];
+    if (allowed === undefined) return false;
+    if (allowed === true) return true;
+
+    // Needs extra validation
+    switch (sub) {
+      case "branch":
+        return !args.some((a) => /^-[dDmMcC]/.test(a));
+      case "stash":
+        return args[1] === "list";
+      case "remote":
+        return args[1] === "-v" || args[1] === "--verbose" || args.length === 1;
+      case "tag":
+        return args[1] === "-l" || args[1] === "--list" || args.length === 1;
+      case "config":
+        return args[1] === "--list" || args[1]?.startsWith("--get") === true || args.length === 1;
+      default:
+        return false;
+    }
+  }
+
+  // Commands needing argument validation
+  const argCheck = COMMANDS_NEEDING_ARG_CHECK[cmd];
+  if (argCheck) {
+    return argCheck(args);
+  }
+
+  // Simple whitelist
+  return READONLY_COMMANDS.has(cmd);
+}
+
 export function systemPromptForMode(m: Mode): string {
   if (m === "plan") {
-    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or bash. Only use read/glob/grep/web-fetch. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
+    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or mutating bash commands. You may use read-only bash commands (e.g., git log, git diff, ls, cat) along with read/glob/grep/web-fetch. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
   }
   if (m === "auto") {
     return "\n\nAUTO MODE is active. The user has opted into autonomous execution — every tool call will be auto-approved. Work efficiently, but do not take irreversible destructive actions (rm -rf, git push --force, dropping tables, etc.) without pausing to describe them in chat first. Prefer smaller reversible steps.";


### PR DESCRIPTION
Plan mode previously blocked ALL bash commands. This change introduces a conservative whitelist so safe read-only commands can run while planning.

## What's allowed

### Git (read-only subcommands)
- log, diff, status, show, blame, describe, rev-parse, ls-files, reflog, shortlog, whatchanged, grep
- branch (blocks -d/-D/-m/-M/-c/-C)
- stash list (blocks push/pop/drop/clear)
- remote -v (blocks add/remove/set-url)
- tag -l (blocks -d/-a/-m)
- config --list/--get (blocks --set/--unset)

### File system
- ls, cat, head, tail, pwd, echo, file, stat, readlink, realpath, dirname, basename
- find (blocks -delete, -exec)
- wc, sort, uniq, diff, cmp

### Search
- grep, rg, ag, fd

### System info
- ps, df, du, env, printenv, which, whereis
- uname, hostname, uptime, free, date, id, whoami, groups

### Dev tools
- npm list/view/config get
- tsc --noEmit/--version/--showConfig
- eslint --version/--print-config
- prettier --version/--check
- jest --version/--listTests/--showConfig
- vitest --version
- go version/env/list/mod graph
- cargo --version/check/test --no-run
- node/python3/ruby/perl --version

### Utilities
- jq, yq, awk, cut, tr
- base64, sha256sum, md5sum, shasum, hexdump, xxd, strings
- tar -tf, zipinfo, unzip -l
- curl -s/-I/--version (blocks -o/-O/-d/-X POST)
- wget (blocks -O/--output-document/--post)
- ping, netstat, ss, lsof
- less, more, man, clear, history

### Safety
Any command containing these patterns is rejected:
- Output redirection: >, >>
- Pipes: |
- Command chaining: ;, &&, ||
- Command substitution: $(, backticks, ${
- Background: &

## Files changed
- src/mode.ts: added isReadOnlyBash() with full whitelist logic, updated system prompt
- src/app.tsx: updated both askPermission callbacks to allow read-only bash through in plan mode

Co-authored-by: kimiflare <kimiflare@proton.me>