### PR TITLE
docs: remove 'no AI gateway' claims

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -30,7 +30,7 @@ Outcome: a `kimiflare` binary that opens a TUI, lets the user chat, calls Kimi-k
 - TypeScript. `tsup` builds, `tsx` for dev.
 - Ink + `ink-text-input`, `ink-spinner`, `ink-select-input`. React 18.
 - `commander` for CLI args. `fast-glob` for globs. `diff` for unified diffs. `turndown` for HTML→markdown.
-- No AI Gateway. No `openai` SDK. Direct `fetch`.
+- No `openai` SDK. Direct `fetch`.
 
 ## File layout
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - **262k context window** — Read entire modules, large configs, and full stack traces without the model losing track.
 - **Image understanding** — Drop image paths into your prompt (PNG, JPG, WebP, GIF, BMP). The model sees them inline — great for UI reviews, diagrams, screenshots, and mockups.
-- **Direct to Cloudflare** — No AI Gateway, no proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account.
+- **Direct to Cloudflare** — No proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account.
 - **Plan mode** — Ask the agent to research and produce a plan without touching your filesystem. Review it, then exit plan mode to execute.
 
 ## Quick start


### PR DESCRIPTION
Removes 'no AI gateway' language from README and PLAN.md so we can add Cloudflare AI Gateway support without contradictory messaging.

Keeps 'no middleman' on the landing page — AI Gateway is Cloudflare, not a third-party middleman.