### PR TITLE
fix: configure release-please to use plain v tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Release-please in manifest mode expects `kimiflare-v0.20.3` style tags by default. Our tags are plain `v0.20.3`, so it couldn't find the last release and scanned all history.