### PR TITLE
feat(commands): custom slash commands from markdown files

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -63,6 +63,9 @@ import { shouldShowCreatorMessage, markCreatorMessageSeen } from "./util/state.j
 import { getAppVersion } from "./util/version.js";
 import { spawn } from "node:child_process";
 import { platform } from "node:os";
+import { loadCustomCommands } from "./commands/loader.js";
+import { renderCommand } from "./commands/renderer.js";
+import type { CustomCommand } from "./commands/types.js";
 
 interface Cfg {
   accountId: string;
@@ -193,6 +196,12 @@ function findImagePaths(text: string): string[] {
   return [...new Set(paths)];
 }
 
+const BUILTIN_COMMAND_NAMES = new Set([
+  "exit", "quit", "clear", "reasoning", "cost", "model", "thinking", "effort",
+  "theme", "mode", "plan", "auto", "edit", "resume", "compact", "init",
+  "update", "mcp", "logout", "help", "memory", "gateway", "hello", "community",
+]);
+
 const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
   low: "low — fastest; lightest reasoning. Best for simple Q&A, small edits, quick coordination.",
   medium: "medium — balanced (default). Solid quality on most edits, fast on trivial prompts.",
@@ -268,6 +277,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   // Batched streaming delta refs to reduce React re-render frequency
   const pendingTextRef = useRef<Map<number, { text: string; reasoning: string }>>(new Map());
   const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const customCommandsRef = useRef<CustomCommand[]>([]);
 
   useEffect(() => {
     if (!cfg) return;
@@ -336,7 +346,21 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       memoryManagerRef.current?.close();
       memoryManagerRef.current = null;
     }
-  }, [cfg]);
+
+    void loadCustomCommands(process.cwd()).then(({ commands, warnings }) => {
+      customCommandsRef.current = commands;
+      for (const w of warnings) {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `commands: ${w}` }]);
+      }
+      const shadowed = commands.filter((c) => BUILTIN_COMMAND_NAMES.has(c.name.toLowerCase()));
+      for (const c of shadowed) {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `commands: /${c.name} (${c.filepath}) shadowed by built-in — will not run` },
+        ]);
+      }
+    });
+  }, [cfg, setEvents]);
 
   useEffect(() => {
     if (!cfg || updateCheckedRef.current) return;
@@ -1420,41 +1444,50 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         return true;
       }
       if (c === "/help") {
+        const lines = [
+          "commands:",
+          "  /mode edit|plan|auto    switch mode (or shift+tab to cycle)",
+          "  /plan /auto /edit       shortcuts for /mode",
+          "  /thinking low|med|high  set reasoning effort (quality vs speed)",
+          "  /theme                  interactive theme picker (or ctrl+t)",
+          "  /theme NAME             set theme by name",
+          "  /resume                 pick a past conversation",
+          "  /compact                summarize old turns to free context",
+          "  /init                   scan this repo and write a KIMI.md for future agents",
+          "  /memory                 show memory stats",
+          "  /memory search <query>  search stored memories",
+          "  /memory clear           wipe memories for this repo",
+          "  /mcp list               list connected MCP servers and tools",
+          "  /mcp reload             reconnect all configured MCP servers",
+          "  /reasoning              toggle show/hide model reasoning",
+          "  /clear                  clear current conversation",
+          "  /hello                  send a voice note to the creator",
+          "  /community              join our Discord server",
+          "  /gateway                show gateway status",
+          "  /gateway ID             enable AI Gateway",
+          "  /gateway off            disable AI Gateway (direct Workers AI)",
+          "  /gateway cache-ttl N    set gateway cache TTL in seconds",
+          "  /gateway skip-cache T|F set gateway skip-cache flag",
+          "  /gateway collect-logs T|F  include payload in gateway logs",
+          "  /gateway metadata K=V   add metadata key-value pair",
+          "  /gateway metadata clear remove all metadata",
+          "  /cost /model /update /logout /help /exit",
+        ];
+        const customs = customCommandsRef.current.filter((c) => !BUILTIN_COMMAND_NAMES.has(c.name.toLowerCase()));
+        if (customs.length > 0) {
+          const nameWidth = Math.max(...customs.map((c) => c.name.length + 1), 22);
+          lines.push("", "custom commands:");
+          for (const c of customs) {
+            const display = `/${c.name}`.padEnd(nameWidth, " ");
+            lines.push(`  ${display}  ${c.description ?? ""}`.trimEnd());
+          }
+        }
+        lines.push(
+          "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o verbose · ctrl+t theme · shift+tab cycle mode · ↑/↓ history",
+        );
         setEvents((e) => [
           ...e,
-          {
-            kind: "info",
-            key: mkKey(),
-            text:
-              "commands:\n" +
-              "  /mode edit|plan|auto    switch mode (or shift+tab to cycle)\n" +
-              "  /plan /auto /edit       shortcuts for /mode\n" +
-              "  /thinking low|med|high  set reasoning effort (quality vs speed)\n" +
-              "  /theme                  interactive theme picker (or ctrl+t)\n" +
-              "  /theme NAME             set theme by name\n" +
-              "  /resume                 pick a past conversation\n" +
-              "  /compact                summarize old turns to free context\n" +
-              "  /init                   scan this repo and write a KIMI.md for future agents\n" +
-              "  /memory                 show memory stats\n" +
-              "  /memory search <query>  search stored memories\n" +
-              "  /memory clear           wipe memories for this repo\n" +
-              "  /mcp list               list connected MCP servers and tools\n" +
-              "  /mcp reload             reconnect all configured MCP servers\n" +
-              "  /reasoning              toggle show/hide model reasoning\n" +
-              "  /clear                  clear current conversation\n" +
-              "  /hello                  send a voice note to the creator\n" +
-              "  /community              join our Discord server\n" +
-              "  /gateway                show gateway status\n" +
-              "  /gateway ID             enable AI Gateway\n" +
-              "  /gateway off            disable AI Gateway (direct Workers AI)\n" +
-              "  /gateway cache-ttl N    set gateway cache TTL in seconds\n" +
-              "  /gateway skip-cache T|F set gateway skip-cache flag\n" +
-              "  /gateway collect-logs T|F  include payload in gateway logs\n" +
-              "  /gateway metadata K=V   add metadata key-value pair\n" +
-              "  /gateway metadata clear remove all metadata\n" +
-              "  /cost /model /update /logout /help /exit\n" +
-              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o verbose · ctrl+t theme · shift+tab cycle mode · ↑/↓ history",
-          },
+          { kind: "info", key: mkKey(), text: lines.join("\n") },
         ]);
         return true;
       }
@@ -1466,12 +1499,41 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const processMessage = useCallback(
     async (text: string, displayText?: string) => {
       if (!cfg) return;
-      const trimmed = text.trim();
+      let trimmed = text.trim();
       if (!trimmed) return;
 
-      if (trimmed.startsWith("/") && handleSlash(trimmed)) return;
+      let overrideModel: string | undefined;
+      let overrideEffort: ReasoningEffort | undefined;
+      let display = displayText?.trim() || trimmed;
 
-      const display = displayText?.trim() || trimmed;
+      if (trimmed.startsWith("/")) {
+        if (handleSlash(trimmed)) return;
+        const head = trimmed.split(/\s+/)[0]!.slice(1);
+        const custom = customCommandsRef.current.find((c) => c.name === head);
+        if (custom) {
+          const info = (text: string) =>
+            setEvents((e) => [...e, { kind: "info", key: mkKey(), text }]);
+          const { prompt: rendered, warnings } = await renderCommand(custom, trimmed, {
+            cwd: process.cwd(),
+          });
+          for (const w of warnings) info(`${custom.name}: ${w}`);
+          if (!rendered.trim()) return;
+          const parts: string[] = [];
+          if (custom.model) {
+            overrideModel = custom.model;
+            parts.push(`model=${custom.model}`);
+          }
+          if (custom.effort) {
+            overrideEffort = custom.effort;
+            parts.push(`effort=${custom.effort}`);
+          }
+          if (parts.length > 0) info(`command '${custom.name}' → ${parts.join(", ")} (this turn)`);
+          if (custom.mode) info(`note: mode override (${custom.mode}) is not yet wired; current mode applies`);
+          display = trimmed;
+          trimmed = rendered;
+        }
+      }
+
       const imagePaths = findImagePaths(trimmed).slice(0, MAX_IMAGES_PER_MESSAGE);
       let images: string[] = [];
       let content: string | ContentPart[] = sanitizeString(trimmed);
@@ -1530,14 +1592,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         await runAgentTurn({
           accountId: cfg.accountId,
           apiToken: cfg.apiToken,
-          model: cfg.model,
+          model: overrideModel ?? cfg.model,
           gateway: gatewayFromConfig(cfg),
           messages: messagesRef.current,
           tools: [...ALL_TOOLS, ...mcpToolsRef.current],
           executor: executorRef.current,
           cwd: process.cwd(),
           signal: controller.signal,
-          reasoningEffort: effortRef.current,
+          reasoningEffort: overrideEffort ?? effortRef.current,
           coauthor:
             cfg.coauthor !== false
               ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "kimiflare@proton.me" }

--- a/src/commands/frontmatter.test.ts
+++ b/src/commands/frontmatter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseFrontmatter } from "./frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  it("returns whole input as body when no frontmatter fence", () => {
+    const r = parseFrontmatter("just body\nno fence");
+    assert.equal(r.body, "just body\nno fence");
+    assert.deepEqual(r.data, {});
+    assert.deepEqual(r.errors, []);
+  });
+
+  it("parses simple flat keys", () => {
+    const r = parseFrontmatter("---\ndescription: hi\nmodel: foo\n---\nbody\n");
+    assert.equal(r.data.description, "hi");
+    assert.equal(r.data.model, "foo");
+    assert.equal(r.body, "body\n");
+    assert.deepEqual(r.errors, []);
+  });
+
+  it("strips matched double-quote pairs", () => {
+    const r = parseFrontmatter('---\ndescription: "hello world"\n---\n');
+    assert.equal(r.data.description, "hello world");
+  });
+
+  it("strips matched single-quote pairs", () => {
+    const r = parseFrontmatter("---\ndescription: 'hello world'\n---\n");
+    assert.equal(r.data.description, "hello world");
+  });
+
+  it("does not strip mismatched quotes", () => {
+    const r = parseFrontmatter("---\ndescription: \"hello'\n---\n");
+    assert.equal(r.data.description, "\"hello'");
+  });
+
+  it("ignores comment lines and blank lines", () => {
+    const r = parseFrontmatter("---\n# a comment\n\nmodel: foo\n---\n");
+    assert.equal(r.data.model, "foo");
+    assert.deepEqual(r.errors, []);
+  });
+
+  it("flags unparseable lines with errors", () => {
+    const r = parseFrontmatter("---\nthis is not valid\n---\nbody\n");
+    assert.deepEqual(r.data, {});
+    assert.ok(r.errors.some((e) => e.includes("unparseable line")));
+  });
+
+  it("flags unclosed frontmatter", () => {
+    const r = parseFrontmatter("---\ndescription: oops\nbody without close\n");
+    assert.ok(r.errors.some((e) => e.includes("not closed")));
+  });
+
+  it("supports CRLF line endings", () => {
+    const r = parseFrontmatter("---\r\ndescription: hi\r\n---\r\nbody\r\n");
+    assert.equal(r.data.description, "hi");
+    assert.equal(r.body, "body\r\n");
+  });
+
+  it("trims trailing whitespace from values", () => {
+    const r = parseFrontmatter("---\ndescription:    hi   \n---\n");
+    assert.equal(r.data.description, "hi");
+  });
+
+  it("accepts keys with hyphens, digits, and underscores", () => {
+    const r = parseFrontmatter("---\nfoo-bar: 1\nfoo1: 2\nfoo_bar: 3\n---\n");
+    assert.equal(r.data["foo-bar"], "1");
+    assert.equal(r.data.foo1, "2");
+    assert.equal(r.data.foo_bar, "3");
+    assert.deepEqual(r.errors, []);
+  });
+});

