### PR TITLE
feat(memory): use Llama 4 Scout for plumbing tasks and deterministic topic keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 .config/
 sessions/
 coverage/
+.kimiflare/

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -93,6 +93,7 @@ interface Cfg {
   memoryMaxAgeDays?: number;
   memoryMaxEntries?: number;
   memoryEmbeddingModel?: string;
+  plumbingModel?: string;
   codeMode?: boolean;
 }
 
@@ -320,6 +321,7 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         accountId: cfg.accountId,
         apiToken: cfg.apiToken,
         model: cfg.model,
+        plumbingModel: cfg.plumbingModel,
         embeddingModel: cfg.memoryEmbeddingModel,
         gateway: gatewayFromConfig(cfg),
         maxAgeDays: cfg.memoryMaxAgeDays ?? RETENTION.memoryMaxAgeDays,

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,8 @@ export interface KimiConfig {
   memoryMaxEntries?: number;
   /** Embedding model for memory vectors. Default: @cf/baai/bge-base-en-v1.5. */
   memoryEmbeddingModel?: string;
+  /** Model for internal plumbing tasks (memory verification, hypothetical queries). Default: @cf/meta/llama-4-scout-17b-16e-instruct. */
+  plumbingModel?: string;
   /** Enable Code Mode: present tools as a TypeScript API and execute generated code in a sandbox. */
   codeMode?: boolean;
 }
@@ -138,6 +140,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envMemoryMaxAgeDays = readNumberEnv("KIMIFLARE_MEMORY_MAX_AGE_DAYS");
   const envMemoryMaxEntries = readNumberEnv("KIMIFLARE_MEMORY_MAX_ENTRIES");
   const envMemoryEmbeddingModel = process.env.KIMIFLARE_MEMORY_EMBEDDING_MODEL;
+  const envPlumbingModel = process.env.KIMIFLARE_PLUMBING_MODEL;
   const envCodeMode = readBooleanEnv("KIMIFLARE_CODE_MODE");
 
   if (envAccount && envToken) {
@@ -163,6 +166,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       memoryMaxAgeDays: envMemoryMaxAgeDays,
       memoryMaxEntries: envMemoryMaxEntries,
       memoryEmbeddingModel: envMemoryEmbeddingModel,
+      plumbingModel: envPlumbingModel,
       codeMode: envCodeMode,
     };
   }
@@ -195,6 +199,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         memoryMaxAgeDays: envMemoryMaxAgeDays ?? parsed.memoryMaxAgeDays,
         memoryMaxEntries: envMemoryMaxEntries ?? parsed.memoryMaxEntries,
         memoryEmbeddingModel: envMemoryEmbeddingModel ?? parsed.memoryEmbeddingModel,
+        plumbingModel: envPlumbingModel ?? parsed.plumbingModel,
         codeMode: envCodeMode ?? parsed.codeMode,
       };
     }

