### PR TITLE
fix(plan-mode): halt agent loop when blocked tool is called in plan mode

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -344,6 +344,21 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       }
     }
 
+    if (toolResults.some((r) => r.halt)) {
+      if (opts.sessionId && lastUsage) {
+        void logTurnDebug({
+          sessionId: opts.sessionId,
+          turn,
+          messages: opts.messages,
+          previousMessages,
+          toolResults,
+          usage: lastUsage,
+          shadowStrip: shadowStripMetrics,
+        });
+      }
+      return;
+    }
+
     if (opts.sessionId && lastUsage) {
       void logTurnDebug({
         sessionId: opts.sessionId,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -65,6 +65,7 @@ import { MemoryManager } from "./memory/manager.js";
 import { RETENTION } from "./storage-limits.js";
 import { shouldShowCreatorMessage, markCreatorMessageSeen } from "./util/state.js";
 import { getAppVersion } from "./util/version.js";
+import { notifyUser } from "./util/notify.js";
 import { spawn } from "node:child_process";
 import { platform } from "node:os";
 import { loadCustomCommands } from "./commands/loader.js";
@@ -971,7 +972,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                     text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
                   },
                 ]);
-                resolve("deny");
+                notifyUser("Kimiflare — Plan Mode", `Blocked ${req.tool.name}. Switch to edit mode to continue.`);
+                resolve("halt");
                 return;
               }
               setPerm({ tool: req.tool, args: req.args, resolve });
@@ -1836,7 +1838,8 @@ function App({ initialCfg, initialUpdateResult }: { initialCfg: Cfg | null; init
                       text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
                     },
                   ]);
-                  resolve("deny");
+                  notifyUser("Kimiflare — Plan Mode", `Blocked ${req.tool.name}. Switch to edit mode to continue.`);
+                  resolve("halt");
                   return;
                 }
                 setPerm({ tool: req.tool, args: req.args, resolve });

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -237,7 +237,7 @@ export function isReadOnlyBash(command: string): boolean {
 
 export function systemPromptForMode(m: Mode): string {
   if (m === "plan") {
-    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or mutating bash commands. You may use read-only bash commands (e.g., git log, git diff, ls, cat, grep) along with read/glob/grep/web-fetch. Scripting interpreters (node, python3, ruby, perl, awk) and build/package tools (npm, cargo, go, tsc, jest, etc.) are blocked in plan mode. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
+    return "\n\nPLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes. Do not call write, edit, or mutating bash commands. You may use read-only bash commands (e.g., git log, git diff, ls, cat, grep) along with read/glob/grep/web-fetch. Scripting interpreters (node, python3, ruby, perl, awk) and build/package tools (npm, cargo, go, tsc, jest, etc.) are blocked in plan mode. IMPORTANT: if you attempt a blocked tool, the session will be halted immediately. Do not try workarounds or alternative blocked commands. At the end, present a concise plan (bullets, files to change, approach). The user will review and then exit plan mode to execute.";
   }
   if (m === "auto") {
     return "\n\nAUTO MODE is active. The user has opted into autonomous execution — every tool call will be auto-approved. Work efficiently, but do not take irreversible destructive actions (rm -rf, git push --force, dropping tables, etc.) without pausing to describe them in chat first. Prefer smaller reversible steps.";

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -26,7 +26,7 @@ export const ALL_TOOLS: ToolSpec[] = [
   memoryForgetTool,
 ];
 
-export type PermissionDecision = "allow" | "allow_session" | "deny";
+export type PermissionDecision = "allow" | "allow_session" | "deny" | "halt";
 
 export interface PermissionRequest {
   tool: ToolSpec;
@@ -53,6 +53,8 @@ export interface ToolResult {
   reducedBytes?: number;
   /** Artifact ID if the raw output was stored for later expansion. */
   artifactId?: string;
+  /** When true, the agent loop should stop after this batch of tool calls. */
+  halt?: boolean;
 }
 
 export class ToolExecutor {
@@ -123,6 +125,15 @@ export class ToolExecutor {
             name: call.name,
             content: `Permission denied by user. Do not retry this exact call; ask the user what they want to do differently.`,
             ok: false,
+          };
+        }
+        if (decision === "halt") {
+          return {
+            tool_call_id: call.id,
+            name: call.name,
+            content: `Blocked by plan mode. Switch to edit mode to execute ${call.name}.`,
+            ok: false,
+            halt: true,
           };
         }
         if (decision === "allow_session") this.sessionAllowed.add(sessionKey);

--- a/src/util/notify.ts
+++ b/src/util/notify.ts
@@ -1,0 +1,41 @@
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+
+export function notifyUser(title: string, message: string): void {
+  const os = platform();
+  try {
+    if (os === "darwin") {
+      const child = spawn(
+        "osascript",
+        ["-e", `display notification "${message.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}"`],
+        { detached: true, stdio: "ignore" },
+      );
+      child.unref();
+      return;
+    }
+    if (os === "linux") {
+      const child = spawn("notify-send", [title, message], {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+      return;
+    }
+    if (os === "win32") {
+      const child = spawn(
+        "powershell.exe",
+        [
+          "-Command",
+          `Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.MessageBox]::Show('${message.replace(/'/g, "''")}', '${title.replace(/'/g, "''")}')`,
+        ],
+        { detached: true, stdio: "ignore" },
+      );
+      child.unref();
+      return;
+    }
+  } catch {
+    /* ignore notification failures */
+  }
+  // Fallback: terminal bell
+  process.stderr.write("\x07");
+}


### PR DESCRIPTION
## Problem

When in plan mode, if the agent calls a blocked tool (write, edit, mutating bash), the permission handler returned "deny". The LLM interpreted this as a retryable failure and kept attempting workarounds with slightly different arguments, burning tokens in an infinite loop. If the user left the session unattended, millions of tokens could be consumed.

## Solution

Introduce a new "halt" permission decision that cleanly stops the agent loop instead of allowing retries.

### Changes

- **PermissionDecision** extended with `"halt"`
- **ToolResult** gets optional `halt?: boolean` flag
- **ToolExecutor.run()** handles `"halt"` by returning a result with `halt: true`
- **runAgentTurn()** checks for halted results after processing a batch and returns early
- **app.tsx** plan mode callbacks now resolve `"halt"` instead of `"deny"`, and trigger a desktop notification
- **New `src/util/notify.ts`** — cross-platform desktop notifications (macOS `osascript`, Linux `notify-send`, Windows PowerShell, fallback terminal bell)
- **Plan mode system prompt** strengthened to warn the model that blocked tool attempts halt the session immediately

## Result

The loop hard-stops after the first blocked tool attempt. No more token burn. User gets notified.

Co-authored-by: kimiflare <kimiflare@proton.me>
