### PR TITLE
docs: simplify landing page headline and subtitle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="kimiflare — AI coding agent in your terminal">
-  <meta property="og:description" content="Moonshot's open-weight Kimi running on your own Cloudflare account. Image understanding, plan mode, 262k context. No middleman.">
+  <meta property="og:description" content="Read files, edit code, and run commands — directly through your Cloudflare account. No middleman.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://sinameraji.github.io/kimiflare/">
   <meta property="og:image" content="https://sinameraji.github.io/kimiflare/logo.png">
@@ -19,7 +19,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="kimiflare — AI coding agent in your terminal">
-  <meta name="twitter:description" content="Moonshot's open-weight Kimi running on your own Cloudflare account. Image understanding, plan mode, 262k context. No middleman.">
+  <meta name="twitter:description" content="Read files, edit code, and run commands — directly through your Cloudflare account. No middleman.">
   <meta name="twitter:image" content="https://sinameraji.github.io/kimiflare/logo.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -575,10 +575,10 @@
   <section class="hero">
     <div class="hero-label fade-in">Kimi-K2.6 · Cloudflare Workers AI</div>
     <h1 class="fade-in delay-1">
-      Kimi K2.6 + Cloudflare<br>in your terminal.<br>No middleman.
+      Kimi K2.6 in your terminal.
     </h1>
     <p class="hero-subtitle fade-in delay-2">
-      A terminal coding agent with image understanding, plan mode, live task panels, 14 themes, and 262k context. Direct to Cloudflare — no middleman.
+      Read files, edit code, and run commands — directly through your Cloudflare account. No middleman.
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>


### PR DESCRIPTION
- Remove redundant 'Cloudflare' and 'No middleman' from headline
- Replace feature-list subtitle with action-oriented description
- Update OG/Twitter meta descriptions to match