### PR TITLE
feat: /cost command + cost debug logging

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -4,6 +4,7 @@ import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executo
 import { sanitizeString } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tasks-state.js";
+import { logTurnDebug } from "../cost-debug.js";
 
 export interface AgentCallbacks {
   onAssistantStart?: () => void;
@@ -34,14 +35,19 @@ export interface AgentTurnOpts {
   maxCompletionTokens?: number;
   reasoningEffort?: "low" | "medium" | "high";
   coauthor?: { name: string; email: string };
+  sessionId?: string;
 }
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const max = opts.maxToolIterations ?? 50;
   const toolDefs = toOpenAIToolDefs(opts.tools);
+  let turn = 0;
+  let lastUsage: Usage | null = null;
 
   for (let iter = 0; iter < max; iter++) {
+    turn++;
     const toolCalls: ToolCall[] = [];
+    const toolResults: ToolResult[] = [];
     let content = "";
     let reasoning = "";
     opts.callbacks.onAssistantStart?.();
@@ -86,6 +92,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           break;
         }
         case "usage":
+          lastUsage = ev.usage;
           opts.callbacks.onUsage?.(ev.usage);
           break;
         case "done":
@@ -112,7 +119,18 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     opts.messages.push(assistantMsg);
     opts.callbacks.onAssistantFinal?.(assistantMsg);
 
-    if (toolCalls.length === 0) return;
+    if (toolCalls.length === 0) {
+      if (opts.sessionId && lastUsage) {
+        void logTurnDebug({
+          sessionId: opts.sessionId,
+          turn,
+          messages: opts.messages,
+          toolResults,
+          usage: lastUsage,
+        });
+      }
+      return;
+    }
 
     for (const tc of toolCalls) {
       if (opts.signal.aborted) throw new DOMException("aborted", "AbortError");
@@ -121,6 +139,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         opts.callbacks.askPermission,
         { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor },
       );
+      toolResults.push(result);
       opts.messages.push({
         role: "tool",
         tool_call_id: result.tool_call_id,
@@ -128,6 +147,16 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         name: result.name,
       });
       opts.callbacks.onToolResult?.(result);
+    }
+
+    if (opts.sessionId && lastUsage) {
+      void logTurnDebug({
+        sessionId: opts.sessionId,
+        turn,
+        messages: opts.messages,
+        toolResults,
+        usage: lastUsage,
+      });
     }
   }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -43,6 +43,7 @@ import {
 } from "./sessions.js";
 import { unlink } from "node:fs/promises";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
+import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
 
 interface Cfg {
   accountId: string;
@@ -321,22 +322,26 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     }
   }, [cfg, initMcp]);
 
+  const ensureSessionId = useCallback(() => {
+    if (sessionIdRef.current) return sessionIdRef.current;
+    const firstUser = messagesRef.current.find((m) => m.role === "user");
+    let firstText = "session";
+    if (typeof firstUser?.content === "string") {
+      firstText = firstUser.content;
+    } else if (Array.isArray(firstUser?.content)) {
+      const textPart = firstUser.content.find((p) => p.type === "text");
+      if (textPart?.text) firstText = textPart.text;
+    }
+    sessionIdRef.current = makeSessionId(firstText);
+    return sessionIdRef.current;
+  }, []);
+
   const saveSessionSafe = useCallback(async () => {
     if (!cfg) return;
-    if (!sessionIdRef.current) {
-      const firstUser = messagesRef.current.find((m) => m.role === "user");
-      let firstText = "session";
-      if (typeof firstUser?.content === "string") {
-        firstText = firstUser.content;
-      } else if (Array.isArray(firstUser?.content)) {
-        const textPart = firstUser.content.find((p) => p.type === "text");
-        if (textPart?.text) firstText = textPart.text;
-      }
-      sessionIdRef.current = makeSessionId(firstText);
-    }
+    ensureSessionId();
     try {
       await saveSession({
-        id: sessionIdRef.current,
+        id: sessionIdRef.current!,
         cwd: process.cwd(),
         model: cfg.model,
         createdAt: new Date().toISOString(),
@@ -346,7 +351,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     } catch {
       /* non-fatal */
     }
-  }, [cfg]);
+  }, [cfg, ensureSessionId]);
 
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
@@ -512,6 +517,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           cfg.coauthor !== false
             ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "kimiflare@proton.me" }
             : undefined,
