### PR TITLE
feat: drop image content from message history after N turns

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,7 +1,7 @@
 import { runKimi } from "./client.js";
 import { toOpenAIToolDefs, type ToolSpec } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
-import { sanitizeString } from "./messages.js";
+import { sanitizeString, stripOldImages } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tasks-state.js";
 import { logTurnDebug, analyzePrompt } from "../cost-debug.js";
@@ -37,6 +37,8 @@ export interface AgentTurnOpts {
   reasoningEffort?: "low" | "medium" | "high";
   coauthor?: { name: string; email: string };
   sessionId?: string;
+  /** Drop image_url parts from user messages older than this many turns. */
+  keepLastImageTurns?: number;
 }
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
@@ -93,6 +95,10 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       if (stripReasoning) {
         apiMessages = stripped;
       }
+    }
+
+    if (opts.keepLastImageTurns !== undefined) {
+      apiMessages = stripOldImages(apiMessages, opts.keepLastImageTurns);
     }
 
     const events = runKimi({

--- a/src/agent/messages.test.ts
+++ b/src/agent/messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { stableStringify } from "./messages.js";
+import { stableStringify, stripOldImages } from "./messages.js";
+import type { ChatMessage } from "./messages.js";
 
 describe("stableStringify", () => {
   it("produces identical strings for objects with different key insertion orders", () => {
@@ -37,5 +38,73 @@ describe("stableStringify", () => {
     const obj = { a: 1 };
     const result = stableStringify(obj, undefined, 2);
     assert.ok(result.includes("\n"));
+  });
+});
+
+describe("stripOldImages", () => {
+  const img = (url: string) => ({ type: "image_url" as const, image_url: { url } });
+  const txt = (text: string) => ({ type: "text" as const, text });
+
+  it("keeps images in recent turns", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: [txt("old"), img("http://old")] },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [txt("new"), img("http://new")] },
+    ];
+    const result = stripOldImages(messages, 1);
+    assert.deepStrictEqual((result[1]!.content as typeof messages[0]["content"])!, [txt("old")]);
+    assert.deepStrictEqual((result[3]!.content as typeof messages[0]["content"])!, [txt("new"), img("http://new")]);
+  });
+
+  it("strips images from older turns while keeping text", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: [txt("a"), img("http://a")] },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [txt("b"), img("http://b")] },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [txt("c"), img("http://c")] },
+    ];
+    const result = stripOldImages(messages, 2);
+    assert.deepStrictEqual((result[0]!.content as typeof messages[0]["content"])!, [txt("a")]);
+    assert.deepStrictEqual((result[2]!.content as typeof messages[0]["content"])!, [txt("b"), img("http://b")]);
+    assert.deepStrictEqual((result[4]!.content as typeof messages[0]["content"])!, [txt("c"), img("http://c")]);
+  });
+
+  it("leaves string-only messages untouched", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    const result = stripOldImages(messages, 1);
+    assert.strictEqual(result[0]!.content, "hello");
+  });
+
+  it("replaces image-only messages with fallback text", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: [img("http://x")] },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [img("http://y")] },
+    ];
+    const result = stripOldImages(messages, 1);
+    assert.strictEqual(result[0]!.content, "[image omitted]");
+    assert.deepStrictEqual((result[2]!.content as typeof messages[0]["content"])!, [img("http://y")]);
+  });
+
+  it("does not mutate the original array", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: [txt("a"), img("http://a")] },
+    ];
+    const original = JSON.stringify(messages);
+    stripOldImages(messages, 0);
+    assert.strictEqual(JSON.stringify(messages), original);
+  });
+
+  it("returns input unchanged when keepLastTurns is negative", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: [img("http://a")] },
+    ];
+    const result = stripOldImages(messages, -1);
+    assert.deepStrictEqual((result[0]!.content as typeof messages[0]["content"])!, [img("http://a")]);
   });
 });

