### PR TITLE
feat: image understanding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 ## Why kimiflare
 
 - **262k context window** — Read entire modules, large configs, and full stack traces without the model losing track.
+- **Image understanding** — Drop image paths into your prompt (PNG, JPG, WebP, GIF, BMP). The model sees them inline — great for UI reviews, diagrams, screenshots, and mockups.
 - **Direct to Cloudflare** — No AI Gateway, no proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account.
 - **Plan mode** — Ask the agent to research and produce a plan without touching your filesystem. Review it, then exit plan mode to execute.
 
@@ -53,6 +54,7 @@ Requires Node.js ≥ 20.
 | **Type-ahead queue** | Type your next prompt while the model is still working. Queued prompts show as `⏳ …` and fire in order. `Ctrl-C` aborts current + clears queue. |
 | **Auto-compaction** | At ~80% context usage, kimiflare nudges you to run `/compact`. It summarizes older turns into a dense summary, keeping the last 4 turns intact. |
 | **Streaming reasoning** | Toggle the model's chain-of-thought with `/reasoning` or `Ctrl-R`. See how it thinks in real time. |
+| **Image understanding** | Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. The model sees them inline — perfect for UI reviews, diagrams, and screenshots. |
 | **Live cost tracking** | Status bar shows real-time cost based on Cloudflare pricing: `$0.95/M input`, `$0.16/M cached`, `$4.00/M output`. |
 | **Session persistence** | Every turn is auto-saved. `/resume` lists past sessions (with message counts) in a paginated picker. |
 | **Smart permissions** | Bash session-allow is keyed by the first token (e.g., allow all `git` commands). Write/edit show a unified diff before you approve. |
