### PR TITLE
feat(code-mode): deterministic TypeScript API generation + cache

### DIFF
--- a/docs/learnings/2026-04-27-agent-system-integration.md
+++ b/docs/learnings/2026-04-27-agent-system-integration.md
@@ -499,7 +499,7 @@ Verification:
 
 Ordering: ArtifactStore persistence → Scout plumbing → Code Mode determinism → session-start recall.
 
-#### PR 1 — `feat/artifact-store-persistence` (in progress)
+#### PR 1 — `feat/artifact-store-persistence` (merged)
 
 Addresses finding §6.2: `ArtifactStore` is not persisted, so `/resume` leaves compiled-context recall broken.
 
@@ -510,3 +510,25 @@ Changes:
 - `src/agent/session-state.test.ts` — 4 new test cases: empty store round-trip, timestamp ordering, 50 KB truncation, and full inverse property.
 
 Verification: `npm run typecheck` clean; `npm test` 145 passing, 0 failing (was 139 before this PR).
+
+#### PR 2 — `feat/scout-plumbing` (merged)
+
+Addresses finding §6.10: Memory write pipeline uses Kimi K2.6 for verification, topic-key normalization, and hypothetical-query generation — 3 LLM calls per `memory_remember`.
+
+Changes:
+- `src/memory/manager.ts` — `verifyMemory` and `generateHypotheticalQueries` now use `plumbingLlmOpts` (Llama 4 Scout) instead of the main model. `normalizeTopicKey` replaced with `deterministicTopicKey`: a pure function that lowercases, strips non-alphanumerics, replaces spaces with `_`, and truncates to 60 chars — zero LLM calls.
+- `src/config.ts` — added `plumbingModel` config key, defaulting to `@cf/meta/llama-4-scout-17b-16e-instruct`.
+- `src/app.tsx` — passes `plumbingModel` through to `MemoryManager`.
+
+Verification: `npm run typecheck` clean; `npm test` passing.
+
+#### PR 3 — `feat/code-mode-determinism` (in progress)
+
+Addresses finding §6.4 / §7.4: Code Mode's TypeScript API is regenerated every turn and embedded in the `execute_code` tool description. Without determinism, property-key ordering jitter invalidates the Workers AI prefix cache from that point onward.
+
+Changes:
+- `src/code-mode/api-generator.ts` — Sorts `Object.entries()` and `Object.keys()` by key in `schemaToTsType`, `generateInterface`, and `generateTypeScriptApi`. Sorts the tools array by name. Sorts `required` arrays before passing to `generateInterface`.
+- `src/agent/loop.ts` — Adds a module-level `codeModeApiCache` keyed by `stableStringify(opts.tools)`. The generated API string is only recomputed when the tool list actually changes (e.g., MCP connect/disconnect).
+- `src/code-mode/api-generator.test.ts` — New test suite covering: identical output across different property-key insertion orders, identical output on repeated calls, tool-name sorting, simple declaration smoke test, no-parameters handling, and nested object property ordering.
+
+Verification: `npm run typecheck` clean; `npm test` passing.

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2,7 +2,7 @@ import { runKimi } from "./client.js";
 import type { AiGatewayOptions, GatewayMeta } from "./client.js";
 import { toOpenAIToolDefs, type ToolSpec } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
-import { sanitizeString, stripOldImages } from "./messages.js";
+import { sanitizeString, stableStringify, stripOldImages } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tasks-state.js";
 import type { MemoryManager } from "../memory/manager.js";
@@ -50,6 +50,8 @@ export interface AgentTurnOpts {
   codeMode?: boolean;
 }
 
+const codeModeApiCache = new Map<string, string>();
+
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const max = opts.maxToolIterations ?? 50;
   const codeMode = opts.codeMode ?? false;
