### PR TITLE
docs: clarify tools section is not exhaustive

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1027,7 +1027,7 @@
   <section>
     <div class="section-header">
       <span class="section-label">Tools</span>
-      <h2>Built-in tools</h2>
+      <h2>Core tools</h2>
     </div>
 
     <table class="tools-table">
@@ -1081,6 +1081,12 @@
         </tr>
       </tbody>
     </table>
+
+    <p style="margin-top: 1.5rem; color: var(--text-secondary); font-size: 0.9rem;">
+      Plus <strong>LSP intelligence</strong> (hover, go-to-definition, references, diagnostics),
+      <strong>cross-session memory</strong> (remember / recall / forget),
+      and <strong>MCP extensibility</strong> for plugging in external tool servers.
+    </p>
   </section>
 
   <footer>


### PR DESCRIPTION
The 'Built-in tools' table implied it was the complete list. Renamed to 'Core tools' and added LSP, memory, and MCP to the description.