--- a/src/agent/messages.ts
+++ b/src/agent/messages.ts
@@ -96,3 +96,35 @@ export function stableStringify(value: unknown, replacer?: (key: string, val: un
   const sorted = sortKeys(value);
   return JSON.stringify(sorted, replacer, space);
 }
+
+/** Remove image_url content parts from user messages older than `keepLastTurns`.
+ *  Returns a new array; input is not mutated. */
+export function stripOldImages(messages: ChatMessage[], keepLastTurns: number): ChatMessage[] {
+  if (keepLastTurns < 0) return messages;
+
+  // Count user messages from the end to find the cutoff index.
+  let userCount = 0;
+  let cutoffIndex = messages.length;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === "user") {
+      userCount++;
+      if (userCount === keepLastTurns) {
+        cutoffIndex = i;
+        break;
+      }
+    }
+  }
+
+  return messages.map((m, idx) => {
+    if (m.role !== "user" || idx >= cutoffIndex) return m;
+    if (!Array.isArray(m.content)) return m;
+
+    const stripped = m.content.filter((p): p is ContentPart => p.type !== "image_url");
+    if (stripped.length === m.content.length) return m;
+
+    return {
+      ...m,
+      content: stripped.length > 0 ? stripped : "[image omitted]",
+    };
+  });
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -68,6 +68,7 @@ interface Cfg {
   mcpServers?: Record<string, { type: "local" | "remote"; command?: string[]; url?: string; env?: Record<string, string>; headers?: Record<string, string>; enabled?: boolean }>;
   cacheStablePrompts?: boolean;
   compiledContext?: boolean;
+  imageHistoryTurns?: number;
 }
 
 interface PendingPermission {
@@ -1157,6 +1158,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
               ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "kimiflare@proton.me" }
               : undefined,
           sessionId: ensureSessionId(),
+          keepLastImageTurns: cfg.imageHistoryTurns ?? 2,
           callbacks: {
             onAssistantStart: () => {
               const id = nextAssistantId++;

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,8 @@ export interface KimiConfig {
   cacheStablePrompts?: boolean;
   /** Enable compiled context (token-optimized state packet + artifact store). */
   compiledContext?: boolean;
+  /** Number of recent user turns to retain image content; older images are dropped. */
+  imageHistoryTurns?: number;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
@@ -64,6 +66,9 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envCompiled = process.env.KIMIFLARE_COMPILED_CONTEXT;
   const compiledContext = envCompiled === "1" || envCompiled === "true" ? true : false;
 
+  const envImageTurns = process.env.KIMIFLARE_IMAGE_HISTORY_TURNS;
+  const imageHistoryTurns = envImageTurns ? parseInt(envImageTurns, 10) : undefined;
+
   if (envAccount && envToken) {
     return {
       accountId: envAccount,
@@ -76,6 +81,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       coauthorEmail: envCoauthor?.email,
       cacheStablePrompts,
       compiledContext,
+      imageHistoryTurns: Number.isNaN(imageHistoryTurns) ? undefined : imageHistoryTurns,
     };
   }
 
@@ -95,6 +101,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         mcpServers: parsed.mcpServers,
         cacheStablePrompts: parsed.cacheStablePrompts ?? cacheStablePrompts,
         compiledContext: parsed.compiledContext ?? compiledContext,
+        imageHistoryTurns: Number.isNaN(imageHistoryTurns) ? parsed.imageHistoryTurns : imageHistoryTurns,
       };
     }
   } catch {


### PR DESCRIPTION
Closes #98

## Summary
Removes `image_url` content parts from user messages older than `keepLastImageTurns` before sending to the API, dramatically reducing token usage for sessions where users paste screenshots.

## Changes
- **`src/agent/messages.ts`** — New `stripOldImages()` utility. Filters out image parts from user messages beyond the N most recent turns, preserving text. Falls back to `[image omitted]` if a message had only images.
- **`src/agent/messages.test.ts`** — 6 unit tests covering retention, stripping, string-only messages, image-only fallback, immutability, and negative threshold.
- **`src/agent/loop.ts`** — New `keepLastImageTurns` option on `AgentTurnOpts`; applied to API messages right before `runKimi`.
- **`src/config.ts`** — New `imageHistoryTurns` config field + `KIMIFLARE_IMAGE_HISTORY_TURNS` env var.
- **`src/app.tsx`** — Passes `cfg.imageHistoryTurns ?? 2` into every agent turn.

## Token savings
A single 500 KB screenshot ≈ ~160K tokens. With the default of 2 kept turns, a session with regular image drops can save **hundreds of thousands to millions of tokens**.

Co-authored-by: kimiflare <kimiflare@proton.me>