### PR TITLE
docs(guardrails): add AI development governance framework

### DIFF
--- a/docs/guardrails/INDEX.md
+++ b/docs/guardrails/INDEX.md
@@ -1,0 +1,51 @@
+# Guardrails Index
+
+This directory contains the AI development governance framework for kimiflare.
+
+## Files
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| [`README.md`](README.md) | Complete guardrail specification with 9 categories, acceptance criteria, and historical context | Human reviewers, AI agents, new contributors |
+| [`scoring-rubric.md`](scoring-rubric.md) | Machine-readable scoring criteria (0–3 scale) with critical/high-priority/standard rule classification | Automated PR review agents, maintainers |
+| [`file-checklist.md`](file-checklist.md) | Per-file checklists — when you touch a file, check these boxes | PR authors, reviewers |
+| [`github-action-example.yml`](github-action-example.yml) | Example GitHub Actions workflow for automated guardrail checks | DevOps, maintainers |
+
+## Quick Start
+
+### For PR Authors
+1. Check [`file-checklist.md`](file-checklist.md) for every file you modified.
+2. Run `npm run typecheck && npm test && npm run build` locally.
+3. Ensure your PR description references any guardrail sections that are relevant.
+
+### For Reviewers
+1. Read the relevant sections of [`README.md`](README.md) based on the PR scope.
+2. Use [`scoring-rubric.md`](scoring-rubric.md) to score the PR objectively.
+3. Copy the checklist from [`file-checklist.md`](file-checklist.md) into your review comment.
+
+### For Automated Agents
+1. Load [`README.md`](README.md) as system context.
+2. Use [`scoring-rubric.md`](scoring-rubric.md) to produce a structured scorecard.
+3. Reference specific guardrail section numbers in your feedback (e.g., "Violates 2.1.3").
+
+## Guardrail Categories at a Glance
+
+1. **Build & Runtime Safety** — TypeScript strictness, ESM conventions, error handling, file size limits
+2. **Token Efficiency & Cost Control** — Prompt cache stability, context management, tool output reduction, LLM call minimization, cost visibility
+3. **Agent Loop Safety** — Anti-loop guardrails, iteration limits, permission model, error recovery
+4. **Data Integrity & Persistence** — Session persistence, memory DB, config backward compatibility
+5. **TUI/UX Stability** — Event management, static rendering, theme contrast, input handling
+6. **Security & Privacy** — Path safety, bash safety, secret redaction, model ID validation, sanitization
+7. **Integration Consistency** — MCP lifecycle, AI Gateway headers, Workers AI API, SSE parsing
+8. **Testing & Verification** — Test coverage, cost regression testing, integration testing
+9. **Architecture & Design Principles** — Explicit-only memory, feature flags, determinism, graceful degradation
+
+## Maintenance
+
+- Update these files when new subsystems are added (e.g., new tool, new UI component, new memory feature).
+- Version-bump the guardrails alongside major releases.
+- Propose changes via PR with empirical justification (cost data, bug reports, user feedback).
+
+---
+
+*Last updated: 2026-04-27*

