### PR TITLE
feat: add optional AI Gateway routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - **262k context window** — Read entire modules, large configs, and full stack traces without the model losing track.
 - **Image understanding** — Drop image paths into your prompt (PNG, JPG, WebP, GIF, BMP). The model sees them inline — great for UI reviews, diagrams, screenshots, and mockups.
-- **Direct to Cloudflare** — No AI Gateway, no proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account.
+- **Direct by default** — No proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account, with optional AI Gateway routing for user-owned logging, caching, and analytics.
 - **Plan mode** — Ask the agent to research and produce a plan without touching your filesystem. Review it, then exit plan mode to execute.
 
 ## Quick start
@@ -57,6 +57,7 @@ Requires Node.js ≥ 20.
 | **Streaming reasoning** | Toggle the model's chain-of-thought with `/reasoning` or `Ctrl-R`. See how it thinks in real time. |
 | **Image understanding** | Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. The model sees them inline — perfect for UI reviews, diagrams, and screenshots. |
 | **Live cost tracking** | Status bar shows real-time cost based on Cloudflare pricing: `$0.95/M input`, `$0.16/M cached`, `$4.00/M output`. |
+| **Optional AI Gateway** | Route Workers AI traffic through your own Cloudflare AI Gateway for request logs, cache status, and analytics while keeping your API token local. |
 | **Session persistence** | Every turn is auto-saved. `/resume` lists past sessions (with message counts) in a paginated picker. |
 | **Smart permissions** | Bash session-allow is keyed by the first token (e.g., allow all `git` commands). Write/edit show a unified diff before you approve. |
 | **Project context (`/init`)** | Scans your repo and writes a concise `KIMI.md` — build commands, layout, conventions. Auto-loaded on every launch. |
@@ -76,6 +77,8 @@ Then either export them each shell:
 ```sh
 export CLOUDFLARE_ACCOUNT_ID=...
 export CLOUDFLARE_API_TOKEN=...
+# Optional: route through a Cloudflare AI Gateway you own
+export KIMIFLARE_AI_GATEWAY_ID=...
 ```
 
 or save them once (`chmod 600` automatically):
@@ -86,11 +89,35 @@ cat > ~/.config/kimiflare/config.json <<'EOF'
 {
   "accountId": "YOUR_ACCOUNT_ID",
   "apiToken":  "YOUR_API_TOKEN",
-  "model":     "@cf/moonshotai/kimi-k2.6"
+  "model":     "@cf/moonshotai/kimi-k2.6",
+  "aiGatewayId": "YOUR_GATEWAY_NAME"
 }
 EOF
 chmod 600 ~/.config/kimiflare/config.json
 ```
+
+### Optional AI Gateway
+
+kimiflare talks directly to Workers AI unless `aiGatewayId` is configured. When set, chat completions are sent to Cloudflare's native Workers AI Gateway endpoint:
+
+```text
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/workers-ai/{model_id}
+```
+
+Create a gateway in the Cloudflare dashboard under **AI > AI Gateway**, then set `aiGatewayId` in `~/.config/kimiflare/config.json` or export `KIMIFLARE_AI_GATEWAY_ID`. The same Workers AI API token stays on your machine and is sent to Cloudflare.
+
+Optional per-request controls:
+
+```json
+{
+  "aiGatewayCacheTtl": 3600,
+  "aiGatewaySkipCache": false,
+  "aiGatewayCollectLogPayload": false,
+  "aiGatewayMetadata": { "tool": "kimiflare" }
+}
+```
+
+`cf-aig-cache-status` from AI Gateway is shown separately from Workers AI prompt-token caching (`cached_tokens`). If you enable gateway logs, kimiflare records metadata such as log id, cache hit/miss, tokens, duration, and status when Cloudflare returns it; prompt and response bodies are not stored by kimiflare.
 
 ## MCP servers (Model Context Protocol)
 
@@ -271,7 +298,7 @@ All tool calls show inline; mutating ones require per-call approval the first ti
                                        @cf/moonshotai/kimi-k2.6
 ```
 
-Direct `fetch` to Workers AI, OpenAI-compatible `messages` + `tools` payload, SSE stream with reasoning + content + tool-call deltas accumulated by index.
+Direct `fetch` to Workers AI by default, or the native Workers AI AI Gateway endpoint when `aiGatewayId` is configured. The payload remains OpenAI-compatible `messages` + `tools`, with an SSE stream containing reasoning + content + tool-call deltas accumulated by index.
 
 ## Development
 

