### PR TITLE
feat(commands): interactive TUI for custom slash commands

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Text, useApp, useInput, render } from "ink";
+import SelectInput from "ink-select-input";
 
 import { runAgentTurn } from "./agent/loop.js";
 import type { AiGatewayOptions, GatewayMeta } from "./agent/client.js";
@@ -69,6 +70,11 @@ import { platform } from "node:os";
 import { loadCustomCommands } from "./commands/loader.js";
 import { renderCommand } from "./commands/renderer.js";
 import type { CustomCommand } from "./commands/types.js";
+import { saveCustomCommand, deleteCustomCommand } from "./commands/save.js";
+import type { SaveCustomCommandOptions } from "./commands/save.js";
+import { CommandWizard } from "./ui/command-wizard.js";
+import { CommandPicker } from "./ui/command-picker.js";
+import { CommandList } from "./ui/command-list.js";
 
 interface Cfg {
   accountId: string;
@@ -247,6 +253,10 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
   const [showThemePicker, setShowThemePicker] = useState(false);
   const [showHelpMenu, setShowHelpMenu] = useState(false);
   const [originalTheme, setOriginalTheme] = useState<Theme | null>(null);
+  const [commandWizard, setCommandWizard] = useState<{ mode: "create" | "edit"; initial?: CustomCommand } | null>(null);
+  const [commandPicker, setCommandPicker] = useState<{ mode: "edit" | "delete" } | null>(null);
+  const [commandToDelete, setCommandToDelete] = useState<CustomCommand | null>(null);
+  const [showCommandList, setShowCommandList] = useState(false);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
   const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
@@ -367,6 +377,21 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       }
     });
   }, [cfg, setEvents]);
+
+  const reloadCustomCommands = useCallback(async () => {
+    const { commands, warnings } = await loadCustomCommands(process.cwd());
+    customCommandsRef.current = commands;
+    for (const w of warnings) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `commands: ${w}` }]);
+    }
+    const shadowed = commands.filter((c) => BUILTIN_COMMAND_NAMES.has(c.name.toLowerCase()));
+    for (const c of shadowed) {
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: `commands: /${c.name} (${c.filepath}) shadowed by built-in — will not run` },
+      ]);
+    }
+  }, [setEvents]);
 
   useEffect(() => {
     if (!cfg || updateCheckedRef.current) return;
@@ -1469,6 +1494,30 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
         setCfg(null);
         return true;
       }
+      if (c === "/command") {
+        const sub = rest[0]?.toLowerCase() ?? "";
+        if (sub === "create") {
+          setCommandWizard({ mode: "create" });
+          return true;
+        }
+        if (sub === "edit") {
+          setCommandPicker({ mode: "edit" });
+          return true;
+        }
+        if (sub === "delete") {
+          setCommandPicker({ mode: "delete" });
+          return true;
+        }
+        if (sub === "list") {
+          setShowCommandList(true);
+          return true;
+        }
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "usage: /command create | edit | delete | list" },
+        ]);
+        return true;
+      }
       if (c === "/help") {
         setShowHelpMenu(true);
         return true;
@@ -1487,6 +1536,50 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
       }
     },
     [handleSlash],
+  );
+
+  const handleCommandSave = useCallback(
+    async (opts: SaveCustomCommandOptions) => {
+      setCommandWizard(null);
+      try {
+        // If editing and name changed, delete the old file first
+        if (commandWizard?.mode === "edit" && commandWizard.initial && commandWizard.initial.name !== opts.name) {
+          await deleteCustomCommand(commandWizard.initial);
+        }
+        const result = await saveCustomCommand(opts);
+        await reloadCustomCommands();
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `saved /${opts.name} → ${result.filepath}` },
+        ]);
+      } catch (err) {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: `failed to save /${opts.name}: ${(err as Error).message}` },
+        ]);
+      }
+    },
+    [commandWizard, reloadCustomCommands, setEvents],
+  );
+
+  const handleCommandDelete = useCallback(
+    async (cmd: CustomCommand) => {
+      setCommandToDelete(null);
+      try {
+        await deleteCustomCommand(cmd);
+        await reloadCustomCommands();
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `deleted /${cmd.name} (${cmd.filepath})` },
+        ]);
+      } catch (err) {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: `failed to delete /${cmd.name}: ${(err as Error).message}` },
+        ]);
+      }
+    },
+    [reloadCustomCommands, setEvents],
   );
 
   const processMessage = useCallback(
@@ -1888,6 +1981,83 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
             .map((c) => ({ name: c.name, description: c.description }))}
           onDone={() => setShowHelpMenu(false)}
           onCommand={handleHelpCommand}
