### PR TITLE
feat(session): persist ArtifactStore across session resume

### DIFF
--- a/docs/learnings/2026-04-27-agent-system-integration.md
+++ b/docs/learnings/2026-04-27-agent-system-integration.md
@@ -465,7 +465,7 @@ This section is updated as work lands. Dates are absolute. The research doc itse
 ### 2026-04-27 — Milestone 1 hotfix (`fix/auto-compact-and-diff-reducer`)
 
 Branch: `fix/auto-compact-and-diff-reducer` off `main` at `5617f68` (PR #169).
-Status: **all commits landed locally; awaiting user OK to push and open a PR.**
+Status: **merged to `main` and in production.**
 
 Plan (from `~/.claude/plans/you-re-picking-up-work-concurrent-hippo.md`):
 
@@ -495,8 +495,18 @@ Verification:
 - `npm test` after the full set: **139 passing, 0 failing**. Before the `$` fix the suite had 138 pass / 1 pre-existing fail (`src/ui/status.test.ts`); the `$` commit fixes it.
 - TUI smoke tests not yet run by the assistant; called out in the plan as a manual user step (drive a long session without `KIMIFLARE_COMPILED_CONTEXT=1` for Fix 1; trigger a merge conflict and ask for `git show`/`git diff` for Fix 2).
 
-If this conversation gets compacted or lost, resuming should be straightforward: branch is local, commits are on it, plan file at `~/.claude/plans/you-re-picking-up-work-concurrent-hippo.md` has the design rationale, and the next step is the user's go/no-go on `git push` + opening a PR.
+### Milestone 2 — in progress
 
-### Milestone 2 — not started
+Ordering: ArtifactStore persistence → Scout plumbing → Code Mode determinism → session-start recall.
 
-Items §7.1 (read-side memory injection at session start), §7.2 (Scout for plumbing + deterministic topic-key normalizer), §7.4 (Code Mode TS API determinism), and ArtifactStore persistence. Each is its own PR; ordering to be discussed with the user before any of them starts.
+#### PR 1 — `feat/artifact-store-persistence` (in progress)
+
+Addresses finding §6.2: `ArtifactStore` is not persisted, so `/resume` leaves compiled-context recall broken.
+
+Changes:
+- `src/agent/session-state.ts` — added `SerializedArtifact` interface, `serializeArtifactStore()`, and `deserializeArtifactStore()` functions. Serialization truncates raw content to 50 KB per artifact (matching the in-memory cap). Deserialization feeds artifacts back through `ArtifactStore.add()` so the same LRU/size limits apply.
+- `src/sessions.ts` — added `artifactStore?: SerializedArtifact[]` to `SessionFile`.
+- `src/app.tsx` — `saveSessionSafe` now includes `artifactStore: serializeArtifactStore(artifactStoreRef.current)`; `handleResumePick` restores the store via `deserializeArtifactStore(file.artifactStore)` when present, falling back to an empty `ArtifactStore` when absent.
+- `src/agent/session-state.test.ts` — 4 new test cases: empty store round-trip, timestamp ordering, 50 KB truncation, and full inverse property.
+
+Verification: `npm run typecheck` clean; `npm test` 145 passing, 0 failing (was 139 before this PR).

--- a/src/agent/session-state.test.ts
+++ b/src/agent/session-state.test.ts
@@ -6,6 +6,8 @@ import {
   formatRecalledArtifacts,
   serializeSessionState,
   buildSessionStateMessage,
+  serializeArtifactStore,
+  deserializeArtifactStore,
 } from "./session-state.js";
 
 describe("emptySessionState", () => {
@@ -121,5 +123,61 @@ describe("buildSessionStateMessage", () => {
     assert.strictEqual(msg.role, "system");
     assert.ok(typeof msg.content === "string");
     assert.ok(msg.content.includes("compiled session state"));
+  });
+});
+
+describe("serializeArtifactStore", () => {
+  it("returns an empty array for an empty store", () => {
+    const store = new ArtifactStore();
+    assert.deepStrictEqual(serializeArtifactStore(store), []);
+  });
+
+  it("serializes artifacts in timestamp order", () => {
+    const store = new ArtifactStore();
+    store.add({ id: "a1", type: "bash_log", summary: "s1", raw: "r1", source: "bash", ts: "2024-01-01T00:00:00Z" });
+    store.add({ id: "a2", type: "read_slice", summary: "s2", raw: "r2", source: "read", ts: "2024-01-02T00:00:00Z" });
+    const data = serializeArtifactStore(store);
+    assert.strictEqual(data.length, 2);
+    assert.strictEqual(data[0]!.id, "a1");
+    assert.strictEqual(data[1]!.id, "a2");
+  });
+
+  it("truncates raw content to 50 KB", () => {
+    const store = new ArtifactStore();
+    const longRaw = "x".repeat(60_000);
+    store.add({ id: "a1", type: "bash_log", summary: "s1", raw: longRaw, source: "bash", ts: "2024-01-01T00:00:00Z" });
+    const data = serializeArtifactStore(store);
+    assert.strictEqual(data[0]!.raw.length, 50_000);
+  });
+});
+
+describe("deserializeArtifactStore", () => {
+  it("restores an empty store from an empty array", () => {
+    const store = deserializeArtifactStore([]);
+    assert.strictEqual(store.size(), 0);
+  });
+
+  it("restores artifacts and respects store limits", () => {
+    const data = [
+      { id: "a1", type: "bash_log" as const, summary: "s1", raw: "r1", source: "bash", ts: "2024-01-01T00:00:00Z" },
+      { id: "a2", type: "read_slice" as const, summary: "s2", raw: "r2", source: "read", ts: "2024-01-02T00:00:00Z" },
+    ];
+    const store = deserializeArtifactStore(data);
+    assert.strictEqual(store.size(), 2);
+    assert.strictEqual(store.get("a1")?.raw, "r1");
+    assert.strictEqual(store.get("a2")?.source, "read");
+  });
+
+  it("is the inverse of serializeArtifactStore", () => {
+    const original = new ArtifactStore();
+    original.add({ id: "a1", type: "bash_log", summary: "s1", raw: "hello world", source: "bash", ts: "2024-01-01T00:00:00Z" });
+    original.add({ id: "a2", type: "grep_result", summary: "s2", raw: "match", source: "grep", path: "src/x.ts", ts: "2024-01-02T00:00:00Z" });
+
+    const data = serializeArtifactStore(original);
+    const restored = deserializeArtifactStore(data);
+
+    assert.strictEqual(restored.size(), 2);
+    assert.strictEqual(restored.get("a1")?.raw, "hello world");
+    assert.strictEqual(restored.get("a2")?.path, "src/x.ts");
   });
 });

--- a/src/agent/session-state.ts
+++ b/src/agent/session-state.ts
@@ -131,6 +131,55 @@ export class ArtifactStore {
   }
 }
 