@@ -58,7 +60,14 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   let codeModeApiString = "";
 
   if (codeMode) {
-    codeModeApiString = generateTypeScriptApi(opts.tools);
+    const toolsKey = stableStringify(opts.tools);
+    const cached = codeModeApiCache.get(toolsKey);
+    if (cached) {
+      codeModeApiString = cached;
+    } else {
+      codeModeApiString = generateTypeScriptApi(opts.tools);
+      codeModeApiCache.set(toolsKey, codeModeApiString);
+    }
     toolDefs = [
       {
         type: "function",

--- a/src/code-mode/api-generator.test.ts
+++ b/src/code-mode/api-generator.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { generateTypeScriptApi } from "./api-generator.js";
+import type { ToolSpec } from "../tools/registry.js";
+
+function makeTool(name: string, description: string, properties?: Record<string, unknown>, required?: string[]): ToolSpec {
+  return {
+    name,
+    description,
+    parameters: properties ? { type: "object", properties, required } : { type: "object" },
+    needsPermission: false,
+    run: async () => "",
+  };
+}
+
+describe("generateTypeScriptApi", () => {
+  it("produces identical output for the same tools in different property-key order", () => {
+    const toolsA: ToolSpec[] = [
+      makeTool("read", "Read a file.", {
+        z: { type: "string", description: "Z field" },
+        a: { type: "number", description: "A field" },
+        m: { type: "boolean", description: "M field" },
+      }, ["z", "a"]),
+      makeTool("write", "Write a file.", {
+        path: { type: "string" },
+        content: { type: "string" },
+      }, ["path", "content"]),
+    ];
+
+    const toolsB: ToolSpec[] = [
+      makeTool("read", "Read a file.", {
+        a: { type: "number", description: "A field" },
+        m: { type: "boolean", description: "M field" },
+        z: { type: "string", description: "Z field" },
+      }, ["a", "z"]),
+      makeTool("write", "Write a file.", {
+        content: { type: "string" },
+        path: { type: "string" },
+      }, ["content", "path"]),
+    ];
+
+    const outA = generateTypeScriptApi(toolsA);
+    const outB = generateTypeScriptApi(toolsB);
+    assert.strictEqual(outA, outB);
+  });
+
+  it("produces identical output when called twice with the same tools", () => {
+    const tools: ToolSpec[] = [
+      makeTool("grep", "Search files.", {
+        pattern: { type: "string" },
+        path: { type: "string" },
+      }),
+    ];
+
+    const out1 = generateTypeScriptApi(tools);
+    const out2 = generateTypeScriptApi(tools);
+    assert.strictEqual(out1, out2);
+  });
+
+  it("sorts tools by name for stable output", () => {
+    const toolsA: ToolSpec[] = [
+      makeTool("z_last", "Z tool."),
+      makeTool("a_first", "A tool."),
+    ];
+    const toolsB: ToolSpec[] = [
+      makeTool("a_first", "A tool."),
+      makeTool("z_last", "Z tool."),
+    ];
+
+    const outA = generateTypeScriptApi(toolsA);
+    const outB = generateTypeScriptApi(toolsB);
+    assert.strictEqual(outA, outB);
+  });
+
+  it("generates expected declarations for a simple tool", () => {
+    const tools: ToolSpec[] = [
+      makeTool("read", "Read a file.", {
+        path: { type: "string", description: "File path" },
+      }, ["path"]),
+    ];
+
+    const out = generateTypeScriptApi(tools);
+    assert.ok(out.includes("interface read_Input {"));
+    assert.ok(out.includes("  path: string;"));
+    assert.ok(out.includes("read(input: read_Input): Promise<string>;"));
+  });
+
+  it("handles tools with no parameters", () => {
+    const tools: ToolSpec[] = [makeTool("exit", "Exit the app.")];
+    const out = generateTypeScriptApi(tools);
+    assert.ok(out.includes("exit(): Promise<string>;"));
+    assert.ok(!out.includes("interface exit_Input"));
+  });
+
+  it("handles nested object properties in sorted order", () => {
+    const tools: ToolSpec[] = [
+      makeTool("complex", "Complex tool.", {
+        config: {
+          type: "object",
+          properties: {
+            z: { type: "string" },
+            a: { type: "number" },
+          },
+        },
+      }),
+    ];
+
+    const out = generateTypeScriptApi(tools);
+    const configIndex = out.indexOf("config");
+    const aIndex = out.indexOf("a?:");
+    const zIndex = out.indexOf("z?:");
+    assert.ok(configIndex !== -1);
+    assert.ok(aIndex !== -1);
+    assert.ok(zIndex !== -1);
+    assert.ok(aIndex < zIndex, "nested properties should be sorted alphabetically");
+  });
+});

--- a/src/code-mode/api-generator.ts
+++ b/src/code-mode/api-generator.ts
@@ -35,6 +35,7 @@ function schemaToTsType(prop: JsonSchemaProperty | undefined, required = true): 
   } else if (prop.type === "object") {
     if (prop.properties && Object.keys(prop.properties).length > 0) {
       const entries = Object.entries(prop.properties)
+        .sort(([a], [b]) => a.localeCompare(b))
         .map(([key, val]) => {
           const isReq = prop.required?.includes(key) ?? false;
           return `  ${key}${isReq ? "" : "?"}: ${schemaToTsType(val, isReq)};`;
@@ -58,6 +59,7 @@ function schemaToTsType(prop: JsonSchemaProperty | undefined, required = true): 
 
 function generateInterface(name: string, properties: Record<string, JsonSchemaProperty>, required: string[] = []): string {
   const entries = Object.entries(properties)
+    .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, val]) => {
       const isReq = required.includes(key);
       return `  ${key}${isReq ? "" : "?"}: ${schemaToTsType(val, isReq)};`;
@@ -84,7 +86,7 @@ export function generateTypeScriptApi(tools: ToolSpec[]): string {
   const outputInterfaces: string[] = [];
   const methodEntries: string[] = [];
 
-  for (const tool of tools) {
+  for (const tool of [...tools].sort((a, b) => a.name.localeCompare(b.name))) {
     const baseName = sanitizeTypeName(tool.name);
     const inputName = `${baseName}_Input`;
     const outputName = `${baseName}_Output`;
@@ -95,8 +97,9 @@ export function generateTypeScriptApi(tools: ToolSpec[]): string {
       required?: string[];
     };
 
-    if (params.properties && Object.keys(params.properties).length > 0) {
-      inputInterfaces.push(generateInterface(inputName, params.properties, params.required));
+    const sortedPropKeys = params.properties ? Object.keys(params.properties).sort((a, b) => a.localeCompare(b)) : [];
+    if (sortedPropKeys.length > 0 && params.properties) {
+      inputInterfaces.push(generateInterface(inputName, params.properties, [...(params.required ?? [])].sort((a, b) => a.localeCompare(b))));
       inputInterfaces.push("");
       methodEntries.push(`  /**`);
       methodEntries.push(`   * ${tool.description.replace(/\n/g, "\n   * ")}`);


### PR DESCRIPTION
Makes `generateTypeScriptApi` produce byte-identical output for the same tool list by sorting all object keys (properties, required, tools). Restores Workers AI prefix-cache hits in Code Mode.

Also adds a module-level `Map` cache in `loop.ts` keyed by `stableStringify(opts.tools)` so the API string is only regenerated when the tool list actually changes.

**Changes:**
- Sort `Object.entries`/`keys` in `schemaToTsType`, `generateInterface`, and `generateTypeScriptApi`
- Sort tools array by name
- Sort `required` arrays before passing to `generateInterface`
- Add `codeModeApiCache` in `loop.ts`
- Add `api-generator.test.ts` with 6 determinism tests

**Verification:**
- `npm run typecheck` clean
- `npm test` — 162 passing, 0 failing

Closes the Code Mode determinism item from Milestone 2 in the agent-system-integration research doc.