--- a/src/memory/manager.test.ts
+++ b/src/memory/manager.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { deterministicTopicKey, pickTopicKey } from "./manager.js";
+
+describe("deterministicTopicKey", () => {
+  it("lowercases and snake_cases a simple phrase", () => {
+    assert.strictEqual(deterministicTopicKey("Project uses tsup"), "project_uses_tsup");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    assert.strictEqual(
+      deterministicTopicKey("User prefers single-quotes & semicolons!"),
+      "user_prefers_singlequotes_semicolons"
+    );
+  });
+
+  it("collapses multiple spaces into a single underscore", () => {
+    assert.strictEqual(deterministicTopicKey("  lots   of    spaces  "), "lots_of_spaces");
+  });
+
+  it("truncates to 60 characters", () => {
+    const long = "a".repeat(100);
+    const result = deterministicTopicKey(long);
+    assert.strictEqual(result.length, 60);
+  });
+
+  it("returns empty string for empty input", () => {
+    assert.strictEqual(deterministicTopicKey(""), "");
+  });
+
+  it("returns empty string for input with only special chars", () => {
+    assert.strictEqual(deterministicTopicKey("!!!@@@###"), "");
+  });
+});
+
+describe("pickTopicKey", () => {
+  it("returns a new key when no existing keys match", () => {
+    const result = pickTopicKey("new topic here", ["old_topic"]);
+    assert.strictEqual(result, "new_topic_here");
+  });
+
+  it("reuses an existing key when it is a substring of the new key", () => {
+    const result = pickTopicKey("project uses tsup for bundling", ["project_uses_tsup"]);
+    assert.strictEqual(result, "project_uses_tsup");
+  });
+
+  it("reuses an existing key when the new key is a substring of it", () => {
+    const result = pickTopicKey("project uses", ["project_uses_tsup"]);
+    assert.strictEqual(result, "project_uses_tsup");
+  });
+
+  it("returns null for empty content", () => {
+    const result = pickTopicKey("", ["existing"]);
+    assert.strictEqual(result, null);
+  });
+
+  it("picks the first matching existing key", () => {
+    const result = pickTopicKey("project uses tsup", ["project", "project_uses_tsup"]);
+    assert.strictEqual(result, "project");
+  });
+});

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -27,6 +27,7 @@ export interface MemoryManagerOpts {
   accountId: string;
   apiToken: string;
   model?: string;
+  plumbingModel?: string;
   embeddingModel?: string;
   gateway?: AiGatewayOptions;
   maxAgeDays?: number;
@@ -74,6 +75,30 @@ function redactSecrets(text: string): string {
     result = result.replace(pattern, replacement);
   }
   return result;
+}
+
+/** Deterministic topic-key normalization: lowercase, strip non-alphanum, replace spaces with _, truncate to 60. */
+export function deterministicTopicKey(content: string): string {
+  return content
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, "")
+    .trim()
+    .replace(/\s+/g, "_")
+    .slice(0, 60);
+}
+
+/** Pick the best existing topic key for a memory, or generate a new one. */
+export function pickTopicKey(content: string, existingKeys: string[]): string | null {
+  const normalized = deterministicTopicKey(content);
+  if (!normalized) return null;
+
+  for (const existing of existingKeys) {
+    if (normalized.includes(existing) || existing.includes(normalized)) {
+      return existing;
+    }
+  }
+
+  return normalized;
 }
 
 const VERIFY_SYSTEM = `You are a fact-checking engine. Given a memory and the conversation context it was extracted from, verify whether the memory is directly supported by the context.
@@ -138,6 +163,15 @@ export class MemoryManager {
     };
   }
 
+  private get plumbingLlmOpts(): LlmOpts {
+    return {
+      accountId: this.opts.accountId,
+      apiToken: this.opts.apiToken,
+      model: this.opts.plumbingModel ?? "@cf/meta/llama-4-scout-17b-16e-instruct",
+      gateway: this.opts.gateway,
+    };
+  }
+
   private shouldRedact(): boolean {
     return this.opts.redactSecrets !== false;
   }
@@ -172,7 +206,7 @@ export class MemoryManager {
     }
 
     // 3. Normalize topic key
-    const topicKey = await this.normalizeTopicKey(safeContent, repoPath, signal);
+    const topicKey = this.normalizeTopicKey(safeContent, repoPath);
 
     // 4. Check for supersession
     const supersededIds: string[] = [];
@@ -312,7 +346,7 @@ export class MemoryManager {
 
   private async verifyMemory(content: string, signal?: AbortSignal): Promise<{ valid: boolean; corrected_content: string | null }> {
     const text = await runKimiText({
-      ...this.llmOpts,
+      ...this.plumbingLlmOpts,
       signal,
       messages: [
         { role: "system", content: VERIFY_SYSTEM },
@@ -340,29 +374,14 @@ export class MemoryManager {
     return { valid, corrected_content: corrected };
   }
 
-  private async normalizeTopicKey(content: string, repoPath: string, signal?: AbortSignal): Promise<string | null> {
+  private normalizeTopicKey(content: string, repoPath: string): string | null {
     const existingKeys = listTopicKeys(this.db!, repoPath);
-    const keysBlock = existingKeys.length > 0 ? existingKeys.join("\n") : "(none yet)";
-
-    const text = await runKimiText({
-      ...this.llmOpts,
-      signal,
-      messages: [
-        { role: "system", content: TOPIC_KEY_SYSTEM },
-        {
-          role: "user",
-          content: `Existing topic keys:\n${keysBlock}\n\nNew memory: "${content}"\n\nReturn only the topic key string.`,
-        },
-      ],
-    });
-
-    const key = text.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, "").slice(0, 60);
-    return key || null;
+    return pickTopicKey(content, existingKeys);
   }
 
   private async generateHypotheticalQueries(content: string, signal?: AbortSignal): Promise<string[]> {
     const text = await runKimiText({
-      ...this.llmOpts,
+      ...this.plumbingLlmOpts,
       signal,
       messages: [
         { role: "system", content: HYPOTHETICAL_QUERIES_SYSTEM },


### PR DESCRIPTION
This PR implements the Scout plumbing model milestone from the agent-system-integration research doc.

## Changes

- **Config** (): Add `plumbingModel` to `KimiConfig`, read from `KIMIFLARE_PLUMBING_MODEL` env var. Defaults to `@cf/meta/llama-4-scout-17b-16e-instruct`.
- **MemoryManager** ():
  - `verifyMemory` and `generateHypotheticalQueries` now use the plumbing model instead of Kimi K2.6.
  - `normalizeTopicKey` is now deterministic — no LLM call. Extracted `deterministicTopicKey` and `pickTopicKey` as pure functions for testability.
- **App** (): Pass `plumbingModel` through to `MemoryManager`.
- **Tests** (): Unit tests for the deterministic topic-key logic.
- **Gitignore**: Add `.kimiflare/` to prevent local memory DBs from being committed.

## Impact

Per `memory_remember` call drops from **3× Kimi K2.6** to **2× Scout + 1 deterministic function** — a significant cost reduction for the write-side memory pipeline.

## Verification

- `npm run typecheck` clean
- `npm test`: **156 passing, 0 failing**

Co-authored-by: kimiflare <kimiflare@proton.me>