+/** Serialized form of an Artifact for session persistence. */
+export interface SerializedArtifact {
+  id: string;
+  type: ArtifactType;
+  summary: string;
+  raw: string;
+  source: string;
+  path?: string;
+  lineRange?: { start: number; end: number };
+  ts: string;
+}
+
+/** Serialize an ArtifactStore to a plain array, respecting size caps. */
+export function serializeArtifactStore(store: ArtifactStore): SerializedArtifact[] {
+  const MAX_ARTIFACT_CHARS = 50_000;
+  const out: SerializedArtifact[] = [];
+  for (const a of store.list()) {
+    out.push({
+      id: a.id,
+      type: a.type,
+      summary: a.summary,
+      raw: a.raw.slice(0, MAX_ARTIFACT_CHARS),
+      source: a.source,
+      path: a.path,
+      lineRange: a.lineRange,
+      ts: a.ts,
+    });
+  }
+  return out;
+}
+
+/** Deserialize a plain array back into an ArtifactStore, respecting limits. */
+export function deserializeArtifactStore(data: SerializedArtifact[]): ArtifactStore {
+  const store = new ArtifactStore();
+  for (const a of data) {
+    store.add({
+      id: a.id,
+      type: a.type,
+      summary: a.summary,
+      raw: a.raw,
+      source: a.source,
+      path: a.path,
+      lineRange: a.lineRange,
+      ts: a.ts,
+    });
+  }
+  return store;
+}
+
 /** Format recalled artifacts as a compact context block for injection into messages. */
 export function formatRecalledArtifacts(recalled: { id: string; artifact: Artifact }[]): string {
   if (recalled.length === 0) return "";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,8 @@ import {
   emptySessionState,
   ArtifactStore,
   formatRecalledArtifacts,
+  serializeArtifactStore,
+  deserializeArtifactStore,
   type SessionState,
 } from "./agent/session-state.js";
 import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/executor.js";
@@ -576,6 +578,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         updatedAt: new Date().toISOString(),
         messages: messagesRef.current,
         sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
+        artifactStore: serializeArtifactStore(artifactStoreRef.current),
       });
     } catch {
       /* non-fatal */
@@ -978,6 +981,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         sessionIdRef.current = file.id;
         if (file.sessionState && compiledContextRef.current) {
           sessionStateRef.current = file.sessionState;
+        }
+        if (file.artifactStore) {
+          artifactStoreRef.current = deserializeArtifactStore(file.artifactStore);
+        } else {
           artifactStoreRef.current = new ArtifactStore();
         }
         setEvents([

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ChatMessage } from "./agent/messages.js";
-import type { SessionState } from "./agent/session-state.js";
+import type { SessionState, SerializedArtifact } from "./agent/session-state.js";
 import { listFilesByMtime, pruneFiles, RETENTION } from "./storage-limits.js";
 
 export interface SessionSummary {
@@ -23,6 +23,8 @@ export interface SessionFile {
   messages: ChatMessage[];
   /** Compiled session state for token-optimized context (optional). */
   sessionState?: SessionState;
+  /** Persisted artifact store for recalled raw tool outputs (optional). */
+  artifactStore?: SerializedArtifact[];
 }
 
 function sessionsDir(): string {


### PR DESCRIPTION
## What

Addresses finding §6.2 from the agent-system integration research: `ArtifactStore` was in-memory only, so after `/resume` compiled-context recall found index entries with no content.

## Changes

- `src/agent/session-state.ts` — added `SerializedArtifact` interface, `serializeArtifactStore()`, and `deserializeArtifactStore()`. Serialization truncates raw content to 50 KB per artifact. Deserialization feeds artifacts back through `ArtifactStore.add()` so the same LRU/size limits apply.
- `src/sessions.ts` — added `artifactStore?: SerializedArtifact[]` to `SessionFile`.
- `src/app.tsx` — `saveSessionSafe` now persists the artifact store; `handleResumePick` restores it on resume.
- `src/agent/session-state.test.ts` — 4 new test cases for round-trip, ordering, truncation, and inverse property.

## Verification

- `npm run typecheck` clean
- `npm test` 145 passing, 0 failing (was 139)

## Next

This is PR 1 of Milestone 2. Next up: Scout plumbing model for memory write pipeline (§7.2).