### PR TITLE
fix(ui): memoize chat components to reduce flicker on large conversations

### DIFF
--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -50,7 +50,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, th
   );
 });
 
-function EventView({
+const EventView = React.memo(function EventView({
   evt,
   showReasoning,
   theme,
@@ -115,4 +115,4 @@ function EventView({
       ! {evt.text}
     </Text>
   );
-}
+});

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -94,7 +94,7 @@ function parseBlocks(src: string): Block[] {
   return out;
 }
 
-function Block({ block, theme }: { block: Block; theme: Theme }) {
+const Block = React.memo(function Block({ block, theme }: { block: Block; theme: Theme }) {
   if (block.kind === "blank") return <Text> </Text>;
   if (block.kind === "heading") {
     return (
@@ -138,7 +138,7 @@ function Block({ block, theme }: { block: Block; theme: Theme }) {
     );
   }
   return <Text>{renderInline(block.text, theme)}</Text>;
-}
+});
 
 function renderInline(src: string, theme: Theme): React.ReactNode {
   const segments = parseInline(src);

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -19,7 +19,7 @@ interface Props {
   verbose?: boolean;
 }
 
-export function ToolView({ evt, verbose }: Props) {
+export const ToolView = React.memo(function ToolView({ evt, verbose }: Props) {
   const statusIcon =
     evt.status === "running" ? (
       <Text color="gray">
@@ -74,7 +74,7 @@ export function ToolView({ evt, verbose }: Props) {
       ) : null}
     </Box>
   );
-}
+});
 
 function compactArgs(raw: string): string {
   const collapsed = collapsePathsInText(raw, process.cwd());


### PR DESCRIPTION
Wrap EventView, Block, and ToolView in React.memo so unchanged messages skip re-rendering when new text deltas arrive during streaming. This cuts the per-delta render tree from O(entire chat history) to O(1) for completed messages, eliminating terminal flicker caused by excessive ANSI repaints.