### PR TITLE
feat: allow plan mode to prompt for non-whitelisted bash commands

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1021,16 +1021,19 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         return true;
       }
       if (c === "/cost") {
-        if (!sessionIdRef.current) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no usage recorded yet" }]);
-          return true;
-        }
-        void getCostReport(sessionIdRef.current).then((report) => {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: formatCostReport(report) },
-          ]);
-        });
+        void getCostReport(sessionIdRef.current ?? undefined)
+          .then((report) => {
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: formatCostReport(report) },
+            ]);
+          })
+          .catch((err) => {
+            setEvents((e) => [
+              ...e,
+              { kind: "error", key: mkKey(), text: `cost report failed: ${(err as Error).message}` },
+            ]);
+          });
         return true;
       }
       if (c === "/model") {
@@ -1274,19 +1277,6 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         } else {
           setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory manager not initialized" }]);
         }
-        return true;
-      }
-      if (c === "/cost") {
-        if (!sessionIdRef.current) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no usage recorded yet" }]);
-          return true;
-        }
-        void getCostReport(sessionIdRef.current).then((report) => {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: formatCostReport(report) },
-          ]);
-        });
         return true;
       }
       if (c === "/resume") {
@@ -1561,6 +1551,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             onUsageFinal: (u, meta) => {
               const sid = ensureSessionId();
               void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
+              void getCostReport(sid).then((report) => setSessionUsage(report.session));
             },
             onGatewayMeta: updateGatewayMeta,
             onTasks: (nextTasks) => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -852,6 +852,11 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                   resolve("allow");
                   return;
                 }
+                if (req.tool.name === "bash") {
+                  // Non-whitelisted bash in plan mode: ask for temporary permission
+                  setPerm({ tool: req.tool, args: req.args, resolve });
+                  return;
+                }
                 setEvents((e) => [
                   ...e,
                   {

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -54,7 +54,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, th
     <Box flexDirection="column">
       <Static items={finalized}>
         {(item) => (
-          <Box flexDirection="column">
+          <Box key={item.id} flexDirection="column">
             {item.showSeparator && (
               <Box marginY={1}>
                 <Text color={theme.info.color} dimColor={theme.info.dim}>

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -228,14 +228,15 @@ export interface CostReport {
   allTime: DailyUsage;
 }
 
-export async function getCostReport(sessionId: string): Promise<CostReport> {
+export async function getCostReport(sessionId?: string): Promise<CostReport> {
   const log = pruneUsageLog(await loadLog());
   const date = today();
   const currentMonth = date.slice(0, 7); // YYYY-MM
 
-  const session =
-    log.sessions.find((s) => s.id === sessionId) ??
-    { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
+  const session = sessionId
+    ? (log.sessions.find((s) => s.id === sessionId) ??
+      { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 })
+    : { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
 
   const todayUsage =
     log.days.find((d) => d.date === date) ??


### PR DESCRIPTION
Plan mode previously auto-denied any bash command not on the read-only whitelist. Now it shows the permission modal for these commands, letting the user allow once, allow for the session, or deny. Write, edit, and MCP tools remain hard-blocked in plan mode.