### PR TITLE
feat: /gateway slash command + model ID validation

### DIFF
--- a/src/agent/client.test.ts
+++ b/src/agent/client.test.ts
@@ -26,7 +26,7 @@ describe("runKimi session affinity header", () => {
     const gen = runKimi({
       accountId: "test",
       apiToken: "token",
-      model: "m",
+      model: "@cf/test/model",
       messages: [{ role: "user", content: "hi" }],
       sessionId: "sess-123",
     });
@@ -43,7 +43,7 @@ describe("runKimi session affinity header", () => {
     const gen = runKimi({
       accountId: "test",
       apiToken: "token",
-      model: "m",
+      model: "@cf/test/model",
       messages: [{ role: "user", content: "hi" }],
     });
     for await (const _ of gen) {

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -135,10 +135,21 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   }
 }
 
+/** Validate that a model ID looks like a legitimate Cloudflare Workers AI model.
+ *  Prevents path traversal via malicious model strings. */
+function validateModelId(model: string): void {
+  // Cloudflare model IDs: @namespace/name or @namespace/name/version
+  // Allowed chars: @ a-z A-Z 0-9 _ - . /
+  if (!/^@[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+(\/[a-zA-Z0-9._-]+)*$/.test(model)) {
+    throw new KimiApiError(`Invalid model ID: ${model}`, 400);
+  }
+}
+
 function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Record<string, string> } {
+  validateModelId(opts.model);
   if (!opts.gateway?.id) {
     return {
-      url: `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${opts.model}`,
+      url: `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(opts.accountId)}/ai/run/${opts.model}`,
       headers: {},
     };
   }
@@ -159,7 +170,7 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
   }
 
   return {
-    url: `https://gateway.ai.cloudflare.com/v1/${opts.accountId}/${encodeURIComponent(
+    url: `https://gateway.ai.cloudflare.com/v1/${encodeURIComponent(opts.accountId)}/${encodeURIComponent(
       opts.gateway.id,
     )}/workers-ai/${opts.model}`,
     headers,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -903,6 +903,110 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         ]);
         return true;
       }
+      if (c === "/gateway") {
+        if (!cfg) {
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no config loaded" }]);
+          return true;
+        }
+        const sub = rest[0]?.toLowerCase() ?? "";
+        const subArg = rest.slice(1).join(" ").trim();
+
+        if (!sub || sub === "status") {
+          const lines: string[] = [];
+          if (cfg.aiGatewayId) {
+            lines.push(`gateway: ${cfg.aiGatewayId}`);
+            lines.push(`cache-ttl: ${cfg.aiGatewayCacheTtl ?? "default"}`);
+            lines.push(`skip-cache: ${cfg.aiGatewaySkipCache ?? false}`);
+            lines.push(`collect-logs: ${cfg.aiGatewayCollectLogPayload ?? false}`);
+            const meta = cfg.aiGatewayMetadata;
+            lines.push(`metadata: ${meta && Object.keys(meta).length > 0 ? JSON.stringify(meta) : "none"}`);
+          } else {
+            lines.push("gateway: off (direct Workers AI)");
+          }
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
+          return true;
+        }
+
+        if (sub === "off") {
+          const next = { ...cfg, aiGatewayId: undefined };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "gateway disabled — using direct Workers AI" }]);
+          return true;
+        }
+
+        if (sub === "cache-ttl") {
+          const ttl = parseInt(subArg, 10);
+          if (Number.isNaN(ttl) || ttl < 0) {
+            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway cache-ttl <seconds>" }]);
+            return true;
+          }
+          const next = { ...cfg, aiGatewayCacheTtl: ttl };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway cache-ttl set to ${ttl}s` }]);
+          return true;
+        }
+
+        if (sub === "skip-cache") {
+          const val = subArg === "true" ? true : subArg === "false" ? false : undefined;
+          if (val === undefined) {
+            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway skip-cache true|false" }]);
+            return true;
+          }
+          const next = { ...cfg, aiGatewaySkipCache: val };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway skip-cache set to ${val}` }]);
+          return true;
+        }
+
+        if (sub === "collect-logs") {
+          const val = subArg === "true" ? true : subArg === "false" ? false : undefined;
+          if (val === undefined) {
+            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway collect-logs true|false" }]);
+            return true;
+          }
+          const next = { ...cfg, aiGatewayCollectLogPayload: val };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway collect-logs set to ${val}` }]);
+          return true;
+        }
+
+        if (sub === "metadata") {
+          if (subArg === "clear") {
+            const next = { ...cfg, aiGatewayMetadata: undefined };
+            setCfg(next);
+            void saveConfig(next).catch(() => {});
+            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "gateway metadata cleared" }]);
+            return true;
+          }
+          const eq = subArg.indexOf("=");
+          if (eq === -1) {
+            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway metadata KEY=VALUE  or  /gateway metadata clear" }]);
+            return true;
+          }
+          const key = subArg.slice(0, eq).trim();
+          let value: string | number | boolean = subArg.slice(eq + 1).trim();
+          if (value === "true") value = true;
+          else if (value === "false") value = false;
+          else if (/^-?\d+$/.test(value)) value = parseInt(value, 10);
+          const nextMeta = { ...(cfg.aiGatewayMetadata ?? {}), [key]: value };
+          const next = { ...cfg, aiGatewayMetadata: nextMeta };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway metadata: ${key}=${JSON.stringify(value)}` }]);
+          return true;
+        }
+
+        // Default: treat sub as a gateway ID to enable
+        const next = { ...cfg, aiGatewayId: rest[0] };
+        setCfg(next);
+        void saveConfig(next).catch(() => {});
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway enabled: ${rest[0]}` }]);
+        return true;
+      }
       if (c === "/thinking" || c === "/effort") {
         if (!arg) {
           setEvents((e) => [
@@ -1117,6 +1221,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
               "  /mcp reload             reconnect all configured MCP servers\n" +
               "  /reasoning              toggle show/hide model reasoning\n" +
               "  /clear                  clear current conversation\n" +
+              "  /gateway                show gateway status\n" +
+              "  /gateway ID             enable AI Gateway\n" +
+              "  /gateway off            disable AI Gateway (direct Workers AI)\n" +
+              "  /gateway cache-ttl N    set gateway cache TTL in seconds\n" +
+              "  /gateway skip-cache T|F set gateway skip-cache flag\n" +
+              "  /gateway collect-logs T|F  include payload in gateway logs\n" +
+              "  /gateway metadata K=V   add metadata key-value pair\n" +
+              "  /gateway metadata clear remove all metadata\n" +
               "  /cost /model /update /logout /help /exit\n" +
               "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o verbose · ctrl+t theme · shift+tab cycle mode · ↑/↓ history",
           },
@@ -1125,7 +1237,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       }
       return false;
     },
-    [cfg, exit, usage, effort, theme, mode, openResumePicker, runCompact, runInit, initMcp],
+    [cfg, exit, usage, effort, theme, mode, openResumePicker, runCompact, runInit, initMcp, setCfg],
   );
 
   const processMessage = useCallback(


### PR DESCRIPTION
Adds interactive /gateway command and security hardening for AI Gateway routing.

## Changes

### /gateway slash command
Users can now configure AI Gateway without editing JSON:
- `/gateway` / `/gateway status` — show current gateway config
- `/gateway ID` — enable gateway (e.g. `/gateway my-gateway`)
- `/gateway off` — disable, use direct Workers AI
- `/gateway cache-ttl N` — set cache TTL in seconds
- `/gateway skip-cache true|false` — toggle cache bypass
- `/gateway collect-logs true|false` — toggle payload logging
- `/gateway metadata KEY=VALUE` — add metadata tag
- `/gateway metadata clear` — remove all metadata

### Security hardening
- **Validate model IDs** with regex before building API URLs. Prevents path traversal from malicious model strings like `../../../etc/passwd`.
- **URL-encode accountId** in both direct Workers AI and AI Gateway request URLs.

## Testing
- All 78 tests pass
- `npm run typecheck` clean

Co-authored-by: kimiflare <kimiflare@proton.me>