### PR TITLE
revert: roll back memory-optimizations commit to isolate flashing bug

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -109,8 +109,6 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   }
 }
 
-const STREAM_TIMEOUT_MS = 60_000;
-
 async function* parseStream(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
@@ -119,26 +117,7 @@ async function* parseStream(
   let lastUsage: Usage | null = null;
   let finishReason: string | null = null;
 
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  let timedOut = false;
-
-  const resetTimeout = () => {
-    if (timeoutId) clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => {
-      timedOut = true;
-    }, STREAM_TIMEOUT_MS);
-  };
-
-  try {
-    for await (const dataStr of readSSE(body, signal)) {
-      if (timedOut) {
-        throw new KimiApiError(
-          `kimiflare: stream timed out (no data for ${STREAM_TIMEOUT_MS / 1000}s)`,
-          undefined,
-          undefined,
-        );
-      }
-      resetTimeout();
+  for await (const dataStr of readSSE(body, signal)) {
     if (dataStr === "[DONE]") break;
     let chunk: StreamChunk | null = null;
     try {
@@ -193,21 +172,6 @@ async function* parseStream(
     }
 
     if (choice.finish_reason) finishReason = choice.finish_reason;
-  }
-
-  for (const [idx, buf] of [...toolCalls.entries()].sort((a, b) => a[0] - b[0])) {
-    if (!buf.name) continue;
-    yield {
-      type: "tool_call_complete",
-      index: idx,
-      id: buf.id,
-      name: buf.name,
-      arguments: buf.args,
-    };
-  }
-
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId);
   }
 
   for (const [idx, buf] of [...toolCalls.entries()].sort((a, b) => a[0] - b[0])) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -92,75 +92,6 @@ const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
   high: "high — deepest reasoning; slowest. Best for complex debugging, architecture, multi-file refactors.",
 };
 
-/** Replace image_url base64 payloads with lightweight text placeholders.
- *  Images are processed by the model in the turn they are sent; keeping
- *  the base64 strings in history forever is the single biggest memory sink. */
-function stripImagesFromHistory(messages: ChatMessage[]): void {
-  for (const m of messages) {
-    if (!Array.isArray(m.content)) continue;
-    let changed = false;
-    const next: ContentPart[] = [];
-    for (const part of m.content) {
-      if (part.type === "image_url") {
-        changed = true;
-        next.push({ type: "text", text: "[image]" });
-      } else {
-        next.push(part);
-      }
-    }
-    if (changed) {
-      m.content = next;
-    }
-  }
-}
-
-/** Truncate tool results older than the most recent `keepRecent` tool messages.
- *  Tool outputs (grep, bash, read) are heavy but rarely useful many turns later. */
-function truncateOldToolResults(messages: ChatMessage[], keepRecent: number): void {
-  const toolIndices: number[] = [];
-  for (let i = 0; i < messages.length; i++) {
-    if (messages[i]!.role === "tool") toolIndices.push(i);
-  }
-  const cutoff = toolIndices.length - keepRecent;
-  for (let i = 0; i < cutoff; i++) {
-    const idx = toolIndices[i]!;
-    const m = messages[idx]!;
-    const text = typeof m.content === "string" ? m.content : "";
-    if (text.length > 500) {
-      m.content = text.slice(0, 500) + "\n… [truncated]";
-    }
-  }
-}
-
-const HEAP_AUTO_COMPACT_THRESHOLD = 2_000_000_000; // 2 GB
-const MSG_AUTO_COMPACT_THRESHOLD = 50;
-
-async function maybeAutoCompact(
-  messages: ChatMessage[],
-  cfg: Cfg,
-  onInfo: (text: string) => void,
-): Promise<boolean> {
-  const heapUsed = process.memoryUsage().heapUsed;
-  if (heapUsed < HEAP_AUTO_COMPACT_THRESHOLD || messages.length <= MSG_AUTO_COMPACT_THRESHOLD) {
-    return false;
-  }
-  onInfo("auto-compacting to reduce memory usage");
-  const result = await compactMessages({
-    accountId: cfg.accountId,
-    apiToken: cfg.apiToken,
-    model: cfg.model,
-    messages,
-    keepLastTurns: 2,
-  });
-  if (result.replacedCount > 0) {
-    messages.length = 0;
-    messages.push(...result.newMessages);
-    onInfo(`compacted ${result.replacedCount} messages into a summary`);
-    return true;
-  }
-  return false;
-}
-
 function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; initialUpdateResult?: UpdateCheckResult }) {
   const { exit } = useApp();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
@@ -609,13 +540,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             }),
         },
       });
-      stripImagesFromHistory(messagesRef.current);
-      truncateOldToolResults(messagesRef.current, 8);
-      await maybeAutoCompact(
-        messagesRef.current,
-        cfg,
-        (text) => setEvents((es) => [...es, { kind: "info", key: mkKey(), text }]),
-      );
 
       if (existsSync(join(cwd, "KIMI.md"))) {
         messagesRef.current[0] = {
@@ -1091,14 +1015,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
               }),
           },
         });
-        stripImagesFromHistory(messagesRef.current);
-        truncateOldToolResults(messagesRef.current, 8);
-        await maybeAutoCompact(
-          messagesRef.current,
-          cfg,
-          (text) => setEvents((es) => [...es, { kind: "info", key: mkKey(), text }]),
-        );
-        void saveSessionSafe();
+        await saveSessionSafe();
       } catch (e) {
         if ((e as Error).name === "AbortError") {
           setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(aborted)" }]);


### PR DESCRIPTION
## Summary

- Reverts `de840a6` ("fix: reduce memory growth during long sessions"), which is the last remaining non-reverted code change between `v0.12.0` (confirmed clean — does not flash) and current `main` (still flashes after the ctrl+c revert PR #75).
- Diagnostic, not a permanent decision. If this branch also does **not** flash, `de840a6` is the confirmed culprit and we can then re-introduce its safe hunks (image stripping, tool-result truncation, $ sign in cost indicator) while omitting or fixing the bad one. If this branch **still** flashes, the bug predates `v0.12.0` and we need to look elsewhere.

## Why this commit is the suspect

After PR #75 merged, the effective delta from `v0.12.0` → `main` is exactly two commits:
- `de840a6` — touches `src/app.tsx` and `src/agent/client.ts`; changes render-adjacent behavior (per-turn history mutation, non-blocking session save via `void saveSessionSafe()`, 60s stream timeout).
- `9053488` — touches only `src/agent/system-prompt.ts` and `src/tools/bash.ts`; no rendering surface, can't cause a flash.

So `de840a6` is the only candidate left.

## What gets lost if this merges

- Base64 image payloads stripped from history after each turn (memory reduction).
- Tool results older than the last 8 truncated to 500 chars (memory reduction).
- Non-blocking session save.
- 60s API stream timeout.
- `$` sign in the cost indicator.

These can be cherry-picked back in a follow-up PR once the flashing hunk is identified.

## Test plan

- [x] `npm run build` succeeds
- [ ] Run `node bin/kimiflare.mjs` from this branch — confirm **no** flashing on idle renders and during turns
- [ ] If clean → merge, then open follow-up to selectively re-introduce `de840a6` hunks
- [ ] If still flashing → close this PR, bug is older than `v0.12.0`, investigate further

🤖 Generated with [Claude Code](https://claude.com/claude-code)