### PR TITLE
feat: polished README, landing page, and plan-mode bash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,28 @@
 </p>
 
 <p align="center">
-  A terminal coding agent powered by <strong><a href="https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/">Kimi-K2.6</a></strong> on Cloudflare Workers AI. Moonshot's 1T-parameter open-source model runs directly on your Cloudflare account. You bring the token, your traffic goes straight to Cloudflare.
+  <strong>A terminal coding agent powered by <a href="https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/">Kimi-K2.6</a> on Cloudflare Workers AI.</strong><br>
+  Moonshot's 1T-parameter open-source model, running directly on your Cloudflare account.
 </p>
 
-```
-$ kimiflare
-kimiflare · /help for commands · ctrl-c to exit
+<p align="center">
+  <img src="docs/screenshot.png" alt="kimiflare TUI" width="900">
+</p>
 
-› what files are here?
-  ✓ glob(*)
-    /Users/you/proj/package.json
-    /Users/you/proj/src/index.ts
-    ...
+## Why kimiflare
 
-› add a /health endpoint to server.ts
-  ✓ read(src/server.ts)
-  ◐ edit src/server.ts
-    ─── permission requested ──────────────────
-    @@ -42,6 +42,10 @@
-       app.get('/', …)
-    +  app.get('/health', (_, res) => res.json({ ok: true }))
-    ─────────────────────────────────────────────
-    [Allow once] [Allow for session] [Deny]
-```
+- **262k context window** — Read entire modules, large configs, and full stack traces without the model losing track.
+- **Direct to Cloudflare** — No AI Gateway, no proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account.
+- **Plan mode** — Ask the agent to research and produce a plan without touching your filesystem. Review it, then exit plan mode to execute.
 
-## Install
+## Quick start
 
 ```sh
 npm install -g kimiflare
+kimiflare
 ```
+
+On first run, an interactive onboarding wizard asks for your Cloudflare Account ID and API Token. That's it — you're ready.
 
 Or run without installing:
 
