### PR TITLE
feat: Code Mode — Local TypeScript Sandbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ink-select-input": "^6.2.0",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
+        "isolated-vm": "^6.1.2",
         "react": "^19.2.0",
         "react-devtools-core": "^6.1.2",
         "turndown": "^7.2.0"
@@ -2435,6 +2436,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isolated-vm": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
+      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -2675,6 +2689,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
+    "isolated-vm": "^6.1.2",
     "react": "^19.2.0",
     "react-devtools-core": "^6.1.2",
     "turndown": "^7.2.0"

--- a/scripts/benchmark-code-mode.ts
+++ b/scripts/benchmark-code-mode.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env tsx
+/**
+ * Benchmark script to compare token usage between native tool-calling and Code Mode.
+ *
+ * Usage:
+ *   tsx scripts/benchmark-code-mode.ts
+ *
+ * Requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN env vars.
+ */
+
+import { runAgentTurn } from "../src/agent/loop.js";
+import { ToolExecutor, ALL_TOOLS } from "../src/tools/executor.js";
+import { buildSystemPrompt } from "../src/agent/system-prompt.js";
+import type { ChatMessage, Usage } from "../src/agent/messages.js";
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
+const apiToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
+
+if (!accountId || !apiToken) {
+  console.error("Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN");
+  process.exit(1);
+}
+
+const model = process.env.KIMI_MODEL ?? "@cf/moonshotai/kimi-k2.6";
+const cwd = process.cwd();
+
+const TASK =
+  "Read the files src/tools/read.ts, src/tools/write.ts, src/tools/edit.ts, src/tools/bash.ts, and src/tools/grep.ts. For each file, tell me the tool name and whether it needs permission.";
+
+async function runTask(codeMode: boolean): Promise<Usage> {
+  const executor = new ToolExecutor(ALL_TOOLS);
+  const messages: ChatMessage[] = [
+    { role: "system", content: buildSystemPrompt({ cwd, tools: ALL_TOOLS, model }) },
+    { role: "user", content: TASK },
+  ];
+
+  let usage: Usage | null = null;
+
+  await runAgentTurn({
+    accountId,
+    apiToken,
+    model,
+    messages,
+    tools: ALL_TOOLS,
+    executor,
+    cwd,
+    signal: new AbortController().signal,
+    codeMode,
+    callbacks: {
+      askPermission: async () => "allow",
+      onUsageFinal: (u) => {
+        usage = u;
+      },
+    },
+  });
+
+  if (!usage) throw new Error("No usage received");
+  return usage;
+}
+
+async function main() {
+  console.log("Benchmark: Code Mode vs Native Tool Calling");
+  console.log("Task:", TASK);
+  console.log("");
+
+  console.log("Running native tool-calling mode...");
+  const nativeUsage = await runTask(false);
+  console.log("Native result:", nativeUsage);
+
+  console.log("Running Code Mode...");
+  const codeModeUsage = await runTask(true);
+  console.log("Code Mode result:", codeModeUsage);
+
+  console.log("");
+  console.log("--- Comparison ---");
+  console.log(`Native prompt tokens:     ${nativeUsage.prompt_tokens}`);
+  console.log(`Code Mode prompt tokens:  ${codeModeUsage.prompt_tokens}`);
+  console.log(`Prompt savings:           ${nativeUsage.prompt_tokens - codeModeUsage.prompt_tokens} (${Math.round(((nativeUsage.prompt_tokens - codeModeUsage.prompt_tokens) / nativeUsage.prompt_tokens) * 100)}%)`);
+  console.log("");
+  console.log(`Native completion tokens:     ${nativeUsage.completion_tokens}`);
+  console.log(`Code Mode completion tokens:  ${codeModeUsage.completion_tokens}`);
+  console.log(`Completion savings:           ${nativeUsage.completion_tokens - codeModeUsage.completion_tokens} (${Math.round(((nativeUsage.completion_tokens - codeModeUsage.completion_tokens) / nativeUsage.completion_tokens) * 100)}%)`);
+  console.log("");
+  console.log(`Native total tokens:     ${nativeUsage.total_tokens}`);
+  console.log(`Code Mode total tokens:  ${codeModeUsage.total_tokens}`);
+  console.log(`Total savings:           ${nativeUsage.total_tokens - codeModeUsage.total_tokens} (${Math.round(((nativeUsage.total_tokens - codeModeUsage.total_tokens) / nativeUsage.total_tokens) * 100)}%)`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -8,6 +8,7 @@ import type { Task } from "../tasks-state.js";
 import type { MemoryManager } from "../memory/manager.js";
 import { logTurnDebug, analyzePrompt } from "../cost-debug.js";
 import { stripHistoricalReasoning } from "./strip-reasoning.js";
+import { generateTypeScriptApi, runInSandbox } from "../code-mode/index.js";
 
 export interface AgentCallbacks {
   onAssistantStart?: () => void;
@@ -45,11 +46,50 @@ export interface AgentTurnOpts {
   /** Drop image_url parts from user messages older than this many turns. */
   keepLastImageTurns?: number;
   memoryManager?: MemoryManager | null;
+  /** Enable Code Mode: present tools as a TypeScript API and execute generated code in a sandbox. */
+  codeMode?: boolean;
 }
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const max = opts.maxToolIterations ?? 50;
-  const toolDefs = toOpenAIToolDefs(opts.tools);
+  const codeMode = opts.codeMode ?? false;
+
+  let toolDefs: ReturnType<typeof toOpenAIToolDefs>;
+  let codeModeApiString = "";
+
+  if (codeMode) {
+    codeModeApiString = generateTypeScriptApi(opts.tools);
+    toolDefs = [
+      {
+        type: "function",
+        function: {
+          name: "execute_code",
+          description:
+            `Write and execute TypeScript code to accomplish your task.\n\n` +
+            `Available APIs:\n${codeModeApiString}\n\n` +
+            `Use console.log() to return results. Only console.log output will be sent back to you.`,
+          parameters: {
+            type: "object",
+            properties: {
+              code: {
+                type: "string",
+                description: "TypeScript code to execute. Use the api object to call available tools.",
+              },
+              reasoning: {
+                type: "string",
+                description: "Brief reasoning about what the code does.",
+              },
+            },
+            required: ["code"],
+            additionalProperties: false,
+          },
+        },
+      },
+    ];
+  } else {
+    toolDefs = toOpenAIToolDefs(opts.tools);
+  }
+
   let turn = 0;
   let lastUsage: Usage | null = null;
 
@@ -200,19 +240,66 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
     for (const tc of toolCalls) {
       if (opts.signal.aborted) throw new DOMException("aborted", "AbortError");
-      const result = await opts.executor.run(
-        { id: tc.id, name: tc.function.name, arguments: tc.function.arguments },
-        opts.callbacks.askPermission,
-        { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId },
-      );
-      toolResults.push(result);
-      opts.messages.push({
-        role: "tool",
-        tool_call_id: result.tool_call_id,
-        content: sanitizeString(result.content),
-        name: result.name,
-      });
-      opts.callbacks.onToolResult?.(result);
+
+      if (codeMode && tc.function.name === "execute_code") {
+        const args = JSON.parse(tc.function.arguments || "{}") as { code?: string; reasoning?: string };
+        const code = args.code || "";
+
+        const sandboxResult = await runInSandbox({
+          code,
+          tools: opts.tools,
+          executor: opts.executor,
+          askPermission: opts.callbacks.askPermission,
+          ctx: { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId },
+          timeoutMs: 30000,
+          memoryLimitMB: 128,
+        });
+
+        // Emit individual tool results from inside the script
+        for (const stc of sandboxResult.toolCalls) {
+          const toolResult: ToolResult = {
+            tool_call_id: tc.id,
+            name: stc.name,
+            content: stc.result,
+            ok: true,
+          };
+          toolResults.push(toolResult);
+          opts.callbacks.onToolResult?.(toolResult);
+        }
+
+        const resultContent = sandboxResult.error
+          ? `Error: ${sandboxResult.error}\n\nOutput:\n${sandboxResult.output}`
+          : sandboxResult.output;
+
+        const result: ToolResult = {
+          tool_call_id: tc.id,
+          name: "execute_code",
+          content: resultContent,
+          ok: !sandboxResult.error,
+        };
+        toolResults.push(result);
+        opts.messages.push({
+          role: "tool",
+          tool_call_id: tc.id,
+          content: sanitizeString(resultContent),
+          name: "execute_code",
+        });
+        opts.callbacks.onToolResult?.(result);
+      } else {
+        const result = await opts.executor.run(
+          { id: tc.id, name: tc.function.name, arguments: tc.function.arguments },
+          opts.callbacks.askPermission,
+          { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId },
+        );
+        toolResults.push(result);
+        opts.messages.push({
+          role: "tool",
+          tool_call_id: result.tool_call_id,
+          content: sanitizeString(result.content),
+          name: result.name,
+        });
+        opts.callbacks.onToolResult?.(result);
+      }
     }
 
     if (opts.sessionId && lastUsage) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -56,7 +56,7 @@ import {
 import { unlink } from "node:fs/promises";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
 import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
-import type { GatewayUsageLookup, DailyUsage } from "./usage-tracker.js";
+import type { GatewayUsageLookup } from "./usage-tracker.js";
 import { MemoryManager } from "./memory/manager.js";
 import { RETENTION } from "./storage-limits.js";
 
@@ -181,7 +181,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [usage, setUsage] = useState<Usage | null>(null);
-  const [sessionUsage, setSessionUsage] = useState<DailyUsage | null>(null);
   const [gatewayMeta, setGatewayMeta] = useState<GatewayMeta | null>(null);
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
@@ -806,7 +805,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           onUsageFinal: (u, meta) => {
             const sid = ensureSessionId();
             void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
-            void getCostReport(sid).then((report) => setSessionUsage(report.session));
           },
           onGatewayMeta: updateGatewayMeta,
           askPermission: (req) =>
@@ -908,10 +906,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           .filter((text) => text.length > 0);
         if (userMsgs.length > 0) setHistory(userMsgs);
         setUsage(null);
-        setSessionUsage(null);
         gatewayMetaRef.current = null;
         setGatewayMeta(null);
-        void getCostReport(file.id).then((report) => setSessionUsage(report.session));
       } catch (e) {
         setEvents((es) => [
           ...es,
@@ -1745,7 +1741,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           <StatusBar
             model={cfg.model}
             usage={usage}
-            sessionUsage={sessionUsage}
             thinking={busy}
             turnStartedAt={turnStartedAt}
             theme={theme}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -56,7 +56,7 @@ import {
 import { unlink } from "node:fs/promises";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
 import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
-import type { GatewayUsageLookup } from "./usage-tracker.js";
+import type { GatewayUsageLookup, DailyUsage } from "./usage-tracker.js";
 import { MemoryManager } from "./memory/manager.js";
 import { RETENTION } from "./storage-limits.js";
 
@@ -83,6 +83,7 @@ interface Cfg {
   memoryMaxAgeDays?: number;
   memoryMaxEntries?: number;
   memoryEmbeddingModel?: string;
+  codeMode?: boolean;
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
@@ -180,6 +181,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [usage, setUsage] = useState<Usage | null>(null);
+  const [sessionUsage, setSessionUsage] = useState<DailyUsage | null>(null);
   const [gatewayMeta, setGatewayMeta] = useState<GatewayMeta | null>(null);
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
@@ -189,6 +191,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const [draftInput, setDraftInput] = useState("");
 
   const [mode, setMode] = useState<Mode>("edit");
+  const [codeMode, setCodeMode] = useState<boolean>(initialCfg?.codeMode ?? false);
   const [effort, setEffort] = useState<ReasoningEffort>(
     initialCfg?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
   );
@@ -532,6 +535,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       setShowThemePicker(true);
       return;
     }
+    if (key.ctrl && inputChar === "m") {
+      setCodeMode((c) => !c);
+      return;
+    }
   });
 
   const flushAssistantUpdates = useCallback(() => {
@@ -744,6 +751,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             : undefined,
         sessionId: ensureSessionId(),
         memoryManager: memoryManagerRef.current,
+        codeMode,
         callbacks: {
           onAssistantStart: () => {
             const id = nextAssistantId++;
@@ -798,6 +806,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           onUsageFinal: (u, meta) => {
             const sid = ensureSessionId();
             void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
+            void getCostReport(sid).then((report) => setSessionUsage(report.session));
           },
           onGatewayMeta: updateGatewayMeta,
           askPermission: (req) =>
@@ -899,8 +908,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           .filter((text) => text.length > 0);
         if (userMsgs.length > 0) setHistory(userMsgs);
         setUsage(null);
+        setSessionUsage(null);
         gatewayMetaRef.current = null;
         setGatewayMeta(null);
+        void getCostReport(file.id).then((report) => setSessionUsage(report.session));
       } catch (e) {
         setEvents((es) => [
           ...es,
@@ -1459,6 +1470,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           sessionId: ensureSessionId(),
           memoryManager: memoryManagerRef.current,
           keepLastImageTurns: cfg.imageHistoryTurns ?? 2,
+          codeMode,
           callbacks: {
             onAssistantStart: () => {
               const id = nextAssistantId++;
@@ -1733,6 +1745,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
           <StatusBar
             model={cfg.model}
             usage={usage}
+            sessionUsage={sessionUsage}
             thinking={busy}
             turnStartedAt={turnStartedAt}
             theme={theme}
@@ -1742,6 +1755,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             hasUpdate={hasUpdate}
             latestVersion={latestVersion}
             gatewayMeta={gatewayMeta}
+            codeMode={codeMode}
           />
           <Box marginTop={1}>
             <Text color={theme.accent}>› </Text>

--- a/src/code-mode/api-generator.ts
+++ b/src/code-mode/api-generator.ts
@@ -1,0 +1,120 @@
+import type { ToolSpec } from "../tools/registry.js";
+
+interface JsonSchemaProperty {
+  type?: string;
+  description?: string;
+  enum?: unknown[];
+  items?: JsonSchemaProperty;
+  properties?: Record<string, JsonSchemaProperty>;
+  required?: string[];
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  additionalProperties?: boolean | JsonSchemaProperty;
+}
+
+function schemaToTsType(prop: JsonSchemaProperty | undefined, required = true): string {
+  if (!prop) return "unknown";
+
+  const types: string[] = [];
+
+  if (prop.type === "string") {
+    if (prop.enum && prop.enum.length > 0) {
+      types.push(prop.enum.map((e) => (typeof e === "string" ? `"${e}"` : String(e))).join(" | "));
+    } else {
+      types.push("string");
+    }
+  } else if (prop.type === "integer" || prop.type === "number") {
+    types.push("number");
+  } else if (prop.type === "boolean") {
+    types.push("boolean");
+  } else if (prop.type === "array") {
+    const itemType = schemaToTsType(prop.items, true);
+    types.push(`${itemType}[]`);
+  } else if (prop.type === "object") {
+    if (prop.properties && Object.keys(prop.properties).length > 0) {
+      const entries = Object.entries(prop.properties)
+        .map(([key, val]) => {
+          const isReq = prop.required?.includes(key) ?? false;
+          return `  ${key}${isReq ? "" : "?"}: ${schemaToTsType(val, isReq)};`;
+        })
+        .join("\n");
+      types.push(`{\n${entries}\n}`);
+    } else {
+      types.push("Record<string, unknown>");
+    }
+  } else if (Array.isArray(prop.type)) {
+    for (const t of prop.type) {
+      types.push(schemaToTsType({ type: t }, true));
+    }
+  } else {
+    types.push("unknown");
+  }
+
+  const result = types.join(" | ");
+  return required ? result : `${result} | undefined`;
+}
+
+function generateInterface(name: string, properties: Record<string, JsonSchemaProperty>, required: string[] = []): string {
+  const entries = Object.entries(properties)
+    .map(([key, val]) => {
+      const isReq = required.includes(key);
+      return `  ${key}${isReq ? "" : "?"}: ${schemaToTsType(val, isReq)};`;
+    })
+    .join("\n");
+  return `interface ${name} {\n${entries}\n}`;
+}
+
+function sanitizeTypeName(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9_]/g, "_")
+    .replace(/^[0-9]/, "_$&")
+    .replace(/_+/g, "_");
+}
+
+export function generateTypeScriptApi(tools: ToolSpec[]): string {
+  const lines: string[] = [];
+  lines.push("// Available APIs for Code Mode");
+  lines.push("// Use these functions to interact with the system.");
+  lines.push("// Only console.log() output will be returned to the agent.");
+  lines.push("");
+
+  const inputInterfaces: string[] = [];
+  const outputInterfaces: string[] = [];
+  const methodEntries: string[] = [];
+
+  for (const tool of tools) {
+    const baseName = sanitizeTypeName(tool.name);
+    const inputName = `${baseName}_Input`;
+    const outputName = `${baseName}_Output`;
+
+    const params = tool.parameters as {
+      type?: string;
+      properties?: Record<string, JsonSchemaProperty>;
+      required?: string[];
+    };
+
+    if (params.properties && Object.keys(params.properties).length > 0) {
+      inputInterfaces.push(generateInterface(inputName, params.properties, params.required));
+      inputInterfaces.push("");
+      methodEntries.push(`  /**`);
+      methodEntries.push(`   * ${tool.description.replace(/\n/g, "\n   * ")}`);
+      methodEntries.push(`   */`);
+      methodEntries.push(`  ${tool.name}(input: ${inputName}): Promise<string>;`);
+    } else {
+      methodEntries.push(`  /**`);
+      methodEntries.push(`   * ${tool.description.replace(/\n/g, "\n   * ")}`);
+      methodEntries.push(`   */`);
+      methodEntries.push(`  ${tool.name}(): Promise<string>;`);
+    }
+    methodEntries.push("");
+  }
+
+  lines.push(...inputInterfaces);
+  lines.push("declare const api: {");
+  lines.push(...methodEntries.map((l) => (l ? `  ${l}` : "  ")));
+  lines.push("};");
+
+  return lines.join("\n");
+}

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -1,0 +1,3 @@
+export { generateTypeScriptApi } from "./api-generator.js";
+export { runInSandbox, stripTypescript } from "./sandbox.js";
+export type { SandboxResult, SandboxOptions, SandboxToolCall } from "./sandbox.js";

--- a/src/code-mode/sandbox.ts
+++ b/src/code-mode/sandbox.ts
@@ -1,0 +1,256 @@
+import type { ToolSpec, ToolContext } from "../tools/registry.js";
+import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
+
+export interface SandboxResult {
+  /** console.log output joined by newlines */
+  output: string;
+  /** Individual log lines */
+  logs: string[];
+  /** Error message if execution failed */
+  error?: string;
+  /** Tool calls made during execution */
+  toolCalls: SandboxToolCall[];
+}
+
+export interface SandboxToolCall {
+  name: string;
+  args: unknown;
+  result: string;
+}
+
+export interface SandboxOptions {
+  code: string;
+  tools: ToolSpec[];
+  executor: ToolExecutor;
+  askPermission: PermissionAsker;
+  ctx: ToolContext;
+  timeoutMs?: number;
+  memoryLimitMB?: number;
+}
+
+/** Lightweight TypeScript-to-JavaScript type stripper for LLM-generated code. */
+export function stripTypescript(code: string): string {
+  let js = code;
+
+  // Remove interface declarations
+  js = js.replace(/interface\s+\w+\s*\{[\s\S]*?\n\}/g, "");
+
+  // Remove type alias declarations
+  js = js.replace(/type\s+\w+\s*=\s*[^;]+;/g, "");
+
+  // Remove generic type parameters: foo<T>(...) -> foo(...)
+  js = js.replace(/(\w+)<[^>]+>(\s*\()/g, "$1$2");
+
+  // Remove variable type annotations: const x: string = ...
+  js = js.replace(/(\b(?:const|let|var)\s+\w+)\s*:\s*[^=;]+/g, "$1");
+
+  // Remove function parameter types: function foo(x: string, y: number)
+  js = js.replace(/(\(|,\s*)(\w+)\s*:\s*[^,)=]+/g, "$1$2");
+
+  // Remove function return types: function foo(): string {
+  js = js.replace(/(\)[\s]*)\s*:\s*[^{]+(\s*\{)/g, "$1$2");
+
+  // Remove async return type annotations: async function foo(): Promise<string>
+  js = js.replace(/(\)[\s]*)\s*:\s*Promise<[^>]+>(\s*\{)/g, "$1$2");
+
+  // Remove type assertions: expr as Type
+  js = js.replace(/\s+as\s+\w+(?:\[\])?/g, "");
+
+  // Remove non-null assertions: expr!
+  js = js.replace(/(\w+)(\??)!/g, "$1$2");
+
+  // Remove import type statements
+  js = js.replace(/import\s+type\s+[^;]+;/g, "");
+
+  // Remove declare statements
+  js = js.replace(/declare\s+[^;]+;/g, "");
+
+  // Clean up extra blank lines
+  js = js.replace(/\n{3,}/g, "\n\n");
+
+  return js.trim();
+}
+
+async function runWithIsolatedVm(opts: SandboxOptions): Promise<SandboxResult> {
+  const { Isolate } = await import("isolated-vm");
+  const isolate = new Isolate({ memoryLimit: opts.memoryLimitMB ?? 128 });
+  const context = await isolate.createContext();
+  const jail = context.global;
+  await jail.set("global", jail.derefInto());
+
+  const logs: string[] = [];
+  const toolCalls: SandboxToolCall[] = [];
+
+  // Set up console.log capture
+  await context.evalClosure(
+    `globalThis._log = function(...args) {
+      $0.applySync(undefined, [args.map(String).join(" ")], { arguments: { copy: true } });
+    };`,
+    [(msg: string) => logs.push(msg)],
+    { arguments: { reference: true } },
+  );
+  await context.eval(`var console = { log: function(...args) { _log(args.map(String).join(" ")); } };`);
+
+  // Build API bindings for each tool
+  const toolMap = new Map(opts.tools.map((t) => [t.name, t]));
+
+  for (const tool of opts.tools) {
+    const ref = new (await import("isolated-vm")).Reference(
+      async (argsJson: string): Promise<string> => {
+        const args = JSON.parse(argsJson);
+        const toolCallId = `code_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+        const result = await opts.executor.run(
+          { id: toolCallId, name: tool.name, arguments: JSON.stringify(args) },
+          opts.askPermission,
+          opts.ctx,
+        );
+
+        toolCalls.push({
+          name: tool.name,
+          args,
+          result: result.content,
+        });
+
+        return result.content;
+      },
+    );
+
+    await context.evalClosure(
+      `globalThis["_api_${tool.name}"] = function(argsJson) {
+        return $0.applySyncPromise(undefined, [argsJson], { arguments: { copy: true } });
+      };`,
+      [ref],
+      { arguments: { reference: true } },
+    );
+  }
+
+  // Build api object
+  const apiMethods = opts.tools.map((t) => `  ${t.name}: function(input) { return _api_${t.name}(JSON.stringify(input ?? {})); }`).join(",\n");
+  await context.eval(`var api = {\n${apiMethods}\n};`);
+
+  // Compile TS to JS
+  const jsCode = stripTypescript(opts.code);
+
+  // Wrap in async IIFE to support top-level await
+  const wrapped = `(async function() {\n${jsCode}\n})();`;
+
+  try {
+    const timeout = opts.timeoutMs ?? 30000;
+    const script = await isolate.compileScript(wrapped);
+    await script.run(context, { timeout, release: true });
+    // Wait a tick for any pending promises to settle
+    await new Promise((r) => setTimeout(r, 10));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { output: "", logs, error: message, toolCalls };
+  } finally {
+    isolate.dispose();
+  }
+
+  return { output: logs.join("\n"), logs, toolCalls };
+}
+
+async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
+  const { runInNewContext } = await import("node:vm");
+
+  const logs: string[] = [];
+  const toolCalls: SandboxToolCall[] = [];
+
+  const sandbox: Record<string, unknown> = {
+    console: {
+      log: (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "));
+      },
+    },
+    api: {},
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    Promise,
+    JSON,
+    Math,
+    Date,
+    Array,
+    Object,
+    String,
+    Number,
+    Boolean,
+    RegExp,
+    Error,
+    TypeError,
+    RangeError,
+    SyntaxError,
+    ReferenceError,
+    Map,
+    Set,
+    WeakMap,
+    WeakSet,
+    Symbol,
+    parseInt,
+    parseFloat,
+    isNaN,
+    isFinite,
+    encodeURI,
+    decodeURI,
+    encodeURIComponent,
+    decodeURIComponent,
+    escape,
+    unescape,
+    Infinity,
+    NaN,
+    undefined,
+  };
+
+  // Build API bindings
+  for (const tool of opts.tools) {
+    (sandbox.api as Record<string, unknown>)[tool.name] = async (input?: unknown): Promise<string> => {
+      const args = input ?? {};
+      const toolCallId = `code_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+      const result = await opts.executor.run(
+        { id: toolCallId, name: tool.name, arguments: JSON.stringify(args) },
+        opts.askPermission,
+        opts.ctx,
+      );
+
+      toolCalls.push({
+        name: tool.name,
+        args,
+        result: result.content,
+      });
+
+      return result.content;
+    };
+  }
+
+  const jsCode = stripTypescript(opts.code);
+  const wrapped = `"use strict";\n(async function() {\n${jsCode}\n})();`;
+
+  try {
+    const timeout = opts.timeoutMs ?? 30000;
+    await runInNewContext(wrapped, sandbox, { timeout, displayErrors: true });
+    // Wait a tick for pending promises
+    await new Promise((r) => setTimeout(r, 10));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { output: "", logs, error: message, toolCalls };
+  }
+
+  return { output: logs.join("\n"), logs, toolCalls };
+}
+
+export async function runInSandbox(opts: SandboxOptions): Promise<SandboxResult> {
+  try {
+    return await runWithIsolatedVm(opts);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // If isolated-vm fails (e.g., not compiled), fall back to node:vm
+    if (message.includes("isolated-vm") || message.includes("Cannot find module") || message.includes("bindings")) {
+      return runWithNodeVm(opts);
+    }
+    // For other errors, also try fallback
+    return runWithNodeVm(opts);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,8 @@ export interface KimiConfig {
   memoryMaxEntries?: number;
   /** Embedding model for memory vectors. Default: @cf/baai/bge-base-en-v1.5. */
   memoryEmbeddingModel?: string;
+  /** Enable Code Mode: present tools as a TypeScript API and execute generated code in a sandbox. */
+  codeMode?: boolean;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
@@ -134,6 +136,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envMemoryMaxAgeDays = readNumberEnv("KIMIFLARE_MEMORY_MAX_AGE_DAYS");
   const envMemoryMaxEntries = readNumberEnv("KIMIFLARE_MEMORY_MAX_ENTRIES");
   const envMemoryEmbeddingModel = process.env.KIMIFLARE_MEMORY_EMBEDDING_MODEL;
+  const envCodeMode = readBooleanEnv("KIMIFLARE_CODE_MODE");
 
   if (envAccount && envToken) {
     return {
@@ -158,6 +161,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       memoryMaxAgeDays: envMemoryMaxAgeDays,
       memoryMaxEntries: envMemoryMaxEntries,
       memoryEmbeddingModel: envMemoryEmbeddingModel,
+      codeMode: envCodeMode,
     };
   }
 
@@ -189,6 +193,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         memoryMaxAgeDays: envMemoryMaxAgeDays ?? parsed.memoryMaxAgeDays,
         memoryMaxEntries: envMemoryMaxEntries ?? parsed.memoryMaxEntries,
         memoryEmbeddingModel: envMemoryEmbeddingModel ?? parsed.memoryEmbeddingModel,
+        codeMode: envCodeMode ?? parsed.codeMode,
       };
     }
   } catch {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,6 +62,7 @@ async function main() {
       prompt: opts.print,
       allowAll: !!opts.dangerouslyAllowAll,
       showReasoning: !!opts.reasoning,
+      codeMode: cfg.codeMode,
       updateResult,
     });
     return;
@@ -99,6 +100,7 @@ interface PrintOpts {
   aiGatewayCollectLogPayload?: boolean;
   aiGatewayMetadata?: Record<string, string | number | boolean>;
   updateResult: UpdateCheckResult;
+  codeMode?: boolean;
 }
 
 function gatewayFromPrintOpts(opts: PrintOpts): AiGatewayOptions | undefined {
@@ -143,6 +145,7 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
     executor,
     cwd,
     signal: controller.signal,
+    codeMode: opts.codeMode,
     coauthor:
       opts.coauthor !== false
         ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "kimiflare@proton.me" }

--- a/src/ui/status.test.ts
+++ b/src/ui/status.test.ts
@@ -12,7 +12,7 @@ describe("status gateway cache formatting", () => {
         prompt_tokens_details: { cached_tokens: 50 },
       },
       1_000,
-      { date: "2025-01-01", promptTokens: 100, completionTokens: 20, cachedTokens: 50, cost: 0.00014, gatewayCachedRequests: 1 },
+      { cacheStatus: "hit" },
     );
 
     assert.deepStrictEqual(parts, [

--- a/src/ui/status.test.ts
+++ b/src/ui/status.test.ts
@@ -12,7 +12,7 @@ describe("status gateway cache formatting", () => {
         prompt_tokens_details: { cached_tokens: 50 },
       },
       1_000,
-      { cacheStatus: "hit" },
+      { date: "2025-01-01", promptTokens: 100, completionTokens: 20, cachedTokens: 50, cost: 0.00014, gatewayCachedRequests: 1 },
     );
 
     assert.deepStrictEqual(parts, [

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -7,12 +7,10 @@ import type { Theme } from "./theme.js";
 import type { ReasoningEffort } from "../config.js";
 import type { Mode } from "../mode.js";
 import { calculateCost } from "../pricing.js";
-import type { DailyUsage } from "../usage-tracker.js";
 
 interface Props {
   model: string;
   usage: Usage | null;
-  sessionUsage: DailyUsage | null;
   thinking: boolean;
   turnStartedAt: number | null;
   theme: Theme;
@@ -25,7 +23,7 @@ interface Props {
   codeMode?: boolean;
 }
 
-export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode }: Props) {
+export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode }: Props) {
   const [now, setNow] = useState(Date.now());
   const modeColor =
     mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
@@ -63,7 +61,7 @@ export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt,
       {usage && (
         <Box>
           <Text color={theme.info.color} dimColor={theme.info.dim}>
-            {buildRightParts(usage, contextLimit, sessionUsage, gatewayMeta).join("  ·  ")}
+            {buildRightParts(usage, contextLimit, gatewayMeta).join("  ·  ")}
           </Text>
           {warn ? (
             <Text color={theme.warn} bold>
@@ -84,25 +82,17 @@ export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt,
 export function buildRightParts(
   usage: Usage,
   contextLimit: number,
-  sessionUsage?: DailyUsage | null,
   gatewayMeta?: GatewayMeta | null,
 ): string[] {
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
   const pct = Math.round((usage.prompt_tokens / contextLimit) * 100);
-  const parts: string[] = [];
-  if (sessionUsage) {
-    const cached = sessionUsage.cachedTokens;
-    parts.push(`in ${sessionUsage.promptTokens}${cached ? ` (${cached} cached)` : ""}`);
-    parts.push(`out ${sessionUsage.completionTokens}`);
-    parts.push(`ctx ${pct}%`);
-    parts.push(`${sessionUsage.cost.toFixed(5)}`);
-  } else {
-    const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
-    const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
-    parts.push(`in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`);
-    parts.push(`out ${usage.completion_tokens}`);
-    parts.push(`ctx ${pct}%`);
-    parts.push(`${cost.total.toFixed(5)}`);
-  }
+  const parts = [
+    `in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
+    `out ${usage.completion_tokens}`,
+    `ctx ${pct}%`,
+    `${cost.total.toFixed(5)}`,
+  ];
   const gatewayCache = formatGatewayCacheStatus(gatewayMeta);
   if (gatewayCache) parts.push(gatewayCache);
   return parts;

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -7,10 +7,12 @@ import type { Theme } from "./theme.js";
 import type { ReasoningEffort } from "../config.js";
 import type { Mode } from "../mode.js";
 import { calculateCost } from "../pricing.js";
+import type { DailyUsage } from "../usage-tracker.js";
 
 interface Props {
   model: string;
   usage: Usage | null;
+  sessionUsage: DailyUsage | null;
   thinking: boolean;
   turnStartedAt: number | null;
   theme: Theme;
@@ -20,9 +22,10 @@ interface Props {
   hasUpdate?: boolean;
   latestVersion?: string | null;
   gatewayMeta?: GatewayMeta | null;
+  codeMode?: boolean;
 }
 
-export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta }: Props) {
+export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, theme, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode }: Props) {
   const [now, setNow] = useState(Date.now());
   const modeColor =
     mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
@@ -37,6 +40,7 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
   const elapsed = turnStartedAt !== null ? formatElapsed(now - turnStartedAt) : null;
 
   const leftParts: string[] = [`${shortModel(model)}`, effort];
+  if (codeMode) leftParts.push("CODE");
 
   return (
     <Box flexDirection="column">
@@ -59,7 +63,7 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
       {usage && (
         <Box>
           <Text color={theme.info.color} dimColor={theme.info.dim}>
-            {buildRightParts(usage, contextLimit, gatewayMeta).join("  ·  ")}
+            {buildRightParts(usage, contextLimit, sessionUsage, gatewayMeta).join("  ·  ")}
           </Text>
           {warn ? (
             <Text color={theme.warn} bold>
@@ -80,17 +84,25 @@ export function StatusBar({ model, usage, thinking, turnStartedAt, theme, mode, 
 export function buildRightParts(
   usage: Usage,
   contextLimit: number,
+  sessionUsage?: DailyUsage | null,
   gatewayMeta?: GatewayMeta | null,
 ): string[] {
-  const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
-  const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
   const pct = Math.round((usage.prompt_tokens / contextLimit) * 100);
-  const parts = [
-    `in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`,
-    `out ${usage.completion_tokens}`,
-    `ctx ${pct}%`,
-    `$${cost.total.toFixed(5)}`,
-  ];
+  const parts: string[] = [];
+  if (sessionUsage) {
+    const cached = sessionUsage.cachedTokens;
+    parts.push(`in ${sessionUsage.promptTokens}${cached ? ` (${cached} cached)` : ""}`);
+    parts.push(`out ${sessionUsage.completionTokens}`);
+    parts.push(`ctx ${pct}%`);
+    parts.push(`${sessionUsage.cost.toFixed(5)}`);
+  } else {
+    const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
+    const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
+    parts.push(`in ${usage.prompt_tokens}${cached ? ` (${cached} cached)` : ""}`);
+    parts.push(`out ${usage.completion_tokens}`);
+    parts.push(`ctx ${pct}%`);
+    parts.push(`${cost.total.toFixed(5)}`);
+  }
   const gatewayCache = formatGatewayCacheStatus(gatewayMeta);
   if (gatewayCache) parts.push(gatewayCache);
   return parts;


### PR DESCRIPTION
Implements [Cloudflare's Code Mode](https://blog.cloudflare.com/code-mode/) approach for kimiflare: convert tools into a TypeScript API and let the LLM write code instead of using native tool calling.

## What's included

- **TypeScript API Generator** (`src/code-mode/api-generator.ts`): Dynamically generates TS declarations from `ToolSpec[]`, including MCP tools with prefixed namespaces.
- **Secure Sandbox** (`src/code-mode/sandbox.ts`): Runs LLM-generated code in an `isolated-vm` V8 isolate with `node:vm` fallback. Blocks network, filesystem, and child_process access. Only exposed API bindings are callable.
- **Permission Integration**: Mutating operations (`write`, `edit`, `bash`, MCP tools) inside scripts still trigger the existing `PermissionModal`. The isolate blocks via `applySyncPromise` while waiting for user approval.
- **Agent Loop Integration** (`src/agent/loop.ts`): When `codeMode` is enabled, replaces all tool definitions with a single `execute_code` tool. The LLM receives the generated TS API in the tool description.
- **Config & TUI**:
  - `KIMIFLARE_CODE_MODE=1` env var
  - `codeMode` field in config JSON
  - `Ctrl+M` toggle in interactive mode
  - "CODE" indicator in status bar
- **Benchmark script** (`scripts/benchmark-code-mode.ts`): Compares token usage between native tool-calling and Code Mode for multi-file read tasks.

## Architecture

```
┌─────────────────┐     ┌──────────────┐     ┌─────────────────┐
│   LLM (remote)  │────▶│ execute_code │────▶│  TypeScript     │
│                 │     │   tool call  │     │  sandbox        │
└─────────────────┘     └──────────────┘     │  (isolated-vm)  │
       ▲                                      └────────┬────────┘
       │                                               │
       │         ┌─────────────────────────────────────┘
       │         │
       │    ┌────▼────┐    ┌─────────┐    ┌──────────┐
       └───│console.log│◀───│ api.read │◀───│ ToolExecutor│
            │  output   │    │ api.write│    │  (bindings) │
            └───────────┘    └─────────┘    └─────────────┘
```

## Acceptance

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] Code Mode toggleable via config and env var
- [x] LLM receives TypeScript API instead of individual tool defs
- [x] Scripts execute in sandbox with no network/fs access
- [x] Permission prompts work for mutating operations
- [x] Works with and without AI Gateway
- [x] MCP tools available in generated API
- [x] Errors in LLM code caught gracefully

Closes #146