### PR TITLE
fix(version): correct package.json path when bundled

### DIFF
--- a/src/util/version.ts
+++ b/src/util/version.ts
@@ -6,14 +6,19 @@ let cachedVersion: string | null = null;
 
 export function getAppVersion(): string {
   if (cachedVersion !== null) return cachedVersion;
-  try {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const pkg = JSON.parse(readFileSync(join(here, "..", "..", "package.json"), "utf8")) as {
-      version?: string;
-    };
-    cachedVersion = pkg.version ?? "0.0.0";
-  } catch {
-    cachedVersion = "0.0.0";
+  const here = dirname(fileURLToPath(import.meta.url));
+  // When running from source: src/util/ -> ../../package.json
+  // When bundled by tsup: dist/ -> ../package.json
+  const candidates = [join(here, "..", "..", "package.json"), join(here, "..", "package.json")];
+  for (const path of candidates) {
+    try {
+      const pkg = JSON.parse(readFileSync(path, "utf8")) as { version?: string };
+      cachedVersion = pkg.version ?? "0.0.0";
+      return cachedVersion;
+    } catch {
+      // try next candidate
+    }
   }
+  cachedVersion = "0.0.0";
   return cachedVersion;
 }


### PR DESCRIPTION
The feedback URL was showing `0.0.0` because `getAppVersion()` only tried the source path (`../../package.json`). When tsup bundles the app into `dist/index.js`, `import.meta.url` points to `dist/`, so the correct path is `../package.json`.

This PR tries both candidates so the version is resolved correctly in both development and production.

Fixes the bug where `/hello` feedback URLs always contained `v=0.0.0`.