--- a/src/agent/client.test.ts
+++ b/src/agent/client.test.ts
@@ -5,6 +5,7 @@ import { runKimi } from "./client.js";
 describe("runKimi session affinity header", () => {
   let originalFetch: typeof globalThis.fetch;
   let lastRequest: Request | null = null;
+  let responseHeaders: Record<string, string> = { "content-type": "text/event-stream" };
 
   before(() => {
     originalFetch = globalThis.fetch;
@@ -12,7 +13,7 @@ describe("runKimi session affinity header", () => {
       lastRequest = new Request(input, init);
       return new Response("data: [DONE]\n\n", {
         status: 200,
-        headers: { "content-type": "text/event-stream" },
+        headers: responseHeaders,
       });
     };
   });
@@ -51,5 +52,84 @@ describe("runKimi session affinity header", () => {
     assert.ok(lastRequest);
     assert.strictEqual(lastRequest!.headers.get("X-Session-ID"), null);
     assert.strictEqual(lastRequest!.headers.get("x-session-affinity"), null);
+  });
+
+  it("uses the direct Workers AI endpoint by default", async () => {
+    const gen = runKimi({
+      accountId: "acct",
+      apiToken: "token",
+      model: "@cf/test/model",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    for await (const _ of gen) {
+      /* noop */
+    }
+    assert.ok(lastRequest);
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/@cf/test/model",
+    );
+  });
+
+  it("routes through native AI Gateway when configured", async () => {
+    const gen = runKimi({
+      accountId: "acct",
+      apiToken: "token",
+      model: "@cf/test/model",
+      messages: [{ role: "user", content: "hi" }],
+      gateway: {
+        id: "my-gateway",
+        cacheTtl: 3600,
+        skipCache: false,
+        collectLogPayload: false,
+        metadata: { team: "cli", test: true },
+      },
+    });
+    for await (const _ of gen) {
+      /* noop */
+    }
+    assert.ok(lastRequest);
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://gateway.ai.cloudflare.com/v1/acct/my-gateway/workers-ai/@cf/test/model",
+    );
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-cache-ttl"), "3600");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-skip-cache"), "false");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-collect-log-payload"), "false");
+    assert.strictEqual(
+      lastRequest!.headers.get("cf-aig-metadata"),
+      '{"team":"cli","test":true}',
+    );
+  });
+
+  it("emits gateway metadata from response headers", async () => {
+    responseHeaders = {
+      "content-type": "text/event-stream",
+      "cf-aig-cache-status": "HIT",
+      "cf-aig-log-id": "log_123",
+      "cf-aig-event-id": "evt_123",
+      "cf-aig-model": "@cf/test/model",
+    };
+    const events: unknown[] = [];
+    const gen = runKimi({
+      accountId: "acct",
+      apiToken: "token",
+      model: "@cf/test/model",
+      messages: [{ role: "user", content: "hi" }],
+      gateway: { id: "my-gateway" },
+    });
+    for await (const ev of gen) {
+      events.push(ev);
+    }
+    assert.deepStrictEqual(events[0], {
+      type: "gateway_meta",
+      meta: {
+        cacheStatus: "HIT",
+        logId: "log_123",
+        eventId: "evt_123",
+        model: "@cf/test/model",
+      },
+    });
+    responseHeaders = { "content-type": "text/event-stream" };
   });
 });

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -4,6 +4,7 @@ import { jsonReplacer, sanitizeString, stableStringify } from "./messages.js";
 import type { ChatMessage, ToolDef, Usage } from "./messages.js";
 
 export type KimiEvent =
+  | { type: "gateway_meta"; meta: GatewayMeta }
   | { type: "reasoning"; delta: string }
   | { type: "text"; delta: string }
   | { type: "tool_call_start"; index: number; id: string; name: string }
