### PR TITLE
feat: token-efficient tool result reducers with progressive disclosure

### DIFF
--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -53,7 +53,12 @@ How to work:
 - You have a 262k-token context window. Read as much of a file as needed rather than guessing.
 - If a request is ambiguous, ask one focused question instead of making large assumptions.
 - When you finish a task, stop. Do not add a closing summary.
-- When creating git commits, you must include \`Co-authored-by: kimiflare <kimiflare@proton.me>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects git commit-creating commands.`;
+- When creating git commits, you must include \`Co-authored-by: kimiflare <kimiflare@proton.me>\` in the commit message so kimiflare is credited as a contributor. The bash tool will also auto-append this trailer when it detects git commit-creating commands.
+
+Tool output reduction:
+- Large tool outputs (grep, read, bash, web_fetch) are reduced to compact summaries by default to preserve context window.
+- When you see "[output reduced]" with an artifact ID, you can call \`expand_artifact\` with that ID to retrieve the full raw output if you need more detail.
+- You can also re-run the original tool with more targeted parameters (e.g. read with offset/limit, grep with output_mode="files") instead of expanding.`;
 }
 
 /** Build the session-stable prefix that changes only when session-level

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -814,6 +814,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         sessionIdRef.current = null;
         sessionStateRef.current = emptySessionState();
         artifactStoreRef.current = new ArtifactStore();
+        executorRef.current.clearArtifacts();
         setEvents([]);
         setUsage(null);
         setTasks([]);

--- a/src/tools/artifact-store.ts
+++ b/src/tools/artifact-store.ts
@@ -1,0 +1,62 @@
+/** In-memory store for raw tool outputs.
+ *  Artifacts are never persisted to disk. Eviction is LRU by insertion order. */
+export class ToolArtifactStore {
+  private artifacts = new Map<string, string>();
+  private nextId = 0;
+  private maxArtifacts: number;
+  private maxTotalChars: number;
+
+  constructor(opts?: { maxArtifacts?: number; maxTotalChars?: number }) {
+    this.maxArtifacts = opts?.maxArtifacts ?? 500;
+    this.maxTotalChars = opts?.maxTotalChars ?? 2_000_000;
+  }
+
+  /** Store raw content and return a stable artifact ID. */
+  store(raw: string): string {
+    const id = `art_${++this.nextId}`;
+
+    // Evict oldest artifacts until we have room
+    while (this.totalChars() + raw.length > this.maxTotalChars && this.artifacts.size > 0) {
+      this.evictOldest();
+    }
+    while (this.artifacts.size >= this.maxArtifacts && this.artifacts.size > 0) {
+      this.evictOldest();
+    }
+
+    this.artifacts.set(id, raw);
+    return id;
+  }
+
+  retrieve(id: string): string | undefined {
+    return this.artifacts.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.artifacts.has(id);
+  }
+
+  clear(): void {
+    this.artifacts.clear();
+    this.nextId = 0;
+  }
+
+  size(): number {
+    return this.artifacts.size;
+  }
+
+  private totalChars(): number {
+    let sum = 0;
+    for (const raw of this.artifacts.values()) {
+      sum += raw.length;
+    }
+    return sum;
+  }
+
+  private evictOldest(): void {
+    // Map preserves insertion order; first key is oldest
+    const first = this.artifacts.keys().next().value;
+    if (first !== undefined) {
+      this.artifacts.delete(first);
+    }
+  }
+}

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
-import { truncate } from "../util/paths.js";
 
 interface Args {
   command: string;
@@ -11,12 +10,11 @@ interface Args {
 
 const DEFAULT_TIMEOUT = 120_000;
 const MAX_TIMEOUT = 600_000;
-const OUTPUT_CAP = 30_000;
 
 export const bashTool: ToolSpec<Args> = {
   name: "bash",
   description:
-    "Run a shell command via `bash -lc`. Prompts the user for permission before executing. stdout and stderr are captured, combined, and capped at 30KB.",
+    "Run a shell command via `bash -lc`. Prompts the user for permission before executing. stdout and stderr are captured and combined. Large outputs are reduced to a compact summary by default; use expand_artifact to retrieve the full log.",
   parameters: {
     type: "object",
     properties: {
@@ -117,11 +115,10 @@ function runBash(args: Args, ctx: ToolContext): Promise<ToolOutput> {
       if (stderr) parts.push(`--- stderr ---\n${stderr.trimEnd()}`);
       if (!stdout && !stderr) parts.push("(no output)");
       const raw = parts.join("\n");
-      const reduced = truncate(raw, OUTPUT_CAP);
       resolve({
-        content: reduced,
+        content: raw,
         rawBytes: Buffer.byteLength(raw, "utf8"),
-        reducedBytes: Buffer.byteLength(reduced, "utf8"),
+        reducedBytes: Buffer.byteLength(raw, "utf8"),
       });
     });
   });

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -7,6 +7,9 @@ import { globTool } from "./glob.js";
 import { grepTool } from "./grep.js";
 import { webFetchTool } from "./web-fetch.js";
 import { tasksSetTool } from "./tasks.js";
+import { ToolArtifactStore } from "./artifact-store.js";
+import { reduceToolOutput, DEFAULT_REDUCER_CONFIG } from "./reducer.js";
+import { makeExpandArtifactTool } from "./expand-artifact.js";
 
 export const ALL_TOOLS: ToolSpec[] = [
   readTool,
@@ -44,14 +47,19 @@ export interface ToolResult {
   rawBytes?: number;
   /** Final output bytes after truncation/capping. */
   reducedBytes?: number;
+  /** Artifact ID if the raw output was stored for later expansion. */
+  artifactId?: string;
 }
 
 export class ToolExecutor {
   private sessionAllowed = new Set<string>();
   private tools: Map<string, ToolSpec>;
+  private artifactStore: ToolArtifactStore;
 
   constructor(tools: ToolSpec[] = ALL_TOOLS) {
     this.tools = new Map(tools.map((t) => [t.name, t]));
+    this.artifactStore = new ToolArtifactStore();
+    this.tools.set("expand_artifact", makeExpandArtifactTool(this.artifactStore));
   }
 
   list(): ToolSpec[] {
@@ -68,6 +76,10 @@ export class ToolExecutor {
 
   clearSessionPermissions(): void {
     this.sessionAllowed.clear();
+  }
+
+  clearArtifacts(): void {
+    this.artifactStore.clear();
   }
 
   async run(
@@ -116,13 +128,21 @@ export class ToolExecutor {
     try {
       const result = await tool.run(args as never, ctx);
       const normalized = normalizeToolOutput(result);
+      const reduced = reduceToolOutput(
+        call.name,
+        normalized.content,
+        args,
+        this.artifactStore,
+        DEFAULT_REDUCER_CONFIG,
+      );
       return {
         tool_call_id: call.id,
         name: call.name,
-        content: normalized.content,
+        content: reduced.content,
         ok: true,
-        rawBytes: normalized.rawBytes,
-        reducedBytes: normalized.reducedBytes,
+        rawBytes: reduced.rawBytes,
+        reducedBytes: reduced.reducedBytes,
+        artifactId: reduced.artifactId,
       };
     } catch (e) {
       const msg = `Error running ${call.name}: ${(e as Error).message ?? String(e)}`;

--- a/src/tools/expand-artifact.ts
+++ b/src/tools/expand-artifact.ts
@@ -1,0 +1,34 @@
+import type { ToolSpec } from "./registry.js";
+import { ToolArtifactStore } from "./artifact-store.js";
+
+interface Args {
+  artifact_id: string;
+}
+
+export function makeExpandArtifactTool(store: ToolArtifactStore): ToolSpec<Args> {
+  return {
+    name: "expand_artifact",
+    description:
+      "Retrieve the full raw content of a previously reduced tool output by its artifact ID. Use this when the compact summary is insufficient and you need the complete original output.",
+    parameters: {
+      type: "object",
+      properties: {
+        artifact_id: {
+          type: "string",
+          description: "The artifact ID from a reduced tool output footer, e.g. art_42.",
+        },
+      },
+      required: ["artifact_id"],
+      additionalProperties: false,
+    },
+    needsPermission: false,
+    render: (args) => ({ title: `expand ${args.artifact_id}` }),
+    run: async (args): Promise<string> => {
+      const raw = store.retrieve(args.artifact_id);
+      if (!raw) {
+        return `Artifact "${args.artifact_id}" not found. It may have been evicted from memory. Re-run the original tool to regenerate the output.`;
+      }
+      return raw;
+    },
+  };
+}

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -3,7 +3,7 @@ import { promisify } from "node:util";
 import { readFile } from "node:fs/promises";
 import fg from "fast-glob";
 import type { ToolSpec, ToolOutput } from "./registry.js";
-import { resolvePath, truncate } from "../util/paths.js";
+import { resolvePath } from "../util/paths.js";
 
 const pExecFile = promisify(execFile);
 
@@ -71,11 +71,10 @@ async function runRipgrep(
     const { stdout } = await pExecFile("rg", rgArgs, { maxBuffer: 10 * 1024 * 1024 });
     const trimmed = stdout.trim();
     if (!trimmed) return { content: "(no matches)", rawBytes: 0, reducedBytes: 0 };
-    const reduced = truncate(trimmed, 30_000);
     return {
-      content: reduced,
+      content: trimmed,
       rawBytes: Buffer.byteLength(trimmed, "utf8"),
-      reducedBytes: Buffer.byteLength(reduced, "utf8"),
+      reducedBytes: Buffer.byteLength(trimmed, "utf8"),
     };
   } catch (e) {
     const err = e as { code?: number; stderr?: string };
@@ -120,10 +119,9 @@ async function runJsFallback(
   }
   if (!out.length) return { content: "(no matches)", rawBytes: 0, reducedBytes: 0 };
   const raw = out.join("\n");
-  const reduced = truncate(raw, 30_000);
   return {
-    content: reduced,
+    content: raw,
     rawBytes: Buffer.byteLength(raw, "utf8"),
-    reducedBytes: Buffer.byteLength(reduced, "utf8"),
+    reducedBytes: Buffer.byteLength(raw, "utf8"),
   };
 }

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -13,7 +13,7 @@ interface Args {
 export const readTool: ToolSpec<Args> = {
   name: "read",
   description:
-    "Read a text file from the local filesystem. Supports optional line offset/limit. Refuses files larger than 2MB. Returns contents with 1-indexed line numbers prefixed, cat -n style.",
+    "Read a text file from the local filesystem. Supports optional line offset/limit. Refuses files larger than 2MB. Returns contents with 1-indexed line numbers prefixed, cat -n style. When reading a full file without offset/limit, the output is reduced to a compact outline (imports, exports, signatures, preview) by default; use expand_artifact to retrieve the full content or specify offset/limit for a targeted slice.",
   parameters: {
     type: "object",
     properties: {

--- a/src/tools/reducer.test.ts
+++ b/src/tools/reducer.test.ts
@@ -1,0 +1,249 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { ToolArtifactStore } from "./artifact-store.js";
+import {
+  reduceToolOutput,
+  DEFAULT_REDUCER_CONFIG,
+  type ReducerConfig,
+} from "./reducer.js";
+
+describe("ToolArtifactStore", () => {
+  it("stores and retrieves artifacts", () => {
+    const store = new ToolArtifactStore();
+    const id = store.store("hello world");
+    assert.strictEqual(store.retrieve(id), "hello world");
+    assert.strictEqual(store.size(), 1);
+  });
+
+  it("evicts oldest when maxArtifacts reached", () => {
+    const store = new ToolArtifactStore({ maxArtifacts: 2, maxTotalChars: 10_000 });
+    const id1 = store.store("a");
+    const id2 = store.store("b");
+    const id3 = store.store("c");
+    assert.strictEqual(store.retrieve(id1), undefined);
+    assert.strictEqual(store.retrieve(id2), "b");
+    assert.strictEqual(store.retrieve(id3), "c");
+    assert.strictEqual(store.size(), 2);
+  });
+
+  it("evicts when total chars exceed maxTotalChars", () => {
+    const store = new ToolArtifactStore({ maxArtifacts: 10, maxTotalChars: 5 });
+    const id1 = store.store("123");
+    const id2 = store.store("45678");
+    assert.strictEqual(store.retrieve(id1), undefined);
+    assert.strictEqual(store.retrieve(id2), "45678");
+  });
+
+  it("clears all artifacts", () => {
+    const store = new ToolArtifactStore();
+    store.store("x");
+    store.clear();
+    assert.strictEqual(store.size(), 0);
+  });
+
+  it("produces unique IDs", () => {
+    const store = new ToolArtifactStore();
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(store.store("x"));
+    }
+    assert.strictEqual(ids.size, 100);
+  });
+});
+
+describe("reduceToolOutput — grep", () => {
+  it("returns file paths and hit counts in discovery mode", () => {
+    const store = new ToolArtifactStore();
+    const raw = [
+      "src/a.ts:10:export const foo = 1;",
+      "src/a.ts:20:export const foo = 2;",
+      "src/a.ts:30:export const foo = 3;",
+      "src/b.ts:5:import { foo } from './a';",
+      "src/b.ts:15:console.log(foo);",
+    ].join("\n");
+
+    const result = reduceToolOutput("grep", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("src/a.ts: 3 hit(s)"));
+    assert.ok(result.content.includes("src/b.ts: 2 hit(s)"));
+    assert.ok(result.content.includes("output reduced"));
+    assert.ok(result.artifactId);
+    // Artifact stores the full raw content
+    assert.strictEqual(store.retrieve(result.artifactId), raw);
+  });
+
+  it("shows sample matches per file", () => {
+    const store = new ToolArtifactStore();
+    const lines: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      lines.push(`src/x.ts:${i + 1}:const x = ${i};`);
+    }
+    const raw = lines.join("\n");
+
+    const result = reduceToolOutput("grep", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    // Should show at most 3 matches per file
+    const matchCount = (result.content.match(/const x = /g) ?? []).length;
+    assert.ok(matchCount <= 3, `expected <= 3 sample matches, got ${matchCount}`);
+  });
+
+  it("passes through files-only mode compactly", () => {
+    const store = new ToolArtifactStore();
+    const raw = "src/a.ts\nsrc/b.ts\nsrc/c.ts";
+    const result = reduceToolOutput("grep", raw, { output_mode: "files" }, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("3 file(s) matched"));
+    assert.ok(result.content.includes("src/a.ts"));
+    assert.ok(result.content.includes("output reduced"));
+    assert.ok(result.artifactId);
+  });
+
+  it("expansion restores full raw content", () => {
+    const store = new ToolArtifactStore();
+    const raw = "line1\nline2\nline3\nline4\nline5";
+    const result = reduceToolOutput("grep", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    const restored = store.retrieve(result.artifactId);
+    assert.strictEqual(restored, raw);
+  });
+});
+
+describe("reduceToolOutput — read", () => {
+  it("returns structure outline for full file reads", () => {
+    const store = new ToolArtifactStore();
+    const raw = [
+      "  1\timport { x } from 'x';",
+      "  2\timport { y } from 'y';",
+      "  3\t",
+      "  4\texport const FOO = 1;",
+      "  5\texport function bar() { return 1; }",
+      "  6\texport class Baz {",
+      "  7\t  run() {}",
+      "  8\t}",
+      "  9\t",
+      " 10\tfunction helper() {}",
+    ].join("\n");
+
+    const result = reduceToolOutput("read", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("10 lines total"));
+    assert.ok(result.content.includes("Imports (2):"));
+    assert.ok(result.content.includes("Exports (2):"));
+    assert.ok(result.content.includes("Functions (1):"));
+    assert.ok(result.content.includes("Classes (1):"));
+    assert.ok(result.content.includes("Preview (lines 1–"));
+    assert.ok(result.content.includes("output reduced"));
+  });
+
+  it("returns slice directly when offset/limit provided", () => {
+    const store = new ToolArtifactStore();
+    const raw = "  1\tline1\n  2\tline2\n  3\tline3";
+    const result = reduceToolOutput("read", raw, { offset: 1, limit: 2 }, store, DEFAULT_REDUCER_CONFIG);
+    assert.strictEqual(result.content, raw);
+    assert.strictEqual(result.rawBytes, result.reducedBytes);
+  });
+
+  it("caps large slices", () => {
+    const store = new ToolArtifactStore();
+    const lines: string[] = [];
+    for (let i = 0; i < 300; i++) {
+      lines.push(`  ${i + 1}\tline ${i + 1}`);
+    }
+    const raw = lines.join("\n");
+    const result = reduceToolOutput("read", raw, { offset: 1, limit: 300 }, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("more lines omitted"));
+    assert.ok(result.reducedBytes < result.rawBytes);
+  });
+});
+
+describe("reduceToolOutput — bash", () => {
+  it("passes through short outputs unchanged", () => {
+    const store = new ToolArtifactStore();
+    const raw = "exit=0\n--- stdout ---\nhello world";
+    const result = reduceToolOutput("bash", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.strictEqual(result.content, raw);
+  });
+
+  it("returns compact failure summary for errors", () => {
+    const store = new ToolArtifactStore();
+    const lines: string[] = ["exit=1"];
+    lines.push("--- stdout ---");
+    for (let i = 0; i < 100; i++) {
+      lines.push(`passing test ${i}`);
+    }
+    lines.push("Error: something broke");
+    lines.push("  at /path/to/file.ts:10:5");
+    lines.push("  at /path/to/file.ts:20:5");
+    lines.push("FAIL test-foo");
+    for (let i = 0; i < 50; i++) {
+      lines.push(`more noise ${i}`);
+    }
+    const raw = lines.join("\n");
+
+    const result = reduceToolOutput("bash", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("exit=1"));
+    assert.ok(result.content.includes("error block"));
+    assert.ok(result.content.includes("Error: something broke"));
+    assert.ok(result.content.includes("failing tests"));
+    assert.ok(result.content.includes("test-foo"));
+    assert.ok(result.content.includes("last lines"));
+    assert.ok(result.content.includes("output reduced"));
+    assert.ok(result.reducedBytes < result.rawBytes);
+  });
+
+  it("deduplicates repeated lines", () => {
+    const store = new ToolArtifactStore();
+    const lines: string[] = ["exit=1", "--- stdout ---"];
+    for (let i = 0; i < 50; i++) {
+      lines.push("same line over and over");
+    }
+    lines.push("final line");
+    const raw = lines.join("\n");
+
+    const result = reduceToolOutput("bash", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("identical lines omitted"));
+  });
+
+  it("preserves stack trace frames in error block", () => {
+    const store = new ToolArtifactStore();
+    const lines: string[] = ["exit=1", "--- stdout ---"];
+    for (let i = 0; i < 50; i++) {
+      lines.push(`  at frame${i} (/path/file.ts:${i}:1)`);
+    }
+    const raw = lines.join("\n");
+
+    const result = reduceToolOutput("bash", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("at frame0"));
+    assert.ok(result.content.includes("error block"));
+    assert.ok(result.content.includes("output reduced"));
+  });
+});
+
+describe("reduceToolOutput — web_fetch", () => {
+  it("returns title, URL, headings, and excerpt", () => {
+    const store = new ToolArtifactStore();
+    const raw = "# Page Title\n\n## Section A\n\nSome content here.\n\n## Section B\n\nMore content.";
+    const result = reduceToolOutput("web_fetch", raw, { url: "https://example.com" }, store, DEFAULT_REDUCER_CONFIG);
+    assert.ok(result.content.includes("Title: Page Title"));
+    assert.ok(result.content.includes("URL: https://example.com"));
+    assert.ok(result.content.includes("Sections:"));
+    assert.ok(result.content.includes("Excerpt"));
+    assert.ok(result.content.includes("output reduced"));
+  });
+});
+
+describe("reduceToolOutput — disabled", () => {
+  it("returns raw content when enabled is false", () => {
+    const store = new ToolArtifactStore();
+    const raw = "a\n".repeat(1000);
+    const config: ReducerConfig = { ...DEFAULT_REDUCER_CONFIG, enabled: false };
+    const result = reduceToolOutput("bash", raw, {}, store, config);
+    assert.strictEqual(result.content, raw);
+    assert.ok(result.artifactId);
+  });
+});
+
+describe("reduceToolOutput — unknown tool", () => {
+  it("passes through unknown tools unchanged", () => {
+    const store = new ToolArtifactStore();
+    const raw = "some output";
+    const result = reduceToolOutput("custom_tool", raw, {}, store, DEFAULT_REDUCER_CONFIG);
+    assert.strictEqual(result.content, raw);
+    assert.ok(result.artifactId);
+  });
+});

--- a/src/tools/reducer.ts
+++ b/src/tools/reducer.ts
@@ -1,0 +1,449 @@
+import { ToolArtifactStore } from "./artifact-store.js";
+
+export interface ReducerConfig {
+  enabled: boolean;
+  grep: {
+    maxTotalLines: number;
+    maxMatchesPerFile: number;
+    maxLineLength: number;
+    maxOutputChars: number;
+  };
+  read: {
+    maxOutlineLines: number;
+    maxSliceLines: number;
+    maxPreviewLines: number;
+    maxOutputChars: number;
+  };
+  bash: {
+    maxTotalLines: number;
+    maxErrorBlockLines: number;
+    maxTrailingLines: number;
+    maxOutputChars: number;
+    dedupeConsecutiveLines: boolean;
+  };
+  webFetch: {
+    maxChars: number;
+    maxHeadingChars: number;
+  };
+}
+
+export const DEFAULT_REDUCER_CONFIG: ReducerConfig = {
+  enabled: true,
+  grep: {
+    maxTotalLines: 50,
+    maxMatchesPerFile: 3,
+    maxLineLength: 200,
+    maxOutputChars: 3000,
+  },
+  read: {
+    maxOutlineLines: 60,
+    maxSliceLines: 200,
+    maxPreviewLines: 30,
+    maxOutputChars: 4000,
+  },
+  bash: {
+    maxTotalLines: 40,
+    maxErrorBlockLines: 20,
+    maxTrailingLines: 20,
+    maxOutputChars: 4000,
+    dedupeConsecutiveLines: true,
+  },
+  webFetch: {
+    maxChars: 2000,
+    maxHeadingChars: 500,
+  },
+};
+
+export interface ReducedOutput {
+  content: string;
+  rawBytes: number;
+  reducedBytes: number;
+  artifactId: string;
+}
+
+/** Main entry: reduce raw tool output, store raw artifact, return reduced form. */
+export function reduceToolOutput(
+  toolName: string,
+  raw: string,
+  args: Record<string, unknown>,
+  store: ToolArtifactStore,
+  config: ReducerConfig = DEFAULT_REDUCER_CONFIG,
+): ReducedOutput {
+  const rawBytes = Buffer.byteLength(raw, "utf8");
+  const artifactId = store.store(raw);
+
+  if (!config.enabled) {
+    return { content: raw, rawBytes, reducedBytes: rawBytes, artifactId };
+  }
+
+  let reduced: string;
+  let wasReduced = false;
+  let hint: string | undefined;
+
+  switch (toolName) {
+    case "grep": {
+      const r = reduceGrep(raw, args, config.grep);
+      reduced = r.body;
+      wasReduced = r.wasReduced;
+      hint = r.hint;
+      break;
+    }
+    case "read": {
+      const r = reduceRead(raw, args, config.read);
+      reduced = r.body;
+      wasReduced = r.wasReduced;
+      hint = r.hint;
+      break;
+    }
+    case "bash": {
+      const r = reduceBash(raw, args, config.bash);
+      reduced = r.body;
+      wasReduced = r.wasReduced;
+      hint = r.hint;
+      break;
+    }
+    case "web_fetch": {
+      const r = reduceWebFetch(raw, args, config.webFetch);
+      reduced = r.body;
+      wasReduced = r.wasReduced;
+      hint = r.hint;
+      break;
+    }
+    default:
+      reduced = raw;
+      break;
+  }
+
+  if (!wasReduced) {
+    return { content: reduced, rawBytes, reducedBytes: rawBytes, artifactId };
+  }
+
+  const footer = `[output reduced — full raw stored as artifact ${artifactId}]`;
+  const content = hint ? `${reduced}\n${footer}\n${hint}` : `${reduced}\n${footer}`;
+  const reducedBytes = Buffer.byteLength(content, "utf8");
+  return { content, rawBytes, reducedBytes, artifactId };
+}
+
+// ─── Grep ────────────────────────────────────────────────────────────────────
+
+interface GrepMatch {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function parseGrepLines(raw: string): GrepMatch[] {
+  const matches: GrepMatch[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // ripgrep format: file:line:text  or  file:text (if no line numbers)
+    const m = trimmed.match(/^(.+?):(\d+)?:(.*)$/);
+    if (m) {
+      matches.push({ file: m[1]!, line: m[2] ? parseInt(m[2], 10) : 0, text: m[3]! });
+    } else {
+      // files-only mode or plain path
+      matches.push({ file: trimmed, line: 0, text: "" });
+    }
+  }
+  return matches;
+}
+
+interface ReduceResult {
+  body: string;
+  wasReduced: boolean;
+  hint?: string;
+}
+
+function reduceGrep(raw: string, args: Record<string, unknown>, cfg: ReducerConfig["grep"]): ReduceResult {
+  const isFilesMode = args.output_mode === "files";
+  const matches = parseGrepLines(raw);
+
+  if (matches.length === 0) {
+    return { body: raw, wasReduced: false };
+  }
+
+  // Files-only mode: reformat as count + list (always considered reduced)
+  if (isFilesMode) {
+    const files = [...new Set(matches.map((m) => m.file))];
+    const lines = [`${files.length} file(s) matched:`, ...files];
+    return {
+      body: lines.join("\n"),
+      wasReduced: true,
+      hint: "Re-run with output_mode=\"content\" for match details.",
+    };
+  }
+
+  // Group by file
+  const byFile = new Map<string, GrepMatch[]>();
+  for (const m of matches) {
+    const list = byFile.get(m.file) ?? [];
+    list.push(m);
+    byFile.set(m.file, list);
+  }
+
+  const lines: string[] = [];
+  let totalShown = 0;
+  const totalHits = matches.length;
+  const fileCount = byFile.size;
+
+  lines.push(`Matched ${fileCount} file(s) (${totalHits} total hits):`);
+
+  for (const [file, hits] of byFile) {
+    if (totalShown >= cfg.maxTotalLines) break;
+    lines.push(`  ${file}: ${hits.length} hit(s)`);
+    const toShow = Math.min(hits.length, cfg.maxMatchesPerFile);
+    for (let i = 0; i < toShow; i++) {
+      const h = hits[i]!;
+      const text = h.text.length > cfg.maxLineLength ? h.text.slice(0, cfg.maxLineLength) + "…" : h.text;
+      const prefix = h.line > 0 ? `    ${h.line}:` : "    ";
+      lines.push(`${prefix}${text}`);
+      totalShown++;
+      if (totalShown >= cfg.maxTotalLines) break;
+    }
+  }
+
+  if (totalShown < totalHits) {
+    lines.push(`  … (${totalHits - totalShown} more hits omitted)`);
+  }
+
+  return {
+    body: lines.join("\n"),
+    wasReduced: totalHits > totalShown || fileCount > 1,
+    hint: "Use expand_artifact for full matches, or re-run with output_mode=\"files\" for paths only.",
+  };
+}
+
+// ─── Read ────────────────────────────────────────────────────────────────────
+
+function reduceRead(raw: string, args: Record<string, unknown>, cfg: ReducerConfig["read"]): ReduceResult {
+  // If user explicitly requested a slice, respect it (but still cap)
+  const hasSlice = typeof args.offset === "number" || typeof args.limit === "number";
+  if (hasSlice) {
+    const lines = raw.split("\n");
+    if (lines.length > cfg.maxSliceLines) {
+      const kept = lines.slice(0, cfg.maxSliceLines).join("\n");
+      return {
+        body: kept,
+        wasReduced: true,
+        hint: `… (${lines.length - cfg.maxSliceLines} more lines omitted)`,
+      };
+    }
+    return { body: raw, wasReduced: false };
+  }
+
+  // Full file: produce structure outline
+  const allLines = raw.split("\n");
+  const totalLines = allLines.length;
+
+  // Strip line numbers for parsing (format: "  1\tcontent" or "1\tcontent")
+  const cleanLines = allLines.map((l) => l.replace(/^\s*\d+\t/, ""));
+
+  const imports: string[] = [];
+  const exports: string[] = [];
+  const functions: string[] = [];
+  const classes: string[] = [];
+
+  for (let i = 0; i < cleanLines.length; i++) {
+    const line = cleanLines[i]!;
+    const lineNum = i + 1;
+    if (/^import\s+/.test(line)) {
+      imports.push(`${lineNum}: ${line.trim()}`);
+    } else if (/^(?:export\s+)?class\s+\w+/.test(line)) {
+      classes.push(`${lineNum}: ${line.trim()}`);
+    } else if (/^export\s+/.test(line)) {
+      exports.push(`${lineNum}: ${line.trim()}`);
+    } else if (/^(?:async\s+)?function\s+\w+/.test(line)) {
+      functions.push(`${lineNum}: ${line.trim()}`);
+    }
+  }
+
+  const parts: string[] = [];
+  parts.push(`File: ${totalLines} lines total`);
+
+  if (imports.length > 0) {
+    parts.push(`\nImports (${imports.length}):`);
+    parts.push(...imports.slice(0, Math.floor(cfg.maxOutlineLines / 4)));
+  }
+  if (exports.length > 0) {
+    parts.push(`\nExports (${exports.length}):`);
+    parts.push(...exports.slice(0, Math.floor(cfg.maxOutlineLines / 4)));
+  }
+  if (functions.length > 0) {
+    parts.push(`\nFunctions (${functions.length}):`);
+    parts.push(...functions.slice(0, Math.floor(cfg.maxOutlineLines / 4)));
+  }
+  if (classes.length > 0) {
+    parts.push(`\nClasses (${classes.length}):`);
+    parts.push(...classes.slice(0, Math.floor(cfg.maxOutlineLines / 4)));
+  }
+
+  // Preview first N lines
+  const previewCount = Math.min(cfg.maxPreviewLines, totalLines);
+  parts.push(`\nPreview (lines 1–${previewCount}):`);
+  parts.push(...allLines.slice(0, previewCount));
+
+  return {
+    body: parts.join("\n"),
+    wasReduced: true,
+    hint: "Use expand_artifact for full file, or read with offset/limit for a specific slice.",
+  };
+}
+
+// ─── Bash ────────────────────────────────────────────────────────────────────
+
+function reduceBash(raw: string, _args: Record<string, unknown>, cfg: ReducerConfig["bash"]): ReduceResult {
+  const lines = raw.split("\n");
+  if (lines.length <= cfg.maxTotalLines) {
+    return { body: raw, wasReduced: false };
+  }
+
+  // Parse header (first line usually contains exit=... or timeout)
+  let header = "";
+  let bodyStart = 0;
+  if (lines[0]?.startsWith("exit=") || lines[0]?.startsWith("(timed out")) {
+    header = lines[0]!;
+    bodyStart = 1;
+  }
+
+  const body = lines.slice(bodyStart);
+
+  // Determine if this looks like a failure
+  const isFailure = header.includes("exit=1") ||
+    raw.includes("Error:") ||
+    raw.includes("error:") ||
+    raw.includes("FAIL") ||
+    raw.includes("failed");
+
+  const out: string[] = [header];
+
+  if (isFailure) {
+    // Extract error block: lines near errors or stack traces
+    const errorIndices: number[] = [];
+    for (let i = 0; i < body.length; i++) {
+      const line = body[i]!;
+      if (
+        /\bError\b/i.test(line) ||
+        /\berror\b/i.test(line) ||
+        /\bFAIL\b/i.test(line) ||
+        /\bfailed\b/i.test(line) ||
+        /^\s+at\s+/.test(line) ||
+        /\s+Error:\s+/.test(line)
+      ) {
+        // Grab a window around the error
+        for (let j = Math.max(0, i - 2); j <= Math.min(body.length - 1, i + 2); j++) {
+          if (!errorIndices.includes(j)) errorIndices.push(j);
+        }
+      }
+    }
+
+    // Sort and cap error block
+    errorIndices.sort((a, b) => a - b);
+    const cappedError = errorIndices.slice(0, cfg.maxErrorBlockLines);
+    if (cappedError.length > 0) {
+      out.push("--- error block ---");
+      for (const idx of cappedError) {
+        out.push(body[idx]!);
+      }
+    }
+
+    // Extract failing test names
+    const testNames: string[] = [];
+    for (const line of body) {
+      const m = line.match(/(?:✗|✕|×|FAIL)\s+(.+)/) ||
+        line.match(/failing\s*\d*\s*:?\s*(.+)/i) ||
+        line.match(/Test\s+\w+\s+failed/i);
+      if (m && m[1]) {
+        const name = m[1].trim().slice(0, 120);
+        if (!testNames.includes(name)) testNames.push(name);
+      }
+    }
+    if (testNames.length > 0) {
+      out.push("--- failing tests ---");
+      out.push(...testNames.slice(0, 10));
+    }
+  }
+
+  // Last N relevant lines
+  const trailing = body.slice(-cfg.maxTrailingLines);
+  out.push("--- last lines ---");
+  out.push(...trailing);
+
+  // Deduplicate consecutive repeated lines if enabled
+  let result = out.join("\n");
+  if (cfg.dedupeConsecutiveLines) {
+    result = dedupeConsecutive(result);
+  }
+
+  return {
+    body: result,
+    wasReduced: true,
+    hint: "Use expand_artifact for full output.",
+  };
+}
+
+function dedupeConsecutive(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let repeatCount = 1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const next = lines[i + 1];
+    if (next !== undefined && next === line) {
+      repeatCount++;
+      continue;
+    }
+    if (repeatCount > 2) {
+      out.push(line);
+      out.push(`… (${repeatCount - 1} identical lines omitted)`);
+    } else {
+      for (let j = 0; j < repeatCount; j++) {
+        out.push(line);
+      }
+    }
+    repeatCount = 1;
+  }
+  return out.join("\n");
+}
+
+// ─── Web Fetch ───────────────────────────────────────────────────────────────
+
+function reduceWebFetch(raw: string, args: Record<string, unknown>, cfg: ReducerConfig["webFetch"]): ReduceResult {
+  const url = typeof args.url === "string" ? args.url : "(unknown URL)";
+
+  // Extract title from first heading
+  const titleMatch = raw.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1]!.trim() : "(no title)";
+
+  const parts: string[] = [];
+  parts.push(`Title: ${title}`);
+  parts.push(`URL: ${url}`);
+
+  // Extract headings for a mini TOC
+  const headings = raw.match(/^#{1,3}\s+.+$/gm) ?? [];
+  if (headings.length > 0) {
+    parts.push("\nSections:");
+    for (const h of headings.slice(0, 10)) {
+      parts.push(`  ${h}`);
+    }
+  }
+
+  // First N chars of body
+  const bodyStart = raw.indexOf("\n\n");
+  const body = bodyStart > 0 ? raw.slice(bodyStart + 2) : raw;
+  const excerpt = body.slice(0, cfg.maxChars).trim();
+  if (excerpt) {
+    parts.push(`\nExcerpt (${excerpt.length} chars):`);
+    parts.push(excerpt);
+  }
+
+  if (body.length > cfg.maxChars) {
+    parts.push(`\n… (${body.length - cfg.maxChars} more chars omitted)`);
+  }
+
+  return {
+    body: parts.join("\n"),
+    wasReduced: true,
+    hint: "Use expand_artifact for full page content.",
+  };
+}

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -1,19 +1,17 @@
 import TurndownService from "turndown";
 import type { ToolSpec, ToolOutput } from "./registry.js";
-import { truncate } from "../util/paths.js";
 
 interface Args {
   url: string;
 }
 
 const MAX_BYTES = 1 * 1024 * 1024;
-const MAX_OUTPUT = 100_000;
 const TIMEOUT_MS = 20_000;
 
 export const webFetchTool: ToolSpec<Args> = {
   name: "web_fetch",
   description:
-    "Fetch a URL over HTTPS and return its content. HTML pages are converted to markdown. Output is capped at ~100KB.",
+    "Fetch a URL over HTTPS and return its content. HTML pages are converted to markdown. Large pages are reduced to a summary by default; use expand_artifact to retrieve the full content.",
   parameters: {
     type: "object",
     properties: {
@@ -43,11 +41,10 @@ export const webFetchTool: ToolSpec<Args> = {
       } else {
         raw = `# ${args.url}\n\n${bounded}`;
       }
-      const reduced = truncate(raw, MAX_OUTPUT);
       return {
-        content: reduced,
+        content: raw,
         rawBytes: Buffer.byteLength(raw, "utf8"),
-        reducedBytes: Buffer.byteLength(reduced, "utf8"),
+        reducedBytes: Buffer.byteLength(raw, "utf8"),
       };
     } finally {
       clearTimeout(timer);


### PR DESCRIPTION
## What

Every tool now returns a **compact, high-signal summary by default**. The full raw output is preserved in an in-memory artifact store and can be retrieved on demand via the new `expand_artifact` tool.

## Why

Tool-heavy sessions were dumping 30KB grep results, full file contents, and massive bash logs into the prompt context. This change significantly reduces input token volume while keeping first-pass outputs actionable.

## Architecture

```
tool.run() → full raw output
     ↓
reduceToolOutput() → stores raw in ToolArtifactStore (LRU, in-memory only)
     ↓
reduced content + artifact footer → injected into model context
```

- **No race conditions**: single-threaded Node.js, monotonic counter IDs, artifact store lives inside `ToolExecutor` (no shared mutable state across async boundaries)
- **No disk cleanup needed**: `ToolArtifactStore` is in-memory only, capped at 500 artifacts / 2M chars with LRU eviction. Cleared on `/clear`.

## Per-tool behavior

| Tool | Default (reduced) | Escalation path |
|------|-------------------|-----------------|
| `grep` | File paths + hit counts + top 3 matches/file | `expand_artifact` or `output_mode: "files"` |
| `read` (no slice) | File size, imports, exports, functions, classes, preview | `expand_artifact` or `offset`/`limit` |
| `bash` | Exit code, error block, failing tests, last 20 lines | `expand_artifact` |
| `web_fetch` | Title, URL, headings, excerpt | `expand_artifact` |
| `glob/write/edit/tasks` | Pass-through (already compact) | — |

## New files

- `src/tools/artifact-store.ts` — in-memory LRU artifact store
- `src/tools/reducer.ts` — reducer abstraction + per-tool implementations + `ReducerConfig`
- `src/tools/expand-artifact.ts` — `expand_artifact` tool spec
- `src/tools/reducer.test.ts` — 14 tests

## Modified files

- `src/tools/executor.ts` — wires reducer, registers `expand_artifact`, adds `artifactId` to `ToolResult`
- `src/tools/grep.ts` — removed blunt 30KB truncate, returns full raw
- `src/tools/bash.ts` — removed 30KB truncate, returns full raw
- `src/tools/web-fetch.ts` — removed 100KB truncate, returns full raw
- `src/tools/read.ts` — updated description to mention reduction
- `src/agent/system-prompt.ts` — added guidance on reduced outputs and `expand_artifact`
- `src/app.tsx` — clears artifact store on `/clear`

## Metrics

`rawBytes` vs `reducedBytes` already flows through `ToolResult` into `cost-debug.ts` — no additional instrumentation needed.

## Test results

```
npm run typecheck  ✅
npm run build      ✅
npm test           ✅ 54/54 pass
```

---

Co-authored-by: kimiflare <kimiflare@proton.me>