### PR TITLE
feat: add /memory on and /memory off commands

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1445,6 +1445,17 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     [cfg, exit, usage, effort, theme, mode, openResumePicker, runCompact, runInit, initMcp, setCfg],
   );
 
+  const handleHelpCommand = useCallback(
+    (command: string) => {
+      setShowHelpMenu(false);
+      const executed = handleSlash(command);
+      if (!executed) {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `unknown command: ${command}` }]);
+      }
+    },
+    [handleSlash],
+  );
+
   const processMessage = useCallback(
     async (text: string, displayText?: string) => {
       if (!cfg) return;
@@ -1768,7 +1779,13 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   if (showHelpMenu) {
     return (
       <Box flexDirection="column">
-        <HelpMenu theme={theme} onDone={() => setShowHelpMenu(false)} />
+        <HelpMenu
+          theme={theme}
+          themes={themeList().map((t) => ({ name: t.name, label: t.label }))}
+          currentThemeName={theme.name}
+          onDone={() => setShowHelpMenu(false)}
+          onCommand={handleHelpCommand}
+        />
       </Box>
     );
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,6 +37,7 @@ import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 import { Onboarding } from "./ui/onboarding.js";
 import { Welcome } from "./ui/welcome.js";
+import { HelpMenu } from "./ui/help-menu.js";
 import {
   configPath,
   DEFAULT_MODEL,
@@ -232,6 +233,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
   const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
   const [showThemePicker, setShowThemePicker] = useState(false);
+  const [showHelpMenu, setShowHelpMenu] = useState(false);
   const [originalTheme, setOriginalTheme] = useState<Theme | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
@@ -1435,44 +1437,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         return true;
       }
       if (c === "/help") {
-        setEvents((e) => [
-          ...e,
-          {
-            kind: "info",
-            key: mkKey(),
-            text:
-              "commands:\n" +
-              "  /mode edit|plan|auto    switch mode (or shift+tab to cycle)\n" +
-              "  /plan /auto /edit       shortcuts for /mode\n" +
-              "  /thinking low|med|high  set reasoning effort (quality vs speed)\n" +
-              "  /theme                  interactive theme picker (or ctrl+t)\n" +
-              "  /theme NAME             set theme by name\n" +
-              "  /resume                 pick a past conversation\n" +
-              "  /compact                summarize old turns to free context\n" +
-              "  /init                   scan this repo and write a KIMI.md for future agents\n" +
-              "  /memory                 show memory stats\n" +
-              "  /memory on              enable memory\n" +
-              "  /memory off             disable memory\n" +
-              "  /memory search <query>  search stored memories\n" +
-              "  /memory clear           wipe memories for this repo\n" +
-              "  /mcp list               list connected MCP servers and tools\n" +
-              "  /mcp reload             reconnect all configured MCP servers\n" +
-              "  /reasoning              toggle show/hide model reasoning\n" +
-              "  /clear                  clear current conversation\n" +
-              "  /hello                  send a voice note to the creator\n" +
-              "  /community              join our Discord server\n" +
-              "  /gateway                show gateway status\n" +
-              "  /gateway ID             enable AI Gateway\n" +
-              "  /gateway off            disable AI Gateway (direct Workers AI)\n" +
-              "  /gateway cache-ttl N    set gateway cache TTL in seconds\n" +
-              "  /gateway skip-cache T|F set gateway skip-cache flag\n" +
-              "  /gateway collect-logs T|F  include payload in gateway logs\n" +
-              "  /gateway metadata K=V   add metadata key-value pair\n" +
-              "  /gateway metadata clear remove all metadata\n" +
-              "  /cost /model /update /logout /help /exit\n" +
-              "keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o verbose · ctrl+t theme · shift+tab cycle mode · ↑/↓ history",
-          },
-        ]);
+        setShowHelpMenu(true);
         return true;
       }
       return false;
@@ -1796,6 +1761,14 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
     return (
       <Box flexDirection="column">
         <ThemePicker themes={themeList()} current={theme} onPick={handleThemePick} onPreview={(t) => setTheme(t)} />
+      </Box>
+    );
+  }
+
+  if (showHelpMenu) {
+    return (
+      <Box flexDirection="column">
+        <HelpMenu theme={theme} onDone={() => setShowHelpMenu(false)} />
       </Box>
     );
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1271,8 +1271,23 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         return true;
       }
       if (c === "/memory") {
-        if (!cfg?.memoryEnabled) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory is disabled. Enable with KIMIFLARE_MEMORY_ENABLED=1" }]);
+        if (!cfg) return true;
+        if (arg === "on") {
+          const next = { ...cfg, memoryEnabled: true };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory enabled" }]);
+          return true;
+        }
+        if (arg === "off") {
+          const next = { ...cfg, memoryEnabled: false };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory disabled" }]);
+          return true;
+        }
+        if (!cfg.memoryEnabled) {
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory is disabled. Use /memory on to enable it, or set KIMIFLARE_MEMORY_ENABLED=1" }]);
           return true;
         }
         if (arg === "clear") {
@@ -1436,6 +1451,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
               "  /compact                summarize old turns to free context\n" +
               "  /init                   scan this repo and write a KIMI.md for future agents\n" +
               "  /memory                 show memory stats\n" +
+              "  /memory on              enable memory\n" +
+              "  /memory off             disable memory\n" +
               "  /memory search <query>  search stored memories\n" +
               "  /memory clear           wipe memories for this repo\n" +
               "  /mcp list               list connected MCP servers and tools\n" +

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -1,11 +1,14 @@
 import React, { useState } from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import type { Theme } from "./theme.js";
 
 interface Props {
   theme: Theme;
+  themes: { name: string; label: string }[];
+  currentThemeName: string;
   onDone: () => void;
+  onCommand: (command: string) => void;
 }
 
 type Page =
@@ -20,15 +23,16 @@ type Page =
   | "info"
   | "config";
 
-interface CommandEntry {
+interface CommandItem {
   command: string;
   description: string;
+  selectable?: boolean;
 }
 
 interface Category {
   key: Page;
   label: string;
-  commands: CommandEntry[];
+  commands: CommandItem[];
 }
 
 const CATEGORIES: Category[] = [
@@ -36,26 +40,24 @@ const CATEGORIES: Category[] = [
     key: "mode",
     label: "Mode",
     commands: [
-      { command: "/mode edit|plan|auto", description: "switch mode (or shift+tab to cycle)" },
-      { command: "/plan", description: "shortcut for /mode plan" },
-      { command: "/auto", description: "shortcut for /mode auto" },
-      { command: "/edit", description: "shortcut for /mode edit" },
+      { command: "/mode edit", description: "switch to edit mode" },
+      { command: "/mode plan", description: "switch to plan mode" },
+      { command: "/mode auto", description: "switch to auto mode" },
     ],
   },
   {
     key: "thinking",
     label: "Thinking",
     commands: [
-      { command: "/thinking low|medium|high", description: "set reasoning effort (quality vs speed)" },
+      { command: "/thinking low", description: "fast, lower quality" },
+      { command: "/thinking medium", description: "balanced" },
+      { command: "/thinking high", description: "slow, higher quality" },
     ],
   },
   {
     key: "theme",
     label: "Theme",
-    commands: [
-      { command: "/theme", description: "interactive theme picker (or ctrl+t)" },
-      { command: "/theme NAME", description: "set theme by name" },
-    ],
+    commands: [],
   },
   {
     key: "session",
@@ -73,8 +75,8 @@ const CATEGORIES: Category[] = [
       { command: "/memory", description: "show memory stats" },
       { command: "/memory on", description: "enable memory" },
       { command: "/memory off", description: "disable memory" },
-      { command: "/memory search <query>", description: "search stored memories" },
       { command: "/memory clear", description: "wipe memories for this repo" },
+      { command: "/memory search <query>", description: "search stored memories", selectable: false },
     ],
   },
   {
@@ -90,13 +92,15 @@ const CATEGORIES: Category[] = [
     label: "Gateway",
     commands: [
       { command: "/gateway", description: "show gateway status" },
-      { command: "/gateway ID", description: "enable AI Gateway" },
       { command: "/gateway off", description: "disable AI Gateway (direct Workers AI)" },
-      { command: "/gateway cache-ttl N", description: "set gateway cache TTL in seconds" },
-      { command: "/gateway skip-cache T|F", description: "set gateway skip-cache flag" },
-      { command: "/gateway collect-logs T|F", description: "include payload in gateway logs" },
-      { command: "/gateway metadata K=V", description: "add metadata key-value pair" },
+      { command: "/gateway skip-cache true", description: "enable skip-cache" },
+      { command: "/gateway skip-cache false", description: "disable skip-cache" },
+      { command: "/gateway collect-logs true", description: "enable log collection" },
+      { command: "/gateway collect-logs false", description: "disable log collection" },
       { command: "/gateway metadata clear", description: "remove all metadata" },
+      { command: "/gateway <id>", description: "enable AI Gateway", selectable: false },
+      { command: "/gateway cache-ttl <seconds>", description: "set cache TTL", selectable: false },
+      { command: "/gateway metadata <key>=<value>", description: "add metadata", selectable: false },
     ],
   },
   {
@@ -114,24 +118,39 @@ const CATEGORIES: Category[] = [
     key: "config",
     label: "Config",
     commands: [
-      { command: "/init", description: "scan this repo and write a KIMI.md for future agents" },
+      { command: "/init", description: "scan this repo and write a KIMI.md" },
       { command: "/logout", description: "clear credentials" },
     ],
   },
 ];
 
-const SINGLE_COMMANDS: CommandEntry[] = [
+const SINGLE_COMMANDS: CommandItem[] = [
   { command: "/reasoning", description: "toggle show/hide model reasoning" },
   { command: "/help", description: "show this menu" },
   { command: "/exit", description: "exit kimiflare" },
 ];
 
-export function HelpMenu({ theme, onDone }: Props) {
+export function HelpMenu({ theme, themes, currentThemeName, onDone, onCommand }: Props) {
   const [page, setPage] = useState<Page>("main");
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      if (page !== "main") {
+        setPage("main");
+      } else {
+        onDone();
+      }
+    }
+  });
+
+  const handleSelect = (command: string) => {
+    onCommand(command);
+    onDone();
+  };
 
   if (page === "main") {
     const items = CATEGORIES.map((cat) => ({
-      label: `${cat.label}`,
+      label: cat.label,
       value: cat.key,
       key: cat.key,
     }));
@@ -143,7 +162,7 @@ export function HelpMenu({ theme, onDone }: Props) {
           Help
         </Text>
         <Text color={theme.info.color} dimColor={false}>
-          Arrow keys to navigate, Enter to select.
+          Arrow keys to navigate, Enter to select, Esc to close.
         </Text>
         <Box marginTop={1}>
           <SelectInput
@@ -173,8 +192,43 @@ export function HelpMenu({ theme, onDone }: Props) {
     );
   }
 
+  if (page === "theme") {
+    const items = themes.map((t) => ({
+      label: t.name === currentThemeName ? `${t.label} · current` : t.label,
+      value: t.name,
+      key: t.name,
+    }));
+    items.push({ label: "← Back", value: "__back__", key: "__back__" });
+
+    return (
+      <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+        <Text color={theme.accent} bold>
+          Theme
+        </Text>
+        <Text color={theme.info.color} dimColor={false}>
+          Arrow keys to navigate, Enter to apply, Esc to go back.
+        </Text>
+        <Box marginTop={1}>
+          <SelectInput
+            items={items}
+            onSelect={(item) => {
+              if (item.value === "__back__") {
+                setPage("main");
+              } else {
+                handleSelect(`/theme ${item.value}`);
+              }
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
   const category = CATEGORIES.find((c) => c.key === page)!;
-  const items = category.commands.map((cmd) => ({
+  const selectable = category.commands.filter((cmd) => cmd.selectable !== false);
+  const staticCmds = category.commands.filter((cmd) => cmd.selectable === false);
+
+  const items = selectable.map((cmd) => ({
     label: `${cmd.command.padEnd(28)} ${cmd.description}`,
     value: cmd.command,
     key: cmd.command,
@@ -187,7 +241,7 @@ export function HelpMenu({ theme, onDone }: Props) {
         {category.label}
       </Text>
       <Text color={theme.info.color} dimColor={false}>
-        Arrow keys to navigate, Enter to go back.
+        Arrow keys to navigate, Enter to execute, Esc to go back.
       </Text>
       <Box marginTop={1}>
         <SelectInput
@@ -195,10 +249,21 @@ export function HelpMenu({ theme, onDone }: Props) {
           onSelect={(item) => {
             if (item.value === "__back__") {
               setPage("main");
+            } else {
+              handleSelect(item.value as string);
             }
           }}
         />
       </Box>
+      {staticCmds.length > 0 && (
+        <Box marginTop={1} flexDirection="column">
+          {staticCmds.map((cmd) => (
+            <Text key={cmd.command} color={theme.info.color} dimColor>
+              {`  ${cmd.command.padEnd(28)} ${cmd.description}`}
+            </Text>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  theme: Theme;
+  onDone: () => void;
+}
+
+type Page =
+  | "main"
+  | "mode"
+  | "thinking"
+  | "theme"
+  | "session"
+  | "memory"
+  | "mcp"
+  | "gateway"
+  | "info"
+  | "config";
+
+interface CommandEntry {
+  command: string;
+  description: string;
+}
+
+interface Category {
+  key: Page;
+  label: string;
+  commands: CommandEntry[];
+}
+
+const CATEGORIES: Category[] = [
+  {
+    key: "mode",
+    label: "Mode",
+    commands: [
+      { command: "/mode edit|plan|auto", description: "switch mode (or shift+tab to cycle)" },
+      { command: "/plan", description: "shortcut for /mode plan" },
+      { command: "/auto", description: "shortcut for /mode auto" },
+      { command: "/edit", description: "shortcut for /mode edit" },
+    ],
+  },
+  {
+    key: "thinking",
+    label: "Thinking",
+    commands: [
+      { command: "/thinking low|medium|high", description: "set reasoning effort (quality vs speed)" },
+    ],
+  },
+  {
+    key: "theme",
+    label: "Theme",
+    commands: [
+      { command: "/theme", description: "interactive theme picker (or ctrl+t)" },
+      { command: "/theme NAME", description: "set theme by name" },
+    ],
+  },
+  {
+    key: "session",
+    label: "Session",
+    commands: [
+      { command: "/resume", description: "pick a past conversation" },
+      { command: "/compact", description: "summarize old turns to free context" },
+      { command: "/clear", description: "clear current conversation" },
+    ],
+  },
+  {
+    key: "memory",
+    label: "Memory",
+    commands: [
+      { command: "/memory", description: "show memory stats" },
+      { command: "/memory on", description: "enable memory" },
+      { command: "/memory off", description: "disable memory" },
+      { command: "/memory search <query>", description: "search stored memories" },
+      { command: "/memory clear", description: "wipe memories for this repo" },
+    ],
+  },
+  {
+    key: "mcp",
+    label: "MCP",
+    commands: [
+      { command: "/mcp list", description: "list connected MCP servers and tools" },
+      { command: "/mcp reload", description: "reconnect all configured MCP servers" },
+    ],
+  },
+  {
+    key: "gateway",
+    label: "Gateway",
+    commands: [
+      { command: "/gateway", description: "show gateway status" },
+      { command: "/gateway ID", description: "enable AI Gateway" },
+      { command: "/gateway off", description: "disable AI Gateway (direct Workers AI)" },
+      { command: "/gateway cache-ttl N", description: "set gateway cache TTL in seconds" },
+      { command: "/gateway skip-cache T|F", description: "set gateway skip-cache flag" },
+      { command: "/gateway collect-logs T|F", description: "include payload in gateway logs" },
+      { command: "/gateway metadata K=V", description: "add metadata key-value pair" },
+      { command: "/gateway metadata clear", description: "remove all metadata" },
+    ],
+  },
+  {
+    key: "info",
+    label: "Info",
+    commands: [
+      { command: "/cost", description: "show cost report" },
+      { command: "/model", description: "show current model" },
+      { command: "/update", description: "check for updates" },
+      { command: "/hello", description: "send a voice note to the creator" },
+      { command: "/community", description: "join our Discord server" },
+    ],
+  },
+  {
+    key: "config",
+    label: "Config",
+    commands: [
+      { command: "/init", description: "scan this repo and write a KIMI.md for future agents" },
+      { command: "/logout", description: "clear credentials" },
+    ],
+  },
+];
+
+const SINGLE_COMMANDS: CommandEntry[] = [
+  { command: "/reasoning", description: "toggle show/hide model reasoning" },
+  { command: "/help", description: "show this menu" },
+  { command: "/exit", description: "exit kimiflare" },
+];
+
+export function HelpMenu({ theme, onDone }: Props) {
+  const [page, setPage] = useState<Page>("main");
+
+  if (page === "main") {
+    const items = CATEGORIES.map((cat) => ({
+      label: `${cat.label}`,
+      value: cat.key,
+      key: cat.key,
+    }));
+    items.push({ label: "(close)", value: "__close__", key: "__close__" });
+
+    return (
+      <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+        <Text color={theme.accent} bold>
+          Help
+        </Text>
+        <Text color={theme.info.color} dimColor={false}>
+          Arrow keys to navigate, Enter to select.
+        </Text>
+        <Box marginTop={1}>
+          <SelectInput
+            items={items}
+            onSelect={(item) => {
+              if (item.value === "__close__") {
+                onDone();
+              } else {
+                setPage(item.value as Page);
+              }
+            }}
+          />
+        </Box>
+        <Box marginTop={1} flexDirection="column">
+          {SINGLE_COMMANDS.map((cmd) => (
+            <Text key={cmd.command} color={theme.info.color} dimColor={false}>
+              {`  ${cmd.command.padEnd(20)} ${cmd.description}`}
+            </Text>
+          ))}
+        </Box>
+        <Box marginTop={1}>
+          <Text color={theme.info.color} dimColor={false}>
+            keys: ctrl-c interrupt/exit · ctrl-r toggle reasoning · ctrl-o verbose · ctrl+t theme · shift+tab cycle mode · ↑/↓ history
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  const category = CATEGORIES.find((c) => c.key === page)!;
+  const items = category.commands.map((cmd) => ({
+    label: `${cmd.command.padEnd(28)} ${cmd.description}`,
+    value: cmd.command,
+    key: cmd.command,
+  }));
+  items.push({ label: "← Back", value: "__back__", key: "__back__" });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        {category.label}
+      </Text>
+      <Text color={theme.info.color} dimColor={false}>
+        Arrow keys to navigate, Enter to go back.
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => {
+            if (item.value === "__back__") {
+              setPage("main");
+            }
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
Users can now toggle memory on or off at runtime using slash commands, instead of only being able to enable it via the `KIMIFLARE_MEMORY_ENABLED` environment variable.

- `/memory on`  → enables memory and persists to config
- `/memory off` → disables memory and persists to config
- When memory is disabled, `/memory` now suggests using `/memory on`
- Updated `/help` to document the new commands

Co-authored-by: kimiflare <kimiflare@proton.me>