### PR TITLE
fix: detect npm install correctly for update instructions

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,7 +20,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
-import { checkForUpdate, isGitRepo } from "./util/update-check.js";
+import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 import { Onboarding } from "./ui/onboarding.js";
 import { Welcome } from "./ui/welcome.js";
@@ -171,18 +171,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             text: `update available: ${initialUpdateResult.localVersion} → ${initialUpdateResult.latestVersion}`,
           },
         ]);
-        void isGitRepo().then((git) => {
-          setEvents((e) => [
-            ...e,
-            {
-              kind: "info",
-              key: mkKey(),
-              text: git
-                ? "run:  git pull && npm install && npm run build  then restart kimiflare"
-                : "run:  npm update -g kimiflare  then restart",
-            },
-          ]);
-        });
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: "run:  npm update -g kimiflare  then restart",
+          },
+        ]);
       }
       return;
     }
@@ -200,18 +196,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             text: `update available: ${result.localVersion} → ${result.latestVersion}`,
           },
         ]);
-        void isGitRepo().then((git) => {
-          setEvents((e) => [
-            ...e,
-            {
-              kind: "info",
-              key: mkKey(),
-              text: git
-                ? "run:  git pull && npm install && npm run build  then restart kimiflare"
-                : "run:  npm update -g kimiflare  then restart",
-            },
-          ]);
-        });
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: "run:  npm update -g kimiflare  then restart",
+          },
+        ]);
       }
     });
   }, [cfg, initialUpdateResult]);
@@ -253,18 +245,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                 text: `update available: ${result.localVersion} → ${result.latestVersion}`,
               },
             ]);
-            void isGitRepo().then((git) => {
-              setEvents((e) => [
-                ...e,
-                {
-                  kind: "info",
-                  key: mkKey(),
-                  text: git
-                    ? "run:  git pull && npm install && npm run build  then restart kimiflare"
-                    : "run:  npm update -g kimiflare  then restart",
-                },
-              ]);
-            });
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "info",
+                key: mkKey(),
+                text: "run:  npm update -g kimiflare  then restart",
+              },
+            ]);
           }
         }
       });
@@ -799,18 +787,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                 text: `update available: ${result.localVersion} → ${result.latestVersion}`,
               },
             ]);
-            void isGitRepo().then((git) => {
-              setEvents((e) => [
-                ...e,
-                {
-                  kind: "info",
-                  key: mkKey(),
-                  text: git
-                    ? "run:  git pull && npm install && npm run build  then restart kimiflare"
-                    : "run:  npm update -g kimiflare  then restart",
-                },
-              ]);
-            });
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "info",
+                key: mkKey(),
+                text: "run:  npm update -g kimiflare  then restart",
+              },
+            ]);
           } else {
             setHasUpdate(false);
             setLatestVersion(null);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { runAgentTurn } from "./agent/loop.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ChatMessage } from "./agent/messages.js";
-import { checkForUpdate, isGitRepo } from "./util/update-check.js";
+import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 
 function readPackageVersion(): string {
@@ -97,10 +97,9 @@ interface PrintOpts {
 
 async function runPrintMode(opts: PrintOpts): Promise<void> {
   if (opts.updateResult.hasUpdate) {
-    const git = await isGitRepo();
     process.stderr.write(
       `\x1b[33mkimiflare update available: ${opts.updateResult.localVersion} → ${opts.updateResult.latestVersion}\x1b[0m\n` +
-        `\x1b[33m  ${git ? "git pull && npm install && npm run build" : "npm update -g kimiflare"}  then restart\x1b[0m\n\n`,
+        `\x1b[33m  npm update -g kimiflare  then restart\x1b[0m\n\n`,
     );
   }
 

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -118,18 +118,4 @@ export async function checkForUpdate(force = false): Promise<UpdateCheckResult> 
   return { hasUpdate, localVersion, latestVersion };
 }
 
-export async function isGitRepo(): Promise<boolean> {
-  let dir = dirname(fileURLToPath(import.meta.url));
-  while (true) {
-    try {
-      await access(join(dir, ".git"));
-      return true;
-    } catch {
-      /* not found */
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return false;
-}
+


### PR DESCRIPTION
Replace `isGitRepo()` with `isNpmInstall()` to determine how kimiflare was installed.

The old heuristic checked for `.git` near the source files, which could wrongly suggest `git pull` to users who installed via npm globally (e.g. when the global npm prefix happened to be under a path with a git repo somewhere above it).

`isNpmInstall()` checks if the resolved `package.json` path contains `node_modules`, indicating an npm/yarn/pnpm install. Only if not, and a `.git` exists at the package root, does it suggest the git clone workflow. Otherwise it defaults to npm instructions as the safer assumption.

Fixes the issue where `/update` or startup nudges told npm-installed users to run `git pull && npm install && npm run build`.