+        sessionId: ensureSessionId(),
         callbacks: {
           onAssistantStart: () => {
             const id = nextAssistantId++;
@@ -562,6 +568,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           onUsage: (u) => {
             usageRef.current = u;
             setUsage(u);
+            const sid = ensureSessionId();
+            void recordUsage(sid, u);
           },
           askPermission: (req) =>
             new Promise<PermissionDecision>((resolve) => {
@@ -823,6 +831,19 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: edit" }]);
         return true;
       }
+      if (c === "/cost") {
+        if (!sessionIdRef.current) {
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no usage recorded yet" }]);
+          return true;
+        }
+        void getCostReport(sessionIdRef.current).then((report) => {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: formatCostReport(report) },
+          ]);
+        });
+        return true;
+      }
       if (c === "/resume") {
         void openResumePicker();
         return true;
@@ -1006,6 +1027,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             cfg.coauthor !== false
               ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "kimiflare@proton.me" }
               : undefined,
+          sessionId: ensureSessionId(),
           callbacks: {
             onAssistantStart: () => {
               const id = nextAssistantId++;

--- a/src/cost-debug.ts
+++ b/src/cost-debug.ts
@@ -1,0 +1,140 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ChatMessage, Usage } from "./agent/messages.js";
+import type { ToolResult } from "./tools/executor.js";
+
+const LOG_VERSION = 1;
+
+export interface PromptSection {
+  role: string;
+  chars: number;
+  approxTokens: number;
+  detail?: string;
+}
+
+export interface ToolByteStats {
+  name: string;
+  rawBytes: number;
+  reducedBytes: number;
+  savingsPct: number;
+}
+
+export interface CostDebugEntry {
+  v: number;
+  ts: string;
+  sessionId: string;
+  turn: number;
+  usage: Usage;
+  promptSections: PromptSection[];
+  promptTotalChars: number;
+  promptTotalApproxTokens: number;
+  toolStats: ToolByteStats[];
+  toolTotalRawBytes: number;
+  toolTotalReducedBytes: number;
+  toolSavingsPct: number;
+}
+
+function debugDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(xdg, "kimiflare");
+}
+
+function debugPath(): string {
+  return join(debugDir(), "cost-debug.jsonl");
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function approxTokens(chars: number): number {
+  // Rough heuristic: ~4 chars per token for English/code
+  return Math.round(chars / 4);
+}
+
+export function analyzePrompt(messages: ChatMessage[]): PromptSection[] {
+  const sections: PromptSection[] = [];
+  for (const m of messages) {
+    let contentStr = "";
+    if (typeof m.content === "string") {
+      contentStr = m.content;
+    } else if (Array.isArray(m.content)) {
+      contentStr = m.content.map((p) => (p.type === "text" ? p.text : "[image]")).join(" ");
+    }
+
+    const chars = contentStr.length;
+    const base: PromptSection = {
+      role: m.role,
+      chars,
+      approxTokens: approxTokens(chars),
+    };
+
+    if (m.role === "assistant" && m.reasoning_content) {
+      sections.push({
+        ...base,
+        detail: `content+reasoning (${approxTokens(m.reasoning_content.length)} reasoning tokens)`,
+        chars: chars + m.reasoning_content.length,
+        approxTokens: approxTokens(chars + m.reasoning_content.length),
+      });
+    } else if (m.role === "tool") {
+      sections.push({
+        ...base,
+        detail: m.name ? `tool: ${m.name}` : undefined,
+      });
+    } else {
+      sections.push(base);
+    }
+  }
+  return sections;
+}
+
+export function buildToolStats(results: ToolResult[]): ToolByteStats[] {
+  return results.map((r) => {
+    const raw = r.rawBytes ?? Buffer.byteLength(r.content, "utf8");
+    const reduced = r.reducedBytes ?? raw;
+    const savings = raw > 0 ? Math.round(((raw - reduced) / raw) * 100) : 0;
+    return {
+      name: r.name,
+      rawBytes: raw,
+      reducedBytes: reduced,
+      savingsPct: savings,
+    };
+  });
+}
+
+export async function logCostDebug(entry: CostDebugEntry): Promise<void> {
+  await mkdir(debugDir(), { recursive: true });
+  await appendFile(debugPath(), JSON.stringify(entry) + "\n", "utf8");
+}
+
+export interface TurnDebugContext {
+  sessionId: string;
+  turn: number;
+  messages: ChatMessage[];
+  toolResults: ToolResult[];
+  usage: Usage;
+}
+
+export async function logTurnDebug(ctx: TurnDebugContext): Promise<void> {
+  const promptSections = analyzePrompt(ctx.messages);
+  const promptTotalChars = promptSections.reduce((sum, s) => sum + s.chars, 0);
+  const toolStats = buildToolStats(ctx.toolResults);
+  const toolTotalRaw = toolStats.reduce((sum, t) => sum + t.rawBytes, 0);
+  const toolTotalReduced = toolStats.reduce((sum, t) => sum + t.reducedBytes, 0);
+
+  await logCostDebug({
+    v: LOG_VERSION,
+    ts: now(),
+    sessionId: ctx.sessionId,
+    turn: ctx.turn,
+    usage: ctx.usage,
+    promptSections,
+    promptTotalChars,
+    promptTotalApproxTokens: approxTokens(promptTotalChars),
+    toolStats,
+    toolTotalRawBytes: toolTotalRaw,
+    toolTotalReducedBytes: toolTotalReduced,
+    toolSavingsPct: toolTotalRaw > 0 ? Math.round(((toolTotalRaw - toolTotalReduced) / toolTotalRaw) * 100) : 0,
+  });
+}

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,0 +1,38 @@
+/**
+ * Cloudflare Workers AI pricing for @cf/moonshotai/kimi-k2.6
+ * Source: https://developers.cloudflare.com/workers-ai/platform/pricing/
+ *
+ * Workers AI bills in Neurons ($0.011 / 1,000 Neurons).
+ * The token prices below are the equivalent per-token rates.
+ */
+
+/** Price per million uncached input tokens (USD) */
+export const PRICE_IN_PER_M = 0.95;
+
+/** Price per million cached input tokens (USD) */
+export const PRICE_IN_CACHED_PER_M = 0.16;
+
+/** Price per million output tokens (USD) */
+export const PRICE_OUT_PER_M = 4.0;
+
+export interface CostBreakdown {
+  uncachedIn: number;
+  cachedIn: number;
+  out: number;
+  total: number;
+}
+
+export function calculateCost(
+  promptTokens: number,
+  completionTokens: number,
+  cachedTokens = 0,
+): CostBreakdown {
+  const uncachedIn = Math.max(0, promptTokens - cachedTokens);
+  const cachedIn = cachedTokens;
+  const out = completionTokens;
+  const total =
+    (uncachedIn * PRICE_IN_PER_M) / 1_000_000 +
+    (cachedIn * PRICE_IN_CACHED_PER_M) / 1_000_000 +
+    (out * PRICE_OUT_PER_M) / 1_000_000;
+  return { uncachedIn, cachedIn, out, total };
+}

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ToolSpec, ToolContext } from "./registry.js";
+import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
 import { truncate } from "../util/paths.js";
 
 interface Args {
@@ -82,10 +82,10 @@ function injectCoauthor(command: string, coauthor?: { name: string; email: strin
   return `_KF_BEFORE_HEAD=$(${beforeHead}); (${command}); _KF_EXIT=$?; [ $_KF_EXIT -eq 0 ] && { ${afterCheck}; }; exit $_KF_EXIT`;
 }
 
-function runBash(args: Args, ctx: ToolContext): Promise<string> {
+function runBash(args: Args, ctx: ToolContext): Promise<ToolOutput> {
   const timeout = Math.min(Math.max(1000, args.timeout_ms ?? DEFAULT_TIMEOUT), MAX_TIMEOUT);
   const command = injectCoauthor(args.command, ctx.coauthor);
-  return new Promise<string>((resolve, reject) => {
+  return new Promise<ToolOutput>((resolve, reject) => {
     const child = spawn("bash", ["-lc", command], {
       cwd: ctx.cwd,
       signal: ctx.signal,
@@ -116,7 +116,13 @@ function runBash(args: Args, ctx: ToolContext): Promise<string> {
       if (stdout) parts.push(`--- stdout ---\n${stdout.trimEnd()}`);
       if (stderr) parts.push(`--- stderr ---\n${stderr.trimEnd()}`);
       if (!stdout && !stderr) parts.push("(no output)");
-      resolve(truncate(parts.join("\n"), OUTPUT_CAP));
+      const raw = parts.join("\n");
+      const reduced = truncate(raw, OUTPUT_CAP);
+      resolve({
+        content: reduced,
+        rawBytes: Buffer.byteLength(raw, "utf8"),
+        reducedBytes: Buffer.byteLength(reduced, "utf8"),
+      });
     });
   });
 }

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -1,4 +1,4 @@
-import type { ToolSpec, ToolContext } from "./registry.js";
+import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
 import { readTool } from "./read.js";
 import { writeTool } from "./write.js";
 import { editTool } from "./edit.js";
@@ -40,6 +40,10 @@ export interface ToolResult {
   name: string;
   content: string;
   ok: boolean;
+  /** Raw output bytes before any truncation/capping. */
+  rawBytes?: number;
+  /** Final output bytes after truncation/capping. */
+  reducedBytes?: number;
 }
 
 export class ToolExecutor {
@@ -110,14 +114,25 @@ export class ToolExecutor {
     }
 
     try {
-      const content = await tool.run(args as never, ctx);
-      return { tool_call_id: call.id, name: call.name, content, ok: true };
-    } catch (e) {
+      const result = await tool.run(args as never, ctx);
+      const normalized = normalizeToolOutput(result);
       return {
         tool_call_id: call.id,
         name: call.name,
-        content: `Error running ${call.name}: ${(e as Error).message ?? String(e)}`,
+        content: normalized.content,
+        ok: true,
+        rawBytes: normalized.rawBytes,
+        reducedBytes: normalized.reducedBytes,
+      };
+    } catch (e) {
+      const msg = `Error running ${call.name}: ${(e as Error).message ?? String(e)}`;
+      return {
+        tool_call_id: call.id,
+        name: call.name,
+        content: msg,
         ok: false,
+        rawBytes: msg.length,
+        reducedBytes: msg.length,
       };
     }
   }
@@ -129,6 +144,14 @@ export class ToolExecutor {
     }
     return tool.name;
   }
+}
+
+function normalizeToolOutput(result: string | ToolOutput): ToolOutput {
+  if (typeof result === "string") {
+    const bytes = Buffer.byteLength(result, "utf8");
+    return { content: result, rawBytes: bytes, reducedBytes: bytes };
+  }
+  return result;
 }
 
 function truncateForError(s: string): string {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { readFile } from "node:fs/promises";
 import fg from "fast-glob";
-import type { ToolSpec } from "./registry.js";
+import type { ToolSpec, ToolOutput } from "./registry.js";
 import { resolvePath, truncate } from "../util/paths.js";
 
 const pExecFile = promisify(execFile);
@@ -61,7 +61,7 @@ async function runRipgrep(
   args: Args,
   root: string,
   mode: "content" | "files",
-): Promise<string> {
+): Promise<ToolOutput> {
   const rgArgs = ["--no-heading", "--color=never", "--line-number"];
   if (args.case_insensitive) rgArgs.push("-i");
   if (args.glob) rgArgs.push("--glob", args.glob);
@@ -70,10 +70,16 @@ async function runRipgrep(
   try {
     const { stdout } = await pExecFile("rg", rgArgs, { maxBuffer: 10 * 1024 * 1024 });
     const trimmed = stdout.trim();
-    return trimmed ? truncate(trimmed, 30_000) : "(no matches)";
+    if (!trimmed) return { content: "(no matches)", rawBytes: 0, reducedBytes: 0 };
+    const reduced = truncate(trimmed, 30_000);
+    return {
+      content: reduced,
+      rawBytes: Buffer.byteLength(trimmed, "utf8"),
+      reducedBytes: Buffer.byteLength(reduced, "utf8"),
+    };
   } catch (e) {
     const err = e as { code?: number; stderr?: string };
-    if (err.code === 1) return "(no matches)";
+    if (err.code === 1) return { content: "(no matches)", rawBytes: 0, reducedBytes: 0 };
     throw new Error(err.stderr || String(e));
   }
 }
@@ -82,7 +88,7 @@ async function runJsFallback(
   args: Args,
   root: string,
   mode: "content" | "files",
-): Promise<string> {
+): Promise<ToolOutput> {
   const re = new RegExp(args.pattern, args.case_insensitive ? "i" : "");
   const globPattern = args.glob ? `**/${args.glob}` : "**/*";
   const files = await fg(globPattern, {
@@ -112,5 +118,12 @@ async function runJsFallback(
     }
     if (out.length > 500) break;
   }
-  return out.length ? truncate(out.join("\n"), 30_000) : "(no matches)";
+  if (!out.length) return { content: "(no matches)", rawBytes: 0, reducedBytes: 0 };
+  const raw = out.join("\n");
+  const reduced = truncate(raw, 30_000);
+  return {
+    content: reduced,
+    rawBytes: Buffer.byteLength(raw, "utf8"),
+    reducedBytes: Buffer.byteLength(reduced, "utf8"),
+  };
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -14,6 +14,12 @@ export interface ToolRender {
   diff?: { path: string; before: string; after: string };
 }
 
+export interface ToolOutput {
+  content: string;
+  rawBytes: number;
+  reducedBytes: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ToolSpec<Args = any> {
   name: string;
@@ -21,7 +27,7 @@ export interface ToolSpec<Args = any> {
   parameters: Record<string, unknown>;
   needsPermission: boolean;
   render?: (args: Args) => ToolRender;
-  run: (args: Args, ctx: ToolContext) => Promise<string>;
+  run: (args: Args, ctx: ToolContext) => Promise<string | ToolOutput>;
 }
 
 export function toOpenAIToolDefs(tools: ToolSpec[]): ToolDef[] {

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -1,5 +1,5 @@
 import TurndownService from "turndown";
-import type { ToolSpec } from "./registry.js";
+import type { ToolSpec, ToolOutput } from "./registry.js";
 import { truncate } from "../util/paths.js";
 
 interface Args {
@@ -24,7 +24,7 @@ export const webFetchTool: ToolSpec<Args> = {
   },
   needsPermission: false,
   render: (args) => ({ title: `GET ${args.url}` }),
-  async run(args) {
+  async run(args): Promise<ToolOutput> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
     try {
@@ -36,11 +36,19 @@ export const webFetchTool: ToolSpec<Args> = {
       const ct = res.headers.get("content-type") ?? "";
       const body = await res.text();
       const bounded = body.length > MAX_BYTES ? body.slice(0, MAX_BYTES) : body;
+      let raw: string;
       if (ct.toLowerCase().includes("html")) {
         const td = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
-        return truncate(`# ${args.url}\n\n${td.turndown(bounded)}`, MAX_OUTPUT);
+        raw = `# ${args.url}\n\n${td.turndown(bounded)}`;
+      } else {
+        raw = `# ${args.url}\n\n${bounded}`;
       }
-      return truncate(`# ${args.url}\n\n${bounded}`, MAX_OUTPUT);
+      const reduced = truncate(raw, MAX_OUTPUT);
+      return {
+        content: reduced,
+        rawBytes: Buffer.byteLength(raw, "utf8"),
+        reducedBytes: Buffer.byteLength(reduced, "utf8"),
+      };
     } finally {
       clearTimeout(timer);
     }

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -5,6 +5,7 @@ import type { Usage } from "../agent/messages.js";
 import type { Theme } from "./theme.js";
 import type { ReasoningEffort } from "../config.js";
 import type { Mode } from "../mode.js";
+import { calculateCost } from "../pricing.js";
 
 interface Props {
   model: string;
@@ -18,10 +19,6 @@ interface Props {
   hasUpdate?: boolean;
   latestVersion?: string | null;
 }
-
-const PRICE_IN_PER_M = 0.95;
-const PRICE_IN_CACHED_PER_M = 0.16;
-const PRICE_OUT_PER_M = 4.0;
 
 export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion }: Props) {
   const [now, setNow] = useState(Date.now());
@@ -80,17 +77,13 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
 
 function buildRightParts(usage: Usage, contextLimit: number): string[] {
   const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
-  const uncachedIn = usage.prompt_tokens - cached;
-  const cost =
-    (uncachedIn * PRICE_IN_PER_M) / 1_000_000 +
-    (cached * PRICE_IN_CACHED_PER_M) / 1_000_000 +
-    (usage.completion_tokens * PRICE_OUT_PER_M) / 1_000_000;
+  const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
   const pct = Math.round((usage.prompt_tokens / contextLimit) * 100);
   return [
     `in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
     `out ${usage.completion_tokens}`,
     `ctx ${pct}%`,
-    `$${cost.toFixed(5)}`,
+    `${cost.total.toFixed(5)}`,
   ];
 }
 

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -1,0 +1,171 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Usage } from "./agent/messages.js";
+import { calculateCost } from "./pricing.js";
+
+const LOG_VERSION = 1;
+
+export interface DailyUsage {
+  date: string; // YYYY-MM-DD
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number;
+  cost: number;
+}
+
+export interface SessionUsage {
+  id: string;
+  date: string;
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number;
+  cost: number;
+}
+
+interface UsageLog {
+  version: number;
+  days: DailyUsage[];
+  sessions: SessionUsage[];
+}
+
+function usageDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(xdg, "kimiflare");
+}
+
+function usagePath(): string {
+  return join(usageDir(), "usage.json");
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function loadLog(): Promise<UsageLog> {
+  try {
+    const raw = await readFile(usagePath(), "utf8");
+    const parsed = JSON.parse(raw) as UsageLog;
+    if (parsed.version === LOG_VERSION) return parsed;
+  } catch {
+    /* no file or unreadable */
+  }
+  return { version: LOG_VERSION, days: [], sessions: [] };
+}
+
+async function saveLog(log: UsageLog): Promise<void> {
+  await mkdir(usageDir(), { recursive: true });
+  await writeFile(usagePath(), JSON.stringify(log, null, 2), "utf8");
+}
+
+function getOrCreateDay(log: UsageLog, date: string): DailyUsage {
+  let day = log.days.find((d) => d.date === date);
+  if (!day) {
+    day = { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
+    log.days.push(day);
+  }
+  return day;
+}
+
+function getOrCreateSession(log: UsageLog, sessionId: string, date: string): SessionUsage {
+  let session = log.sessions.find((s) => s.id === sessionId);
+  if (!session) {
+    session = { id: sessionId, date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
+    log.sessions.push(session);
+  }
+  return session;
+}
+
+export async function recordUsage(sessionId: string, usage: Usage): Promise<void> {
+  const log = await loadLog();
+  const date = today();
+  const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, usage.prompt_tokens_details?.cached_tokens ?? 0);
+
+  const day = getOrCreateDay(log, date);
+  day.promptTokens += usage.prompt_tokens;
+  day.completionTokens += usage.completion_tokens;
+  day.cachedTokens += usage.prompt_tokens_details?.cached_tokens ?? 0;
+  day.cost += cost.total;
+
+  const session = getOrCreateSession(log, sessionId, date);
+  session.promptTokens += usage.prompt_tokens;
+  session.completionTokens += usage.completion_tokens;
+  session.cachedTokens += usage.prompt_tokens_details?.cached_tokens ?? 0;
+  session.cost += cost.total;
+
+  await saveLog(log);
+}
+
+export interface CostReport {
+  session: DailyUsage;
+  today: DailyUsage;
+  month: DailyUsage;
+  allTime: DailyUsage;
+}
+
+export async function getCostReport(sessionId: string): Promise<CostReport> {
+  const log = await loadLog();
+  const date = today();
+  const currentMonth = date.slice(0, 7); // YYYY-MM
+
+  const session =
+    log.sessions.find((s) => s.id === sessionId) ??
+    { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
+
+  const todayUsage =
+    log.days.find((d) => d.date === date) ??
+    { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
+
+  const monthUsage: DailyUsage = {
+    date: currentMonth,
+    promptTokens: 0,
+    completionTokens: 0,
+    cachedTokens: 0,
+    cost: 0,
+  };
+  for (const d of log.days) {
+    if (d.date.startsWith(currentMonth)) {
+      monthUsage.promptTokens += d.promptTokens;
+      monthUsage.completionTokens += d.completionTokens;
+      monthUsage.cachedTokens += d.cachedTokens;
+      monthUsage.cost += d.cost;
+    }
+  }
+
+  const allTime: DailyUsage = {
+    date: "all",
+    promptTokens: 0,
+    completionTokens: 0,
+    cachedTokens: 0,
+    cost: 0,
+  };
+  for (const d of log.days) {
+    allTime.promptTokens += d.promptTokens;
+    allTime.completionTokens += d.completionTokens;
+    allTime.cachedTokens += d.cachedTokens;
+    allTime.cost += d.cost;
+  }
+
+  return { session, today: todayUsage, month: monthUsage, allTime };
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function formatCostReport(report: CostReport): string {
+  const lines: string[] = [];
+  const add = (label: string, u: DailyUsage) => {
+    const cached = u.cachedTokens > 0 ? ` (${fmtTokens(u.cachedTokens)} cached)` : "";
+    lines.push(
+      `${label.padEnd(9)} $${u.cost.toFixed(4)}  (in: ${fmtTokens(u.promptTokens)}${cached}  out: ${fmtTokens(u.completionTokens)})`,
+    );
+  };
+  add("Session", report.session);
+  add("Today", report.today);
+  add("Month", report.month);
+  add("All time", report.allTime);
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Adds local cost tracking and detailed per-turn debug logging to help optimize token spend.

## What's new

### User-facing
- **`/cost`** slash command shows estimated USD spend across:
  - Current session
  - Today
  - This month
  - All time
- Costs are computed from Cloudflare Workers AI published rates for Kimi K2.6:
  - Input: $0.95 / M tokens
  - Cached input: $0.16 / M tokens
  - Output: $4.00 / M tokens

### Developer-facing (cost debug logging)
Every turn is logged to `~/.local/share/kimiflare/cost-debug.jsonl` with:
- **Token usage**: input, cached input, output
- **Tool byte stats**: raw bytes vs reduced bytes (post-truncation) per tool call
- **Prompt assembly breakdown**: size by section (system, user, assistant, tool) with approximate token counts

### Tool instrumentation
Tools that truncate output now report raw/reduced byte counts:
- `bash` (30KB cap)
- `grep` (30KB cap)
- `web_fetch` (100KB cap)

### Refactoring
- Extracted shared pricing constants into `src/pricing.ts`
- Updated `src/ui/status.tsx` to use shared pricing module

## Files changed
- `src/pricing.ts` (new)
- `src/usage-tracker.ts` (new)
- `src/cost-debug.ts` (new)
- `src/app.tsx`
- `src/ui/status.tsx`
- `src/agent/loop.ts`
- `src/tools/executor.ts`
- `src/tools/registry.ts`
- `src/tools/bash.ts`
- `src/tools/grep.ts`
- `src/tools/web-fetch.ts`

## Testing
- `npm run typecheck` passes

---

Co-authored-by: kimiflare <kimiflare@proton.me>