@@ -48,6 +41,24 @@ npx kimiflare
 ```
 
 Requires Node.js ≥ 20.
+
+## Features
+
+| Feature | What it does |
+|---------|-------------|
+| **Plan / Edit / Auto modes** | `plan` blocks all mutating tools for safe research. `edit` (default) prompts per mutating call. `auto` approves everything for trusted tasks. |
+| **Live task panel** | For multi-step work, the agent publishes a task list with progress icons (■ active, ☐ pending, ✓ done), elapsed time, and token deltas. |
+| **14 terminal themes** | dark, light, high-contrast, dracula, nord, one-dark, monokai, solarized-dark/light, tokyo-night, gruvbox-dark/light, catppuccin-mocha, rose-pine. Interactive picker with live preview (`Ctrl+T`). |
+| **Paste collapse** | Large pastes (≥200 chars or ≥2 newlines) collapse to `[pasted N lines #id]`. Full content still goes to the model — scrollback stays clean. |
+| **Type-ahead queue** | Type your next prompt while the model is still working. Queued prompts show as `⏳ …` and fire in order. `Ctrl-C` aborts current + clears queue. |
+| **Auto-compaction** | At ~80% context usage, kimiflare nudges you to run `/compact`. It summarizes older turns into a dense summary, keeping the last 4 turns intact. |
+| **Streaming reasoning** | Toggle the model's chain-of-thought with `/reasoning` or `Ctrl-R`. See how it thinks in real time. |
+| **Live cost tracking** | Status bar shows real-time cost based on Cloudflare pricing: `$0.95/M input`, `$0.16/M cached`, `$4.00/M output`. |
+| **Session persistence** | Every turn is auto-saved. `/resume` lists past sessions (with message counts) in a paginated picker. |
+| **Smart permissions** | Bash session-allow is keyed by the first token (e.g., allow all `git` commands). Write/edit show a unified diff before you approve. |
+| **Project context (`/init`)** | Scans your repo and writes a concise `KIMI.md` — build commands, layout, conventions. Auto-loaded on every launch. |
+| **Co-author auto-append** | Detects `git commit` commands and auto-injects `Co-authored-by: kimiflare <kimiflare@proton.me>`. |
+| **Resilient transport** | Retries Cloudflare capacity errors (code 3040) and 5xx with exponential backoff up to 5 attempts. |
 
 ## Configure
 
@@ -79,50 +90,85 @@ chmod 600 ~/.config/kimiflare/config.json
 
 ## Usage
 
+### Interactive TUI
+
 ```sh
-kimiflare                             # interactive TUI
-kimiflare -p "summarize PLAN.md"      # one-shot, streams answer to stdout
-kimiflare -p "..." --dangerously-allow-all   # auto-approve mutating tools (for scripts)
+kimiflare                             # launch TUI
 kimiflare --model @cf/moonshotai/kimi-k2.6   # override model
-kimiflare --reasoning                 # (print mode) stream chain-of-thought to stderr
 ```
 
-Interactive slash commands:
+### Print mode (one-shot, non-interactive)
 
-| Command                     | Effect                                                                          |
-|-----------------------------|---------------------------------------------------------------------------------|
-| `/mode edit\|plan\|auto`     | Switch mode. `edit` prompts for permission (default), `plan` is read-only research, `auto` auto-approves every tool call. |
-| `/plan` `/auto` `/edit`     | Shortcuts for the three modes.                                                  |
+```sh
+kimiflare -p "summarize PLAN.md"                    # stream answer to stdout
+kimiflare -p "..." --dangerously-allow-all          # auto-approve mutating tools (for scripts)
+kimiflare -p "..." --reasoning                      # include chain-of-thought in stderr
+```
+
+### CLI flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--print <prompt>` | `-p` | One-shot mode: send prompt, stream reply, exit |
+| `--model <id>` | `-m` | Model ID (default: `@cf/moonshotai/kimi-k2.6`) |
+| `--dangerously-allow-all` | — | Auto-approve every permission prompt (print mode only) |
+| `--reasoning` | — | Stream chain-of-thought to stderr (print mode only) |
+| `--version` | `-V` | Show version |
+| `--help` | `-h` | Show help |
+
+## Slash commands
+
+| Command | Effect |
+|---------|--------|
+| `/mode edit\|plan\|auto` | Switch mode. `edit` prompts for permission (default), `plan` is read-only research, `auto` auto-approves every tool call. |
+| `/plan` `/auto` `/edit` | Shortcuts for the three modes. |
 | `/thinking low\|medium\|high` | Reasoning effort. `low` = fastest, shallow; `medium` = balanced (default); `high` = deepest, slowest. Saved to config. |
-| `/theme NAME`               | Switch color scheme: `dark` (default), `light` (bright terminals), `high-contrast`. Saved to config. |
-| `/resume`                   | Pick a past conversation to restore.                                            |
-| `/compact`                  | Summarize older turns to free context. Suggested automatically at ~80% full.    |
-| `/init`                     | Scan the repo and write a `KIMI.md` so future agents have project context.      |
-| `/reasoning`                | Toggle chain-of-thought display.                                                |
-| `/clear`                    | Reset the current conversation.                                                 |
-| `/cost` `/model` `/update`  | Info commands.                                                                  |
-| `/logout`                   | Clear saved credentials.                                                        |
-| `/help` `/exit`             | List commands / quit.                                                           |
+| `/theme` | Interactive theme picker with live preview (`Ctrl+T`). Saved to config. |
+| `/theme NAME` | Set theme by name directly. |
+| `/resume` | Pick a past conversation to restore. |
+| `/compact` | Summarize older turns to free context. Suggested automatically at ~80% full. |
+| `/init` | Scan the repo and write a `KIMI.md` so future agents have project context. |
+| `/reasoning` | Toggle chain-of-thought display. |
+| `/clear` | Reset the current conversation. |
+| `/cost` | Show token usage for the current turn. |
+| `/model` | Show current model. |
+| `/update` | Check for updates manually. |
+| `/logout` | Clear saved credentials. |
+| `/help` | List all commands. |
+| `/exit` | Quit. |
 
-Keys: `Shift+Tab` cycles mode · `Ctrl-R` toggles reasoning · `Ctrl-O` toggles verbose tool output · `Ctrl-C` interrupts an in-flight turn (press again to exit) · `↑`/`↓` walks prompt history.
+## Keyboard shortcuts
 
-Editing keys (macOS):
+### Global
 
-- `⌥←` / `⌥→` — jump word left/right (also works with `Esc b` / `Esc f`)
-- `⌘←` / `⌘→` — jump to start / end of line (in iTerm2's default profile; in Terminal.app you may need to map these to send `Ctrl-A` / `Ctrl-E`)
-- `⌥⌫` — delete word backward
-- `⌘⌫` — delete to start of line (iTerm2 sends this as `Ctrl-U`; map in Terminal.app if needed)
-- `⌥⌦` — delete word forward
-- `Ctrl-A` / `Ctrl-E` — start / end of line (always works)
-- `Ctrl-W` / `Ctrl-U` / `Ctrl-K` — delete word backward / to start of line / to end of line
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+C` | Interrupt current turn (press again to exit) |
+| `Ctrl+R` | Toggle reasoning display |
+| `Ctrl+O` | Toggle verbose tool output |
+| `Ctrl+T` | Open theme picker |
+| `Shift+Tab` | Cycle mode (edit → plan → auto) |
+| `↑` / `↓` | Walk prompt history |
 
-### Modes
+### Editing (macOS / Linux)
+
+| Shortcut | Action |
+|----------|--------|
+| `⌥←` / `⌥→` | Jump word left/right |
+| `⌘←` / `⌘→` | Jump to start / end of line |
+| `⌥⌫` | Delete word backward |
+| `⌘⌫` | Delete to start of line |
+| `⌥⌦` | Delete word forward |
+| `Ctrl+A` / `Ctrl+E` | Start / end of line |
+| `Ctrl+W` / `Ctrl+U` / `Ctrl+K` | Delete word backward / to start / to end of line |
+
+## Modes
 
 - **edit** — default. The agent calls tools freely for read-only work; mutating tools (`write`, `edit`, `bash`) pause for your approval.
 - **plan** — read-only. Mutating tools are hard-blocked. Ask "plan a refactor" and the agent will investigate and produce a plan without touching the filesystem. Exit plan mode to execute.
 - **auto** — autonomous. Every tool call is auto-approved. Use for trusted, well-scoped tasks.
 
-### Thinking level (quality vs speed)
+## Thinking level (quality vs speed)
 
 Kimi-K2.6 always reasons, but you can cap the effort:
 
@@ -132,52 +178,26 @@ Kimi-K2.6 always reasons, but you can cap the effort:
 
 Set with `/thinking medium` (persists), or per-launch via `KIMI_REASONING_EFFORT=high`.
 
-### Type-ahead queue
-
-You can type the next prompt while the model is still executing. Submitted prompts show up as `⏳ …` and fire in order as each turn completes. `Ctrl-C` aborts the current turn and clears the queue.
-
-### Session persistence
-
-Sessions are saved to `~/.local/share/kimiflare/sessions/` after each turn. `/resume` lists the most recent (with first prompt + message count) so you can pick one up later.
-
-### Task panel
-
-For multi-step requests, the agent can publish a live task list via the `tasks_set` tool. The panel shows progress inline with status icons (`■` active, `☐` pending, `✓` done), elapsed time, and tokens consumed for the current task batch. Press `Ctrl-O` while a turn is running to switch tool output between compact (first line) and verbose (full output) modes.
-
-### Paste collapse
-
-Paste a large block (≥ 200 chars or ≥ 3 newlines in one paste) into the prompt and the input collapses it to `[pasted N lines #id]`. The full content still goes to the model on submit — only the on-screen display and chat history are collapsed, so scrollback doesn't get buried by a wall of code.
-
-### Project context (KIMI.md)
-
-Run `/init` inside a repo and kimiflare scans the project (reads `package.json`, `README`, source layout, etc.) and writes a concise `KIMI.md` at the repo root — project overview, build/test commands, conventions, quirks. On every subsequent launch in that directory, `KIMI.md` (or `KIMIFLARE.md` or `AGENT.md`, whichever exists) is auto-loaded into the system prompt so the agent already "knows" the project. If the file already exists, `/init` refuses so you don't overwrite hand-edited context.
-
-## Why
-
-- **262k context.** Read entire modules without pagination.
-- **Native tool use.** File I/O, shell, globs, grep, web fetch — all wired up, with per-call approval for anything mutating.
-- **Streaming reasoning + content.** The model's chain-of-thought streams separately; toggle with `/reasoning` or `Ctrl-R`.
-- **Pay your own way.** Your Cloudflare account, your credits, your rate limits. `$0.95 / M input`, `$0.16 / M cached input`, `$4.00 / M output`. The bottom status line shows live cost.
-
 ## Tools
 
 All tool calls show inline; mutating ones require per-call approval the first time, with an option to allow for the rest of the session.
 
-| Tool        | Permission | What it does |
-|-------------|------------|--------------|
-| `read`      | auto       | Read a text file (≤ 2MB) with optional line range. |
-| `write`     | prompt     | Create or overwrite a file. Shows a unified diff before you approve. |
-| `edit`      | prompt     | Replace an exact substring. Fails unless `old_string` is unique (or `replace_all=true`). |
-| `bash`      | prompt     | Run a shell command via `bash -lc`. Session-allow is keyed by the first token of the command. |
-| `glob`      | auto       | Match files by pattern (`**/*.ts`), sorted by mtime. |
-| `grep`      | auto       | Regex search. Uses `rg` if installed; falls back to a JS walk. |
-| `web_fetch` | auto       | Fetch a URL, convert HTML → markdown (≤ 100KB). |
+| Tool | Permission | What it does |
+|------|------------|--------------|
+| `read` | auto | Read a text file (≤ 2MB) with optional line range. |
+| `write` | prompt | Create or overwrite a file. Shows a unified diff before you approve. |
+| `edit` | prompt | Replace an exact substring. Fails unless `old_string` is unique (or `replace_all=true`). |
+| `bash` | prompt | Run a shell command via `bash -lc`. Session-allow is keyed by the first token of the command. |
+| `glob` | auto | Match files by pattern (`**/*.ts`), sorted by mtime. |
+| `grep` | auto | Regex search. Uses `rg` if installed; falls back to a JS walk. |
+| `web_fetch` | auto | Fetch a URL, convert HTML → markdown (≤ 100KB). |
+| `tasks_set` | auto | Publish a live task list for multi-step work. |
 
 ## How it works
 
 ```
            ┌───────────────────────────────────────────────────────────┐
-           │ kimiflare (Node + Ink TUI)                                │
+           │ kimiflare (Node.js TUI)                                   │
  user ─▶   │                                                           │
            │   user msg ─▶ agent loop ─▶ runKimi() ──[POST SSE]──▶     │
            │                       ▲                                   │
@@ -204,9 +224,23 @@ npm run build
 npm link          # or: ln -s "$PWD/bin/kimiflare.mjs" ~/.local/bin/kimiflare
 ```
 
-## Status
+Scripts:
+- `npm run build` — bundle with tsup (`dist/` + `bin/kimiflare.mjs`)
+- `npm run dev` — run via tsx (`tsx src/index.tsx`)
+- `npm run typecheck` — `tsc --noEmit`
+- `npm start` — run compiled bin
 
-Early but functional. Transport + tools + agent loop + print mode are verified end-to-end. Interactive TUI ships modes, themes, thinking levels, session resume, compaction, and type-ahead queue.
+## Contributing
+
+Contributions are welcome!
+
+1. Fork the repository
+2. Create a branch: `git checkout -b feat/your-feature`
+3. Make your changes
+4. Run `npm run typecheck` and `npm run build`
+5. Commit: `git commit -m "feat: description"`
+6. Push: `git push origin feat/your-feature`
+7. Open a Pull Request
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -568,7 +568,7 @@
     <ul class="nav-links">
       <li><a href="#features">Features</a></li>
       <li><a href="#install">Install</a></li>
-      <li><a href="https://github.com/sinameraji/kimiflare" class="nav-cta" target="_blank">X GitHub →</a></li>
+      <li><a href="https://github.com/sinameraji/kimiflare" class="nav-cta" target="_blank">GitHub →</a></li>
     </ul>
   </nav>
 
@@ -582,7 +582,7 @@
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
-      <a href="https://github.com/sinameraji/kimiflare" class="btn btn-secondary" target="_blank">X View source</a>
+      <a href="https://github.com/sinameraji/kimiflare" class="btn btn-secondary" target="_blank">View source</a>
     </div>
 
     <div class="fade-in delay-3" style="margin-top: 1.5rem;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -578,7 +578,7 @@
       Kimi K2.6 + Cloudflare<br>in your terminal.<br>No middleman.
     </h1>
     <p class="hero-subtitle fade-in delay-2">
-      Moonshot's open-weight Kimi running on your own Cloudflare account. No middleman.
+      A terminal coding agent with plan mode, live task panels, 14 themes, and 262k context. Direct to Cloudflare — no middleman.
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
@@ -692,45 +692,90 @@
     <div class="features-list">
       <div class="feature-item">
         <span class="feature-num">01</span>
-        <h3>262K context window</h3>
-        <p>Read entire modules, large configs, and full stack traces without the model losing track.</p>
+        <h3>Plan / Edit / Auto modes</h3>
+        <p>Plan mode blocks all mutating tools for safe research. Edit mode prompts per call. Auto mode approves everything for trusted tasks.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">02</span>
-        <h3>Native tool use</h3>
-        <p>File I/O, shell execution, globs, grep, and web fetch — all with per-call approval for anything destructive.</p>
+        <h3>Live task panel</h3>
+        <p>For multi-step work, the agent publishes a task list with progress icons, elapsed time, and token deltas. Multi-step work feels managed.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">03</span>
+        <h3>14 terminal themes</h3>
+        <p>dark, light, high-contrast, dracula, nord, one-dark, monokai, solarized, tokyo-night, gruvbox, catppuccin, rose-pine. Live preview with Ctrl+T.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">04</span>
+        <h3>Paste collapse</h3>
+        <p>Large pastes collapse to <code>[pasted N lines #id]</code>. Full content still goes to the model — scrollback stays clean.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">05</span>
+        <h3>Type-ahead queue</h3>
+        <p>Type your next prompt while the model is still working. Queued prompts fire in order. Ctrl-C aborts current and clears queue.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">06</span>
+        <h3>Auto-compaction</h3>
+        <p>At ~80% context usage, kimiflare nudges you to run /compact. It summarizes older turns, keeping the last 4 intact.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">07</span>
         <h3>Streaming reasoning</h3>
         <p>Toggle the model's chain-of-thought with /reasoning or Ctrl-R. See how it thinks in real time.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">04</span>
-        <h3>Direct to Cloudflare</h3>
-        <p>No AI Gateway, no proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account.</p>
+        <span class="feature-num">08</span>
+        <h3>Session persistence</h3>
+        <p>Every turn is auto-saved. /resume lists past sessions with message counts in a paginated picker. Never lose your place.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">05</span>
-        <h3>BYO API key</h3>
-        <p>Your Cloudflare account, your credits, your rate limits. Live cost tracking in the status line.</p>
+        <span class="feature-num">09</span>
+        <h3>Smart permissions</h3>
+        <p>Bash session-allow is keyed by the first token (allow all git commands). Write/edit show a unified diff before you approve.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">06</span>
-        <h3>Built with Ink</h3>
-        <p>React for terminals. Clean rendering under a pty with real-time streaming and permission modals.</p>
+        <span class="feature-num">10</span>
+        <h3>262K context window</h3>
+        <p>Read entire modules, large configs, and full stack traces without the model losing track. Direct to Cloudflare — no middleman.</p>
       </div>
     </div>
 
     <div class="arch-section">
       <span class="section-label">Architecture</span>
       <div class="arch-flow">
-        <strong>kimiflare</strong> <span class="accent">Node + Ink TUI</span><br>
+        <strong>kimiflare</strong> <span class="accent">Node.js TUI</span><br>
         <span class="arrow">↓</span> user msg → agent loop → runKimi()<br>
         <span class="arrow">↓</span> <span class="accent">POST SSE</span> to Workers AI<br>
         <strong>api.cloudflare.com</strong> <span class="accent">@cf/moonshotai/kimi-k2.6</span><br>
         <span class="arrow">↑</span> tool result ← tool executor ← tool_calls<br>
         <span class="arrow">↑</span> permission modal for write / edit / bash
+      </div>
+    </div>
+  </section>
+
+  <section id="modes">
+    <div class="section-header">
+      <span class="section-label">Modes</span>
+      <h2>Three ways to work</h2>
+    </div>
+
+    <div class="features-list">
+      <div class="feature-item">
+        <span class="feature-num">01</span>
+        <h3>Plan</h3>
+        <p>Read-only research. Mutating tools are hard-blocked. Ask "plan a refactor" and the agent investigates without touching your filesystem. Review, then exit plan mode to execute.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">02</span>
+        <h3>Edit</h3>
+        <p>Default mode. The agent calls tools freely for read-only work; mutating tools pause for your approval with a unified diff preview.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">03</span>
+        <h3>Auto</h3>
+        <p>Autonomous execution. Every tool call is auto-approved. Use for trusted, well-scoped tasks. The agent still warns before irreversible actions.</p>
       </div>
     </div>
   </section>
@@ -836,6 +881,11 @@
           <td>web_fetch</td>
           <td>auto</td>
           <td>Fetch a URL, convert HTML → markdown (≤ 100KB)</td>
+        </tr>
+        <tr>
+          <td>tasks_set</td>
+          <td>auto</td>
+          <td>Publish a live task list for multi-step work</td>
         </tr>
       </tbody>
     </table>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,7 @@ import {
   type ReasoningEffort,
 } from "./config.js";
 import { resolveTheme, themeNames, themeList, type Theme } from "./ui/theme.js";
-import { nextMode, type Mode, isBlockedInPlanMode } from "./mode.js";
+import { nextMode, type Mode, isBlockedInPlanMode, isReadOnlyBash } from "./mode.js";
 import {
   listSessions,
   loadSession,
@@ -497,7 +497,26 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           },
           askPermission: (req) =>
             new Promise<PermissionDecision>((resolve) => {
-              if (modeRef.current === "auto") return resolve("allow");
+              if (modeRef.current === "auto") {
+                resolve("allow");
+                return;
+              }
+              if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
+                if (req.tool.name === "bash" && typeof req.args.command === "string" && isReadOnlyBash(req.args.command)) {
+                  resolve("allow");
+                  return;
+                }
+                setEvents((e) => [
+                  ...e,
+                  {
+                    kind: "info",
+                    key: mkKey(),
+                    text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
+                  },
+                ]);
+                resolve("deny");
+                return;
+              }
               setPerm({ tool: req.tool, args: req.args, resolve });
             }),
         },
@@ -922,6 +941,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                   return;
                 }
                 if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
+                  if (req.tool.name === "bash" && typeof req.args.command === "string" && isReadOnlyBash(req.args.command)) {
+                    resolve("allow");
+                    return;
+                  }
                   setEvents((e) => [
                     ...e,
                     {

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -12,7 +12,7 @@ export function modeDescription(m: Mode): string {
     case "edit":
       return "edit — default; prompts for permission before mutating tools";
     case "plan":
-      return "plan — read-only research; blocks writes/edits/bash until you exit plan mode";
+      return "plan — read-only research; blocks writes/edits/mutating bash until you exit plan mode";
     case "auto":
       return "auto — autonomous; auto-approves every tool call (use with care)";
   }
@@ -24,9 +24,179 @@ export function isBlockedInPlanMode(toolName: string): boolean {
   return MUTATING_TOOLS.has(toolName);
 }
 
+// Dangerous shell patterns that disqualify any command from read-only status
+const DANGEROUS_PATTERNS = /[<>|;&`$]|\$\(|\$\{|&&|\|\||\b&\s*$/;
+
+// Git subcommands that are read-only (value = true means always safe, false means needs arg check)
+const GIT_READONLY_SUBCOMMANDS: Record<string, boolean> = {
+  log: true,
+  diff: true,
+  status: true,
+  show: true,
+  blame: true,
+  describe: true,
+  "rev-parse": true,
+  "ls-files": true,
+  reflog: true,
+  shortlog: true,
+  whatchanged: true,
+  grep: true,
+  branch: false, // needs check: block -d/-D/-m/-M/-c/-C
+  stash: false, // needs check: only allow "list"
+  remote: false, // needs check: only allow -v
+  tag: false, // needs check: only allow -l
+  config: false, // needs check: only allow --list/--get
+};
+
+// Whitelisted non-git commands (must be exact first token)
+const READONLY_COMMANDS = new Set([
+  // File system
+  "ls", "cat", "head", "tail", "pwd", "echo",
+  "file", "stat", "readlink", "realpath", "dirname", "basename",
+  "wc", "sort", "uniq", "diff", "cmp",
+  // Search
+  "grep", "rg", "ag", "fd",
+  // System info
+  "ps", "df", "du", "env", "printenv", "which", "whereis",
+  "uname", "hostname", "uptime", "free", "date", "id", "whoami", "groups",
+  // Dev tools (version/info only)
+  "node", "npx", "python3", "ruby", "perl",
+  // Utilities
+  "jq", "yq", "awk", "cut", "tr",
+  "base64", "sha256sum", "md5sum", "shasum", "hexdump", "xxd", "strings",
+  "less", "more", "man", "clear", "history",
+  // Archive inspection
+  "zipinfo",
+  // Network
+  "ping", "netstat", "ss", "lsof",
+]);
+
+// Commands that need argument validation
+const COMMANDS_NEEDING_ARG_CHECK: Record<string, (args: string[]) => boolean> = {
+  find: (args) => !args.some((a) => a === "-delete" || a === "-exec"),
+  sed: (args) => !args.some((a) => a === "-i" || a.startsWith("-i")),
+  tar: (args) => args[0] === "-tf" || args[0] === "--list",
+  unzip: (args) => args[0] === "-l",
+  curl: (args) =>
+    !args.some((a) => a === "-o" || a === "-O" || a === "-d" || a === "--data" || a.startsWith("-X")),
+  wget: (args) =>
+    !args.some((a) => a === "-O" || a === "--output-document" || a.startsWith("--post")),
+  npm: (args) =>
+    ["list", "view", "config"].includes(args[0] ?? "") &&
+    !(args[0] === "config" && args[1] && !args[1].startsWith("get") && args[1] !== "list"),
+  tsc: (args) =>
+    args.every((a) =>
+      ["--noEmit", "--version", "--showConfig", "--help", "-h", "--init"].includes(a),
+    ),
+  eslint: (args) =>
+    args.every((a) =>
+      ["--version", "--print-config", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  prettier: (args) =>
+    args.every((a) =>
+      ["--version", "--check", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  jest: (args) =>
+    args.every((a) =>
+      ["--version", "--listTests", "--showConfig", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  vitest: (args) =>
+    args.every((a) =>
+      ["--version", "--help", "-h"].includes(a) || !a.startsWith("-"),
+    ),
+  go: (args) =>
+    ["version", "env", "list", "mod"].includes(args[0] ?? "") &&
+    !(args[0] === "mod" && args[1] && !["graph", "download", "why", "verify"].includes(args[1])),
+  cargo: (args) =>
+    ["--version", "-V", "check", "test", "metadata"].includes(args[0] ?? "") &&
+    !(args[0] === "test" && args.includes("--no-run") === false),
+};
+
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+  for (const ch of command) {
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+export function isReadOnlyBash(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+
+  // Reject any command with dangerous shell patterns
+  if (DANGEROUS_PATTERNS.test(trimmed)) return false;
+
+  const tokens = tokenizeCommand(trimmed);
+  if (tokens.length === 0) return false;
+
+  const first = tokens[0]!;
+
+  // Handle cd prefix: cd somewhere && real_command
+  let cmdIndex = 0;
+  if (first === "cd" && tokens.length >= 3 && tokens[1] && tokens[2] === "&&") {
+    cmdIndex = 3;
+  }
+
+  const cmd = tokens[cmdIndex];
+  if (!cmd) return false;
+  const args = tokens.slice(cmdIndex + 1);
+
+  // Git commands
+  if (cmd === "git") {
+    const sub = args[0] ?? "";
+    const allowed = GIT_READONLY_SUBCOMMANDS[sub];
+    if (allowed === undefined) return false;
+    if (allowed === true) return true;
+
+    // Needs extra validation
+    switch (sub) {
+      case "branch":
+        return !args.some((a) => /^-[dDmMcC]/.test(a));
+      case "stash":
+        return args[1] === "list";
+      case "remote":
+        return args[1] === "-v" || args[1] === "--verbose" || args.length === 1;
+      case "tag":
+        return args[1] === "-l" || args[1] === "--list" || args.length === 1;
+      case "config":
+        return args[1] === "--list" || args[1]?.startsWith("--get") === true || args.length === 1;
+      default:
+        return false;
+    }
+  }
+
+  // Commands needing argument validation
+  const argCheck = COMMANDS_NEEDING_ARG_CHECK[cmd];
+  if (argCheck) {
+    return argCheck(args);
+  }
+
+  // Simple whitelist
+  return READONLY_COMMANDS.has(cmd);
+}
+
 export function systemPromptForMode(m: Mode): string {
   if (m === "plan") {
-    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or bash. Only use read/glob/grep/web-fetch. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
+    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or mutating bash commands. You may use read-only bash commands (e.g., git log, git diff, ls, cat) along with read/glob/grep/web-fetch. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
   }
   if (m === "auto") {
     return "\n\nAUTO MODE is active. The user has opted into autonomous execution — every tool call will be auto-approved. Work efficiently, but do not take irreversible destructive actions (rm -rf, git push --force, dropping tables, etc.) without pausing to describe them in chat first. Prefer smaller reversible steps.";


### PR DESCRIPTION
This PR includes:

- **docs:** rewrite README and landing page for clarity and polish
- **fix(docs):** remove stray X placeholders from landing page buttons
- **feat:** allow read-only bash commands in plan mode

### Files changed
- `README.md` — rewritten with improved structure and content
- `docs/index.html` — updated landing page
- `docs/screenshot.png` — new screenshot asset
- `src/app.tsx` — TUI adjustments
- `src/mode.ts` — plan mode logic for read-only bash commands