### PR TITLE
fix: remove redundant global SIGINT handler causing screen flashing

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1169,14 +1169,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   );
 
   useEffect(() => {
-    const onSigint = () => exit();
-    process.on("SIGINT", onSigint);
-    return () => {
-      process.off("SIGINT", onSigint);
-    };
-  }, [exit]);
-
-  useEffect(() => {
     if (!busy && queue.length > 0) {
       const next = queue[0]!;
       setQueue((q) => q.slice(1));


### PR DESCRIPTION
## Problem

Commit c6e9c1f added a raw `process.on('SIGINT')` handler that unconditionally called Ink's `exit()`. This conflicted with the existing `useInput` Ctrl+C logic:

- When busy, `useInput` interrupts the operation **without** exiting.
- But the SIGINT signal also fired, triggering `exit()`.
- Ink unmounted while async work was still running, corrupting terminal state and causing visible flashing on every subsequent render (including Ctrl+O toggles and new chat events).

## Fix

Remove the redundant global SIGINT handler. The `useInput` handler already covers all cases:
- Not busy → `exit()` (graceful Ink cleanup)
- Busy, first Ctrl+C → interrupt operation
- Busy, second Ctrl+C → `process.exit(0)` (force kill)

## Verification

- `npm run typecheck` passes.
- Manual testing confirms no more flashing when interrupting or toggling verbose mode.