--- a/src/commands/frontmatter.ts
+++ b/src/commands/frontmatter.ts
@@ -1,0 +1,45 @@
+export type FrontmatterParse = {
+  data: Record<string, string>;
+  body: string;
+  errors: string[];
+};
+
+const FENCE = /^---\s*\r?\n/;
+const KV = /^([A-Za-z][\w-]*)\s*:\s*(.*?)\s*$/;
+
+export function parseFrontmatter(input: string): FrontmatterParse {
+  const errors: string[] = [];
+  if (!FENCE.test(input)) {
+    return { data: {}, body: input, errors };
+  }
+  const afterOpen = input.replace(FENCE, "");
+  const closeIdx = afterOpen.search(/\r?\n---\s*(\r?\n|$)/);
+  if (closeIdx === -1) {
+    errors.push("frontmatter not closed with ---");
+    return { data: {}, body: input, errors };
+  }
+  const yaml = afterOpen.slice(0, closeIdx);
+  const closeMatch = afterOpen.slice(closeIdx).match(/\r?\n---\s*(\r?\n|$)/);
+  const body = closeMatch ? afterOpen.slice(closeIdx + closeMatch[0].length) : "";
+
+  const data: Record<string, string> = {};
+  const lines = yaml.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const m = line.match(KV);
+    if (!m) {
+      errors.push(`unparseable line: ${line.trim()}`);
+      continue;
+    }
+    const key = m[1]!;
+    let value = m[2] ?? "";
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1);
+    }
+    data[key] = value;
+  }
+  return { data, body, errors };
+}

