### PR TITLE
fix: restore TUI entry point when running bare kimiflare command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.20.0](https://github.com/sinameraji/kimiflare/compare/v0.19.0...v0.20.0) (2026-04-24)
+
+
+### Features
+
+* reduce token usage by 70-90% via bounded context and tool output summarization ([#126](https://github.com/sinameraji/kimiflare/issues/126)) ([e75099e](https://github.com/sinameraji/kimiflare/commit/e75099e61b4f34730cd5c192913ee15b428cdbf6))
+
 ## [0.19.0](https://github.com/sinameraji/kimiflare/compare/v0.18.0...v0.19.0) (2026-04-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kimiflare",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kimiflare",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Image understanding, plan mode, MCP server integration, 262k context.",
   "keywords": [
     "ai",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ program
     await showUsageLog();
   });
 
+program.action(() => {});
 program.parse();
 
 const opts = program.opts<{


### PR DESCRIPTION
## Problem

In v0.20.0, the `usage` subcommand was added to the CLI. This caused a regression: running `kimiflare` with no arguments would print the help text and exit immediately, instead of opening the interactive TUI.

## Root Cause

Commander.js auto-prints help and exits when a program has subcommands but **no action on the parent command**. The `usage` subcommand was added without a parent action, so bare `kimiflare` never reached `main()`.

## Fix

Add an empty action to the parent command: `program.action(() => {})`. This prevents Commander from auto-showing help, allowing `main()` to run and the TUI to open as before.

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅
- `node dist/index.js` reaches main (TTY check) instead of printing help ✅
- `node dist/index.js usage` still works ✅

Fixes regression introduced in v0.20.0.