### PR TITLE
fix: show USD currency symbol in status bar cost display

### DIFF
--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -83,7 +83,7 @@ function buildRightParts(usage: Usage, contextLimit: number): string[] {
     `in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
     `out ${usage.completion_tokens}`,
     `ctx ${pct}%`,
-    `${cost.total.toFixed(5)}`,
+    `$${cost.total.toFixed(5)}`,
   ];
 }
 


### PR DESCRIPTION
Prefixes the estimated cost in the status bar with `$` so users know it's USD.