### PR TITLE
fix: bump CI and engines to Node 22 for isolated-vm compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "PLAN.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
isolated-vm@6.1.2 (added by Code Mode) requires Node >=22. Without this, `npm ci` on Node 20 fails during native compilation because `v8::SourceLocation` does not exist in Node 20's V8.