@@ -23,6 +24,22 @@ export interface RunKimiOpts {
   maxCompletionTokens?: number;
   reasoningEffort?: "low" | "medium" | "high";
   sessionId?: string;
+  gateway?: AiGatewayOptions;
+}
+
+export interface AiGatewayOptions {
+  id: string;
+  cacheTtl?: number;
+  skipCache?: boolean;
+  collectLogPayload?: boolean;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface GatewayMeta {
+  cacheStatus?: string;
+  logId?: string;
+  eventId?: string;
+  model?: string;
 }
 
 const RETRYABLE_CODES = new Set([3040]); // "Capacity temporarily exceeded"
@@ -42,7 +59,7 @@ function isRetryable(err: KimiApiError, attempt: number): boolean {
 }
 
 export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, void, void> {
-  const url = `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${opts.model}`;
+  const { url, headers: gatewayHeaders } = buildKimiRequestTarget(opts);
   const body: Record<string, unknown> = {
     messages: sanitizeMessagesForApi(opts.messages),
     ...(opts.tools && opts.tools.length
@@ -62,6 +79,7 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
       const headers: Record<string, string> = {
         Authorization: `Bearer ${opts.apiToken}`,
         "Content-Type": "application/json",
+        ...gatewayHeaders,
       };
       if (opts.sessionId) {
         headers["X-Session-ID"] = opts.sessionId;
@@ -110,9 +128,57 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
 
     if (!res.body) throw new KimiApiError("kimiflare: empty response body", undefined, res.status);
 
+    const meta = readGatewayMeta(res.headers);
+    if (meta) yield { type: "gateway_meta", meta };
     yield* parseStream(res.body, opts.signal);
     return;
   }
+}
+
+function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Record<string, string> } {
+  if (!opts.gateway?.id) {
+    return {
+      url: `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${opts.model}`,
+      headers: {},
+    };
+  }
+
+  const headers: Record<string, string> = {};
+  if (opts.gateway.cacheTtl !== undefined) {
+    headers["cf-aig-cache-ttl"] = String(opts.gateway.cacheTtl);
+  }
+  if (opts.gateway.skipCache !== undefined) {
+    headers["cf-aig-skip-cache"] = String(opts.gateway.skipCache);
+  }
+  if (opts.gateway.collectLogPayload !== undefined) {
+    headers["cf-aig-collect-log-payload"] = String(opts.gateway.collectLogPayload);
+  }
+  if (opts.gateway.metadata && Object.keys(opts.gateway.metadata).length > 0) {
+    const entries = Object.entries(opts.gateway.metadata).slice(0, 5);
+    headers["cf-aig-metadata"] = stableStringify(Object.fromEntries(entries), jsonReplacer);
+  }
+
+  return {
+    url: `https://gateway.ai.cloudflare.com/v1/${opts.accountId}/${encodeURIComponent(
+      opts.gateway.id,
+    )}/workers-ai/${opts.model}`,
+    headers,
+  };
+}
+
+function readGatewayMeta(headers: Headers): GatewayMeta | null {
+  const meta: GatewayMeta = {};
+  const cacheStatus = headers.get("cf-aig-cache-status");
+  const logId = headers.get("cf-aig-log-id");
+  const eventId = headers.get("cf-aig-event-id");
+  const model = headers.get("cf-aig-model");
+
+  if (cacheStatus) meta.cacheStatus = cacheStatus;
+  if (logId) meta.logId = logId;
+  if (eventId) meta.eventId = eventId;
+  if (model) meta.model = model;
+
+  return Object.keys(meta).length > 0 ? meta : null;
 }
 
 async function* parseStream(

--- a/src/agent/compact.ts
+++ b/src/agent/compact.ts
@@ -1,4 +1,5 @@
 import { runKimi } from "./client.js";
+import type { AiGatewayOptions } from "./client.js";
 import type { ChatMessage } from "./messages.js";
 
 export interface CompactOpts {
@@ -8,6 +9,7 @@ export interface CompactOpts {
   messages: ChatMessage[];
   keepLastTurns?: number;
   signal?: AbortSignal;
+  gateway?: AiGatewayOptions;
 }
 
 export interface CompactResult {
@@ -89,6 +91,7 @@ export async function compactMessages(opts: CompactOpts): Promise<CompactResult>
     signal: opts.signal,
     temperature: 0.1,
     reasoningEffort: "low",
+    gateway: opts.gateway,
   });
   for await (const ev of events) {
     if (ev.type === "text") summary += ev.delta;

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,4 +1,5 @@
 import { runKimi } from "./client.js";
+import type { AiGatewayOptions, GatewayMeta } from "./client.js";
 import { toOpenAIToolDefs, type ToolSpec } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
 import { sanitizeString, stripOldImages } from "./messages.js";
@@ -15,6 +16,8 @@ export interface AgentCallbacks {
   onToolCallArgs?: (index: number, delta: string) => void;
   onToolCallFinalized?: (call: ToolCall) => void;
   onUsage?: (usage: Usage) => void;
+  onUsageFinal?: (usage: Usage, gatewayMeta?: GatewayMeta) => void;
+  onGatewayMeta?: (meta: GatewayMeta) => void;
   onAssistantFinal?: (msg: ChatMessage) => void;
   onToolResult?: (result: ToolResult) => void;
   onTasks?: (tasks: Task[]) => void;
@@ -37,6 +40,7 @@ export interface AgentTurnOpts {
   reasoningEffort?: "low" | "medium" | "high";
   coauthor?: { name: string; email: string };
   sessionId?: string;
+  gateway?: AiGatewayOptions;
   /** Drop image_url parts from user messages older than this many turns. */
   keepLastImageTurns?: number;
 }
@@ -54,6 +58,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     const toolResults: ToolResult[] = [];
     let content = "";
     let reasoning = "";
+    let gatewayMeta: GatewayMeta | undefined;
     opts.callbacks.onAssistantStart?.();
 
     const stripReasoning = process.env.KIMIFLARE_STRIP_REASONING === "1";
@@ -112,10 +117,15 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       maxCompletionTokens: opts.maxCompletionTokens,
       reasoningEffort: opts.reasoningEffort,
       sessionId: opts.sessionId,
+      gateway: opts.gateway,
     });
 
     for await (const ev of events) {
       switch (ev.type) {
+        case "gateway_meta":
+          gatewayMeta = ev.meta;
+          opts.callbacks.onGatewayMeta?.(ev.meta);
+          break;
         case "reasoning":
           reasoning += ev.delta;
           opts.callbacks.onReasoningDelta?.(ev.delta);
@@ -149,6 +159,8 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           break;
       }
     }
+
+    if (lastUsage) opts.callbacks.onUsageFinal?.(lastUsage, gatewayMeta);
 
     const assistantMsg: ChatMessage = {
       role: "assistant",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Text, useApp, useInput, render } from "ink";
 
 import { runAgentTurn } from "./agent/loop.js";
+import type { AiGatewayOptions, GatewayMeta } from "./agent/client.js";
 import { buildSystemPrompt, buildSystemMessages, buildSessionPrefix } from "./agent/system-prompt.js";
 import { compactMessages } from "./agent/compact.js";
 import {
@@ -55,11 +56,17 @@ import {
 import { unlink } from "node:fs/promises";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
 import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
+import type { GatewayUsageLookup } from "./usage-tracker.js";
 
 interface Cfg {
   accountId: string;
   apiToken: string;
   model: string;
+  aiGatewayId?: string;
+  aiGatewayCacheTtl?: number;
+  aiGatewaySkipCache?: boolean;
+  aiGatewayCollectLogPayload?: boolean;
+  aiGatewayMetadata?: Record<string, string | number | boolean>;
   theme?: string;
   reasoningEffort?: ReasoningEffort;
   coauthor?: boolean;
@@ -69,6 +76,30 @@ interface Cfg {
   cacheStablePrompts?: boolean;
   compiledContext?: boolean;
   imageHistoryTurns?: number;
+}
+
+function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
+  if (!cfg.aiGatewayId) return undefined;
+  return {
+    id: cfg.aiGatewayId,
+    cacheTtl: cfg.aiGatewayCacheTtl,
+    skipCache: cfg.aiGatewaySkipCache,
+    collectLogPayload: cfg.aiGatewayCollectLogPayload,
+    metadata: cfg.aiGatewayMetadata,
+  };
+}
+
+function gatewayUsageLookupFromConfig(
+  cfg: Cfg,
+  meta: GatewayMeta | null,
+): GatewayUsageLookup | undefined {
+  if (!cfg.aiGatewayId || !meta) return undefined;
+  return {
+    accountId: cfg.accountId,
+    apiToken: cfg.apiToken,
+    gatewayId: cfg.aiGatewayId,
+    meta,
+  };
 }
 
 interface PendingPermission {
@@ -142,6 +173,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [usage, setUsage] = useState<Usage | null>(null);
+  const [gatewayMeta, setGatewayMeta] = useState<GatewayMeta | null>(null);
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
   const [queue, setQueue] = useState<Array<{ full: string; display: string }>>([]);
@@ -177,6 +209,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const effortRef = useRef<ReasoningEffort>(effort);
   const tasksRef = useRef<Task[]>([]);
   const usageRef = useRef<Usage | null>(null);
+  const gatewayMetaRef = useRef<GatewayMeta | null>(null);
   const updateCheckedRef = useRef(false);
   const sessionStateRef = useRef<SessionState>(emptySessionState());
   const artifactStoreRef = useRef<ArtifactStore>(new ArtifactStore());
@@ -472,6 +505,11 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     [],
   );
 
+  const updateGatewayMeta = useCallback((meta: GatewayMeta) => {
+    gatewayMetaRef.current = meta;
+    setGatewayMeta(meta);
+  }, []);
+
   const runCompact = useCallback(async () => {
     if (!cfg) return;
     if (busy) {
@@ -514,6 +552,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           model: cfg.model,
           messages: messagesRef.current,
           signal: controller.signal,
+          gateway: gatewayFromConfig(cfg),
         });
         if (result.replacedCount === 0) {
           setEvents((e) => [
@@ -600,6 +639,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         accountId: cfg.accountId,
         apiToken: cfg.apiToken,
         model: cfg.model,
+        gateway: gatewayFromConfig(cfg),
         messages: messagesRef.current,
         tools: [...ALL_TOOLS, ...mcpToolsRef.current],
         executor: executorRef.current,
@@ -661,9 +701,12 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           onUsage: (u) => {
             usageRef.current = u;
             setUsage(u);
-            const sid = ensureSessionId();
-            void recordUsage(sid, u);
           },
+          onUsageFinal: (u, meta) => {
+            const sid = ensureSessionId();
+            void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
+          },
+          onGatewayMeta: updateGatewayMeta,
           askPermission: (req) =>
             new Promise<PermissionDecision>((resolve) => {
               if (modeRef.current === "auto") {
@@ -731,7 +774,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
     }
-  }, [cfg, busy, updateAssistant, updateTool]);
+  }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
 
   const handleResumePick = useCallback(
     async (picked: SessionSummary | null) => {
@@ -763,6 +806,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           .filter((text) => text.length > 0);
         if (userMsgs.length > 0) setHistory(userMsgs);
         setUsage(null);
+        gatewayMetaRef.current = null;
+        setGatewayMeta(null);
       } catch (e) {
         setEvents((es) => [
           ...es,
@@ -818,6 +863,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         executorRef.current.clearArtifacts();
         setEvents([]);
         setUsage(null);
+        gatewayMetaRef.current = null;
+        setGatewayMeta(null);
         setTasks([]);
         setTasksStartedAt(null);
         setTasksStartTokens(0);
@@ -1137,6 +1184,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       }
 
       setBusy(true);
+      gatewayMetaRef.current = null;
+      setGatewayMeta(null);
       setTurnStartedAt(Date.now());
 
       const controller = new AbortController();
@@ -1147,6 +1196,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           accountId: cfg.accountId,
           apiToken: cfg.apiToken,
           model: cfg.model,
+          gateway: gatewayFromConfig(cfg),
           messages: messagesRef.current,
           tools: [...ALL_TOOLS, ...mcpToolsRef.current],
           executor: executorRef.current,
@@ -1213,6 +1263,11 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
               usageRef.current = u;
               setUsage(u);
             },
+            onUsageFinal: (u, meta) => {
+              const sid = ensureSessionId();
+              void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
+            },
+            onGatewayMeta: updateGatewayMeta,
             onTasks: (nextTasks) => {
               const prevEmpty = tasksRef.current.length === 0;
               tasksRef.current = nextTasks;
@@ -1307,7 +1362,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         activeControllerRef.current = null;
       }
     },
-    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe],
+    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe, updateGatewayMeta],
   );
 
   useEffect(() => {
@@ -1436,6 +1491,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             contextLimit={CONTEXT_LIMIT}
             hasUpdate={hasUpdate}
             latestVersion={latestVersion}
+            gatewayMeta={gatewayMeta}
           />
           <Box marginTop={1}>
             <Text color={theme.accent}>› </Text>

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,11 @@ export interface KimiConfig {
   accountId: string;
   apiToken: string;
   model: string;
+  aiGatewayId?: string;
+  aiGatewayCacheTtl?: number;
+  aiGatewaySkipCache?: boolean;
+  aiGatewayCollectLogPayload?: boolean;
+  aiGatewayMetadata?: Record<string, string | number | boolean>;
   theme?: string;
   reasoningEffort?: ReasoningEffort;
   coauthor?: boolean;
@@ -52,6 +57,44 @@ function readCoauthorEnv(): { enabled: boolean; name: string; email: string } | 
   return { enabled: true, name, email };
 }
 
+function readBooleanEnv(name: string): boolean | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+  const normalized = raw.toLowerCase();
+  if (normalized === "1" || normalized === "true") return true;
+  if (normalized === "0" || normalized === "false") return false;
+  return undefined;
+}
+
+function readNumberEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function readGatewayMetadataEnv(): Record<string, string | number | boolean> | undefined {
+  const raw = process.env.KIMIFLARE_AI_GATEWAY_METADATA;
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const out: Record<string, string | number | boolean> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ) {
+        out[key] = value;
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function loadConfig(): Promise<KimiConfig | null> {
   const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
   const envToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
@@ -59,6 +102,13 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envEffort = readReasoningEffortEnv();
   const envTheme = process.env.KIMI_THEME;
   const envCoauthor = readCoauthorEnv();
+  const envAiGatewayId = process.env.KIMIFLARE_AI_GATEWAY_ID;
+  const envAiGatewayCacheTtl = readNumberEnv("KIMIFLARE_AI_GATEWAY_CACHE_TTL");
+  const envAiGatewaySkipCache = readBooleanEnv("KIMIFLARE_AI_GATEWAY_SKIP_CACHE");
+  const envAiGatewayCollectLogPayload = readBooleanEnv(
+    "KIMIFLARE_AI_GATEWAY_COLLECT_LOG_PAYLOAD",
+  );
+  const envAiGatewayMetadata = readGatewayMetadataEnv();
 
   const envCacheStable = process.env.KIMIFLARE_CACHE_STABLE_PROMPTS;
   const cacheStablePrompts = envCacheStable === "0" || envCacheStable === "false" ? false : true;
@@ -74,6 +124,11 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       accountId: envAccount,
       apiToken: envToken,
       model: envModel,
+      aiGatewayId: envAiGatewayId,
+      aiGatewayCacheTtl: envAiGatewayCacheTtl,
+      aiGatewaySkipCache: envAiGatewaySkipCache,
+      aiGatewayCollectLogPayload: envAiGatewayCollectLogPayload,
+      aiGatewayMetadata: envAiGatewayMetadata,
       theme: envTheme,
       reasoningEffort: envEffort,
       coauthor: envCoauthor?.enabled ?? true,
@@ -93,6 +148,12 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         accountId: envAccount ?? parsed.accountId,
         apiToken: envToken ?? parsed.apiToken,
         model: envModel ?? parsed.model ?? DEFAULT_MODEL,
+        aiGatewayId: envAiGatewayId ?? parsed.aiGatewayId,
+        aiGatewayCacheTtl: envAiGatewayCacheTtl ?? parsed.aiGatewayCacheTtl,
+        aiGatewaySkipCache: envAiGatewaySkipCache ?? parsed.aiGatewaySkipCache,
+        aiGatewayCollectLogPayload:
+          envAiGatewayCollectLogPayload ?? parsed.aiGatewayCollectLogPayload,
+        aiGatewayMetadata: envAiGatewayMetadata ?? parsed.aiGatewayMetadata,
         theme: envTheme ?? parsed.theme,
         reasoningEffort: envEffort ?? parsed.reasoningEffort,
         coauthor: envCoauthor?.enabled ?? parsed.coauthor ?? true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { loadConfig, DEFAULT_MODEL } from "./config.js";
 import { runAgentTurn } from "./agent/loop.js";
+import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ChatMessage } from "./agent/messages.js";
@@ -92,7 +93,23 @@ interface PrintOpts {
   coauthor?: boolean;
   coauthorName?: string;
   coauthorEmail?: string;
+  aiGatewayId?: string;
+  aiGatewayCacheTtl?: number;
+  aiGatewaySkipCache?: boolean;
+  aiGatewayCollectLogPayload?: boolean;
+  aiGatewayMetadata?: Record<string, string | number | boolean>;
   updateResult: UpdateCheckResult;
+}
+
+function gatewayFromPrintOpts(opts: PrintOpts): AiGatewayOptions | undefined {
+  if (!opts.aiGatewayId) return undefined;
+  return {
+    id: opts.aiGatewayId,
+    cacheTtl: opts.aiGatewayCacheTtl,
+    skipCache: opts.aiGatewaySkipCache,
+    collectLogPayload: opts.aiGatewayCollectLogPayload,
+    metadata: opts.aiGatewayMetadata,
+  };
 }
 
 async function runPrintMode(opts: PrintOpts): Promise<void> {
@@ -120,6 +137,7 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
     accountId: opts.accountId,
     apiToken: opts.apiToken,
     model: opts.model,
+    gateway: gatewayFromPrintOpts(opts),
     messages,
     tools: ALL_TOOLS,
     executor,

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -4,6 +4,10 @@
  *
  * Workers AI bills in Neurons ($0.011 / 1,000 Neurons).
  * The token prices below are the equivalent per-token rates.
+ *
+ * Cloudflare AI Gateway routing does not change Workers AI token pricing for
+ * self-owned gateways. Gateway logs may report per-request cost; when present,
+ * usage tracking can use that metadata as a more accurate request total.
  */
 
 /** Price per million uncached input tokens (USD) */

--- a/src/ui/status.test.ts
+++ b/src/ui/status.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { buildRightParts, formatGatewayCacheStatus } from "./status.js";
+
+describe("status gateway cache formatting", () => {
+  it("shows gateway cache status separately from token cache", () => {
+    const parts = buildRightParts(
+      {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 50 },
+      },
+      1_000,
+      { cacheStatus: "hit" },
+    );
+
+    assert.deepStrictEqual(parts, [
+      "in 100 (50 cached)",
+      "out 20",
+      "ctx 10%",
+      "$0.00014",
+      "AI Gateway · cache hit",
+    ]);
+  });
+
+  it("omits gateway cache status when Cloudflare does not return it", () => {
+    assert.strictEqual(formatGatewayCacheStatus({ logId: "log_123" }), null);
+  });
+});

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import type { Usage } from "../agent/messages.js";
+import type { GatewayMeta } from "../agent/client.js";
 import type { Theme } from "./theme.js";
 import type { ReasoningEffort } from "../config.js";
 import type { Mode } from "../mode.js";
@@ -18,9 +19,10 @@ interface Props {
   contextLimit: number;
   hasUpdate?: boolean;
   latestVersion?: string | null;
+  gatewayMeta?: GatewayMeta | null;
 }
 
-export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion }: Props) {
+export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta }: Props) {
   const [now, setNow] = useState(Date.now());
   const modeColor =
     mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
@@ -57,7 +59,7 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
       {usage && (
         <Box>
           <Text color={theme.info.color} dimColor={theme.info.dim}>
-            {buildRightParts(usage, contextLimit).join("  ·  ")}
+            {buildRightParts(usage, contextLimit, gatewayMeta).join("  ·  ")}
           </Text>
           {warn ? (
             <Text color={theme.warn} bold>
@@ -75,16 +77,28 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
   );
 }
 
-function buildRightParts(usage: Usage, contextLimit: number): string[] {
+export function buildRightParts(
+  usage: Usage,
+  contextLimit: number,
+  gatewayMeta?: GatewayMeta | null,
+): string[] {
   const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
   const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
   const pct = Math.round((usage.prompt_tokens / contextLimit) * 100);
-  return [
+  const parts = [
     `in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
     `out ${usage.completion_tokens}`,
     `ctx ${pct}%`,
     `$${cost.total.toFixed(5)}`,
   ];
+  const gatewayCache = formatGatewayCacheStatus(gatewayMeta);
+  if (gatewayCache) parts.push(gatewayCache);
+  return parts;
+}
+
+export function formatGatewayCacheStatus(gatewayMeta?: GatewayMeta | null): string | null {
+  const status = gatewayMeta?.cacheStatus?.trim();
+  return status ? `AI Gateway · cache ${status.toLowerCase()}` : null;
 }
 
 function shortModel(m: string): string {

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Usage } from "./agent/messages.js";
+import type { GatewayMeta } from "./agent/client.js";
 import { calculateCost } from "./pricing.js";
 import { RETENTION } from "./storage-limits.js";
 
@@ -13,6 +14,9 @@ export interface DailyUsage {
   completionTokens: number;
   cachedTokens: number;
   cost: number;
+  gatewayRequests?: number;
+  gatewayCachedRequests?: number;
+  gatewayCost?: number;
 }
 
 export interface SessionUsage {
@@ -22,6 +26,31 @@ export interface SessionUsage {
   completionTokens: number;
   cachedTokens: number;
   cost: number;
+  gatewayRequests?: number;
+  gatewayCachedRequests?: number;
+  gatewayCost?: number;
+  gatewayLogs?: GatewayUsageSnapshot[];
+}
+
+export interface GatewayUsageSnapshot {
+  logId?: string;
+  eventId?: string;
+  cacheStatus?: string;
+  cached?: boolean;
+  duration?: number;
+  statusCode?: number;
+  model?: string;
+  provider?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  cost?: number;
+}
+
+export interface GatewayUsageLookup {
+  accountId: string;
+  apiToken: string;
+  gatewayId: string;
+  meta: GatewayMeta;
 }
 
 interface UsageLog {
@@ -82,6 +111,62 @@ function getOrCreateSession(log: UsageLog, sessionId: string, date: string): Ses
   return session;
 }
 
+function gatewaySnapshotFromMeta(meta: GatewayMeta): GatewayUsageSnapshot | undefined {
+  if (!meta.logId && !meta.eventId && !meta.cacheStatus && !meta.model) return undefined;
+  return {
+    logId: meta.logId,
+    eventId: meta.eventId,
+    cacheStatus: meta.cacheStatus,
+    cached: meta.cacheStatus ? meta.cacheStatus.toUpperCase() === "HIT" : undefined,
+    model: meta.model,
+  };
+}
+
+function toGatewaySnapshot(entry: unknown, meta: GatewayMeta): GatewayUsageSnapshot | undefined {
+  if (!entry || typeof entry !== "object") return gatewaySnapshotFromMeta(meta);
+  const raw = entry as Record<string, unknown>;
+  const cacheStatus = typeof meta.cacheStatus === "string" ? meta.cacheStatus : undefined;
+  const cached = typeof raw.cached === "boolean" ? raw.cached : cacheStatus?.toUpperCase() === "HIT";
+  return {
+    logId: typeof raw.id === "string" ? raw.id : meta.logId,
+    eventId: meta.eventId,
+    cacheStatus,
+    cached,
+    duration: typeof raw.duration === "number" ? raw.duration : undefined,
+    statusCode: typeof raw.status_code === "number" ? raw.status_code : undefined,
+    model: typeof raw.model === "string" ? raw.model : meta.model,
+    provider: typeof raw.provider === "string" ? raw.provider : undefined,
+    tokensIn: typeof raw.tokens_in === "number" ? raw.tokens_in : undefined,
+    tokensOut: typeof raw.tokens_out === "number" ? raw.tokens_out : undefined,
+    cost: typeof raw.cost === "number" ? raw.cost : undefined,
+  };
+}
+
+export async function fetchGatewayUsageSnapshot(
+  lookup: GatewayUsageLookup,
+): Promise<GatewayUsageSnapshot | undefined> {
+  if (!lookup.meta.logId) return gatewaySnapshotFromMeta(lookup.meta);
+  const url = `https://api.cloudflare.com/client/v4/accounts/${lookup.accountId}/ai-gateway/gateways/${encodeURIComponent(
+    lookup.gatewayId,
+  )}/logs`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${lookup.apiToken}` },
+  });
+  if (!res.ok) return gatewaySnapshotFromMeta(lookup.meta);
+  const parsed = (await res.json()) as { result?: unknown[] };
+  const match = Array.isArray(parsed.result)
+    ? parsed.result.find((entry) => {
+        return (
+          entry &&
+          typeof entry === "object" &&
+          (entry as Record<string, unknown>).id === lookup.meta.logId
+        );
+      })
+    : undefined;
+  return toGatewaySnapshot(match, lookup.meta);
+}
+
 /** Prune old day and session entries to enforce retention policy. */
 export function pruneUsageLog(log: UsageLog): UsageLog {
   const dayCutoff = cutoffDate(RETENTION.usageDayMaxAgeDays);
@@ -97,22 +182,41 @@ export function pruneUsageLog(log: UsageLog): UsageLog {
   return { ...log, days, sessions };
 }
 
-export async function recordUsage(sessionId: string, usage: Usage): Promise<void> {
+export async function recordUsage(
+  sessionId: string,
+  usage: Usage,
+  gateway?: GatewayUsageLookup,
+): Promise<void> {
   const log = pruneUsageLog(await loadLog());
   const date = today();
+  const gatewaySnapshot = gateway
+    ? await fetchGatewayUsageSnapshot(gateway).catch(() => gatewaySnapshotFromMeta(gateway.meta))
+    : undefined;
   const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, usage.prompt_tokens_details?.cached_tokens ?? 0);
+  const totalCost = gatewaySnapshot?.cost ?? cost.total;
 
   const day = getOrCreateDay(log, date);
   day.promptTokens += usage.prompt_tokens;
   day.completionTokens += usage.completion_tokens;
   day.cachedTokens += usage.prompt_tokens_details?.cached_tokens ?? 0;
-  day.cost += cost.total;
+  day.cost += totalCost;
+  if (gatewaySnapshot) {
+    day.gatewayRequests = (day.gatewayRequests ?? 0) + 1;
+    day.gatewayCachedRequests = (day.gatewayCachedRequests ?? 0) + (gatewaySnapshot.cached ? 1 : 0);
+    day.gatewayCost = (day.gatewayCost ?? 0) + (gatewaySnapshot.cost ?? 0);
+  }
 
   const session = getOrCreateSession(log, sessionId, date);
   session.promptTokens += usage.prompt_tokens;
   session.completionTokens += usage.completion_tokens;
   session.cachedTokens += usage.prompt_tokens_details?.cached_tokens ?? 0;
-  session.cost += cost.total;
+  session.cost += totalCost;
+  if (gatewaySnapshot) {
+    session.gatewayRequests = (session.gatewayRequests ?? 0) + 1;
+    session.gatewayCachedRequests = (session.gatewayCachedRequests ?? 0) + (gatewaySnapshot.cached ? 1 : 0);
+    session.gatewayCost = (session.gatewayCost ?? 0) + (gatewaySnapshot.cost ?? 0);
+    session.gatewayLogs = [...(session.gatewayLogs ?? []), gatewaySnapshot].slice(-100);
+  }
 
   await saveLog(log);
 }
@@ -150,6 +254,10 @@ export async function getCostReport(sessionId: string): Promise<CostReport> {
       monthUsage.completionTokens += d.completionTokens;
       monthUsage.cachedTokens += d.cachedTokens;
       monthUsage.cost += d.cost;
+      monthUsage.gatewayRequests = (monthUsage.gatewayRequests ?? 0) + (d.gatewayRequests ?? 0);
+      monthUsage.gatewayCachedRequests =
+        (monthUsage.gatewayCachedRequests ?? 0) + (d.gatewayCachedRequests ?? 0);
+      monthUsage.gatewayCost = (monthUsage.gatewayCost ?? 0) + (d.gatewayCost ?? 0);
     }
   }
 
@@ -165,6 +273,10 @@ export async function getCostReport(sessionId: string): Promise<CostReport> {
     allTime.completionTokens += d.completionTokens;
     allTime.cachedTokens += d.cachedTokens;
     allTime.cost += d.cost;
+    allTime.gatewayRequests = (allTime.gatewayRequests ?? 0) + (d.gatewayRequests ?? 0);
+    allTime.gatewayCachedRequests =
+      (allTime.gatewayCachedRequests ?? 0) + (d.gatewayCachedRequests ?? 0);
+    allTime.gatewayCost = (allTime.gatewayCost ?? 0) + (d.gatewayCost ?? 0);
   }
 
   return { session, today: todayUsage, month: monthUsage, allTime };
@@ -176,12 +288,19 @@ function fmtTokens(n: number): string {
   return String(n);
 }
 
+function fmtGateway(u: DailyUsage): string {
+  if (!u.gatewayRequests) return "";
+  const cached = u.gatewayCachedRequests ? `, ${u.gatewayCachedRequests} cached` : "";
+  const cost = u.gatewayCost ? `, gateway $${u.gatewayCost.toFixed(4)}` : "";
+  return `  gateway: ${u.gatewayRequests} req${cached}${cost}`;
+}
+
 export function formatCostReport(report: CostReport): string {
   const lines: string[] = [];
   const add = (label: string, u: DailyUsage) => {
     const cached = u.cachedTokens > 0 ? ` (${fmtTokens(u.cachedTokens)} cached)` : "";
     lines.push(
-      `${label.padEnd(9)} $${u.cost.toFixed(4)}  (in: ${fmtTokens(u.promptTokens)}${cached}  out: ${fmtTokens(u.completionTokens)})`,
+      `${label.padEnd(9)} $${u.cost.toFixed(4)}  (in: ${fmtTokens(u.promptTokens)}${cached}  out: ${fmtTokens(u.completionTokens)})${fmtGateway(u)}`,
     );
   };
   add("Session", report.session);

--- a/src/util/config.test.ts
+++ b/src/util/config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "../config.js";
+
+const ENV_KEYS = [
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_API_TOKEN",
+  "CF_ACCOUNT_ID",
+  "CF_API_TOKEN",
+  "KIMIFLARE_AI_GATEWAY_ID",
+  "KIMIFLARE_AI_GATEWAY_CACHE_TTL",
+  "KIMIFLARE_AI_GATEWAY_SKIP_CACHE",
+  "KIMIFLARE_AI_GATEWAY_COLLECT_LOG_PAYLOAD",
+  "KIMIFLARE_AI_GATEWAY_METADATA",
+  "XDG_CONFIG_HOME",
+] as const;
+
+async function withCleanEnv(fn: () => Promise<void>): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of ENV_KEYS) previous.set(key, process.env[key]);
+  for (const key of ENV_KEYS) delete process.env[key];
+  try {
+    await fn();
+  } finally {
+    for (const key of ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe("loadConfig AI Gateway fields", () => {
+  it("loads AI Gateway settings from env credentials", async () => {
+    await withCleanEnv(async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      process.env.KIMIFLARE_AI_GATEWAY_ID = "gateway";
+      process.env.KIMIFLARE_AI_GATEWAY_CACHE_TTL = "3600";
+      process.env.KIMIFLARE_AI_GATEWAY_SKIP_CACHE = "false";
+      process.env.KIMIFLARE_AI_GATEWAY_COLLECT_LOG_PAYLOAD = "false";
+      process.env.KIMIFLARE_AI_GATEWAY_METADATA = '{"team":"cli","test":true}';
+
+      const cfg = await loadConfig();
+      assert.ok(cfg);
+      assert.strictEqual(cfg.aiGatewayId, "gateway");
+      assert.strictEqual(cfg.aiGatewayCacheTtl, 3600);
+      assert.strictEqual(cfg.aiGatewaySkipCache, false);
+      assert.strictEqual(cfg.aiGatewayCollectLogPayload, false);
+      assert.deepStrictEqual(cfg.aiGatewayMetadata, { team: "cli", test: true });
+    });
+  });
+
+  it("loads AI Gateway settings from config file", async () => {
+    await withCleanEnv(async () => {
+      const dir = await mkdtemp(join(tmpdir(), "kimiflare-config-"));
+      process.env.XDG_CONFIG_HOME = dir;
+      const configDir = join(dir, "kimiflare");
+      await mkdir(configDir, { recursive: true });
+      await writeFile(
+        join(configDir, "config.json"),
+        JSON.stringify({
+          accountId: "acct",
+          apiToken: "token",
+          model: "@cf/test/model",
+          aiGatewayId: "gateway",
+          aiGatewayCacheTtl: 120,
+          aiGatewaySkipCache: true,
+          aiGatewayCollectLogPayload: false,
+          aiGatewayMetadata: { team: "cli" },
+        }),
+      );
+
+      try {
+        const cfg = await loadConfig();
+        assert.ok(cfg);
+        assert.strictEqual(cfg.aiGatewayId, "gateway");
+        assert.strictEqual(cfg.aiGatewayCacheTtl, 120);
+        assert.strictEqual(cfg.aiGatewaySkipCache, true);
+        assert.strictEqual(cfg.aiGatewayCollectLogPayload, false);
+        assert.deepStrictEqual(cfg.aiGatewayMetadata, { team: "cli" });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/util/usage-tracker.test.ts
+++ b/src/util/usage-tracker.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fetchGatewayUsageSnapshot, getCostReport, recordUsage } from "../usage-tracker.js";
+
+describe("AI Gateway usage enrichment", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalXdgDataHome: string | undefined;
+  let lastRequest: Request | null = null;
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+    originalXdgDataHome = process.env.XDG_DATA_HOME;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      lastRequest = new Request(input, init);
+      return Response.json({
+        result: [
+          {
+            id: "log_123",
+            cached: true,
+            duration: 42,
+            model: "@cf/test/model",
+            provider: "workers-ai",
+            status_code: 200,
+            tokens_in: 10,
+            tokens_out: 2,
+            cost: 0.00001,
+          },
+        ],
+      });
+    };
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = originalXdgDataHome;
+  });
+
+  it("fetches a gateway log by cf-aig-log-id", async () => {
+    const snapshot = await fetchGatewayUsageSnapshot({
+      accountId: "acct",
+      apiToken: "token",
+      gatewayId: "gateway",
+      meta: { logId: "log_123", cacheStatus: "HIT", eventId: "evt_123" },
+    });
+
+    assert.ok(lastRequest);
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai-gateway/gateways/gateway/logs",
+    );
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer token");
+    assert.deepStrictEqual(snapshot, {
+      logId: "log_123",
+      eventId: "evt_123",
+      cacheStatus: "HIT",
+      cached: true,
+      duration: 42,
+      statusCode: 200,
+      model: "@cf/test/model",
+      provider: "workers-ai",
+      tokensIn: 10,
+      tokensOut: 2,
+      cost: 0.00001,
+    });
+  });
+
+  it("records local usage with gateway metadata as best-effort enrichment", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-usage-"));
+    process.env.XDG_DATA_HOME = dir;
+    try {
+      await recordUsage(
+        "session_1",
+        {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
+          prompt_tokens_details: { cached_tokens: 0 },
+        },
+        {
+          accountId: "acct",
+          apiToken: "token",
+          gatewayId: "gateway",
+          meta: { logId: "log_123", cacheStatus: "HIT" },
+        },
+      );
+
+      const report = await getCostReport("session_1");
+      assert.strictEqual(report.session.promptTokens, 10);
+      assert.strictEqual(report.session.completionTokens, 2);
+      assert.strictEqual(report.session.gatewayRequests, 1);
+      assert.strictEqual(report.session.gatewayCachedRequests, 1);
+      assert.strictEqual(report.session.gatewayCost, 0.00001);
+      assert.strictEqual(report.session.cost, 0.00001);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

<img width="650" height="370" alt="image" src="https://github.com/user-attachments/assets/b524a2ce-4f6b-40e9-af4e-2b58fdd51aa8" />

<img width="1279" height="823" alt="image" src="https://github.com/user-attachments/assets/28452fed-c501-48e8-9a00-8adc977ee181" />



- Implements [#115: Phase 1 — AI Gateway + Usage Analytics](https://github.com/sinameraji/kimiflare/issues/115) with optional native Cloudflare AI Gateway routing for Workers AI requests via `aiGatewayId` / `KIMIFLARE_AI_GATEWAY_ID`, preserving direct Workers AI as the default.
- Captures AI Gateway response metadata (`cf-aig-cache-status`, `cf-aig-log-id`, `cf-aig-event-id`, `cf-aig-model`) and shows cache state as `AI Gateway · cache hit/miss` in the TUI.
- Adds best-effort AI Gateway log enrichment keyed by `cf-aig-log-id`, plus docs and focused tests for routing, config, status formatting, and usage enrichment.

## Test plan
- `source ~/.nvm/nvm.sh && nvm use 23 && npm test`
- `source ~/.nvm/nvm.sh && nvm use 23 && npm run typecheck`
- `source ~/.nvm/nvm.sh && nvm use 23 && npm run build`
- Live direct Workers AI smoke: `npm run dev -- -p "reply with exactly ok"` returned `ok` with gateway unset.
- Live AI Gateway smoke: `KIMIFLARE_AI_GATEWAY_ID=<gateway> npm run dev -- -p "reply with exactly ok"` returned `ok`.
- Live metadata/log probe confirmed gateway cache status, log/event ids, and successful AI Gateway logs lookup.

Closes https://github.com/sinameraji/kimiflare/issues/115