+        />
+      </Box>
+    );
+  }
+
+  if (commandWizard) {
+    return (
+      <Box flexDirection="column">
+        <CommandWizard
+          theme={theme}
+          mode={commandWizard.mode}
+          initial={commandWizard.initial}
+          existingNames={customCommandsRef.current.map((c) => c.name)}
+          builtinNames={BUILTIN_COMMAND_NAMES}
+          onDone={() => setCommandWizard(null)}
+          onSave={handleCommandSave}
+        />
+      </Box>
+    );
+  }
+
+  if (commandPicker) {
+    return (
+      <Box flexDirection="column">
+        <CommandPicker
+          theme={theme}
+          commands={customCommandsRef.current}
+          title={commandPicker.mode === "edit" ? "Edit custom command" : "Delete custom command"}
+          onPick={(cmd) => {
+            setCommandPicker(null);
+            if (!cmd) return;
+            if (commandPicker.mode === "edit") {
+              setCommandWizard({ mode: "edit", initial: cmd });
+            } else {
+              setCommandToDelete(cmd);
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+
+  if (commandToDelete) {
+    return (
+      <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+        <Text color={theme.accent} bold>
+          Delete /{commandToDelete.name}?
+        </Text>
+        <Text color={theme.info.color} dimColor>
+          {commandToDelete.filepath}
+        </Text>
+        <Box marginTop={1}>
+          <SelectInput
+            items={[
+              { label: "Yes, delete", value: "yes", key: "yes" },
+              { label: "Cancel", value: "cancel", key: "cancel" },
+            ]}
+            onSelect={(item) => {
+              if (item.value === "yes") {
+                void handleCommandDelete(commandToDelete);
+              } else {
+                setCommandToDelete(null);
+              }
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (showCommandList) {
+    return (
+      <Box flexDirection="column">
+        <CommandList
+          theme={theme}
+          commands={customCommandsRef.current}
+          onDone={() => setShowCommandList(false)}
         />
       </Box>
     );

--- a/src/commands/frontmatter.ts
+++ b/src/commands/frontmatter.ts
@@ -7,6 +7,16 @@ export type FrontmatterParse = {
 const FENCE = /^---\s*\r?\n/;
 const KV = /^([A-Za-z][\w-]*)\s*:\s*(.*?)\s*$/;
 
+export function serializeFrontmatter(data: Record<string, string | undefined>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (value === undefined || value === "") continue;
+    lines.push(`${key}: ${value}`);
+  }
+  if (lines.length === 0) return "";
+  return `---\n${lines.join("\n")}\n---\n`;
+}
+
 export function parseFrontmatter(input: string): FrontmatterParse {
   const errors: string[] = [];
   if (!FENCE.test(input)) {

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -1,0 +1,45 @@
+import { mkdir, writeFile, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { Mode } from "../mode.js";
+import type { ReasoningEffort } from "../config.js";
+import type { CommandSource, CustomCommand } from "./types.js";
+import { serializeFrontmatter } from "./frontmatter.js";
+import { projectCommandsDir, globalCommandsDir } from "./loader.js";
+
+export interface SaveCustomCommandOptions {
+  name: string;
+  description?: string;
+  template: string;
+  source: CommandSource;
+  mode?: Mode;
+  model?: string;
+  effort?: ReasoningEffort;
+  cwd?: string;
+}
+
+export interface SaveResult {
+  filepath: string;
+}
+
+export async function saveCustomCommand(opts: SaveCustomCommandOptions): Promise<SaveResult> {
+  const dir = opts.source === "project" ? projectCommandsDir(opts.cwd) : globalCommandsDir();
+  const filepath = `${dir}/${opts.name}.md`;
+
+  const data: Record<string, string | undefined> = {};
+  if (opts.description) data.description = opts.description;
+  if (opts.mode) data.mode = opts.mode;
+  if (opts.model) data.model = opts.model;
+  if (opts.effort) data.effort = opts.effort;
+
+  const frontmatter = serializeFrontmatter(data);
+  const content = frontmatter + opts.template;
+
+  await mkdir(dirname(filepath), { recursive: true });
+  await writeFile(filepath, content, "utf8");
+
+  return { filepath };
+}
+
+export async function deleteCustomCommand(cmd: CustomCommand): Promise<void> {
+  await unlink(cmd.filepath);
+}

--- a/src/ui/command-list.tsx
+++ b/src/ui/command-list.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+import type { CustomCommand } from "../commands/types.js";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  theme: Theme;
+  commands: CustomCommand[];
+  onDone: () => void;
+}
+
+export function CommandList({ theme, commands, onDone }: Props) {
+  useInput((_input, key) => {
+    if (key.escape) {
+      onDone();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        Custom commands
+      </Text>
+      <Text color={theme.info.color} dimColor={false}>
+        Esc to close.
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {commands.length === 0 && (
+          <Text color={theme.info.color} dimColor>
+            No custom commands found.
+          </Text>
+        )}
+        {commands.map((cmd) => (
+          <Box key={cmd.name} flexDirection="column" marginBottom={1}>
+            <Text color={theme.accent} bold>
+              /{cmd.name}
+            </Text>
+            <Text color={theme.info.color} dimColor>
+              {"  "}source:  {cmd.source}
+            </Text>
+            <Text color={theme.info.color} dimColor>
+              {"  "}path:    {cmd.filepath}
+            </Text>
+            {cmd.description && (
+              <Text color={theme.info.color} dimColor>
+                {"  "}desc:    {cmd.description}
+              </Text>
+            )}
+            {cmd.mode && (
+              <Text color={theme.info.color} dimColor>
+                {"  "}mode:    {cmd.mode}
+              </Text>
+            )}
+            {cmd.effort && (
+              <Text color={theme.info.color} dimColor>
+                {"  "}effort:  {cmd.effort}
+              </Text>
+            )}
+            {cmd.model && (
+              <Text color={theme.info.color} dimColor>
+                {"  "}model:   {cmd.model}
+              </Text>
+            )}
+            <Text color={theme.info.color} dimColor>
+              {"  "}template:
+            </Text>
+            {cmd.template.split("\n").slice(0, 5).map((line, i) => (
+              <Text key={i} color={theme.info.color} dimColor>
+                {"    "}{line || " "}
+              </Text>
+            ))}
+            {cmd.template.split("\n").length > 5 && (
+              <Text color={theme.info.color} dimColor>
+                {"    "}...
+              </Text>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/command-picker.tsx
+++ b/src/ui/command-picker.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { CustomCommand } from "../commands/types.js";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  theme: Theme;
+  commands: CustomCommand[];
+  title: string;
+  onPick: (cmd: CustomCommand | null) => void;
+}
+
+export function CommandPicker({ theme, commands, title, onPick }: Props) {
+  const items = commands.map((cmd) => ({
+    label: `/${cmd.name.padEnd(20)} ${cmd.description ?? ""}`,
+    value: cmd,
+    key: cmd.name,
+  }));
+  items.push({ label: "← Cancel", value: null as unknown as CustomCommand, key: "__cancel__" });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        {title}
+      </Text>
+      <Text color={theme.info.color} dimColor={false}>
+        Arrow keys to navigate, Enter to select.
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => {
+            if (item.key === "__cancel__") {
+              onPick(null);
+            } else {
+              onPick(item.value as CustomCommand);
+            }
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/command-wizard.tsx
+++ b/src/ui/command-wizard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Text, useInput } from "ink";
+import { Box, Text, useInput, useWindowSize } from "ink";
 import SelectInput from "ink-select-input";
 import { CustomTextInput } from "./text-input.js";
 import type { Theme } from "./theme.js";
@@ -41,6 +41,7 @@ export function CommandWizard({ theme, mode, initial, existingNames, builtinName
   const [cmdModel, setCmdModel] = useState<string | undefined>(initial?.model);
   const [source, setSource] = useState<CommandSource>(initial?.source ?? "project");
   const [error, setError] = useState<string | null>(null);
+  const { columns } = useWindowSize();
 
   const totalSteps = 5; // approximate for progress indicator
   const stepIndex =
@@ -214,12 +215,59 @@ export function CommandWizard({ theme, mode, initial, existingNames, builtinName
           </>
         );
 
-      case "template":
-        return (
-          <>
+      case "template": {
+        const guide = (
+          <Box flexDirection="column" paddingLeft={1}>
             <Text color={theme.accent} bold>
-              {mode === "create" ? "Create" : "Edit"} custom command — Template ({stepIndex}/{totalSteps})
+              What is this?
             </Text>
+            <Text color={theme.info.color} dimColor>
+              A prompt template — instructions to the AI.
+            </Text>
+            <Text color={theme.info.color} dimColor>
+              When you type /{name || "yourcommand"} later, this gets sent to the model.
+            </Text>
+            <Box marginTop={1} flexDirection="column">
+              <Text color={theme.accent} bold>
+                Variables
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"  "}$1, $2 ...     → arguments you type
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"  "}$ARGUMENTS     → everything after the command
+              </Text>
+            </Box>
+            <Box marginTop={1} flexDirection="column">
+              <Text color={theme.accent} bold>
+                Dynamic inlines
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"  "}!`git diff`    → shell output inlined
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"  "}@README.md     → file contents inlined
+              </Text>
+            </Box>
+            <Box marginTop={1} flexDirection="column">
+              <Text color={theme.accent} bold>
+                Example
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                Review this PR diff:
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                !`git diff main...HEAD`
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                Focus on: $1
+              </Text>
+            </Box>
+          </Box>
+        );
+
+        const inputArea = (
+          <Box flexDirection="column" flexGrow={1}>
             {error && <Text color={theme.error}>{error}</Text>}
             <Box marginTop={1}>
               <CustomTextInput
@@ -230,14 +278,41 @@ export function CommandWizard({ theme, mode, initial, existingNames, builtinName
                 enablePaste
               />
             </Box>
-            <Text color={theme.info.color} dimColor>
-              Paste multi-line templates with Ctrl+V. Variables: $1 $2 ... $ARGUMENTS
+            {columns < 100 && (
+              <>
+                <Text color={theme.info.color} dimColor>
+                  Paste multi-line templates with Ctrl+V.
+                </Text>
+                <Text color={theme.info.color} dimColor>
+                  Variables: $1 $2 ... $ARGUMENTS  Shell: !`cmd`  File: @path
+                </Text>
+              </>
+            )}
+          </Box>
+        );
+
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              {mode === "create" ? "Create" : "Edit"} custom command — Template ({stepIndex}/{totalSteps})
             </Text>
-            <Text color={theme.info.color} dimColor>
-              Shell: !`cmd`    File: @path
-            </Text>
+            {columns >= 100 ? (
+              <Box flexDirection="row" marginTop={1}>
+                <Box flexDirection="column" width="50%">
+                  {inputArea}
+                </Box>
+                <Box flexDirection="column" width="50%">
+                  {guide}
+                </Box>
+              </Box>
+            ) : (
+              <Box flexDirection="column" marginTop={1}>
+                {inputArea}
+              </Box>
+            )}
           </>
         );
+      }
 
       case "advanced": {
         const items = [

--- a/src/ui/command-wizard.tsx
+++ b/src/ui/command-wizard.tsx
@@ -1,0 +1,406 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { CustomTextInput } from "./text-input.js";
+import type { Theme } from "./theme.js";
+import type { Mode } from "../mode.js";
+import type { ReasoningEffort } from "../config.js";
+import type { CommandSource, CustomCommand } from "../commands/types.js";
+import type { SaveCustomCommandOptions } from "../commands/save.js";
+
+interface Props {
+  theme: Theme;
+  mode: "create" | "edit";
+  initial?: CustomCommand;
+  existingNames: string[];
+  builtinNames: Set<string>;
+  onDone: () => void;
+  onSave: (opts: SaveCustomCommandOptions) => void;
+}
+
+type Step =
+  | "name"
+  | "description"
+  | "template"
+  | "advanced"
+  | "mode"
+  | "effort"
+  | "model"
+  | "location"
+  | "confirm";
+
+const NAME_RE = /^[a-zA-Z][a-zA-Z0-9_\-/]*$/;
+
+export function CommandWizard({ theme, mode, initial, existingNames, builtinNames, onDone, onSave }: Props) {
+  const [step, setStep] = useState<Step>("name");
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [template, setTemplate] = useState(initial?.template ?? "");
+  const [cmdMode, setCmdMode] = useState<Mode | undefined>(initial?.mode);
+  const [cmdEffort, setCmdEffort] = useState<ReasoningEffort | undefined>(initial?.effort);
+  const [cmdModel, setCmdModel] = useState<string | undefined>(initial?.model);
+  const [source, setSource] = useState<CommandSource>(initial?.source ?? "project");
+  const [error, setError] = useState<string | null>(null);
+
+  const totalSteps = 5; // approximate for progress indicator
+  const stepIndex =
+    step === "name" ? 1 :
+    step === "description" ? 2 :
+    step === "template" ? 3 :
+    step === "advanced" || step === "mode" || step === "effort" || step === "model" ? 4 :
+    step === "location" ? 4 :
+    5;
+
+  const isEditingSelf = (n: string) => initial !== undefined && initial.name === n;
+
+  const validateName = (n: string): string | null => {
+    const trimmed = n.trim();
+    if (!trimmed) return "name is required";
+    if (!NAME_RE.test(trimmed)) return "invalid name: use letters, numbers, _ - / only; must start with a letter";
+    if (builtinNames.has(trimmed.toLowerCase())) return `/${trimmed} is a built-in command`;
+    if (existingNames.includes(trimmed) && !isEditingSelf(trimmed)) return `/${trimmed} already exists`;
+    return null;
+  };
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onDone();
+    }
+  });
+
+  const handleNameSubmit = (value: string) => {
+    const trimmed = value.trim();
+    const err = validateName(trimmed);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError(null);
+    setName(trimmed);
+    setStep("description");
+  };
+
+  const handleDescriptionSubmit = (value: string) => {
+    setDescription(value.trim());
+    setStep("template");
+  };
+
+  const handleTemplateSubmit = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setError("template cannot be empty");
+      return;
+    }
+    setError(null);
+    setTemplate(trimmed);
+    setStep("advanced");
+  };
+
+  const handleAdvancedChoice = (choice: "set" | "skip") => {
+    if (choice === "skip") {
+      setCmdMode(undefined);
+      setCmdEffort(undefined);
+      setCmdModel("");
+      if (mode === "edit" && initial) {
+        setSource(initial.source);
+        setStep("confirm");
+      } else {
+        setStep("location");
+      }
+    } else {
+      setStep("mode");
+    }
+  };
+
+  const handleModeChoice = (m: Mode | "none") => {
+    setCmdMode(m === "none" ? undefined : m);
+    setStep("effort");
+  };
+
+  const handleEffortChoice = (e: ReasoningEffort | "none") => {
+    setCmdEffort(e === "none" ? undefined : e);
+    setStep("model");
+  };
+
+  const handleModelSubmit = (value: string) => {
+    const trimmed = value.trim();
+    setCmdModel(trimmed || undefined);
+    if (mode === "edit" && initial) {
+      setSource(initial.source);
+      setStep("confirm");
+    } else {
+      setStep("location");
+    }
+  };
+
+  const handleLocationChoice = (s: CommandSource) => {
+    setSource(s);
+    setStep("confirm");
+  };
+
+  const handleConfirm = (choice: "save" | "cancel") => {
+    if (choice === "cancel") {
+      onDone();
+      return;
+    }
+    onSave({
+      name,
+      description: description || undefined,
+      template,
+      source,
+      mode: cmdMode,
+      model: cmdModel || undefined,
+      effort: cmdEffort,
+    });
+  };
+
+  const previewContent = () => {
+    const data: Record<string, string | undefined> = {};
+    if (description) data.description = description;
+    if (cmdMode) data.mode = cmdMode;
+    if (cmdModel) data.model = cmdModel;
+    if (cmdEffort) data.effort = cmdEffort;
+
+    const fm = Object.entries(data)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join("\n");
+
+    if (fm) {
+      return `---\n${fm}\n---\n${template}`;
+    }
+    return template;
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case "name":
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              {mode === "create" ? "Create" : "Edit"} custom command — Name ({stepIndex}/{totalSteps})
+            </Text>
+            {error && <Text color={theme.error}>{error}</Text>}
+            <Box marginTop={1}>
+              <CustomTextInput
+                value={name}
+                onChange={setName}
+                onSubmit={handleNameSubmit}
+                focus
+              />
+            </Box>
+            <Text color={theme.info.color} dimColor>
+              letters, numbers, _ - / only; must start with a letter
+            </Text>
+          </>
+        );
+
+      case "description":
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              {mode === "create" ? "Create" : "Edit"} custom command — Description ({stepIndex}/{totalSteps})
+            </Text>
+            <Box marginTop={1}>
+              <CustomTextInput
+                value={description}
+                onChange={setDescription}
+                onSubmit={handleDescriptionSubmit}
+                focus
+              />
+            </Box>
+            <Text color={theme.info.color} dimColor>
+              Press Enter to skip
+            </Text>
+          </>
+        );
+
+      case "template":
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              {mode === "create" ? "Create" : "Edit"} custom command — Template ({stepIndex}/{totalSteps})
+            </Text>
+            {error && <Text color={theme.error}>{error}</Text>}
+            <Box marginTop={1}>
+              <CustomTextInput
+                value={template}
+                onChange={setTemplate}
+                onSubmit={handleTemplateSubmit}
+                focus
+                enablePaste
+              />
+            </Box>
+            <Text color={theme.info.color} dimColor>
+              Paste multi-line templates with Ctrl+V. Variables: $1 $2 ... $ARGUMENTS
+            </Text>
+            <Text color={theme.info.color} dimColor>
+              Shell: !`cmd`    File: @path
+            </Text>
+          </>
+        );
+
+      case "advanced": {
+        const items = [
+          { label: "Set advanced options", value: "set", key: "set" },
+          { label: "Skip", value: "skip", key: "skip" },
+          { label: "← Cancel", value: "cancel", key: "cancel" },
+        ];
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              {mode === "create" ? "Create" : "Edit"} custom command — Options ({stepIndex}/{totalSteps})
+            </Text>
+            <Box marginTop={1}>
+              <SelectInput
+                items={items}
+                onSelect={(item) => {
+                  if (item.value === "cancel") onDone();
+                  else handleAdvancedChoice(item.value as "set" | "skip");
+                }}
+              />
+            </Box>
+          </>
+        );
+      }
+
+      case "mode": {
+        const items = [
+          { label: cmdMode === undefined ? "none · current" : "none", value: "none", key: "none" },
+          { label: cmdMode === "edit" ? "edit · current" : "edit", value: "edit", key: "edit" },
+          { label: cmdMode === "plan" ? "plan · current" : "plan", value: "plan", key: "plan" },
+          { label: cmdMode === "auto" ? "auto · current" : "auto", value: "auto", key: "auto" },
+          { label: "← Back", value: "__back__", key: "__back__" },
+        ];
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              Mode override ({stepIndex}/{totalSteps})
+            </Text>
+            <Text color={theme.info.color} dimColor>
+              Saved to file but not yet enforced at runtime
+            </Text>
+            <Box marginTop={1}>
+              <SelectInput
+                items={items}
+                onSelect={(item) => {
+                  if (item.value === "__back__") setStep("advanced");
+                  else handleModeChoice(item.value as Mode | "none");
+                }}
+              />
+            </Box>
+          </>
+        );
+      }
+
+      case "effort": {
+        const items = [
+          { label: cmdEffort === undefined ? "none · current" : "none", value: "none", key: "none" },
+          { label: cmdEffort === "low" ? "low · current" : "low", value: "low", key: "low" },
+          { label: cmdEffort === "medium" ? "medium · current" : "medium", value: "medium", key: "medium" },
+          { label: cmdEffort === "high" ? "high · current" : "high", value: "high", key: "high" },
+          { label: "← Back", value: "__back__", key: "__back__" },
+        ];
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              Reasoning effort ({stepIndex}/{totalSteps})
+            </Text>
+            <Box marginTop={1}>
+              <SelectInput
+                items={items}
+                onSelect={(item) => {
+                  if (item.value === "__back__") setStep("mode");
+                  else handleEffortChoice(item.value as ReasoningEffort | "none");
+                }}
+              />
+            </Box>
+          </>
+        );
+      }
+
+      case "model":
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              Model override ({stepIndex}/{totalSteps})
+            </Text>
+            <Box marginTop={1}>
+              <CustomTextInput
+                value={cmdModel ?? ""}
+                onChange={setCmdModel}
+                onSubmit={handleModelSubmit}
+                focus
+              />
+            </Box>
+            <Text color={theme.info.color} dimColor>
+              Press Enter to skip
+            </Text>
+          </>
+        );
+
+      case "location": {
+        const items = [
+          { label: source === "project" ? "Project · current" : "Project", value: "project", key: "project" },
+          { label: source === "global" ? "Global · current" : "Global", value: "global", key: "global" },
+          { label: "← Back", value: "__back__", key: "__back__" },
+        ];
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              Save location ({stepIndex}/{totalSteps})
+            </Text>
+            <Box marginTop={1}>
+              <SelectInput
+                items={items}
+                onSelect={(item) => {
+                  if (item.value === "__back__") setStep("advanced");
+                  else handleLocationChoice(item.value as CommandSource);
+                }}
+              />
+            </Box>
+            <Text color={theme.info.color} dimColor>
+              Project: .kimiflare/commands/    Global: ~/.config/kimiflare/commands/
+            </Text>
+          </>
+        );
+      }
+
+      case "confirm": {
+        const items = [
+          { label: "Save", value: "save", key: "save" },
+          { label: "Cancel", value: "cancel", key: "cancel" },
+        ];
+        return (
+          <>
+            <Text color={theme.accent} bold>
+              {mode === "create" ? "Create" : "Edit"} custom command — Confirm ({stepIndex}/{totalSteps})
+            </Text>
+            <Text color={theme.info.color} dimColor>
+              {source === "project" ? ".kimiflare/commands/" : "~/.config/kimiflare/commands/"}
+              {name}.md
+            </Text>
+            <Box marginTop={1} flexDirection="column">
+              {previewContent().split("\n").map((line, i) => (
+                <Text key={i} color={theme.info.color} dimColor>
+                  {line || " "}
+                </Text>
+              ))}
+            </Box>
+            <Box marginTop={1}>
+              <SelectInput
+                items={items}
+                onSelect={(item) => handleConfirm(item.value as "save" | "cancel")}
+              />
+            </Box>
+          </>
+        );
+      }
+    }
+  };
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      {renderStep()}
+    </Box>
+  );
+}

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -28,6 +28,7 @@ type Page =
   | "gateway"
   | "info"
   | "config"
+  | "commands"
   | "custom";
 
 interface CommandItem {
@@ -122,6 +123,16 @@ const CATEGORIES: Category[] = [
     ],
   },
   {
+    key: "commands",
+    label: "Commands",
+    commands: [
+      { command: "/command create", description: "create a new custom slash command" },
+      { command: "/command edit", description: "edit an existing custom command" },
+      { command: "/command delete", description: "delete a custom command" },
+      { command: "/command list", description: "list all custom commands" },
+    ],
+  },
+  {
     key: "config",
     label: "Config",
     commands: [
@@ -163,7 +174,7 @@ export function HelpMenu({ theme, themes, currentThemeName, customCommands, onDo
       key: cat.key,
     }));
     if (customs.length > 0) {
-      items.push({ label: "Custom commands", value: "custom", key: "custom" });
+      items.push({ label: "Run custom commands", value: "custom", key: "custom" });
     }
     items.push({ label: "(close)", value: "__close__", key: "__close__" });
 


### PR DESCRIPTION
Adds a new "Commands" category to the /help menu with four actions:
- /command create  — multi-step wizard to define and save a new command
- /command edit    — pick an existing command and modify it
- /command delete  — pick and confirm deletion of a command
- /command list    — browse all loaded commands with metadata

New files:
- src/commands/save.ts         — saveCustomCommand() and deleteCustomCommand()
- src/ui/command-wizard.tsx    — step-by-step wizard (name, desc, template, options, confirm)
- src/ui/command-picker.tsx    — SelectInput wrapper for picking a command
- src/ui/command-list.tsx      — scrollable detail view of all commands

Changes:
- src/commands/frontmatter.ts  — added serializeFrontmatter() helper
- src/ui/help-menu.tsx         — added Commands category, renamed dynamic entry
- src/app.tsx                  — wired all overlays, added /command slash handler

Co-authored-by: kimiflare <kimiflare@proton.me>