### PR TITLE
feat: strip reasoning_content from historical assistant messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.17.0](https://github.com/sinameraji/kimiflare/compare/v0.16.0...v0.17.0) (2026-04-23)
+
+
+### Features
+
+* token-efficient tool result reducers with progressive disclosure ([1e42eb4](https://github.com/sinameraji/kimiflare/commit/1e42eb47104e019840e78338dba6016419491ea0))
+* token-efficient tool result reducers with progressive disclosure ([0ce4bf8](https://github.com/sinameraji/kimiflare/commit/0ce4bf891d211a64ddaaa81e6d242857fa23d6a5))
+
+
+### Bug Fixes
+
+* lock down plan mode to strictly read-only bash commands ([d33c7cb](https://github.com/sinameraji/kimiflare/commit/d33c7cbc13e8b08d3280aa1fd3779f00225c5fdd))
+* lock down plan mode to strictly read-only bash commands ([78b87fc](https://github.com/sinameraji/kimiflare/commit/78b87fc741723749700491fc5797e26dd4560f8b))
+* show USD currency symbol in status bar cost display ([eb6e0ea](https://github.com/sinameraji/kimiflare/commit/eb6e0eacf2b426e1cf39c7226d2af840924e38d1))
+* show USD currency symbol in status bar cost display ([80b43f2](https://github.com/sinameraji/kimiflare/commit/80b43f2360eeb8394794974c128e1bbf104ee059))
+* show USD currency symbol in status bar cost display ([2378d8e](https://github.com/sinameraji/kimiflare/commit/2378d8e428472c2645d74f1a849412eb8f3b247c))
+
 ## [0.16.0](https://github.com/sinameraji/kimiflare/compare/v0.15.0...v0.16.0) (2026-04-23)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kimiflare",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kimiflare",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Image understanding, plan mode, MCP server integration, 262k context.",
   "keywords": [
     "ai",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -4,7 +4,8 @@ import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executo
 import { sanitizeString } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tasks-state.js";
-import { logTurnDebug } from "../cost-debug.js";
+import { logTurnDebug, analyzePrompt } from "../cost-debug.js";
+import { stripHistoricalReasoning } from "./strip-reasoning.js";
 
 export interface AgentCallbacks {
   onAssistantStart?: () => void;
@@ -53,11 +54,52 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     let reasoning = "";
     opts.callbacks.onAssistantStart?.();
 
+    const stripReasoning = process.env.KIMIFLARE_STRIP_REASONING === "1";
+    const shadowStrip = process.env.KIMIFLARE_SHADOW_STRIP === "1";
+    const keepLastRaw = process.env.KIMIFLARE_REASONING_KEEP_LAST;
+    const keepLast = keepLastRaw ? parseInt(keepLastRaw, 10) : 1;
+
+    let apiMessages = opts.messages;
+    let shadowStripMetrics:
+      | { originalApproxTokens: number; strippedApproxTokens: number; savingsPct: number }
+      | undefined;
+
+    if (stripReasoning || shadowStrip) {
+      const stripped = stripHistoricalReasoning(opts.messages, {
+        keepLast: Number.isNaN(keepLast) ? 1 : keepLast,
+      });
+      if (shadowStrip) {
+        const originalSections = analyzePrompt(opts.messages);
+        const strippedSections = analyzePrompt(stripped);
+        const originalApproxTokens = originalSections.reduce(
+          (sum, s) => sum + s.approxTokens,
+          0,
+        );
+        const strippedApproxTokens = strippedSections.reduce(
+          (sum, s) => sum + s.approxTokens,
+          0,
+        );
+        shadowStripMetrics = {
+          originalApproxTokens,
+          strippedApproxTokens,
+          savingsPct:
+            originalApproxTokens > 0
+              ? Math.round(
+                  ((originalApproxTokens - strippedApproxTokens) / originalApproxTokens) * 100,
+                )
+              : 0,
+        };
+      }
+      if (stripReasoning) {
+        apiMessages = stripped;
+      }
+    }
+
     const events = runKimi({
       accountId: opts.accountId,
       apiToken: opts.apiToken,
       model: opts.model,
-      messages: opts.messages,
+      messages: apiMessages,
       tools: toolDefs,
       signal: opts.signal,
       temperature: opts.temperature,
@@ -130,6 +172,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           previousMessages,
           toolResults,
           usage: lastUsage,
+          shadowStrip: shadowStripMetrics,
         });
       }
       return;
@@ -160,6 +203,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         previousMessages,
         toolResults,
         usage: lastUsage,
+        shadowStrip: shadowStripMetrics,
       });
     }
   }

--- a/src/agent/strip-reasoning.test.ts
+++ b/src/agent/strip-reasoning.test.ts
@@ -1,0 +1,135 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { stripHistoricalReasoning } from "./strip-reasoning.js";
+import type { ChatMessage } from "./messages.js";
+
+describe("stripHistoricalReasoning", () => {
+  it("leaves system and user messages untouched", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hi" },
+    ];
+    const out = stripHistoricalReasoning(messages);
+    assert.deepStrictEqual(out, messages);
+  });
+
+  it("preserves reasoning on the most recent assistant message by default", () => {
+    const messages: ChatMessage[] = [
+      {
+        role: "assistant",
+        content: "old",
+        reasoning_content: "old reasoning",
+        tool_calls: [
+          { id: "tc1", type: "function", function: { name: "read", arguments: "{}" } },
+        ],
+      },
+      { role: "tool", content: "result", tool_call_id: "tc1" },
+      {
+        role: "assistant",
+        content: "new",
+        reasoning_content: "new reasoning",
+      },
+    ];
+    const out = stripHistoricalReasoning(messages);
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+    assert.strictEqual(out[0]!.content, "");
+    assert.strictEqual(out[2]!.reasoning_content, "new reasoning");
+    assert.strictEqual(out[2]!.content, "new");
+  });
+
+  it("strips reasoning from all assistant messages when keepLast=0", () => {
+    const messages: ChatMessage[] = [
+      {
+        role: "assistant",
+        content: "a",
+        reasoning_content: "r1",
+      },
+      {
+        role: "assistant",
+        content: "b",
+        reasoning_content: "r2",
+      },
+    ];
+    const out = stripHistoricalReasoning(messages, { keepLast: 0 });
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+    assert.strictEqual(out[1]!.reasoning_content, undefined);
+  });
+
+  it("preserves text-only messages when text is substantive (>200 chars)", () => {
+    const longText = "x".repeat(201);
+    const messages: ChatMessage[] = [
+      { role: "assistant", content: longText, reasoning_content: "reason" },
+    ];
+    const out = stripHistoricalReasoning(messages, { keepLast: 0 });
+    assert.strictEqual(out[0]!.content, longText);
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+  });
+
+  it("strips text-only messages when text is short (≤200 chars)", () => {
+    const messages: ChatMessage[] = [
+      { role: "assistant", content: "short", reasoning_content: "reason" },
+    ];
+    const out = stripHistoricalReasoning(messages, { keepLast: 0 });
+    assert.strictEqual(out[0]!.content, "");
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+  });
+
+  it("strips text but preserves multiple tool_calls", () => {
+    const messages: ChatMessage[] = [
+      {
+        role: "assistant",
+        content: "Let me check",
+        reasoning_content: "plan",
+        tool_calls: [
+          { id: "tc1", type: "function", function: { name: "read", arguments: "{}" } },
+          { id: "tc2", type: "function", function: { name: "grep", arguments: "{}" } },
+        ],
+      },
+    ];
+    const out = stripHistoricalReasoning(messages, { keepLast: 0 });
+    assert.strictEqual(out[0]!.content, "");
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+    assert.strictEqual(out[0]!.tool_calls!.length, 2);
+  });
+
+  it("handles array content correctly", () => {
+    const messages: ChatMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "narration" },
+          { type: "image_url", image_url: { url: "http://example.com/img.png" } },
+        ],
+        reasoning_content: "plan",
+        tool_calls: [
+          { id: "tc1", type: "function", function: { name: "read", arguments: "{}" } },
+        ],
+      },
+    ];
+    const out = stripHistoricalReasoning(messages, { keepLast: 0 });
+    const content = out[0]!.content as Array<{ type: string; text?: string }>;
+    assert.strictEqual(content[0]!.text, "");
+    assert.strictEqual(content[1]!.type, "image_url");
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+  });
+
+  it("does not modify tool messages", () => {
+    const messages: ChatMessage[] = [
+      { role: "tool", content: "result", tool_call_id: "tc1" },
+    ];
+    const out = stripHistoricalReasoning(messages);
+    assert.deepStrictEqual(out, messages);
+  });
+
+  it("preserves the last N assistant messages based on keepLast", () => {
+    const messages: ChatMessage[] = [
+      { role: "assistant", content: "first", reasoning_content: "r1" },
+      { role: "assistant", content: "second", reasoning_content: "r2" },
+      { role: "assistant", content: "third", reasoning_content: "r3" },
+    ];
+    const out = stripHistoricalReasoning(messages, { keepLast: 2 });
+    assert.strictEqual(out[0]!.reasoning_content, undefined);
+    assert.strictEqual(out[1]!.reasoning_content, "r2");
+    assert.strictEqual(out[2]!.reasoning_content, "r3");
+  });
+});

--- a/src/agent/strip-reasoning.ts
+++ b/src/agent/strip-reasoning.ts
@@ -1,0 +1,86 @@
+import type { ChatMessage } from "./messages.js";
+
+export interface StripReasoningOpts {
+  /** Number of most-recent assistant messages to preserve reasoning on. Default 1. */
+  keepLast?: number;
+}
+
+const DEFAULT_KEEP_LAST = 1;
+const SUBSTANTIVE_TEXT_THRESHOLD = 200;
+
+/**
+ * Strip reasoning_content and narration text from historical assistant messages.
+ *
+ * Rules:
+ * - Keep reasoning_content on the N most recent assistant messages (default N=1).
+ * - On older assistant messages:
+ *   - Delete reasoning_content key entirely.
+ *   - If the message has both text content and tool_calls, replace text with "".
+ *   - If the message has only text (no tool_calls), preserve it only when text
+ *     length > SUBSTANTIVE_TEXT_THRESHOLD chars; otherwise replace with "".
+ * - tool, system, and user messages are never modified.
+ */
+export function stripHistoricalReasoning(
+  messages: ChatMessage[],
+  opts: StripReasoningOpts = {},
+): ChatMessage[] {
+  const keepLast = opts.keepLast ?? DEFAULT_KEEP_LAST;
+
+  // Identify indices of assistant messages so we know which are "recent".
+  const assistantIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i]!.role === "assistant") {
+      assistantIndices.push(i);
+    }
+  }
+
+  // The last `keepLast` assistant messages are preserved; everything older is stripped.
+  const preservedSet =
+    keepLast === 0
+      ? new Set<number>()
+      : new Set(assistantIndices.slice(-keepLast));
+
+  return messages.map((m, idx) => {
+    if (m.role !== "assistant") return m;
+    if (preservedSet.has(idx)) return m;
+
+    const next: ChatMessage = { ...m };
+
+    // Delete reasoning_content entirely.
+    delete (next as unknown as Record<string, unknown>).reasoning_content;
+
+    // Strip narration text when tool_calls are present.
+    if (next.tool_calls && next.tool_calls.length > 0) {
+      if (typeof next.content === "string") {
+        next.content = "";
+      } else if (Array.isArray(next.content)) {
+        next.content = next.content.map((part) =>
+          part.type === "text" ? { ...part, text: "" } : part,
+        );
+      }
+      return next;
+    }
+
+    // No tool_calls — decide whether text is substantive.
+    const textLen =
+      typeof next.content === "string"
+        ? next.content.length
+        : Array.isArray(next.content)
+          ? next.content
+              .filter((p) => p.type === "text")
+              .reduce((sum, p) => sum + p.text.length, 0)
+          : 0;
+
+    if (textLen <= SUBSTANTIVE_TEXT_THRESHOLD) {
+      if (typeof next.content === "string") {
+        next.content = "";
+      } else if (Array.isArray(next.content)) {
+        next.content = next.content.map((part) =>
+          part.type === "text" ? { ...part, text: "" } : part,
+        );
+      }
+    }
+
+    return next;
+  });
+}

--- a/src/cost-debug.ts
+++ b/src/cost-debug.ts
@@ -54,6 +54,7 @@ export interface CostDebugEntry {
   toolSavingsPct: number;
   cacheDiagnostics?: CacheDiagnostics;
   compaction?: CompactionMetrics;
+  shadowStrip?: ShadowStripMetrics;
 }
 
 function debugDir(): string {
@@ -130,6 +131,12 @@ export async function logCostDebug(entry: CostDebugEntry): Promise<void> {
   await appendFile(debugPath(), JSON.stringify(entry) + "\n", "utf8");
 }
 
+export interface ShadowStripMetrics {
+  originalApproxTokens: number;
+  strippedApproxTokens: number;
+  savingsPct: number;
+}
+
 export interface TurnDebugContext {
   sessionId: string;
   turn: number;
@@ -138,6 +145,7 @@ export interface TurnDebugContext {
   usage: Usage;
   previousMessages?: ChatMessage[];
   compaction?: CompactionMetrics;
+  shadowStrip?: ShadowStripMetrics;
 }
 
 /** Serialize the prompt prefix (all leading system messages) for comparison. */
@@ -242,5 +250,6 @@ export async function logTurnDebug(ctx: TurnDebugContext): Promise<void> {
     toolSavingsPct: toolTotalRaw > 0 ? Math.round(((toolTotalRaw - toolTotalReduced) / toolTotalRaw) * 100) : 0,
     cacheDiagnostics,
     compaction: ctx.compaction,
+    shadowStrip: ctx.shadowStrip,
   });
 }


### PR DESCRIPTION
Implements the message-array transformation described in #94 to reduce input tokens by ~10–20%.

### What's new
- `stripHistoricalReasoning()` in `src/agent/strip-reasoning.ts` removes `reasoning_content` from older assistant messages and replaces narration text with empty strings when `tool_calls` are present.
- Preserves substantive text-only messages (>200 chars) and the last N assistant messages (configurable via `KIMIFLARE_REASONING_KEEP_LAST`, default 1).
- Gated behind `KIMIFLARE_STRIP_REASONING=1` (default OFF for initial rollout).
- Shadow mode via `KIMIFLARE_SHADOW_STRIP=1` logs expected token savings to `cost-debug.jsonl` without changing API behavior.

### Env flags
| Variable | Default | Description |
|---|---|---|
| `KIMIFLARE_STRIP_REASONING` | unset (OFF) | Set to `1` to send the stripped message array to the API. |
| `KIMIFLARE_SHADOW_STRIP` | unset (OFF) | Set to `1` to log shadow metrics while still sending the unstripped array. |
| `KIMIFLARE_REASONING_KEEP_LAST` | `1` | Number of most-recent assistant messages to preserve reasoning on. |

### Acceptance criteria tracking
- [ ] Shadow-mode logs show ≥10% input token reduction across ≥50 sessions.
- [ ] Benchmark suite shows <2% regression vs unstripped baseline.

Closes #94

Co-authored-by: kimiflare <kimiflare@proton.me>