### PR TITLE
fix: brighten theme-picker hint text and add $ to cost display

### DIFF
--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -90,7 +90,7 @@ function buildRightParts(usage: Usage, contextLimit: number): string[] {
     `in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
     `out ${usage.completion_tokens}`,
     `ctx ${pct}%`,
-    `${cost.toFixed(5)}`,
+    `$${cost.toFixed(5)}`,
   ];
 }
 

--- a/src/ui/theme-picker.tsx
+++ b/src/ui/theme-picker.tsx
@@ -23,7 +23,7 @@ export function ThemePicker({ themes, current, onPick, onPreview }: Props) {
       <Text color={current.accent} bold>
         Pick a theme
       </Text>
-      <Text color={current.info.color} dimColor={current.info.dim}>
+      <Text color={current.info.color} dimColor={false}>
         Arrow keys to preview, Enter to confirm.
       </Text>
       <Box marginTop={1}>


### PR DESCRIPTION
- Remove dimColor from hint text in theme-picker so it's readable across themes
- Add missing $ prefix to live cost in status bar