@@ -104,6 +106,19 @@ kimiflare -p "summarize PLAN.md"                    # stream answer to stdout
 kimiflare -p "..." --dangerously-allow-all          # auto-approve mutating tools (for scripts)
 kimiflare -p "..." --reasoning                      # include chain-of-thought in stderr
 ```
+
+### Image understanding
+
+Reference image files directly in your prompt — the model sees them inline:
+
+```sh
+kimiflare
+› fix the layout bug in this screenshot docs/bug.png
+› convert this mockup design.png to Tailwind HTML
+› explain this architecture diagram.png
+```
+
+Supported formats: PNG, JPG, JPEG, WebP, GIF, BMP (up to 5 MB each, 10 per message).
 
 ### CLI flags
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>kimiflare — AI coding agent in your terminal</title>
-  <meta name="description" content="A terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Open-weight, direct to Cloudflare.">
+  <meta name="description" content="A terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Image understanding, plan mode, 262k context. Direct to Cloudflare.">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://sinameraji.github.io/kimiflare/">
   <meta name="theme-color" content="#f48120">
 
   <!-- Open Graph -->
   <meta property="og:title" content="kimiflare — AI coding agent in your terminal">
-  <meta property="og:description" content="Moonshot's open-weight Kimi running on your own Cloudflare account. No middleman.">
+  <meta property="og:description" content="Moonshot's open-weight Kimi running on your own Cloudflare account. Image understanding, plan mode, 262k context. No middleman.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://sinameraji.github.io/kimiflare/">
   <meta property="og:image" content="https://sinameraji.github.io/kimiflare/logo.png">
@@ -19,7 +19,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="kimiflare — AI coding agent in your terminal">
-  <meta name="twitter:description" content="Moonshot's open-weight Kimi running on your own Cloudflare account. No middleman.">
+  <meta name="twitter:description" content="Moonshot's open-weight Kimi running on your own Cloudflare account. Image understanding, plan mode, 262k context. No middleman.">
   <meta name="twitter:image" content="https://sinameraji.github.io/kimiflare/logo.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -32,7 +32,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "kimiflare",
-    "description": "A terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Open-weight, direct to Cloudflare.",
+    "description": "A terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Image understanding, plan mode, 262k context. Direct to Cloudflare.",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux, Windows",
     "offers": {
@@ -578,7 +578,7 @@
       Kimi K2.6 + Cloudflare<br>in your terminal.<br>No middleman.
     </h1>
     <p class="hero-subtitle fade-in delay-2">
-      A terminal coding agent with plan mode, live task panels, 14 themes, and 262k context. Direct to Cloudflare — no middleman.
+      A terminal coding agent with image understanding, plan mode, live task panels, 14 themes, and 262k context. Direct to Cloudflare — no middleman.
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
@@ -702,41 +702,46 @@
       </div>
       <div class="feature-item">
         <span class="feature-num">03</span>
+        <h3>Image understanding</h3>
+        <p>Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. The model sees them inline — perfect for UI reviews, diagrams, and screenshots.</p>
+      </div>
+      <div class="feature-item">
+        <span class="feature-num">04</span>
         <h3>14 terminal themes</h3>
         <p>dark, light, high-contrast, dracula, nord, one-dark, monokai, solarized, tokyo-night, gruvbox, catppuccin, rose-pine. Live preview with Ctrl+T.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">04</span>
+        <span class="feature-num">05</span>
         <h3>Paste collapse</h3>
         <p>Large pastes collapse to <code>[pasted N lines #id]</code>. Full content still goes to the model — scrollback stays clean.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">05</span>
+        <span class="feature-num">06</span>
         <h3>Type-ahead queue</h3>
         <p>Type your next prompt while the model is still working. Queued prompts fire in order. Ctrl-C aborts current and clears queue.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">06</span>
+        <span class="feature-num">07</span>
         <h3>Auto-compaction</h3>
         <p>At ~80% context usage, kimiflare nudges you to run /compact. It summarizes older turns, keeping the last 4 intact.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">07</span>
+        <span class="feature-num">08</span>
         <h3>Streaming reasoning</h3>
         <p>Toggle the model's chain-of-thought with /reasoning or Ctrl-R. See how it thinks in real time.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">08</span>
+        <span class="feature-num">09</span>
         <h3>Session persistence</h3>
         <p>Every turn is auto-saved. /resume lists past sessions with message counts in a paginated picker. Never lose your place.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">09</span>
+        <span class="feature-num">10</span>
         <h3>Smart permissions</h3>
         <p>Bash session-allow is keyed by the first token (allow all git commands). Write/edit show a unified diff before you approve.</p>
       </div>
       <div class="feature-item">
-        <span class="feature-num">10</span>
+        <span class="feature-num">11</span>
         <h3>262K context window</h3>
         <p>Read entire modules, large configs, and full stack traces without the model losing track. Direct to Cloudflare — no middleman.</p>
       </div>
@@ -827,7 +832,11 @@
 <span class="v">kimiflare</span> --model @cf/moonshotai/kimi-k2.6<br>
 <br>
 <span class="c"># Stream reasoning to stderr</span><br>
-<span class="v">kimiflare</span> --reasoning
+<span class="v">kimiflare</span> --reasoning<br>
+<br>
+<span class="c"># Image understanding — reference images inline</span><br>
+<span class="v">kimiflare</span><br>
+<span class="v">kimiflare</span> -p <span class="s">"explain this diagram.png"
       </div>
     </div>
   </section>
@@ -904,9 +913,9 @@
     // Typing effect
     const phrases = [
       "explain this codebase",
-      "find and fix a bug",
+      "fix the layout bug in screenshot.png",
       "refactor a file",
-      "write tests for utils.ts"
+      "convert mockup.png to Tailwind HTML"
     ];
     let phraseIndex = 0;
     let charIndex = 0;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,22 @@
 {
   "name": "kimiflare",
   "version": "0.11.0",
-  "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI.",
+  "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Image understanding, plan mode, 262k context.",
+  "keywords": [
+    "ai",
+    "cli",
+    "coding-agent",
+    "terminal",
+    "kimi",
+    "k2.6",
+    "cloudflare",
+    "workers-ai",
+    "vision",
+    "image-understanding",
+    "llm",
+    "code-generation",
+    "tui"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sinameraji/kimiflare.git"

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -1,6 +1,6 @@
 import { readSSE } from "../util/sse.js";
 import { KimiApiError } from "../util/errors.js";
-import { jsonReplacer } from "./messages.js";
+import { jsonReplacer, sanitizeString } from "./messages.js";
 import type { ChatMessage, ToolDef, Usage } from "./messages.js";
 
 export type KimiEvent =
@@ -212,10 +212,19 @@ interface StreamToolCall {
 
 function sanitizeMessagesForApi(messages: ChatMessage[]): ChatMessage[] {
   return messages.map((m) => {
-    if (!m.tool_calls || m.tool_calls.length === 0) return m;
+    let next: ChatMessage = m;
+    if (Array.isArray(m.content)) {
+      next = {
+        ...m,
+        content: m.content.map((part) =>
+          part.type === "text" ? { ...part, text: sanitizeString(part.text) } : part,
+        ),
+      };
+    }
+    if (!next.tool_calls || next.tool_calls.length === 0) return next;
     return {
-      ...m,
-      tool_calls: m.tool_calls.map((tc) => ({
+      ...next,
+      tool_calls: next.tool_calls.map((tc) => ({
         ...tc,
         function: {
           name: tc.function.name,

--- a/src/agent/compact.ts
+++ b/src/agent/compact.ts
@@ -54,17 +54,21 @@ export async function compactMessages(opts: CompactOpts): Promise<CompactResult>
 
   const transcript = toSummarize
     .map((m) => {
+      const contentStr =
+        typeof m.content === "string"
+          ? m.content
+          : m.content?.map((p) => (p.type === "text" ? p.text : "[image]")).join(" ") ?? "";
       if (m.role === "tool") {
-        const snippet = (m.content ?? "").slice(0, 500);
+        const snippet = contentStr.slice(0, 500);
         return `[tool ${m.name ?? ""}] ${snippet}`;
       }
       if (m.role === "assistant") {
         const calls = m.tool_calls
           ? ` (tool_calls: ${m.tool_calls.map((c) => c.function.name).join(", ")})`
           : "";
-        return `[assistant]${calls} ${m.content ?? ""}`;
+        return `[assistant]${calls} ${contentStr}`;
       }
-      return `[${m.role}] ${m.content ?? ""}`;
+      return `[${m.role}] ${contentStr}`;
     })
     .join("\n");
 

--- a/src/agent/messages.ts
+++ b/src/agent/messages.ts
@@ -6,9 +6,21 @@ export interface ToolCall {
   function: { name: string; arguments: string };
 }
 
+export interface TextContentPart {
+  type: "text";
+  text: string;
+}
+
+export interface ImageContentPart {
+  type: "image_url";
+  image_url: { url: string };
+}
+
+export type ContentPart = TextContentPart | ImageContentPart;
+
 export interface ChatMessage {
   role: Role;
-  content: string | null;
+  content: string | ContentPart[] | null;
   reasoning_content?: string | null;
   tool_calls?: ToolCall[];
   tool_call_id?: string;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,7 +7,7 @@ import { compactMessages } from "./agent/compact.js";
 import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/executor.js";
 import type { ToolSpec } from "./tools/registry.js";
 import { sanitizeString } from "./agent/messages.js";
-import type { ChatMessage, Usage } from "./agent/messages.js";
+import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
 import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
@@ -41,6 +41,7 @@ import {
   type SessionSummary,
 } from "./sessions.js";
 import { unlink } from "node:fs/promises";
+import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
 
 interface Cfg {
   accountId: string;
@@ -70,6 +71,19 @@ const mkKey = () => `evt_${nextKey++}`;
 function capEvents(prev: ChatEvent[]): ChatEvent[] {
   if (prev.length <= MAX_EVENTS) return prev;
   return prev.slice(prev.length - MAX_EVENTS);
+}
+
+const MAX_IMAGES_PER_MESSAGE = 10;
+
+function findImagePaths(text: string): string[] {
+  const paths: string[] = [];
+  for (const token of text.split(/\s+/)) {
+    const clean = token.replace(/^["']|["',;:!?]$/g, "").replace(/[.,;:!?]$/, "");
+    if (isImagePath(clean) && existsSync(clean)) {
+      paths.push(clean);
+    }
+  }
+  return [...new Set(paths)];
 }
 
 const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
@@ -262,8 +276,13 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     if (!cfg) return;
     if (!sessionIdRef.current) {
       const firstUser = messagesRef.current.find((m) => m.role === "user");
-      const firstText =
-        typeof firstUser?.content === "string" ? firstUser.content : "session";
+      let firstText = "session";
+      if (typeof firstUser?.content === "string") {
+        firstText = firstUser.content;
+      } else if (Array.isArray(firstUser?.content)) {
+        const textPart = firstUser.content.find((p) => p.type === "text");
+        if (textPart?.text) firstText = textPart.text;
+      }
       sessionIdRef.current = makeSessionId(firstText);
     }
     try {
@@ -568,8 +587,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           },
         ]);
         const userMsgs = file.messages
-          .filter((m) => m.role === "user" && typeof m.content === "string")
-          .map((m) => m.content as string);
+          .filter((m) => m.role === "user" && m.content)
+          .map((m) => {
+            if (!m.content) return "";
+            if (typeof m.content === "string") return m.content;
+            const textPart = m.content.find((p) => p.type === "text");
+            return textPart?.text ?? "";
+          })
+          .filter((text) => text.length > 0);
         if (userMsgs.length > 0) setHistory(userMsgs);
         setUsage(null);
       } catch (e) {
@@ -844,8 +869,38 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       if (trimmed.startsWith("/") && handleSlash(trimmed)) return;
 
       const display = displayText?.trim() || trimmed;
-      setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display }]);
-      messagesRef.current.push({ role: "user", content: sanitizeString(trimmed) });
+      const imagePaths = findImagePaths(trimmed).slice(0, MAX_IMAGES_PER_MESSAGE);
+      let images: string[] = [];
+      let content: string | ContentPart[] = sanitizeString(trimmed);
+
+      if (imagePaths.length > 0) {
+        const encoded = await Promise.all(
+          imagePaths.map(async (path) => {
+            try {
+              const img = await encodeImageFile(path);
+              return { path, img };
+            } catch (e) {
+              setEvents((es) => [
+                ...es,
+                { kind: "error", key: mkKey(), text: `failed to encode image ${path}: ${(e as Error).message}` },
+              ]);
+              return null;
+            }
+          }),
+        );
+        const valid = encoded.filter((x): x is { path: string; img: EncodedImage } => x !== null);
+        if (valid.length > 0) {
+          images = valid.map((v) => v.img.filename);
+          const parts: ContentPart[] = [
+            { type: "text", text: sanitizeString(trimmed) },
+            ...valid.map((v) => ({ type: "image_url" as const, image_url: { url: v.img.dataUrl } })),
+          ];
+          content = parts;
+        }
+      }
+
+      setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined }]);
+      messagesRef.current.push({ role: "user", content });
       setBusy(true);
       setTurnStartedAt(Date.now());
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -66,7 +66,11 @@ export async function listSessions(limit = 30): Promise<SessionSummary[]> {
       const parsed = JSON.parse(raw) as SessionFile;
       const firstUser = parsed.messages.find((m) => m.role === "user");
       const firstPrompt =
-        typeof firstUser?.content === "string" ? firstUser.content : "(no prompt)";
+        typeof firstUser?.content === "string"
+          ? firstUser.content
+          : firstUser?.content
+            ? firstUser.content.find((p) => p.type === "text")?.text ?? "(no prompt)"
+            : "(no prompt)";
       summaries.push({
         id: parsed.id,
         filePath: path,

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -6,7 +6,7 @@ import { MD } from "./markdown.js";
 import type { Theme } from "./theme.js";
 
 export type ChatEvent =
-  | { kind: "user"; key: string; text: string }
+  | { kind: "user"; key: string; text: string; images?: string[] }
   | {
       kind: "assistant";
       key: string;
@@ -63,11 +63,20 @@ function EventView({
 }) {
   if (evt.kind === "user") {
     return (
-      <Box>
-        <Text bold color={theme.user}>
-          ›{" "}
-        </Text>
-        <Text bold>{evt.text}</Text>
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={theme.user}>
+            ›{" "}
+          </Text>
+          <Text bold>{evt.text}</Text>
+        </Box>
+        {evt.images && evt.images.length > 0 && (
+          <Box paddingLeft={2}>
+            <Text color={theme.info.color} dimColor={theme.info.dim}>
+              🖼️ {evt.images.join(", ")}
+            </Text>
+          </Box>
+        )}
       </Box>
     );
   }

--- a/src/util/image.ts
+++ b/src/util/image.ts
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+const EXT_TO_MIME: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+};
+
+export interface EncodedImage {
+  filename: string;
+  mime: string;
+  dataUrl: string;
+}
+
+export async function encodeImageFile(filePath: string): Promise<EncodedImage> {
+  const buf = await readFile(filePath);
+  if (buf.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error(
+      `image too large (${(buf.byteLength / 1024 / 1024).toFixed(1)} MB); max is ${MAX_IMAGE_BYTES / 1024 / 1024} MB`,
+    );
+  }
+  const ext = filePath.slice(filePath.lastIndexOf(".")).toLowerCase();
+  const mime = EXT_TO_MIME[ext] ?? "image/jpeg";
+  const b64 = buf.toString("base64");
+  return {
+    filename: basename(filePath),
+    mime,
+    dataUrl: `data:${mime};base64,${b64}`,
+  };
+}
+
+export function isImagePath(path: string): boolean {
+  const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+  return ext in EXT_TO_MIME;
+}


### PR DESCRIPTION
This PR adds image understanding (vision) support to kimiflare.

## What's new

- **Image understanding** — Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. The model sees them inline via base64 data URLs sent as OpenAI-compatible  content parts.
- Up to 10 images per message.
- Images are displayed in the TUI chat as 🖼️ attachments.
- Session resume, compaction, and listing all handle array  properly.

## Files changed

-  — new image encoding utility
-  — detect image paths, encode, send as 
-  —  types
-  — sanitize array content for API
-  — display image attachments
-  — handle array content in transcripts
-  — extract text from array content for summaries
- , ,  — documentation & discoverability

## Usage