--- a/src/commands/loader.test.ts
+++ b/src/commands/loader.test.ts
@@ -1,0 +1,206 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, symlink, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { filenameToCommandName, loadCustomCommands } from "./loader.js";
+
+async function setup(): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
+  const cwd = await mkdtemp(join(tmpdir(), "kf-loader-"));
+  return {
+    cwd,
+    cleanup: async () => {
+      await rm(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+async function writeCmd(dir: string, rel: string, content: string): Promise<void> {
+  const path = join(dir, rel);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf8");
+}
+
+describe("filenameToCommandName", () => {
+  it("strips extension", () => {
+    assert.equal(filenameToCommandName("/root/test.md", "/root"), "test");
+  });
+  it("uses subdir as namespace", () => {
+    assert.equal(filenameToCommandName("/root/git/commit.md", "/root"), "git/commit");
+  });
+  it("rejects path traversal", () => {
+    assert.equal(filenameToCommandName("/elsewhere/x.md", "/root"), null);
+  });
+  it("rejects empty stem", () => {
+    assert.equal(filenameToCommandName("/root/.md", "/root"), null);
+  });
+});
+
+describe("loadCustomCommands", () => {
+  it("returns empty when no dirs exist", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands.length, 0);
+      assert.equal(r.warnings.length, 0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("parses frontmatter and body", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      await writeCmd(
+        join(cwd, ".kimiflare", "commands"),
+        "test.md",
+        "---\ndescription: Run tests\nmode: plan\nmodel: foo\neffort: high\n---\nBody here\n",
+      );
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands.length, 1);
+      const c = r.commands[0]!;
+      assert.equal(c.name, "test");
+      assert.equal(c.description, "Run tests");
+      assert.equal(c.mode, "plan");
+      assert.equal(c.model, "foo");
+      assert.equal(c.effort, "high");
+      assert.equal(c.source, "project");
+      assert.match(c.template, /Body here/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("treats agent as alias for mode and maps build->edit", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      await writeCmd(
+        join(cwd, ".kimiflare", "commands"),
+        "x.md",
+        "---\nagent: build\n---\nbody\n",
+      );
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands[0]!.mode, "edit");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("namespaces commands by subdir", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      await writeCmd(
+        join(cwd, ".kimiflare", "commands"),
+        "git/commit.md",
+        "---\ndescription: Commit\n---\nbody\n",
+      );
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands[0]!.name, "git/commit");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("warns on unknown mode and ignores it", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      await writeCmd(
+        join(cwd, ".kimiflare", "commands"),
+        "x.md",
+        "---\nmode: nonsense\n---\nbody\n",
+      );
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands[0]!.mode, undefined);
+      assert.ok(r.warnings.some((w) => w.includes("unknown mode")));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips files with unclosed frontmatter and warns", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      await writeCmd(
+        join(cwd, ".kimiflare", "commands"),
+        "x.md",
+        "---\ndescription: oops\nbody without close\n",
+      );
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands.length, 0);
+      assert.ok(r.warnings.some((w) => w.includes("not closed")));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("project commands override global on name collision", async () => {
+    const { cwd, cleanup } = await setup();
+    const xdg = await mkdtemp(join(tmpdir(), "kf-loader-xdg-"));
+    const prevXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = xdg;
+    try {
+      await writeCmd(join(xdg, "kimiflare", "commands"), "test.md", "---\ndescription: from-global\n---\nGLOBAL\n");
+      await writeCmd(join(cwd, ".kimiflare", "commands"), "test.md", "---\ndescription: from-project\n---\nPROJECT\n");
+      const r = await loadCustomCommands(cwd);
+      const test = r.commands.find((c) => c.name === "test");
+      assert.ok(test, "expected test command to load");
+      assert.equal(test!.source, "project");
+      assert.equal(test!.description, "from-project");
+      assert.match(test!.template, /PROJECT/);
+    } finally {
+      if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = prevXdg;
+      await rm(xdg, { recursive: true, force: true });
+      await cleanup();
+    }
+  });
+
+  it("skips files with unparseable frontmatter lines", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      await writeCmd(
+        join(cwd, ".kimiflare", "commands"),
+        "x.md",
+        "---\nthis is not a valid line\n---\nbody\n",
+      );
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands.length, 0);
+      assert.ok(r.warnings.some((w) => w.includes("unparseable line")));
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects project commands dir when it is a symlink escaping cwd", async () => {
+    const { cwd, cleanup } = await setup();
+    const outside = await mkdtemp(join(tmpdir(), "kf-loader-outside-"));
+    try {
+      await writeCmd(outside, "test.md", "---\ndescription: leaked\n---\nbody\n");
+      await mkdir(join(cwd, ".kimiflare"), { recursive: true });
+      await symlink(outside, join(cwd, ".kimiflare", "commands"));
+      const r = await loadCustomCommands(cwd);
+      assert.equal(r.commands.length, 0);
+      assert.ok(r.warnings.some((w) => w.includes("escapes workspace")));
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+      await cleanup();
+    }
+  });
+
+  it("returns commands sorted by name", async () => {
+    const { cwd, cleanup } = await setup();
+    try {
+      const dir = join(cwd, ".kimiflare", "commands");
+      await writeCmd(dir, "zebra.md", "x");
+      await writeCmd(dir, "alpha.md", "x");
+      await writeCmd(dir, "mike.md", "x");
+      const r = await loadCustomCommands(cwd);
+      assert.deepEqual(
+        r.commands.map((c) => c.name),
+        ["alpha", "mike", "zebra"],
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/commands/loader.ts
+++ b/src/commands/loader.ts
@@ -1,0 +1,168 @@
+import { open, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, relative, sep } from "node:path";
+import fg from "fast-glob";
+import { MODES, type Mode } from "../mode.js";
+import { EFFORTS, type ReasoningEffort } from "../config.js";
+import { isPathOutside } from "../util/paths.js";
+import { parseFrontmatter } from "./frontmatter.js";
+import type { CommandSource, CustomCommand, LoadResult } from "./types.js";
+
+const MAX_COMMAND_FILE_BYTES = 256 * 1024;
+
+export function projectCommandsDir(cwd: string = process.cwd()): string {
+  return join(cwd, ".kimiflare", "commands");
+}
+
+export function globalCommandsDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "commands");
+}
+
+export async function loadCustomCommands(
+  cwd: string = process.cwd(),
+): Promise<LoadResult> {
+  const warnings: string[] = [];
+  const byName = new Map<string, CustomCommand>();
+
+  const sources: Array<{ dir: string; source: CommandSource }> = [
+    { dir: globalCommandsDir(), source: "global" },
+    { dir: projectCommandsDir(cwd), source: "project" },
+  ];
+
+  const perSource = await Promise.all(
+    sources.map(async ({ dir, source }) => {
+      const safeDir = await resolveSafeDir(dir, source, cwd, warnings);
+      if (safeDir === null) return [] as Array<CustomCommand | null>;
+      const files = await fg("**/*.md", {
+        cwd: safeDir,
+        absolute: true,
+        onlyFiles: true,
+        followSymbolicLinks: false,
+        suppressErrors: true,
+      });
+      return Promise.all(files.map((file) => loadOne(file, safeDir, source, warnings)));
+    }),
+  );
+  for (const loaded of perSource) {
+    for (const cmd of loaded) {
+      if (cmd) byName.set(cmd.name, cmd);
+    }
+  }
+
+  return {
+    commands: [...byName.values()].sort((a, b) => a.name.localeCompare(b.name)),
+    warnings,
+  };
+}
+
+async function resolveSafeDir(
+  dir: string,
+  source: CommandSource,
+  cwd: string,
+  warnings: string[],
+): Promise<string | null> {
+  let realDir: string;
+  try {
+    realDir = await realpath(dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && code !== "ENOTDIR") {
+      warnings.push(`commands dir ${dir} unreadable: ${(err as Error).message}`);
+    }
+    return null;
+  }
+  if (source === "project") {
+    let realCwd: string;
+    try {
+      realCwd = await realpath(cwd);
+    } catch {
+      return null;
+    }
+    const rel = relative(realCwd, realDir);
+    if (rel !== "" && isPathOutside(rel)) {
+      warnings.push(`commands dir ${dir} escapes workspace via symlink — skipped`);
+      return null;
+    }
+  }
+  return realDir;
+}
+
+async function loadOne(
+  file: string,
+  rootDir: string,
+  source: CommandSource,
+  warnings: string[],
+): Promise<CustomCommand | null> {
+  let content: string;
+  try {
+    const handle = await open(file, "r");
+    try {
+      const stats = await handle.stat();
+      if (stats.size > MAX_COMMAND_FILE_BYTES) {
+        warnings.push(`command file ${file} exceeds ${MAX_COMMAND_FILE_BYTES} bytes — skipped`);
+        return null;
+      }
+      content = await handle.readFile("utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch (e) {
+    warnings.push(`failed to read command file ${file}: ${(e as Error).message}`);
+    return null;
+  }
+
+  const name = filenameToCommandName(file, rootDir);
+  if (!name) {
+    warnings.push(`invalid command name from ${file}`);
+    return null;
+  }
+
+  const { data, body, errors } = parseFrontmatter(content);
+  if (errors.length > 0) {
+    warnings.push(`frontmatter errors in ${file}: ${errors.join("; ")} — skipped`);
+    return null;
+  }
+
+  const cmd: CustomCommand = {
+    name,
+    template: body,
+    source,
+    filepath: file,
+  };
+  if (data.description) cmd.description = data.description;
+
+  const modeRaw = data.mode ?? data.agent;
+  if (modeRaw !== undefined) {
+    const normalized = modeRaw === "build" ? "edit" : modeRaw;
+    if ((MODES as readonly string[]).includes(normalized)) {
+      cmd.mode = normalized as Mode;
+    } else {
+      warnings.push(`unknown mode "${modeRaw}" in ${file} — ignored`);
+    }
+  }
+
+  if (data.model !== undefined && data.model !== "") {
+    cmd.model = data.model;
+  }
+
+  if (data.effort !== undefined) {
+    if ((EFFORTS as readonly string[]).includes(data.effort)) {
+      cmd.effort = data.effort as ReasoningEffort;
+    } else {
+      warnings.push(`unknown effort "${data.effort}" in ${file} — ignored`);
+    }
+  }
+
+  return cmd;
+}
+
+export function filenameToCommandName(file: string, rootDir: string): string | null {
+  const rel = relative(rootDir, file);
+  if (!rel || isPathOutside(rel)) return null;
+  const noExt = rel.replace(/\.md$/i, "");
+  const parts = noExt.split(sep).filter((p) => p.length > 0);
+  if (parts.length === 0) return null;
+  if (parts.some((p) => !/^[\w.-]+$/.test(p))) return null;
+  return parts.join("/");
+}

--- a/src/commands/renderer.test.ts
+++ b/src/commands/renderer.test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { renderCommand, tokenizeArgs } from "./renderer.js";
+import type { CustomCommand } from "./types.js";
+
+const cmd = (template: string, extras: Partial<CustomCommand> = {}): CustomCommand => ({
+  name: "test", template, source: "project", filepath: "/fake.md", ...extras,
+});
+const tempDir = (): Promise<string> => mkdtemp(path.join(os.tmpdir(), "kimiflare-renderer-"));
+const writeIn = async (dir: string, name: string, contents: string): Promise<string> => {
+  await writeFile(path.join(dir, name), contents, "utf8");
+  return name;
+};
+
+describe("renderer", () => {
+  it("tokenizes bare words", () => {
+    assert.deepStrictEqual(tokenizeArgs("hello world"), ["hello", "world"]);
+  });
+  it("keeps double-quoted words together", () => {
+    assert.deepStrictEqual(tokenizeArgs('"two words" three'), ["two words", "three"]);
+  });
+  it("keeps mixed quoted words together", () => {
+    assert.deepStrictEqual(tokenizeArgs("'a b' c \"d e\""), ["a b", "c", "d e"]);
+  });
+  it("$ARGUMENTS raw substitution preserves quotes/whitespace", async () => {
+    const result = await renderCommand(cmd("run $ARGUMENTS"), '  "a b"   c  ');
+    assert.strictEqual(result.prompt, 'run   "a b"   c  ');
+  });
+  it("$1 $2 substitutes first/second token", async () => {
+    assert.strictEqual((await renderCommand(cmd("$1 $2"), "hello world")).prompt, "hello world");
+  });
+  it("highest $N absorbs trailing tokens", async () => {
+    const result = await renderCommand(cmd("$1 $3"), "a b c d e");
+    assert.match(result.prompt, /a/);
+    assert.match(result.prompt, /c d e/);
+  });
+  it("implicitly appends args when template has no placeholders", async () => {
+    assert.strictEqual((await renderCommand(cmd("base"), "foo bar")).prompt, "base\n\nfoo bar");
+  });
+  it("does not append when template has $ARGUMENTS even if rendered args are empty", async () => {
+    assert.strictEqual((await renderCommand(cmd("base $ARGUMENTS"), "")).prompt, "base ");
+  });
+  it("does not append when args are empty", async () => {
+    assert.strictEqual((await renderCommand(cmd("base"), "")).prompt, "base");
+  });
+  it("substitutes shell output", async () => {
+    assert.strictEqual((await renderCommand(cmd("!`echo hello`"), "")).prompt, "hello");
+  });
+  it("warns and substitutes empty string on shell timeout", async () => {
+    const result = await renderCommand(cmd("!`sleep 2`"), "", { shellTimeoutMs: 100 });
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((warning) => warning.includes("shell command failed")));
+  });
+  it("substitutes existing temp file contents", async () => {
+    const dir = await tempDir();
+    const name = await writeIn(dir, "fixture.txt", "hello file");
+    assert.strictEqual((await renderCommand(cmd(`@${name}`), "", { cwd: dir })).prompt, "hello file");
+  });
+  it("warns and substitutes empty string for missing file", async () => {
+    const dir = await tempDir();
+    const result = await renderCommand(cmd("@missing.txt"), "", { cwd: dir });
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((warning) => warning.includes("file inclusion failed")));
+  });
+  it("warns and substitutes empty string for oversize file", async () => {
+    const dir = await tempDir();
+    const name = await writeIn(dir, "big.txt", "x".repeat(200));
+    const result = await renderCommand(cmd(`@${name}`), "", { cwd: dir, maxFileBytes: 100 });
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((warning) => warning.includes("exceeds")));
+  });
+  it("does not treat email addresses as file inclusions", async () => {
+    const result = await renderCommand(cmd("Contact me@example.com today"), "");
+    assert.strictEqual(result.prompt, "Contact me@example.com today");
+  });
+  it("does not include backtick-wrapped @ paths", async () => {
+    assert.strictEqual((await renderCommand(cmd("`@foo.txt`"), "")).prompt, "`@foo.txt`");
+  });
+  it("warns when rendered prompt is empty", async () => {
+    const result = await renderCommand(cmd("   "), "");
+    assert.strictEqual(result.prompt.trim(), "");
+    assert.ok(result.warnings.includes("rendered prompt is empty"));
+  });
+  it("strips leading slash command name before substitution", async () => {
+    assert.strictEqual((await renderCommand(cmd("X $ARGUMENTS"), "/test foo bar")).prompt, "X foo bar");
+  });
+  it("treats args-only input as args", async () => {
+    assert.strictEqual((await renderCommand(cmd("X $ARGUMENTS"), "foo bar")).prompt, "X foo bar");
+  });
+  it("single $N absorbs all remaining tokens", async () => {
+    assert.strictEqual((await renderCommand(cmd("$1"), "foo bar baz")).prompt, "foo bar baz");
+  });
+  it("rejects @file paths outside cwd (parent traversal)", async () => {
+    const result = await renderCommand(cmd("@../escape.txt"), "");
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((w) => w.includes("outside workspace")));
+  });
+  it("rejects @file paths with absolute prefix", async () => {
+    const result = await renderCommand(cmd("@/etc/passwd"), "");
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((w) => w.includes("outside workspace")));
+  });
+  it("rejects @file paths with ~ prefix", async () => {
+    const result = await renderCommand(cmd("@~/.ssh/id_rsa"), "");
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((w) => w.includes("outside workspace")));
+  });
+  it("preserves trailing sentence punctuation outside @file path", async () => {
+    const dir = await tempDir();
+    const name = await writeIn(dir, "note.txt", "FILE");
+    const result = await renderCommand(cmd(`See @${name}.`), "", { cwd: dir });
+    assert.strictEqual(result.prompt, "See FILE.");
+  });
+  it("allows filenames that begin with two dots inside cwd", async () => {
+    const dir = await tempDir();
+    await writeIn(dir, "..notes.md", "TWO_DOT_NAME");
+    const result = await renderCommand(cmd("@..notes.md"), "", { cwd: dir });
+    assert.strictEqual(result.prompt, "TWO_DOT_NAME");
+  });
+  it("rejects symlinks inside cwd that point outside", async () => {
+    const dir = await tempDir();
+    const outside = await tempDir();
+    const secret = path.join(outside, "secret.txt");
+    await writeFile(secret, "SECRET", "utf8");
+    await symlink(secret, path.join(dir, "link.txt"));
+    const result = await renderCommand(cmd("@link.txt"), "", { cwd: dir });
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((w) => w.includes("symlink escapes workspace")));
+  });
+  it("uses a default shell timeout to bound renders", async () => {
+    const start = Date.now();
+    const result = await renderCommand(cmd("!`sleep 30`"), "");
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 10_000, `expected default timeout to bound render, took ${elapsed}ms`);
+    assert.strictEqual(result.prompt, "");
+    assert.ok(result.warnings.some((w) => w.includes("shell command failed")));
+  });
+});

