### PR TITLE
fix: prevent Ctrl+C from hanging the app

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -223,6 +223,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const updateCheckedRef = useRef(false);
   const updateNudgedRef = useRef(false);
   const compactSuggestedRef = useRef(false);
+  const interruptRequestedRef = useRef(false);
 
   useEffect(() => {
     if (!cfg || updateCheckedRef.current) return;
@@ -372,6 +373,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
       if (busy) {
+        if (interruptRequestedRef.current) {
+          process.exit(0);
+        }
+        interruptRequestedRef.current = true;
         activeControllerRef.current?.abort();
         permResolveRef.current?.("deny");
         permResolveRef.current = null;
@@ -470,6 +475,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       setBusy(false);
       setTurnStartedAt(null);
       activeControllerRef.current = null;
+      interruptRequestedRef.current = false;
     }
   }, [cfg, busy, saveSessionSafe]);
 
@@ -660,6 +666,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
       permResolveRef.current = null;
+      interruptRequestedRef.current = false;
     }
   }, [cfg, busy, updateAssistant, updateTool]);
 
@@ -1155,10 +1162,19 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
         permResolveRef.current = null;
+        interruptRequestedRef.current = false;
       }
     },
     [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],
   );
+
+  useEffect(() => {
+    const onSigint = () => exit();
+    process.on("SIGINT", onSigint);
+    return () => {
+      process.off("SIGINT", onSigint);
+    };
+  }, [exit]);
 
   useEffect(() => {
     if (!busy && queue.length > 0) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -112,7 +112,10 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
   ];
 
   const controller = new AbortController();
-  process.on("SIGINT", () => controller.abort());
+  process.once("SIGINT", () => {
+    controller.abort();
+    setTimeout(() => process.exit(1), 500);
+  });
 
   let printedReasoningHeader = false;
   let printedAnswerHeader = false;

--- a/src/util/sse.ts
+++ b/src/util/sse.ts
@@ -13,6 +13,10 @@ export async function* readSSE(
   const reader = stream.getReader();
   const decoder = new TextDecoder("utf-8");
   let buffer = "";
+
+  const onAbort = () => reader.cancel(new DOMException("aborted", "AbortError"));
+  signal?.addEventListener("abort", onAbort, { once: true });
+
   try {
     while (true) {
       if (signal?.aborted) throw new DOMException("aborted", "AbortError");
@@ -34,6 +38,7 @@ export async function* readSSE(
     const tail = extractData(buffer.trim());
     if (tail !== null) yield tail;
   } finally {
+    signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
   }
 }


### PR DESCRIPTION
- Force-cancel the SSE reader on abort so pending reads don't block forever
- Implement double-tap Ctrl+C: second press exits if first didn't break the loop
- Add global SIGINT handler in TUI mode for graceful Ink cleanup
- Ensure print mode exits after abort grace period