### PR TITLE
fix: robust co-author injection for all git commit-creating commands

### DIFF
--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -70,7 +70,7 @@ How to work:
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.
 - If a request is ambiguous, ask one focused question instead of making large assumptions.
 - When you finish a task, stop. Do not add a closing summary.
-- When creating git commits, you may include \`Co-authored-by: kimiflare <kimiflare@proton.me>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects \`git commit\` commands.`;
+- When creating git commits, you must include \`Co-authored-by: kimiflare <kimiflare@proton.me>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects git commit-creating commands.`;
 
   const ctx = loadContextFile(opts.cwd);
   const contextBlock = ctx

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ToolSpec, ToolContext } from "./registry.js";
 import { truncate } from "../util/paths.js";
 
@@ -46,15 +48,38 @@ function injectCoauthor(command: string, coauthor?: { name: string; email: strin
   const trailer = `Co-authored-by: ${coauthor.name} <${coauthor.email}>`;
 
   const trimmed = command.trim();
-  if (!/\bgit\s+commit\b/.test(trimmed)) return command;
   if (command.includes(trailer)) return command;
-  // Skip dry-run or rebase-continue style invocations
-  if (/\b(--dry-run|-n)\b/.test(trimmed) && !/-m\b|--message\b/.test(trimmed)) return command;
 
-  const tmpFile = `/tmp/kf-coauthor-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const check = `! git log -1 --pretty=%B 2>/dev/null | grep -qF "${trailer}"`;
-  const append = `git log -1 --pretty=%B | git interpret-trailers --trailer "${trailer}" > "${tmpFile}" && git commit --amend -F "${tmpFile}" --no-edit && rm -f "${tmpFile}"`;
-  return `(${command}) && ${check} && ${append}`;
+  // Detect git commands that create commits
+  const createsCommit = /\bgit\s+(commit|merge|revert|cherry-pick)\b/.test(trimmed);
+  const isRebaseContinue = /\bgit\s+rebase\b/.test(trimmed) && !/\b--abort\b|\b--skip\b/.test(trimmed);
+  const mentionsGit = /\bgit\b/.test(trimmed);
+
+  if (!createsCommit && !isRebaseContinue && !mentionsGit) return command;
+
+  const tmpFile = join(tmpdir(), `kf-coauthor-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  const amendBlock = `
+    if ! git log -1 --pretty=%B 2>/dev/null | grep -qF "${trailer}"; then
+      git log -1 --pretty=%B | git interpret-trailers --trailer "${trailer}" > "${tmpFile}" && git commit --amend -F "${tmpFile}" --no-edit && rm -f "${tmpFile}"
+    fi
+  `.trim();
+
+  if (createsCommit || isRebaseContinue) {
+    // Primary path: known commit-creating command — amend immediately after success
+    return `(${command}) && { ${amendBlock}; }`;
+  }
+
+  // Safety net: command mentions git but isn't obviously commit-creating
+  // (e.g., a script or Makefile that calls git internally).
+  // Record HEAD before and after; amend if a new commit lacks the trailer.
+  const beforeHead = `git rev-parse HEAD 2>/dev/null || echo "NO_HEAD"`;
+  const afterCheck = `
+    _KF_AFTER_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "NO_HEAD")
+    if [ "$_KF_BEFORE_HEAD" != "$_KF_AFTER_HEAD" ] && [ "$_KF_AFTER_HEAD" != "NO_HEAD" ]; then
+      ${amendBlock}
+    fi
+  `.trim();
+  return `_KF_BEFORE_HEAD=$(${beforeHead}); (${command}); _KF_EXIT=$?; [ $_KF_EXIT -eq 0 ] && { ${afterCheck}; }; exit $_KF_EXIT`;
 }
 
 function runBash(args: Args, ctx: ToolContext): Promise<string> {


### PR DESCRIPTION
## Problem
The co-author trailer was often missed for commits created by kimiflare. The previous implementation only detected explicit `git commit` commands via regex, missing:
- `git merge`, `git revert`, `git cherry-pick`
- `git rebase --continue`
- Commits made inside scripts, Makefiles, or other indirect invocations
- It also had a buggy skip for `-n` (meant to catch dry-run but actually skipped `--no-verify` commits)

## Changes
- **Expand detection** to catch `git merge`, `git revert`, `git cherry-pick`, and `git rebase` (excluding `--abort` / `--skip`)
- **Add safety net** for any bash command mentioning `git` that doesn't match the explicit regex — records HEAD before/after and amends if a new commit lacks the trailer
- **Remove buggy dry-run check** that incorrectly skipped commits using `-n` (`--no-verify`)
- **Use `os.tmpdir()`** instead of hardcoded `/tmp` for cross-platform portability
- **Use `grep || amend`** instead of `! grep && amend` for better shell compatibility
- **Strengthen system prompt** from "you may include" to "you must include" the co-author trailer

## Limitations
GitHub-generated commits (merge commits from the "Merge pull request" button, release-please commits) are still created by GitHub/GitHub Actions and cannot be amended by the local bash tool. These require repository-level changes (e.g., squash merging, or a post-merge GitHub Action) if they also need the co-author trailer.