### PR TITLE
revert: roll ctrl+c interrupt work back to v0.12.0 behavior

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -214,7 +214,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const executorRef = useRef<ToolExecutor>(new ToolExecutor(ALL_TOOLS));
   const activeAsstIdRef = useRef<number | null>(null);
   const activeControllerRef = useRef<AbortController | null>(null);
-  const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const modeRef = useRef<Mode>(mode);
   const effortRef = useRef<ReasoningEffort>(effort);
@@ -371,11 +370,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
 
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
-      if (busy) {
-        activeControllerRef.current?.abort();
-        permResolveRef.current?.("deny");
-        permResolveRef.current = null;
-        setPerm(null);
+      if (busy && activeControllerRef.current) {
+        activeControllerRef.current.abort();
         setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
       } else {
@@ -609,11 +605,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                 resolve("deny");
                 return;
               }
-              permResolveRef.current = resolve;
-              setPerm({ tool: req.tool, args: req.args, resolve: (d) => {
-                permResolveRef.current = null;
-                resolve(d);
-              } });
+              setPerm({ tool: req.tool, args: req.args, resolve });
             }),
         },
       });
@@ -641,25 +633,17 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         ]);
       }
     } catch (e) {
-      if ((e as Error).name === "AbortError") {
-        setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
-        setEvents((evts) =>
-          evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
-        );
-      } else {
+      if ((e as Error).name !== "AbortError") {
         setEvents((es) => [
           ...es,
           { kind: "error", key: mkKey(), text: `init failed: ${(e as Error).message}` },
         ]);
       }
     } finally {
-      const asstId = activeAsstIdRef.current;
-      if (asstId !== null) updateAssistant(asstId, () => ({ streaming: false }));
       setBusy(false);
       setTurnStartedAt(null);
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
-      permResolveRef.current = null;
     }
   }, [cfg, busy, updateAssistant, updateTool]);
 
@@ -1103,11 +1087,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                   resolve("deny");
                   return;
                 }
-                permResolveRef.current = resolve;
-                setPerm({ tool: req.tool, args: req.args, resolve: (d) => {
-                  permResolveRef.current = null;
-                  resolve(d);
-                } });
+                setPerm({ tool: req.tool, args: req.args, resolve });
               }),
           },
         });
@@ -1121,10 +1101,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         void saveSessionSafe();
       } catch (e) {
         if ((e as Error).name === "AbortError") {
-          setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
-          setEvents((evts) =>
-            evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
-          );
+          setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(aborted)" }]);
         } else {
           const isInvalidJson400 =
             e instanceof KimiApiError &&
@@ -1148,13 +1125,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           }
         }
       } finally {
-        const asstId = activeAsstIdRef.current;
-        if (asstId !== null) updateAssistant(asstId, () => ({ streaming: false }));
         setBusy(false);
         setTurnStartedAt(null);
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
-        permResolveRef.current = null;
       }
     },
     [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1169,6 +1169,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   );
 
   useEffect(() => {
+    const onSigint = () => exit();
+    process.on("SIGINT", onSigint);
+    return () => {
+      process.off("SIGINT", onSigint);
+    };
+  }, [exit]);
+
+  useEffect(() => {
     if (!busy && queue.length > 0) {
       const next = queue[0]!;
       setQueue((q) => q.slice(1));

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -223,7 +223,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const updateCheckedRef = useRef(false);
   const updateNudgedRef = useRef(false);
   const compactSuggestedRef = useRef(false);
-  const interruptRequestedRef = useRef(false);
 
   useEffect(() => {
     if (!cfg || updateCheckedRef.current) return;
@@ -373,10 +372,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
       if (busy) {
-        if (interruptRequestedRef.current) {
-          process.exit(0);
-        }
-        interruptRequestedRef.current = true;
         activeControllerRef.current?.abort();
         permResolveRef.current?.("deny");
         permResolveRef.current = null;
@@ -475,7 +470,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       setBusy(false);
       setTurnStartedAt(null);
       activeControllerRef.current = null;
-      interruptRequestedRef.current = false;
     }
   }, [cfg, busy, saveSessionSafe]);
 
@@ -666,7 +660,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
       permResolveRef.current = null;
-      interruptRequestedRef.current = false;
     }
   }, [cfg, busy, updateAssistant, updateTool]);
 
@@ -1162,19 +1155,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
         permResolveRef.current = null;
-        interruptRequestedRef.current = false;
       }
     },
     [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],
   );
-
-  useEffect(() => {
-    const onSigint = () => exit();
-    process.on("SIGINT", onSigint);
-    return () => {
-      process.off("SIGINT", onSigint);
-    };
-  }, [exit]);
 
   useEffect(() => {
     if (!busy && queue.length > 0) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -112,10 +112,7 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
   ];
 
   const controller = new AbortController();
-  process.once("SIGINT", () => {
-    controller.abort();
-    setTimeout(() => process.exit(1), 500);
-  });
+  process.on("SIGINT", () => controller.abort());
 
   let printedReasoningHeader = false;
   let printedAnswerHeader = false;

--- a/src/util/sse.ts
+++ b/src/util/sse.ts
@@ -13,10 +13,6 @@ export async function* readSSE(
   const reader = stream.getReader();
   const decoder = new TextDecoder("utf-8");
   let buffer = "";
-
-  const onAbort = () => reader.cancel(new DOMException("aborted", "AbortError"));
-  signal?.addEventListener("abort", onAbort, { once: true });
-
   try {
     while (true) {
       if (signal?.aborted) throw new DOMException("aborted", "AbortError");
@@ -38,7 +34,6 @@ export async function* readSSE(
     const tail = extractData(buffer.trim());
     if (tail !== null) yield tail;
   } finally {
-    signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
   }
 }


### PR DESCRIPTION
## Summary

- Reverts the three ctrl+c-related commits that introduced a terminal flashing / race-like input lag in kimiflare:
  - `bf46eb8` — fix attempt: removed the redundant global SIGINT handler (did not resolve the flashing)
  - `c6e9c1f` — fix: prevent Ctrl+C from hanging (added SIGINT handler, SSE reader force-cancel, double-tap)
  - `3307c8f` — feat: ctrl+c interrupts current operation without exiting
- Restores the v0.12.0 Ctrl+C behavior (abort when busy, exit when idle). The independent memory (`de840a6`) and co-author (`9053488`) fixes from 0.13.1/0.13.2 are preserved.
- `git diff v0.12.0 HEAD -- src/app.tsx src/index.tsx src/util/sse.ts` shows only the memory-compaction code as the remaining delta, confirming the ctrl+c work is fully rolled back.

## Test plan

- [x] `npm run build` succeeds
- [ ] Launch kimiflare in a terminal — confirm the flashing / input-lag symptom is gone on idle renders
- [ ] Idle prompt + Ctrl+C → exits cleanly
- [ ] Mid-operation + Ctrl+C → aborts the in-flight request (pre-0.13.0 UX, without permission-modal dismissal or `(interrupted)` tool marking — expected)
- [ ] If flashing still persists after merge, culprit is older than `3307c8f`; use `git bisect start HEAD v0.12.0` to pin it

## Follow-up

Once the flashing is confirmed gone on `main`, the non-flashing subset of the ctrl+c UX (permission-resolver tracking, streaming-spinner stop) can be cherry-picked back from `3307c8f` in isolation and tested incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)