### PR TITLE
feat(agent): send x-session-affinity header for prefix caching

### DIFF
--- a/src/agent/client.test.ts
+++ b/src/agent/client.test.ts
@@ -21,7 +21,7 @@ describe("runKimi session affinity header", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("sends X-Session-ID header when sessionId is provided", async () => {
+  it("sends X-Session-ID and x-session-affinity headers when sessionId is provided", async () => {
     const gen = runKimi({
       accountId: "test",
       apiToken: "token",
@@ -35,9 +35,10 @@ describe("runKimi session affinity header", () => {
     }
     assert.ok(lastRequest);
     assert.strictEqual(lastRequest!.headers.get("X-Session-ID"), "sess-123");
+    assert.strictEqual(lastRequest!.headers.get("x-session-affinity"), "sess-123");
   });
 
-  it("does not send X-Session-ID header when sessionId is omitted", async () => {
+  it("does not send session headers when sessionId is omitted", async () => {
     const gen = runKimi({
       accountId: "test",
       apiToken: "token",
@@ -49,5 +50,6 @@ describe("runKimi session affinity header", () => {
     }
     assert.ok(lastRequest);
     assert.strictEqual(lastRequest!.headers.get("X-Session-ID"), null);
+    assert.strictEqual(lastRequest!.headers.get("x-session-affinity"), null);
   });
 });

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -65,6 +65,7 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
       };
       if (opts.sessionId) {
         headers["X-Session-ID"] = opts.sessionId;
+        headers["x-session-affinity"] = opts.sessionId;
       }
       res = await fetch(url, {
         method: "POST",


### PR DESCRIPTION
Cloudflare Workers AI requires the `x-session-affinity` header to route requests to the same model instance that holds cached prefix tensors. Without this header, prefix caching (which bills at $0.16 vs full rate) has near-zero hit rate regardless of `sessionId` being present.

**Changes:**
- Send `x-session-affinity` alongside existing `X-Session-ID` when `sessionId` is provided in `RunKimiOpts`
- Update tests to assert both headers are sent

**Why it matters:**
At ~130M tokens/month and climbing, prefix caching is one of the biggest cost optimizations available. This single header is the difference between paying full price for every request and getting discounted cached-prefix rates.

All 69 tests pass, typecheck clean.

Co-authored-by: kimiflare <kimiflare@proton.me>