--- a/docs/guardrails/README.md
+++ b/docs/guardrails/README.md
@@ -1,0 +1,363 @@
+# AI Development Guardrails for Kimiflare
+
+> **Purpose:** This directory contains the governance framework that AI coding agents must follow when modifying the kimiflare codebase. These guardrails are designed to be read and evaluated by both human reviewers and automated PR review agents.
+>
+> **Scope:** Every pull request that touches `src/`, `bin/`, `feedback-worker/`, or `docs/` must be evaluated against these guardrails.
+>
+> **Last updated:** 2026-04-27
+
+---
+
+## Table of Contents
+
+1. [Build & Runtime Safety](#1-build--runtime-safety)
+2. [Token Efficiency & Cost Control](#2-token-efficiency--cost-control)
+3. [Agent Loop Safety](#3-agent-loop-safety)
+4. [Data Integrity & Persistence](#4-data-integrity--persistence)
+5. [TUI/UX Stability](#5-tuiux-stability)
+6. [Security & Privacy](#6-security--privacy)
+7. [Integration Consistency](#7-integration-consistency)
+8. [Testing & Verification](#8-testing--verification)
+9. [Architecture & Design Principles](#9-architecture--design-principles)
+10. [How to Use This Document](#10-how-to-use-this-document)
+
+---
+
+## 1. Build & Runtime Safety
+
+### 1.1 TypeScript Strictness
+- **Rule:** All code must compile under `tsc --noEmit` with zero errors.
+- **Rule:** `noUncheckedIndexedAccess` is enabled — every array/object index access must be guarded or use non-null assertion (`!`) with justification.
+- **Rule:** `noImplicitOverride` is enabled — overridden methods must use the `override` keyword.
+- **Rule:** `isolatedModules` is enabled — no cross-file type dependencies that require full type-checking to resolve.
+- **Acceptance Criteria:** `npm run typecheck` passes cleanly on every PR.
+
+### 1.2 ESM & Import Conventions
+- **Rule:** All imports must use `.js` extensions, even for `.ts`/`.tsx` files (TypeScript `moduleResolution: Bundler`).
+- **Rule:** All Node.js built-ins must use the `node:` prefix (e.g., `node:fs/promises`, not `fs/promises`).
+- **Rule:** No CommonJS `require()` or `module.exports` — ESM only.
+- **Acceptance Criteria:** `npm run build` produces a valid `dist/` and `bin/kimiflare.mjs`.
+
+### 1.3 Runtime Error Prevention
+- **Rule:** Every `JSON.parse()` must be wrapped in `try/catch` or validated with a schema guard.
+- **Rule:** Every `await` on a potentially failing operation (file I/O, network, DB) must have error handling.
+- **Rule:** No unhandled promise rejections — `void` prefix is acceptable only for truly fire-and-forget operations (telemetry, background cleanup).
+- **Rule:** AbortSignal must be propagated through all async call chains that support it.
+- **Acceptance Criteria:** No new `throw` statements without corresponding error handling in the call stack.
+
+### 1.4 File Size & Memory Limits
+- **Rule:** `read` tool refuses files > 2MB.
+- **Rule:** `write`/`edit` tools should warn on files > 100KB.
+- **Rule:** Image encoding refuses files > 5MB.
+- **Rule:** Web fetch refuses responses > 1MB.
+- **Acceptance Criteria:** New file I/O operations must have explicit size guards.
+
+---
+
+## 2. Token Efficiency & Cost Control
+
+### 2.1 Prompt Cache Stability
+- **Rule:** The static system prompt prefix must be byte-for-byte identical across all turns in a session.
+- **Rule:** The session prefix must only change when mode, tools, or KIMI.md content changes — not on every turn.
+- **Rule:** Code Mode TypeScript API generation must be deterministic (sorted keys, stable JSDoc rendering) and cached by tool list hash.
+- **Rule:** No volatile data (timestamps, random IDs, unordered iteration) may appear in cache-stable prefixes.
+- **Acceptance Criteria:** `cacheDiagnostics.cacheHitRatio` should not regress. New features must include cache impact analysis.
+
+### 2.2 Context Window Management
+- **Rule:** Auto-compaction must fire when messages cross 80K tokens or 12 turns, regardless of feature flags.
+- **Rule:** Compiled context (heuristic compaction) and LLM summarizer (`/compact`) must both be available as fallback paths.
+- **Rule:** Image content must be dropped from message history after N turns (default 2, configurable).
+- **Rule:** Reasoning content must be stripped from historical assistant messages (keep only last 1 by default).
+- **Acceptance Criteria:** A 50-turn session must not exceed 200K tokens in the prompt.
+
+### 2.3 Tool Output Reduction
+- **Rule:** All tool outputs must pass through the reducer before reaching the model, except explicitly whitelisted commands (diff-style git commands).
+- **Rule:** Reducer config defaults must not be relaxed without explicit cost justification:
+  - `bash`: max 40 lines, 4000 chars, dedupe consecutive lines
+  - `grep`: max 50 lines, 3 matches per file, 200 chars per line
+  - `read`: max 60 outline lines, 200 slice lines, 30 preview lines
+  - `web_fetch`: max 2000 chars, 500 heading chars
+- **Rule:** Diff-style git commands (`git show`, `git diff`, `git log -p`, `git format-patch`, `git stash show -p`) must bypass the bash reducer to preserve line-level meaning.
+- **Acceptance Criteria:** Tool output byte counts must be logged in cost-debug JSONL. No regression in `toolSavingsPct`.
+
+### 2.4 LLM Call Minimization
+- **Rule:** Internal/plumbing tasks must use the small model (`@cf/meta/llama-4-scout-17b-16e-instruct` by default), not Kimi K2.6.
+- **Rule:** Deterministic operations (topic key normalization, simple transforms) must not use any LLM call.
+- **Rule:** Memory write pipeline must batch operations where possible.
+- **Rule:** No speculative LLM calls — only call the model when the result is needed for the next turn.
+- **Acceptance Criteria:** New features must document expected LLM call count per user turn.
+
+### 2.5 Cost Visibility
+- **Rule:** Every turn's token usage must be tracked in `usage-tracker.ts`.
+- **Rule:** Status bar must show session cost and token count.
+- **Rule:** `/cost` command must return accurate USD breakdown.
+- **Acceptance Criteria:** Cost tracking must not drift > 5% from Cloudflare billing dashboard.
+
+---
+
+## 3. Agent Loop Safety
+
+### 3.1 Anti-Loop Guardrails
+- **Rule:** The agent loop must detect repeated identical tool calls (same name + stable-stringified args) within a sliding window of 8 calls.
+- **Rule:** On the 3rd identical call, inject a synthetic error: `"Loop detected: you have called {tool} with the same arguments multiple times in a row. Consider a different approach."`
+- **Rule:** The loop detector must not block legitimate retries with different args.
+- **Acceptance Criteria:** Merge-conflict resolution scenarios must not exceed 10 tool iterations.
+
+### 3.2 Iteration Limits
+- **Rule:** Hard cap of 50 tool iterations per turn.
+- **Rule:** Bash timeout default 120s, max 600s.
+- **Rule:** Code Mode sandbox timeout 30s, memory limit 128MB.
+- **Acceptance Criteria:** No user-visible hang beyond configured timeouts.
+
+### 3.3 Permission Model
+- **Rule:** Mutating tools (`write`, `edit`, `bash`) must require user permission in `edit` mode.
+- **Rule:** `plan` mode must block all mutating tools except read-only bash commands.
+- **Rule:** Read-only bash whitelist must be explicit and validated per segment (pipes and `&&` chains allowed if all segments are read-only).
+- **Rule:** `auto` mode must auto-approve but still log all tool calls.
+- **Acceptance Criteria:** Permission modal must render correctly with diff preview for `write`/`edit`.
+
+### 3.4 Error Recovery
+- **Rule:** The model must not retry the exact same failed tool call blindly.
+- **Rule:** JSON parse errors in tool arguments must return a clear error message, not crash.
+- **Rule:** API 400 errors with "invalid escaped character" must pop the offending message and suggest `/clear`.
+- **Acceptance Criteria:** Error messages must be actionable for the model.
+
+---
+
+## 4. Data Integrity & Persistence
+
+### 4.1 Session Persistence
+- **Rule:** Session files must include `messages`, `sessionState`, and `artifactStore`.
+- **Rule:** Artifact store serialization must truncate to 50KB per artifact (matching in-memory cap).
+- **Rule:** Session resume must restore artifact store via `deserializeArtifactStore()`.
+- **Rule:** Session pruning must respect retention policy: 30 days max age, 100 files max count.
+- **Acceptance Criteria:** `/resume` must restore recall functionality for archived artifacts.
+
+### 4.2 Memory Database
+- **Rule:** SQLite schema must include migration path for new columns (see `migrateV1()` pattern).
+- **Rule:** WAL mode must be enabled (`journal_mode = WAL`).
+- **Rule:** Cleanup must run on startup: drop memories > 90 days, deduplicate by cosine similarity ≥ 0.95, enforce max 1000 entries per repo.
+- **Rule:** Tasks category must be excluded from vector search (searchable only via FTS).
+- **Acceptance Criteria:** DB operations must not block the main thread for > 100ms.
+
+### 4.3 Config Backward Compatibility
+- **Rule:** New config fields must have sensible defaults.
+- **Rule:** Config file must be chmod 600.
+- **Rule:** Unknown config fields must be ignored, not cause crashes.
+- **Acceptance Criteria:** Upgrading from v0.20 to v0.26 must not require config regeneration.
+
+---
+
+## 5. TUI/UX Stability
+
+### 5.1 Event Management
+- **Rule:** Chat events must be capped at 500 (`MAX_EVENTS`).
+- **Rule:** Visual compaction must collapse old turns into a placeholder, keeping last 4 turns visible.
+- **Rule:** Streaming assistant updates must be batched at ~60fps (16ms flush interval) to reduce React re-render churn.
+- **Acceptance Criteria:** 100-turn session must not cause TUI lag or memory growth.
+
+### 5.2 Static Rendering
+- **Rule:** `Static` component from Ink must be used for finalized events.
+- **Rule:** Static items must have stable keys to prevent React reconciliation issues.
+- **Acceptance Criteria:** No missing user messages or duplicate rendering.
+
+### 5.3 Theme & Accessibility
+- **Rule:** All themes must use truecolor hex codes, not ANSI 256-color codes.
+- **Rule:** Contrast must be legible on Terminal.app (avoid `dimColor` on low-contrast combinations).
+- **Rule:** Theme picker must support live preview without closing on arrow keys.
+- **Acceptance Criteria:** All 6 built-in themes must pass WCAG AA contrast on black/white backgrounds.
+
+### 5.4 Input Handling
+- **Rule:** Paste detection threshold: ≥200 chars or ≥1 newline.
+- **Rule:** History navigation (up/down) must preserve draft input.
+- **Rule:** Queue items must be deletable individually.
+- **Acceptance Criteria:** No input loss on rapid key presses.
+
+---
+
+## 6. Security & Privacy
+
+### 6.1 Path Safety
+- **Rule:** All user-provided paths must be resolved via `resolvePath()` which blocks `..` traversal.
+- **Rule:** `isPathOutside()` must be used before any file operation outside cwd.
+- **Rule:** Custom command loader must reject files outside the commands directory.
+- **Acceptance Criteria:** No file read/write outside the project directory without explicit user permission.
+
+### 6.2 Bash Safety
+- **Rule:** Bash commands run via `bash -lc` with cwd set explicitly.
+- **Rule:** Co-author injection (`Co-authored-by: kimiflare <kimiflare@proton.me>`) must only apply to git commit-creating commands, not commands that only move HEAD (`git checkout`, `git reset`, etc.).
+- **Rule:** Timeout must be enforced via `AbortController` + `spawn` kill.
+- **Acceptance Criteria:** `rm -rf /` must be blocked by plan mode and require permission in edit mode.
+
+### 6.3 Secret Redaction
+- **Rule:** Memory content must be redacted via `redactSecrets()` before storage.
+- **Rule:** API tokens must never appear in logs, session files, or memory DB.
+- **Acceptance Criteria:** `grep -r "apiToken" ~/.local/share/kimiflare/` must return only the config file.
+
+### 6.4 Model ID Validation
+- **Rule:** Model IDs must match `/^@[a-zA-Z0-9_-]+\/[a-zA-Z0-9._-]+(\/[a-zA-Z0-9._-]+)*$/`.
+- **Rule:** Invalid model IDs must throw `KimiApiError` with 400 status, not make network requests.
+- **Acceptance Criteria:** Path traversal via model string (`../../../etc/passwd`) must be rejected.
+
+### 6.5 Sanitization
+- **Rule:** All strings entering JSON or SSE must be sanitized for lone UTF-16 surrogates (`sanitizeString()`).
+- **Rule:** Tool arguments must be validated via `validateToolArguments()` before being stored in message history.
+- **Acceptance Criteria:** No `JSON.parse` errors from model-generated content.
+
+---
+
+## 7. Integration Consistency
+
+### 7.1 MCP Server Lifecycle
+- **Rule:** MCP tools must be unregistered before re-registering on reload.
+- **Rule:** MCP connection failures must be non-fatal — log error, continue without that server.
+- **Rule:** MCP tool names must be prefixed with `mcp_{serverName}_{toolName}`.
+- **Acceptance Criteria:** `/mcp reload` must not leak old tool registrations.
+
+### 7.2 AI Gateway Headers
+- **Rule:** Gateway headers (`cf-aig-cache-ttl`, `cf-aig-skip-cache`, etc.) must only be sent when gateway is configured.
+- **Rule:** Gateway metadata must be limited to 5 entries and stable-stringified.
+- **Acceptance Criteria:** Direct Workers AI mode must not send gateway headers.
+
+### 7.3 Workers AI API
+- **Rule:** Retry logic must only retry on 5xx and known retryable codes (3040 capacity error).
+- **Rule:** Max 5 retry attempts with exponential backoff (500ms * 2^attempt + jitter).
+- **Rule:** `x-session-affinity` and `X-Session-ID` headers must be sent for cache stability.
+- **Acceptance Criteria:** 99% of requests succeed within 3 attempts.
+
+### 7.4 SSE Parsing
+- **Rule:** SSE parser must handle line splits across chunk boundaries, multi-line data, CRLF/LF, and ignored events.
+- **Rule:** Malformed SSE chunks must be skipped, not crash the stream.
+- **Acceptance Criteria:** Streaming must survive 1MB+ responses without dropping events.
+
+---
+
+## 8. Testing & Verification
+
+### 8.1 Test Coverage Requirements
+- **Rule:** Every new tool must have a unit test in `src/tools/{tool}.test.ts`.
+- **Rule:** Every new agent loop feature must have a test in `src/agent/{feature}.test.ts`.
+- **Rule:** Reducer changes must include before/after byte count assertions.
+- **Acceptance Criteria:** `npm test` must pass with 0 failures.
+
+### 8.2 Cost Regression Testing
+- **Rule:** Changes to prompt construction must include `cacheDiagnostics` verification.
+- **Rule:** Changes to tool output reduction must include `toolStats` verification.
+- **Rule:** New LLM call sites must document expected token count.
+- **Acceptance Criteria:** Cost-debug JSONL must show no regression in `promptTotalApproxTokens` for standard benchmark prompts.
+
+### 8.3 Integration Testing
+- **Rule:** Session save/resume must be tested end-to-end.
+- **Rule:** Memory cleanup/backfill must be tested with mock DB.
+- **Rule:** MCP tool registration must be tested with mock transport.
+- **Acceptance Criteria:** No manual TUI smoke test should reveal regressions.
+
+---
+
+## 9. Architecture & Design Principles
+
+### 9.1 Explicit-Only Memory
+- **Rule:** Agent memory writes must only occur via explicit `memory_remember` tool calls — no auto-extraction from conversation.
+- **Rule:** Memory reads at session start and compaction time are allowed (surfacing existing explicit memories).
+- **Acceptance Criteria:** No surveillance-like behavior — user must consciously choose to remember.
+
+### 9.2 Feature Flag Hygiene
+- **Rule:** New features must be gated behind explicit flags (env vars or config), defaulting to off until proven stable.
+- **Rule:** Feature flags must be documented in `KIMI.md` and help menu.
+- **Rule:** Flags must be removable once the feature is stable (deprecation path).
+- **Acceptance Criteria:** `compiledContext`, `codeMode`, `memoryEnabled` all follow this pattern.
+
+### 9.3 Determinism
+- **Rule:** Any generated content that affects prompt caching must be deterministic (sorted keys, stable iteration order).
+- **Rule:** `stableStringify()` must be used for all JSON that enters the prompt or cache key.
+- **Acceptance Criteria:** Two identical sessions must produce identical cache hit ratios.
+
+### 9.4 Graceful Degradation
+- **Rule:** Every optional subsystem (memory, MCP, gateway, code mode) must degrade gracefully when unavailable.
+- **Rule:** Core functionality (read, edit, write, bash, agent loop) must work with zero optional dependencies.
+- **Acceptance Criteria:** `kimiflare` must start and answer simple prompts even if SQLite, isolated-vm, or MCP are missing.
+
+---
+
+## 10. How to Use This Document
+
+### For Human Reviewers
+1. Check the PR diff against each relevant section above.
+2. Flag any violation with the section number (e.g., "Violates 2.1.3 — introduces non-deterministic key ordering").
+3. Require test updates for any modified guardrail.
+
+### For Automated PR Review Agents
+1. Parse the PR diff and identify touched files.
+2. Load the relevant guardrail sections (e.g., `src/agent/loop.ts` changes → check sections 1, 2, 3, 7).
+3. Evaluate each rule against the diff:
+   - **PASS:** Rule is satisfied or not applicable.
+   - **WARN:** Rule may be violated — requires human review.
+   - **FAIL:** Rule is clearly violated — block PR.
+4. Output a structured report with section references and acceptance criteria checks.
+
+### Example Automated Report Format
+
+```markdown
+## Guardrail Evaluation for PR #XXX
+
+### 1. Build & Runtime Safety
+- [PASS] 1.1 TypeScript strictness — no new `any` types introduced.
+- [WARN] 1.3 Runtime error prevention — new `JSON.parse()` at line 45 without `try/catch`.
+
+### 2. Token Efficiency
+- [FAIL] 2.1.2 Session prefix includes timestamp — breaks cache stability.
+  - **File:** `src/agent/system-prompt.ts:78`
+  - **Fix:** Move timestamp to dynamic suffix.
+
+### 3. Agent Loop Safety
+- [PASS] 3.1 Anti-loop — loop signature uses `stableStringify()`.
+```
+
+---
+
+## Appendix A: Known Sharp Edges (Historical Bugs)
+
+These are past failures that informed the guardrails above. New code must not reintroduce these patterns.
+
+| Bug | Root Cause | Guardrail Section |
+|-----|-----------|-------------------|
+| Context window blowup (424K → 262K) | Auto-compaction gated behind `compiledContext` flag (default off) | 2.2.1 |
+| Merge conflict loop (12 `git show` variants) | Bash reducer deduped diff lines, model couldn't see conflict | 2.3.4, 3.1 |
+| TUI missing user messages | `Static` component key instability caused React reconciliation drops | 5.2 |
+| Status bar cost drift | Intern's token count work didn't account for cached tokens | 2.5 |
+| Plan mode allowed `git commit` | Bash whitelist didn't distinguish commit-creating vs HEAD-moving | 3.3, 6.2 |
+| Memory write cost explosion | Verification + topic + hypotheticals all used Kimi K2.6 | 2.4.1 |
+| Code Mode cache misses | TypeScript API regenerated non-deterministically every turn | 2.1.3 |
+| Artifact store lost on resume | `ArtifactStore` not persisted in session file | 4.1.1 |
+| Co-author on `git checkout` | Co-author injection applied to all git commands | 6.2 |
+| Theme picker closed on arrows | `useInput` handler didn't filter arrow keys | 5.3 |
+| Ctrl+C hung the app | Global SIGINT handler conflicted with Ink's handler | 3.4 |
+| Memory growth in long sessions | Images and reasoning content never stripped from history | 2.2.2, 2.2.3 |
+| Invalid JSON 400 loops | Model generated malformed JSON, no validation before retry | 3.4 |
+
+---
+
+## Appendix B: Quick Reference — File → Guardrail Sections
+
+| File Pattern | Primary Sections |
+|-------------|------------------|
+| `src/agent/loop.ts` | 1, 2, 3, 7 |
+| `src/agent/client.ts` | 1, 6, 7 |
+| `src/agent/system-prompt.ts` | 2, 9 |
+| `src/agent/compaction.ts` | 2, 4 |
+| `src/agent/compact.ts` | 2, 4 |
+| `src/agent/session-state.ts` | 4 |
+| `src/tools/*.ts` | 1, 2, 3, 6 |
+| `src/tools/reducer.ts` | 2 |
+| `src/memory/*.ts` | 2, 4, 6, 9 |
+| `src/ui/*.tsx` | 1, 5 |
+| `src/app.tsx` | 1, 3, 4, 5 |
+| `src/config.ts` | 4, 6 |
+| `src/mode.ts` | 3, 6 |
+| `src/pricing.ts` | 2 |
+| `src/usage-tracker.ts` | 2 |
+| `feedback-worker/*` | 6, 7 |
+
+---
+
+*This document is a living specification. Propose changes via PR with justification referencing empirical cost or quality data.*

--- a/docs/guardrails/file-checklist.md
+++ b/docs/guardrails/file-checklist.md
@@ -1,0 +1,331 @@
+# Per-File Guardrail Checklist
+
+> **Purpose:** Quick-reference checklist for reviewers. When a file is modified in a PR, check the corresponding items.
+>
+> **Usage:** Copy the relevant section into the PR description or review comment.
+
+---
+
+## `src/agent/loop.ts`
+
+- [ ] Anti-loop guardrail still tracks signatures with `stableStringify()`
+- [ ] `LOOP_WINDOW` (8) and `LOOP_THRESHOLD` (2) constants unchanged unless justified
+- [ ] `maxToolIterations` (50) cap preserved
+- [ ] New tool call sites include `recentToolCalls.push()` and window trimming
+- [ ] Code Mode API cache uses `stableStringify(opts.tools)` as key
+- [ ] `validateToolArguments()` handles empty/malformed JSON
+- [ ] `stripHistoricalReasoning()` and `stripOldImages()` applied before API call
+- [ ] AbortSignal propagated to `runKimi()`
+- [ ] No new unbounded arrays or Maps in the loop
+
+---
+
+## `src/agent/client.ts`
+
+- [ ] `validateModelId()` regex unchanged unless Cloudflare schema changes
+- [ ] Retry logic only retries 5xx and code 3040
+- [ ] `x-session-affinity` and `X-Session-ID` headers sent when `sessionId` provided
+- [ ] Gateway headers only sent when `gateway.id` is set
+- [ ] `sanitizeMessagesForApi()` sanitizes all string content
+- [ ] SSE parser skips malformed chunks without crashing
+- [ ] `sleep()` respects AbortSignal
+
+---
+
+## `src/agent/system-prompt.ts`
+
+- [ ] `buildStaticPrefix()` contains no volatile data (no dates, no cwd, no random IDs)
+- [ ] `buildSessionPrefix()` changes only when mode/tools/KIMI.md change
+- [ ] `loadContextFile()` respects 20KB cap
+- [ ] Tool list iteration is sorted/deterministic
+- [ ] New system prompt instructions are terse (model has 262K context but every token counts)
+
+---
+
+## `src/agent/compaction.ts`
+
+- [ ] `shouldCompact()` thresholds (80K tokens / 12 turns) unchanged unless measured
+- [ ] `keepLastTurns` (4) preserved in working memory after compaction
+- [ ] `extractArtifactsFromTurn()` handles all tool types safely
+- [ ] `recallArtifacts()` caps recalled artifacts at 5
+- [ ] Failure-keyword recall requires `meta.summary` match (not just any bash artifact)
+- [ ] No new artifact types without corresponding `ArtifactType` union member
+
+---
+
+## `src/agent/compact.ts`
+
+- [ ] `SUMMARY_SYSTEM` prompt unchanged unless explicitly redesigned
+- [ ] `keepLastTurns` default (4) preserved
+- [ ] Compaction runs on the main model (Kimi K2.6) — justified because synthesis quality matters
+- [ ] AbortSignal passed through to `runKimi()`
+
+---
+
+## `src/agent/session-state.ts`
+
+- [ ] `ArtifactStore` size caps preserved: 200 entries, 500K total chars
+- [ ] `serializeArtifactStore()` truncates to 50KB per artifact
+- [ ] `deserializeArtifactStore()` feeds back through `add()` to enforce caps
+- [ ] `emptySessionState()` includes all required fields
+- [ ] New `SessionState` fields have defaults in `emptySessionState()`
+
+---
+
+## `src/tools/executor.ts`
+
+- [ ] `isDiffCommand()` whitelist matches exactly: `git show`, `git diff`, `git log -p`, `git format-patch`, `git stash show -p`
+- [ ] Diff commands store artifact but return unreduced content
+- [ ] Non-diff commands pass through `reduceToolOutput()`
+- [ ] Permission check happens before tool execution
+- [ ] `sessionAllowed` cleared on mode change to `plan`
+- [ ] Unknown tool returns helpful error with valid tool list
+
+---
+
+## `src/tools/reducer.ts`
+
+- [ ] `DEFAULT_REDUCER_CONFIG` defaults unchanged unless cost-justified:
+  - `grep`: 50 lines, 3 matches/file, 200 chars/line, 3000 chars total
+  - `read`: 60 outline, 200 slice, 30 preview, 4000 chars total
+  - `bash`: 40 lines, 20 error lines, 20 trailing lines, 4000 chars, dedupe on
+  - `webFetch`: 2000 chars, 500 heading chars
+- [ ] New tool types added to `reduceToolOutput()` switch statement
+- [ ] Artifact ID included in reduced output footer
+- [ ] `wasReduced` flag accurate — don't claim reduction when nothing changed
+
+---
+
+## `src/tools/bash.ts`
+
+- [ ] `DEFAULT_TIMEOUT` (120s) and `MAX_TIMEOUT` (600s) preserved
+- [ ] `injectCoauthor()` only applies to commit-creating commands
+- [ ] Co-author injection skipped for HEAD-moving commands (`checkout`, `reset`, `switch`, etc.)
+- [ ] Command runs via `bash -lc` with explicit cwd
+- [ ] Timeout enforced via `AbortController` + `spawn` kill
+- [ ] Exit code non-zero returns error content, not crash
+
+---
+
+## `src/tools/read.ts`
+
+- [ ] `MAX_BYTES` (2MB) preserved
+- [ ] `offset` and `limit` validated (minimum 1)
+- [ ] Full-file read without offset/limit returns outline, not full content
+- [ ] Line numbers are 1-indexed
+
+---
+
+## `src/tools/write.ts`
+
+- [ ] `needsPermission: true` preserved
+- [ ] `render()` returns diff preview
+- [ ] Parent directories created via `mkdir`
+- [ ] No overwrite confirmation — permission modal is the gate
+
+---
+
+## `src/tools/edit.ts`
+
+- [ ] `needsPermission: true` preserved
+- [ ] `replace_all: false` requires exactly one match
+- [ ] `replace_all: true` replaces all occurrences
+- [ ] `render()` returns diff preview with before/after
+
+---
+
+## `src/memory/manager.ts`
+
+- [ ] `plumbingModel` used for verification and hypothetical queries
+- [ ] `deterministicTopicKey()` is pure function — no LLM call
+- [ ] `memory_remember` pipeline: verify → topic key → hypotheticals → embed → store
+- [ ] `synthesizeRecalled()` uses plumbing model, not main model
+- [ ] `redactSecrets()` applied before storage
+- [ ] Cleanup and backfill are non-blocking (fire-and-forget with `void`)
+
+---
+
+## `src/memory/db.ts`
+
+- [ ] `initSchema()` creates all tables and indexes
+- [ ] `migrateV1()` handles additive schema changes
+- [ ] FTS5 triggers sync `memories_fts` with `memories`
+- [ ] `searchMemoriesFts()` excludes tasks if `category != 'task'` filter is required
+- [ ] `listMemoriesForVectorSearch()` excludes tasks
+- [ ] All DB operations use parameterized queries (no SQL injection)
+
+---
+
+## `src/memory/retrieval.ts`
+
+- [ ] RRF weights unchanged unless re-tuned: `topicKey:0.35, fts:0.20, vector:0.20, exact:0.15, rawMessage:0.10`
+- [ ] `normalizeFtsRank()` clamps to 0–10 range
+- [ ] `normalizeVectorScore()` clamps to 0.5–1.0 range
+- [ ] `computeExactScore()` handles file path and keyword matches
+- [ ] Results limited to requested `limit`
+
+---
+
+## `src/memory/embeddings.ts`
+
+- [ ] `DEFAULT_MODEL` (`@cf/baai/bge-base-en-v1.5`) preserved
+- [ ] `MAX_EMBED_CHARS` (2000) preserved
+- [ ] `truncateForEmbedding()` truncates, doesn't error
+- [ ] `fetchWithRetry()` retries 3 times with backoff
+- [ ] Batch embedding requests when possible
+
+---
+
+## `src/memory/cleanup.ts`
+
+- [ ] `findDuplicates()` threshold (0.95) preserved
+- [ ] Cleanup interval (24h) respected via `shouldCleanup()`
+- [ ] `maxAgeDays` and `maxEntries` passed through from config
+- [ ] Superseded memories kept for audit (not deleted)
+
+---
+
+## `src/ui/chat.tsx`
+
+- [ ] `ChatEvent` union includes all event kinds
+- [ ] `Static` items have stable keys (`e.key`)
+- [ ] Streaming assistant events not added to `Static`
+- [ ] Separator shown between user and assistant/tool events
+- [ ] `verbose` prop passed through to `ToolView`
+
+---
+
+## `src/ui/status.tsx`
+
+- [ ] Cost display includes `$` prefix
+- [ ] Token count includes cached vs uncached breakdown
+- [ ] `/compact recommended` warning at 80% context
+- [ ] Update nudge includes version numbers and install command
+- [ ] Gateway cache status shown when available
+
+---
+
+## `src/ui/permission.tsx`
+
+- [ ] Three options: Allow once, Allow session, Deny
+- [ ] Diff preview shown for `write`/`edit`
+- [ ] Tool name and args visible
+- [ ] Escape key or selection resolves the promise
+
+---
+
+## `src/app.tsx`
+
+- [ ] `CONTEXT_LIMIT` (262_000) preserved
+- [ ] `AUTO_COMPACT_SUGGEST_PCT` (0.8) preserved
+- [ ] `MAX_EVENTS` (500) preserved
+- [ ] `capEvents()` enforces event cap
+- [ ] `compactEventsVisual()` collapses old turns
+- [ ] `makePrefixMessages()` respects `cacheStable` flag
+- [ ] `findImagePaths()` caps at `MAX_IMAGES_PER_MESSAGE` (10)
+- [ ] `BUILTIN_COMMAND_NAMES` updated if new slash command added
+- [ ] Session save includes `artifactStore`
+- [ ] Auto-compact fires after turn when thresholds met
+- [ ] Memory recall after compaction uses `sessionState.task || cwd`
+- [ ] Ctrl+C interrupts current operation without exiting
+- [ ] Shift+Tab cycles modes
+
+---
+
+## `src/config.ts`
+
+- [ ] `DEFAULT_MODEL` (`@cf/moonshotai/kimi-k2.6`) preserved
+- [ ] `DEFAULT_REASONING_EFFORT` (`medium`) preserved
+- [ ] New config fields have defaults in `loadConfig()`
+- [ ] Config file chmod 600 on save
+- [ ] Env var overrides documented
+
+---
+
+## `src/mode.ts`
+
+- [ ] `MUTATING_TOOLS` set includes `write`, `edit`, `bash`
+- [ ] `isBlockedInPlanMode()` blocks `mcp_*` tools
+- [ ] `isReadOnlyBash()` validates each segment of pipes/`&&` chains
+- [ ] Dangerous patterns (redirection, subshells, etc.) disqualify read-only status
+- [ ] `systemPromptForMode()` returns mode-specific instructions
+
+---
+
+## `src/pricing.ts`
+
+- [ ] `PRICE_IN_PER_M` (0.95) matches Cloudflare pricing
+- [ ] `PRICE_IN_CACHED_PER_M` (0.16) matches Cloudflare pricing
+- [ ] `PRICE_OUT_PER_M` (4.0) matches Cloudflare pricing
+- [ ] `calculateCost()` handles all three token types
+
+---
+
+## `src/usage-tracker.ts`
+
+- [ ] `LOG_VERSION` incremented on schema change
+- [ ] Retention: 90 days daily, 30 days session, 200 session entries max
+- [ ] `recordUsage()` updates both daily and session totals
+- [ ] `getCostReport()` returns accurate USD amounts
+- [ ] Gateway usage snapshot included when available
+
+---
+
+## `src/sessions.ts`
+
+- [ ] `RETENTION.sessionMaxAgeDays` (30) and `sessionMaxCount` (100) preserved
+- [ ] `saveSession()` writes atomically
+- [ ] `loadSession()` parses JSON safely
+- [ ] `pruneSessions()` removes old files, returns count
+
+---
+
+## `src/index.tsx`
+
+- [ ] Print mode (`-p`) requires TTY check
+- [ ] `--dangerously-allow-all` only works in print mode
+- [ ] `--reasoning` only works in print mode
+- [ ] Version from `getAppVersion()`
+
+---
+
+## `feedback-worker/src/index.ts`
+
+- [ ] Rate limit: 5 requests per hour per IP
+- [ ] Max file size: 10MB
+- [ ] Allowed audio types whitelist enforced
+- [ ] `DISCORD_WEBHOOK_URL` env var required
+- [ ] No PII logged beyond session UUID and version
+
+---
+
+## `package.json`
+
+- [ ] `engines.node` >= 22 (for `isolated-vm` compatibility)
+- [ ] `type: "module"` preserved
+- [ ] `bin` points to `bin/kimiflare.mjs`
+- [ ] `tsup` config externalizes runtime deps
+- [ ] New dependencies justified (bundle size impact)
+
+---
+
+## `tsconfig.json`
+
+- [ ] `strict: true` preserved
+- [ ] `noUncheckedIndexedAccess: true` preserved
+- [ ] `noImplicitOverride: true` preserved
+- [ ] `isolatedModules: true` preserved
+- [ ] `moduleResolution: "Bundler"` preserved
+
+---
+
+## `KIMI.md` / `KIMIFLARE.md`
+
+- [ ] Build/test/run commands accurate
+- [ ] Layout section reflects current directory structure
+- [ ] Conventions section up to date
+- [ ] Do/Don't section aligned with guardrails
+
+---
+
+*Add new files to this checklist as the project grows. Keep checkboxes concrete and verifiable.*

--- a/docs/guardrails/github-action-example.yml
+++ b/docs/guardrails/github-action-example.yml
@@ -1,0 +1,234 @@
+# Example GitHub Actions Workflow for Automated Guardrail Review
+#
+# Copy this to .github/workflows/guardrail-review.yml to enable automated PR review.
+# This workflow runs on every PR and uses a lightweight script to evaluate the diff
+# against the guardrails. For a full AI-agent review, replace the script step with
+# a call to your preferred LLM API with the guardrails as system context.
+#
+# NOTE: This is a template. Customize the scoring thresholds and notification
+# channels for your team's needs.
+
+name: Guardrail Review
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'feedback-worker/**'
+      - 'docs/**'
+      - 'package.json'
+      - 'tsconfig.json'
+
+jobs:
+  guardrail-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ─── Critical Auto-Checks ───
+      - name: TypeScript compile check
+        run: npm run typecheck
+        id: typecheck
+
+      - name: Run tests
+        run: npm test
+        id: tests
+
+      - name: Build check
+        run: npm run build
+        id: build
+
+      # ─── Static Analysis Checks ───
+      - name: Check for unsafe path operations
+        run: |
+          echo "=== Checking for file operations without resolvePath ==="
+          UNSAFE=$(git diff origin/main...HEAD --name-only | grep -E '\.ts$' | xargs -I {} sh -c 'grep -n "readFile\\|writeFile\\|readdir" "{}" | grep -v "resolvePath" | grep -v "test" | grep -v "node:" || true')
+          if [ -n "$UNSAFE" ]; then
+            echo "⚠️ POTENTIAL UNSAFE PATH OPERATIONS:"
+            echo "$UNSAFE"
+            echo "unsafe_paths=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No unsafe path operations detected"
+            echo "unsafe_paths=false" >> $GITHUB_OUTPUT
+          fi
+        id: path_check
+
+      - name: Check for secret exposure
+        run: |
+          echo "=== Checking for potential secret exposure ==="
+          SECRETS=$(git diff origin/main...HEAD --name-only | grep -E '\.ts$' | xargs -I {} sh -c 'grep -n "apiToken\\|apiKey\\|password\\|secret" "{}" | grep -v "config.ts" | grep -v "test" | grep -v "redact" | grep -v "// " || true')
+          if [ -n "$SECRETS" ]; then
+            echo "⚠️ POTENTIAL SECRET EXPOSURE:"
+            echo "$SECRETS"
+            echo "secrets_exposed=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No secret exposure detected"
+            echo "secrets_exposed=false" >> $GITHUB_OUTPUT
+          fi
+        id: secret_check
+
+      - name: Check for cache stability risks
+        run: |
+          echo "=== Checking for volatile data in system prompt ==="
+          VOLATILE=$(git diff origin/main...HEAD -- src/agent/system-prompt.ts | grep -E '^\+.*(new Date|Date\.now|Math\.random|crypto\.randomUUID)' || true)
+          if [ -n "$VOLATILE" ]; then
+            echo "⚠️ VOLATILE DATA IN SYSTEM PROMPT:"
+            echo "$VOLATILE"
+            echo "volatile_prompt=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No volatile data in system prompt"
+            echo "volatile_prompt=false" >> $GITHUB_OUTPUT
+          fi
+        id: cache_check
+
+      - name: Check for unbounded loops
+        run: |
+          echo "=== Checking for unbounded iteration ==="
+          LOOPS=$(git diff origin/main...HEAD --name-only | grep -E '\.ts$' | xargs -I {} sh -c 'grep -n "while (true)\\|for (;;)\\|while (!done)" "{}" || true')
+          if [ -n "$LOOPS" ]; then
+            echo "⚠️ UNBOUNDED LOOPS DETECTED:"
+            echo "$LOOPS"
+            echo "unbounded_loops=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No unbounded loops detected"
+            echo "unbounded_loops=false" >> $GITHUB_OUTPUT
+          fi
+        id: loop_check
+
+      - name: Check reducer config changes
+        run: |
+          echo "=== Checking for reducer config modifications ==="
+          REDUCER=$(git diff origin/main...HEAD -- src/tools/reducer.ts | grep -E '^\+.*(maxTotalLines|maxOutputChars|dedupeConsecutiveLines)' || true)
+          if [ -n "$REDUCER" ]; then
+            echo "⚠️ REDUCER CONFIG CHANGED:"
+            echo "$REDUCER"
+            echo "reducer_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ No reducer config changes"
+            echo "reducer_changed=false" >> $GITHUB_OUTPUT
+          fi
+        id: reducer_check
+
+      # ─── Generate Review Report ───
+      - name: Generate guardrail report
+        id: report
+        run: |
+          REPORT="## 🤖 Automated Guardrail Review\n\n"
+          REPORT+="| Check | Status |\n"
+          REPORT+="|-------|--------|\n"
+
+          if [ "${{ steps.typecheck.outcome }}" == "success" ]; then
+            REPORT+="| TypeScript Compile | ✅ PASS |\n"
+          else
+            REPORT+="| TypeScript Compile | ❌ FAIL |\n"
+          fi
+
+          if [ "${{ steps.tests.outcome }}" == "success" ]; then
+            REPORT+="| Tests | ✅ PASS |\n"
+          else
+            REPORT+="| Tests | ❌ FAIL |\n"
+          fi
+
+          if [ "${{ steps.build.outcome }}" == "success" ]; then
+            REPORT+="| Build | ✅ PASS |\n"
+          else
+            REPORT+="| Build | ❌ FAIL |\n"
+          fi
+
+          if [ "${{ steps.path_check.outputs.unsafe_paths }}" == "false" ]; then
+            REPORT+="| Path Safety | ✅ PASS |\n"
+          else
+            REPORT+="| Path Safety | ⚠️ WARN |\n"
+          fi
+
+          if [ "${{ steps.secret_check.outputs.secrets_exposed }}" == "false" ]; then
+            REPORT+="| Secret Exposure | ✅ PASS |\n"
+          else
+            REPORT+="| Secret Exposure | ⚠️ WARN |\n"
+          fi
+
+          if [ "${{ steps.cache_check.outputs.volatile_prompt }}" == "false" ]; then
+            REPORT+="| Cache Stability | ✅ PASS |\n"
+          else
+            REPORT+="| Cache Stability | ⚠️ WARN |\n"
+          fi
+
+          if [ "${{ steps.loop_check.outputs.unbounded_loops }}" == "false" ]; then
+            REPORT+="| Loop Safety | ✅ PASS |\n"
+          else
+            REPORT+="| Loop Safety | ⚠️ WARN |\n"
+          fi
+
+          if [ "${{ steps.reducer_check.outputs.reducer_changed }}" == "false" ]; then
+            REPORT+="| Reducer Config | ✅ PASS |\n"
+          else
+            REPORT+="| Reducer Config | ⚠️ WARN |\n"
+          fi
+
+          REPORT+="\n### 📋 Next Steps\n\n"
+          REPORT+="- Review the [Guardrails README](/docs/guardrails/README.md)\n"
+          REPORT+="- Check the [File Checklist](/docs/guardrails/file-checklist.md) for modified files\n"
+          REPORT+="- Ensure the [Scoring Rubric](/docs/guardrails/scoring-rubric.md) criteria are met\n"
+
+          echo "report<<EOF" >> $GITHUB_OUTPUT
+          echo "$REPORT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      # ─── Post PR Comment ───
+      - name: Post guardrail review comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const report = `${{ steps.report.outputs.report }}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Automated Guardrail Review')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: report,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: report,
+              });
+            }
+
+      # ─── Fail on Critical Issues ───
+      - name: Fail if critical checks failed
+        if: |
+          steps.typecheck.outcome == 'failure' ||
+          steps.tests.outcome == 'failure' ||
+          steps.build.outcome == 'failure'
+        run: |
+          echo "❌ Critical guardrail checks failed. Please fix before merging."
+          exit 1

--- a/docs/guardrails/scoring-rubric.md
+++ b/docs/guardrails/scoring-rubric.md
@@ -1,0 +1,232 @@
+# Automated PR Review Scoring Rubric
+
+> **Purpose:** Machine-readable scoring criteria for an AI agent or GitHub Action to evaluate PRs against the guardrails.
+>
+> **Usage:** Each rule is scored 0–3. A PR must score ≥ 2 on all critical rules and average ≥ 2.5 overall to pass.
+
+---
+
+## Scoring Scale
+
+| Score | Meaning |
+|-------|---------|
+| 3 — **Exceeds** | Not only satisfies the rule but includes tests, documentation, or measurable improvement. |
+| 2 — **Meets** | Satisfies the rule with no concerns. |
+| 1 — **Partial** | Attempts to satisfy the rule but has gaps or risks. |
+| 0 — **Fails** | Clearly violates the rule or introduces regression. |
+| N/A | Rule does not apply to this PR's scope. |
+
+---
+
+## Critical Rules (Must Score ≥ 2)
+
+These rules are non-negotiable. A score of 0 or 1 blocks the PR.
+
+### CRIT-1: TypeScript Compiles
+- **Source:** Guardrail 1.1
+- **Check:** `npm run typecheck` exits 0.
+- **Auto-check:** ✅ Yes — CI command.
+- **Scoring:**
+  - 3: Adds new strict types, removes existing `any`.
+  - 2: Compiles cleanly, no new type looseness.
+  - 1: Compiles but introduces `as` casts or `// @ts-ignore`.
+  - 0: Fails `tsc --noEmit`.
+
+### CRIT-2: Tests Pass
+- **Source:** Guardrail 8.1
+- **Check:** `npm test` exits 0.
+- **Auto-check:** ✅ Yes — CI command.
+- **Scoring:**
+  - 3: Adds tests for new code with >80% branch coverage.
+  - 2: All existing tests pass; new code has at least smoke tests.
+  - 1: Tests pass but new code is untested.
+  - 0: Tests fail or CI broken.
+
+### CRIT-3: Build Succeeds
+- **Source:** Guardrail 1.2
+- **Check:** `npm run build` produces valid `dist/` and `bin/kimiflare.mjs`.
+- **Auto-check:** ✅ Yes — CI command.
+- **Scoring:**
+  - 3: Build output size decreases or stays flat.
+  - 2: Builds successfully.
+  - 1: Builds with warnings.
+  - 0: Build fails.
+
+### CRIT-4: No Path Traversal
+- **Source:** Guardrail 6.1
+- **Check:** No new file operations without `resolvePath()` or `isPathOutside()` guards.
+- **Auto-check:** ⚠️ Partial — static analysis via grep.
+- **Scoring:**
+  - 3: New file ops use both resolve and guard, with tests.
+  - 2: Uses existing safe path utilities.
+  - 1: Uses path operations but no obvious traversal bug.
+  - 0: Raw `fs.readFile(userInput)` or similar.
+
+### CRIT-5: No Secret Leakage
+- **Source:** Guardrail 6.3
+- **Check:** No new logging of credentials, tokens, or config values.
+- **Auto-check:** ⚠️ Partial — grep for `apiToken`, `apiKey`, `password` in diff.
+- **Scoring:**
+  - 3: Adds redaction for new sensitive fields.
+  - 2: No new secret exposure.
+  - 1: Refactors near secrets but doesn't add exposure.
+  - 0: Logs or stores credentials in plain text.
+
+### CRIT-6: Cache Stability Preserved
+- **Source:** Guardrail 2.1
+- **Check:** No new volatile data in system prompt or tool definitions.
+- **Auto-check:** ⚠️ Partial — requires semantic review.
+- **Scoring:**
+  - 3: Improves cache hit ratio (measured).
+  - 2: No change to cache-stable prefixes.
+  - 1: Adds data to prompt but argues it's necessary.
+  - 0: Adds timestamps, random IDs, or unordered data to cache-stable sections.
+
+---
+
+## High-Priority Rules (Average Must Be ≥ 2)
+
+### HP-1: Token Efficiency
+- **Source:** Guardrail 2
+- **Check:** No relaxation of reducer defaults; no new unmeasured LLM calls.
+- **Auto-check:** ⚠️ Partial — grep for reducer config changes, new `runKimi` calls.
+- **Scoring:**
+  - 3: Reduces tokens per turn (measured via cost-debug).
+  - 2: No regression in token count.
+  - 1: Slight increase with justification.
+  - 0: Significant increase without measurement.
+
+### HP-2: Agent Loop Safety
+- **Source:** Guardrail 3
+- **Check:** No removal of loop guardrails; no new infinite-loop risks.
+- **Auto-check:** ⚠️ Partial — grep for `while (true)`, `for (;;)`, recursion.
+- **Scoring:**
+  - 3: Adds new guardrail or improves loop detection.
+  - 2: No change to loop safety.
+  - 1: Adds iteration without clear bound.
+  - 0: Removes loop guardrails or adds unbounded recursion.
+
+### HP-3: Graceful Degradation
+- **Source:** Guardrail 9.4
+- **Check:** Optional subsystems fail non-fatally.
+- **Auto-check:** ⚠️ Partial — grep for `throw` in optional init paths.
+- **Scoring:**
+  - 3: Adds graceful fallback for new optional dependency.
+  - 2: Existing degradation paths preserved.
+  - 1: New dependency without fallback.
+  - 0: Hard failure on missing optional component.
+
+### HP-4: Data Integrity
+- **Source:** Guardrail 4
+- **Check:** Schema migrations, serialization, and retention policies respected.
+- **Auto-check:** ⚠️ Partial — grep for `ALTER TABLE`, schema changes.
+- **Scoring:**
+  - 3: Adds migration with backward compatibility and tests.
+  - 2: No schema changes; or changes are additive with defaults.
+  - 1: Schema change without migration.
+  - 0: Breaking schema change without backward compatibility.
+
+### HP-5: TUI Stability
+- **Source:** Guardrail 5
+- **Check:** No new unbounded state growth; event keys are stable.
+- **Auto-check:** ⚠️ Partial — grep for `new Map()`, `new Set()`, array pushes without bounds.
+- **Scoring:**
+  - 3: Fixes existing TUI memory leak or adds bounds.
+  - 2: No new unbounded growth.
+  - 1: Adds state without explicit cap.
+  - 0: Adds obvious memory leak or breaks Static rendering.
+
+---
+
+## Standard Rules (Tracked, Not Blocking)
+
+### STD-1: Documentation
+- **Source:** Guardrail 9.2
+- **Check:** New features documented in help menu, KIMI.md, or guardrails.
+- **Scoring:**
+  - 3: Updates all relevant docs including guardrails.
+  - 2: Updates KIMI.md or help menu.
+  - 1: Code comments only.
+  - 0: No documentation.
+
+### STD-2: Determinism
+- **Source:** Guardrail 9.3
+- **Check:** Generated content uses `stableStringify()` and sorted iteration.
+- **Scoring:**
+  - 3: Adds determinism where it was missing.
+  - 2: Preserves existing determinism.
+  - 1: Uses iteration without explicit sorting.
+  - 0: Introduces non-deterministic output that affects caching.
+
+### STD-3: Error Handling
+- **Source:** Guardrail 1.3, 3.4
+- **Check:** New async operations have `try/catch` or `.catch()`.
+- **Scoring:**
+  - 3: Adds structured error types and recovery paths.
+  - 2: Basic try/catch present.
+  - 1: Some paths unhandled.
+  - 0: Naked awaits on fallible operations.
+
+### STD-4: Test Quality
+- **Source:** Guardrail 8
+- **Check:** Tests are meaningful, not just coverage padding.
+- **Scoring:**
+  - 3: Tests verify behavior, not just execution.
+  - 2: Tests cover happy path and one error case.
+  - 1: Tests exist but are shallow.
+  - 0: No tests for new code.
+
+---
+
+## Scoring Worksheet Template
+
+```markdown
+## PR Guardrail Scorecard
+
+| Rule | Score | Notes |
+|------|-------|-------|
+| CRIT-1 TypeScript | 2 | Compiles cleanly |
+| CRIT-2 Tests | 3 | Added 4 new tests |
+| CRIT-3 Build | 2 | No size change |
+| CRIT-4 Path Safety | 2 | Uses resolvePath |
+| CRIT-5 Secrets | 2 | No new exposure |
+| CRIT-6 Cache | 1 | Adds model name to prefix — justified |
+| HP-1 Tokens | 2 | No regression |
+| HP-2 Loop Safety | 2 | No change |
+| HP-3 Degradation | 2 | Fallback present |
+| HP-4 Data Integrity | N/A | No schema changes |
+| HP-5 TUI | 2 | No new unbounded state |
+| STD-1 Docs | 2 | Updated KIMI.md |
+| STD-2 Determinism | 2 | stableStringify used |
+| STD-3 Errors | 2 | try/catch present |
+| STD-4 Test Quality | 3 | Branch coverage 85% |
+
+**Critical Average:** 2.17 / 3 (PASS — all ≥ 2 except CRIT-6 at 1, needs human review)
+**High-Priority Average:** 2.00 / 3 (PASS)
+**Standard Average:** 2.25 / 3 (PASS)
+**Overall Average:** 2.14 / 3 (PASS with CRIT-6 warning)
+```
+
+---
+
+## Automated Check Commands
+
+Run these in CI or locally for quick validation:
+
+```bash
+# Critical auto-checks
+npm run typecheck        # CRIT-1
+npm test                 # CRIT-2
+npm run build            # CRIT-3
+
+# Partial auto-checks (grep-based)
+grep -n "readFile\|writeFile\|readdir" src/**/*.ts | grep -v "resolvePath" | grep -v "test"  # CRIT-4
+grep -n "apiToken\|apiKey\|password" src/**/*.ts | grep -v "config.ts" | grep -v "test"      # CRIT-5
+grep -n "new Date()\|Math.random()\|crypto.randomUUID()" src/agent/system-prompt.ts          # CRIT-6
+grep -n "while (true)\|for (;;)\|while (!done)" src/agent/loop.ts                             # HP-2
+grep -n "throw " src/app.tsx | grep -v "AbortError" | grep -v "KimiApiError"                   # HP-3
+```
+
+---
+
+*Update this rubric when new guardrail sections are added. Version bump the rubric alongside the guardrails README.*


### PR DESCRIPTION
Adds the AI-readable guardrails / governance framework under `docs/guardrails/`.

**Includes:**
- `README.md` — 9-category spec with acceptance criteria and historical context (Appendix A)
- `scoring-rubric.md` — 0–3 scoring scale for automated PR review agents
- `file-checklist.md` — per-source-file validation checklists
- `github-action-example.yml` — example CI workflow for guardrail enforcement
- `INDEX.md` — quick-start for authors, reviewers, and agents

**Goal:** give human reviewers and future automated agents a concrete rubric to rate PRs against.

Co-authored-by: kimiflare <kimiflare@proton.me>