--- a/src/commands/renderer.ts
+++ b/src/commands/renderer.ts
@@ -1,0 +1,175 @@
+import { exec } from "node:child_process";
+import { open, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve as resolvePathJoin } from "node:path";
+import { promisify } from "node:util";
+import { isPathOutside } from "../util/paths.js";
+import type { CustomCommand, RenderResult } from "./types.js";
+
+const execAsync = promisify(exec);
+const ARG_TOKEN_RE = /(?:"[^"]*"|'[^']*'|[^\s"']+)/g;
+const POSITIONAL_RE = /\$(\d+)/g;
+const HAS_POSITIONAL = /\$\d+/;
+const SHELL_RE = /!`([^`]+)`/g;
+const FILE_RE = /(?<![\w`])@(\.?[^\s`,]+?)([.,;:!?)\]}]*)(?=[\s`,]|$)/g;
+const DEFAULT_MAX_FILE_BYTES = 100 * 1024;
+const DEFAULT_SHELL_TIMEOUT_MS = 5000;
+
+export function tokenizeArgs(s: string): string[] {
+  return [...s.matchAll(ARG_TOKEN_RE)].map((match) => {
+    const token = match[0];
+    if (
+      token.length >= 2 &&
+      ((token.startsWith('"') && token.endsWith('"')) ||
+        (token.startsWith("'") && token.endsWith("'")))
+    ) {
+      return token.slice(1, -1);
+    }
+    return token;
+  });
+}
+
+export async function renderCommand(
+  cmd: CustomCommand,
+  rawInput: string,
+  opts: { cwd?: string; shellTimeoutMs?: number; maxFileBytes?: number } = {},
+): Promise<RenderResult> {
+  const warnings: string[] = [];
+  const cwd = opts.cwd ?? process.cwd();
+  const maxFileBytes = opts.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const argsString = stripCommandName(rawInput);
+  const args = tokenizeArgs(argsString);
+  const originalTemplate = cmd.template;
+  const hadArguments = originalTemplate.includes("$ARGUMENTS");
+  const hadPositionals = HAS_POSITIONAL.test(originalTemplate);
+
+  let prompt = replacePositionals(originalTemplate, args);
+  prompt = prompt.replaceAll("$ARGUMENTS", argsString);
+
+  if (!hadArguments && !hadPositionals && argsString !== "") {
+    prompt += `\n\n${argsString}`;
+  }
+
+  prompt = await replaceShell(prompt, warnings, opts.shellTimeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS);
+  prompt = await replaceFiles(prompt, warnings, cwd, maxFileBytes);
+
+  if (prompt.trim() === "") {
+    warnings.push("rendered prompt is empty");
+  }
+
+  return { prompt, warnings };
+}
+
+function stripCommandName(rawInput: string): string {
+  if (!rawInput.startsWith("/")) {
+    return rawInput;
+  }
+  return rawInput.replace(/^\/\S+\s*/, "");
+}
+
+function replacePositionals(template: string, args: string[]): string {
+  const indexes = [...template.matchAll(POSITIONAL_RE)].map((match) =>
+    Number(match[1]),
+  );
+  const highest = indexes.length === 0 ? -1 : Math.max(...indexes);
+
+  return template.replace(POSITIONAL_RE, (_match, n: string) => {
+    const index = Number(n);
+    if (index <= 0) {
+      return "";
+    }
+    if (index === highest) {
+      return args.slice(index - 1).join(" ");
+    }
+    return args[index - 1] ?? "";
+  });
+}
+
+async function replaceShell(
+  prompt: string,
+  warnings: string[],
+  shellTimeoutMs: number,
+): Promise<string> {
+  const matches = [...prompt.matchAll(SHELL_RE)];
+  const replacements = await Promise.all(
+    matches.map(async (match) => {
+      const command = match[1] ?? "";
+      try {
+        const { stdout } = await execAsync(command, {
+          timeout: shellTimeoutMs,
+          maxBuffer: 1024 * 1024,
+        });
+        return String(stdout).trimEnd();
+      } catch (error) {
+        warnings.push(`shell command failed: \`${command}\` — ${message(error)}`);
+        return "";
+      }
+    }),
+  );
+
+  let index = 0;
+  return prompt.replace(SHELL_RE, () => replacements[index++] ?? "");
+}
+
+async function replaceFiles(
+  prompt: string,
+  warnings: string[],
+  cwd: string,
+  maxFileBytes: number,
+): Promise<string> {
+  const matches = [...prompt.matchAll(FILE_RE)];
+  if (matches.length === 0) return prompt;
+  const realCwd = await realpath(cwd).catch(() => cwd);
+  const replacements = await Promise.all(
+    matches.map(async (match) => {
+      const rawPath = match[1] ?? "";
+      if (isAbsolute(rawPath) || rawPath.startsWith("~")) {
+        warnings.push(`file inclusion skipped: @${rawPath} — outside workspace`);
+        return "";
+      }
+      const resolved = resolvePathJoin(cwd, rawPath);
+      if (isPathOutside(relative(cwd, resolved))) {
+        warnings.push(`file inclusion skipped: @${rawPath} — outside workspace`);
+        return "";
+      }
+      let real: string;
+      try {
+        real = await realpath(resolved);
+      } catch (error) {
+        warnings.push(`file inclusion failed: @${rawPath} — ${message(error)}`);
+        return "";
+      }
+      if (isPathOutside(relative(realCwd, real))) {
+        warnings.push(`file inclusion skipped: @${rawPath} — symlink escapes workspace`);
+        return "";
+      }
+      try {
+        const handle = await open(real, "r");
+        try {
+          const stats = await handle.stat();
+          if (stats.size > maxFileBytes) {
+            warnings.push(
+              `file inclusion skipped: @${rawPath} — exceeds ${maxFileBytes} bytes`,
+            );
+            return "";
+          }
+          return await handle.readFile("utf8");
+        } finally {
+          await handle.close();
+        }
+      } catch (error) {
+        warnings.push(`file inclusion failed: @${rawPath} — ${message(error)}`);
+        return "";
+      }
+    }),
+  );
+
+  let index = 0;
+  return prompt.replace(FILE_RE, (_match, _path, trailing: string = "") => {
+    const replacement = replacements[index++] ?? "";
+    return replacement + trailing;
+  });
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,25 @@
+import type { Mode } from "../mode.js";
+import type { ReasoningEffort } from "../config.js";
+
+export type CommandSource = "project" | "global";
+
+export type CustomCommand = {
+  name: string;
+  description?: string;
+  template: string;
+  source: CommandSource;
+  filepath: string;
+  mode?: Mode;
+  model?: string;
+  effort?: ReasoningEffort;
+};
+
+export type RenderResult = {
+  prompt: string;
+  warnings: string[];
+};
+
+export type LoadResult = {
+  commands: CustomCommand[];
+  warnings: string[];
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 export type ReasoningEffort = "low" | "medium" | "high";
+export const EFFORTS: readonly ReasoningEffort[] = ["low", "medium", "high"];
 
 export interface McpServerConfig {
   type: "local" | "remote";
@@ -57,8 +58,9 @@ export function configPath(): string {
 
 function readReasoningEffortEnv(): ReasoningEffort | undefined {
   const raw = process.env.KIMI_REASONING_EFFORT?.toLowerCase();
-  if (raw === "low" || raw === "medium" || raw === "high") return raw;
-  return undefined;
+  return (EFFORTS as readonly string[]).includes(raw ?? "")
+    ? (raw as ReasoningEffort)
+    : undefined;
 }
 
 function readCoauthorEnv(): { enabled: boolean; name: string; email: string } | undefined {

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -8,6 +8,11 @@ export function resolvePath(cwd: string, input: string): string {
   return isAbsolute(input) ? input : resolve(cwd, input);
 }
 
+// Caller must pass a path produced by node:path `relative(...)`; raw user input is not safe.
+export function isPathOutside(relPath: string): boolean {
+  return relPath === ".." || relPath.startsWith(`..${sep}`) || isAbsolute(relPath);
+}
+
 export function truncate(s: string, n: number): string {
   if (s.length <= n) return s;
   return s.slice(0, n) + `\n... [truncated, ${s.length - n} chars omitted]`;


### PR DESCRIPTION
Closes #85.

## Summary

Adds user-defined `/` commands authored as markdown files in `.kimiflare/commands/` (project) and `~/.config/kimiflare/commands/` (global). Project commands override global on name collision; subdirectories namespace commands (`git/commit.md` → `/git/commit`).

Reference implementations consulted: [opencode commands](https://github.com/anomalyco/opencode) and [Claude Code commands](https://code.claude.com/docs/en/commands). Behavior matches the issue spec; deviations are called out below.

## Frontmatter

```yaml
---
description: shown in /help
mode: edit | plan | auto    # alias `agent`; `build` → `edit` for compat
model: <override>            # per-turn
effort: low | medium | high  # per-turn
---
```

`mode` is parsed and validated but **not yet enforced at runtime** — it emits a runtime note instead. Per-turn mode override would require rebuilding the system message and invalidating the prompt cache; deferred to a v2 follow-up. The `agent`/`build` aliases match the issue spec.

## Template substitutions

| Syntax | Behavior |
|--------|----------|
| `$1`..`$N` | positional args; the highest `$N` absorbs trailing tokens |
| `$ARGUMENTS` | raw arg string, whitespace preserved |
| `` !`cmd` `` | shell substitution; **5s default timeout**, 1MB output cap |
| `@path/file` | file inclusion; **workspace-confined** |

## Security boundaries

- `@file` rejects absolute paths, `~/`, `..` traversal, and symlinks that escape `cwd` after `realpath`
- Loader rejects symlinked command roots that escape the workspace (project source only)
- Per-file 256KB cap on command templates to bound memory
- Built-in command names win at dispatch; case-insensitive shadow detection logs a warning and hides shadowed commands from `/help`
- Malformed frontmatter skips the file with a warning rather than registering raw markdown as a command
- Shell substitution is **intentionally** open — matches the feature's purpose in opencode/Claude Code; a hostile project = hostile code

## Files changed

- New: `src/commands/{loader,renderer,frontmatter,types,*.test}.ts` (~600 lines)
- Modified: `src/app.tsx` (custom-command branch in `processMessage`, load on cfg change, `/help` listing, `BUILTIN_COMMAND_NAMES`)
- Modified: `src/util/paths.ts` (`isPathOutside` helper used in 3 places)
- Modified: `src/config.ts` (added `EFFORTS` constant)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 129/129 passing (49 new tests for commands feature)
- [x] `npm run build` — 243.88 KB ESM, ~30ms
- [x] Manual: `/test foo bar` — `$ARGUMENTS` substitution end-to-end through TUI
- [x] Manual: `@file` confined to cwd — `/escape` fixture with `@~/.ssh/id_rsa` produced two `· escape: file inclusion skipped: ... — outside workspace` info events; rendered prompt sent to model had the references replaced with empty
- [x] Manual: `` !`date` `` substitution — `/now` fixture rendered current date with timezone; under 5s default timeout
- [x] Manual: `mode: plan` runtime note — `/plan-it` fixture produced `· note: mode override (plan) is not yet wired; current mode applies`
- [x] Manual: shadow a built-in (`.kimiflare/commands/help.md`) — startup logged `· commands: /help (...) shadowed by built-in — will not run`; `/help` correctly omitted the shadowed entry from "custom commands:" listing