### PR TITLE
feat: interrupt current turn with Ctrl+C or Escape without exiting session

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Supported formats: PNG, JPG, JPEG, WebP, GIF, BMP (up to 5 MB each, 10 per messa
 
 | Shortcut | Action |
 |----------|--------|
-| `Ctrl+C` | Interrupt current turn (press again to exit) |
+| `Ctrl+C` / `Esc` | Interrupt current turn when busy; exit when idle |
 | `Ctrl+R` | Toggle reasoning display |
 | `Ctrl+O` | Toggle verbose tool output |
 | `Ctrl+T` | Open theme picker |

--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { runAgentTurn } from "./loop.js";
+import type { ToolExecutor } from "../tools/executor.js";
+import type { ChatMessage } from "./messages.js";
+
+describe("runAgentTurn", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("exits gracefully when signal aborts during streaming", async () => {
+    const controller = new AbortController();
+    const messages: ChatMessage[] = [
+      { role: "system", content: "test" },
+      { role: "user", content: "hi" },
+    ];
+
+    globalThis.fetch = async () => {
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(c) {
+          // Delay data so readSSE is pending when abort fires.
+          const t = setTimeout(() => {
+            try {
+              c.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hello"}}]}\n\n'));
+              c.close();
+            } catch {
+              /* controller may already be closed */
+            }
+          }, 200);
+          // Clean up timeout if stream is cancelled early.
+          controller.signal.addEventListener("abort", () => clearTimeout(t), { once: true });
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+
+    const executor = {
+      list: () => [],
+      run: async () => {
+        throw new Error("should not reach executor");
+      },
+    } as unknown as ToolExecutor;
+
+    // Abort while the stream is pending.
+    setTimeout(() => controller.abort(), 50);
+
+    // Should throw because runAgentTurn checks signal.aborted after streaming.
+    await assert.rejects(
+      async () => {
+        await runAgentTurn({
+          accountId: "test",
+          apiToken: "token",
+          model: "@cf/test/model",
+          messages,
+          tools: [],
+          executor,
+          cwd: "/tmp",
+          signal: controller.signal,
+          callbacks: {
+            askPermission: async () => "allow",
+          },
+        });
+      },
+      (err: unknown) => err instanceof DOMException && err.name === "AbortError",
+    );
+
+    // No assistant message should have been appended because abort happened
+    // before the stream produced any usable content.
+    assert.strictEqual(messages.length, 2);
+  });
+
+  it("throws AbortError when signal aborts after streaming but before tool execution", async () => {
+    const controller = new AbortController();
+    const messages: ChatMessage[] = [
+      { role: "system", content: "test" },
+      { role: "user", content: "hi" },
+    ];
+
+    globalThis.fetch = async () => {
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(
+            encoder.encode(
+              'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc_1","function":{"name":"read","arguments":""}}]}}]}\n\n',
+            ),
+          );
+          c.enqueue(
+            encoder.encode(
+              'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"path\\":\\"x\\"}"}}]}}]}\n\n',
+            ),
+          );
+          c.enqueue(encoder.encode('data: {"choices":[{"finish_reason":"tool_calls"}]}\n\n'));
+          c.close();
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+
+    const executor = {
+      list: () => [],
+      run: async () => {
+        throw new Error("should not reach executor");
+      },
+    } as unknown as ToolExecutor;
+
+    await assert.rejects(
+      async () => {
+        await runAgentTurn({
+          accountId: "test",
+          apiToken: "token",
+          model: "@cf/test/model",
+          messages,
+          tools: [],
+          executor,
+          cwd: "/tmp",
+          signal: controller.signal,
+          callbacks: {
+            // Abort as soon as the assistant message is finalized (after streaming,
+            // before tool execution starts).
+            onAssistantFinal: () => {
+              controller.abort();
+            },
+            askPermission: async () => "allow",
+          },
+        });
+      },
+      (err: unknown) => err instanceof DOMException && err.name === "AbortError",
+    );
+
+    // Assistant message should have been appended during streaming.
+    assert.strictEqual(messages.length, 3);
+    assert.strictEqual(messages[2]!.role, "assistant");
+    assert.ok(Array.isArray(messages[2]!.tool_calls));
+    assert.strictEqual(messages[2]!.tool_calls!.length, 1);
+
+    // No tool result should have been appended because abort happened before execution.
+    assert.strictEqual(messages.filter((m) => m.role === "tool").length, 0);
+  });
+});

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -218,6 +218,8 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       }
     }
 
+    if (opts.signal.aborted) throw new DOMException("aborted", "AbortError");
+
     if (lastUsage) opts.callbacks.onUsageFinal?.(lastUsage, gatewayMeta);
 
     const assistantMsg: ChatMessage = {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -313,6 +313,8 @@ function App({
   const executorRef = useRef<ToolExecutor>(new ToolExecutor(ALL_TOOLS));
   const activeAsstIdRef = useRef<number | null>(null);
   const activeControllerRef = useRef<AbortController | null>(null);
+  const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
+  const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
   const sessionIdRef = useRef<string | null>(null);
   const modeRef = useRef<Mode>(mode);
   const effortRef = useRef<ReasoningEffort>(effort);
@@ -748,14 +750,42 @@ function App({
 
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
+      const hadPerm = permResolveRef.current !== null;
+      if (hadPerm) {
+        permResolveRef.current!("deny");
+        permResolveRef.current = null;
+        setPerm(null);
+      }
       if (busy && activeControllerRef.current) {
         activeControllerRef.current.abort();
         setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
-      } else {
+      } else if (!hadPerm) {
         void lspManagerRef.current.stopAll().finally(() => exit());
       }
       return;
+    }
+    if (key.escape) {
+      const modalOpen =
+        perm !== null ||
+        showHelpMenu ||
+        showThemePicker ||
+        showLspWizard ||
+        showCommandList ||
+        commandWizard !== null ||
+        commandToDelete !== null ||
+        resumeSessions !== null;
+      if (!modalOpen && busy && activeControllerRef.current) {
+        if (permResolveRef.current) {
+          permResolveRef.current("deny");
+          permResolveRef.current = null;
+          setPerm(null);
+        }
+        activeControllerRef.current.abort();
+        setQueue([]);
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
+        return;
+      }
     }
     if (key.ctrl && inputChar === "r") {
       setShowReasoning((s) => !s);
@@ -931,6 +961,8 @@ function App({
       setBusy(false);
       setTurnStartedAt(null);
       activeControllerRef.current = null;
+      permResolveRef.current = null;
+      pendingToolCallsRef.current.clear();
     }
   }, [cfg, busy, saveSessionSafe]);
 
@@ -1035,6 +1067,7 @@ function App({
             if (id !== null) updateAssistant(id, () => ({ streaming: false }));
           },
           onToolCallFinalized: (call) => {
+            pendingToolCallsRef.current.set(call.id, call.function.name);
             const spec = executorRef.current.list().find((t) => t.name === call.function.name);
             let renderMeta: ToolRender | undefined;
             try {
@@ -1058,6 +1091,7 @@ function App({
             ]);
           },
           onToolResult: (r) => {
+            pendingToolCallsRef.current.delete(r.tool_call_id);
             updateTool(r.tool_call_id, { status: r.ok ? "done" : "error", result: r.content });
           },
           onUsage: (u) => {
@@ -1083,6 +1117,7 @@ function App({
                 }
                 if (req.tool.name === "bash") {
                   // Non-whitelisted bash in plan mode: ask for temporary permission
+                  permResolveRef.current = resolve;
                   setPerm({ tool: req.tool, args: req.args, resolve });
                   return;
                 }
@@ -1097,6 +1132,7 @@ function App({
                 resolve("deny");
                 return;
               }
+              permResolveRef.current = resolve;
               setPerm({ tool: req.tool, args: req.args, resolve });
             }),
         },
@@ -1130,17 +1166,33 @@ function App({
         ]);
       }
     } catch (e) {
-      if ((e as Error).name !== "AbortError") {
+      if ((e as Error).name === "AbortError") {
+        for (const [tcId, tcName] of pendingToolCallsRef.current) {
+          messagesRef.current.push({
+            role: "tool",
+            tool_call_id: tcId,
+            content: "(interrupted)",
+            name: tcName,
+          });
+        }
+        setEvents((evts) =>
+          evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
+        );
+      } else {
         setEvents((es) => [
           ...es,
           { kind: "error", key: mkKey(), text: `init failed: ${(e as Error).message}` },
         ]);
       }
     } finally {
+      const asstId = activeAsstIdRef.current;
+      if (asstId !== null) updateAssistant(asstId, () => ({ streaming: false }));
       setBusy(false);
       setTurnStartedAt(null);
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
+      permResolveRef.current = null;
+      pendingToolCallsRef.current.clear();
     }
   }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
 
@@ -1978,6 +2030,7 @@ function App({
               if (id !== null) updateAssistant(id, () => ({ streaming: false }));
             },
             onToolCallFinalized: (call) => {
+              pendingToolCallsRef.current.set(call.id, call.function.name);
               const spec = executorRef.current.list().find((t) => t.name === call.function.name);
               let renderMeta: ToolRender | undefined;
               try {
@@ -2001,6 +2054,7 @@ function App({
               ]);
             },
             onToolResult: (r) => {
+              pendingToolCallsRef.current.delete(r.tool_call_id);
               updateTool(r.tool_call_id, {
                 status: r.ok ? "done" : "error",
                 result: r.content,
@@ -2054,6 +2108,7 @@ function App({
                   resolve("deny");
                   return;
                 }
+                permResolveRef.current = resolve;
                 setPerm({ tool: req.tool, args: req.args, resolve });
               }),
           },
@@ -2148,7 +2203,19 @@ function App({
         }
       } catch (e) {
         if ((e as Error).name === "AbortError") {
-          setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "(aborted)" }]);
+          // Inject synthetic tool results for any pending tool calls so message
+          // history remains valid (assistant msg with tool_calls needs 1:1 results).
+          for (const [tcId, tcName] of pendingToolCallsRef.current) {
+            messagesRef.current.push({
+              role: "tool",
+              tool_call_id: tcId,
+              content: "(interrupted)",
+              name: tcName,
+            });
+          }
+          setEvents((evts) =>
+            evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
+          );
         } else {
           const isInvalidJson400 =
             e instanceof KimiApiError &&
@@ -2172,10 +2239,14 @@ function App({
           }
         }
       } finally {
+        const asstId = activeAsstIdRef.current;
+        if (asstId !== null) updateAssistant(asstId, () => ({ streaming: false }));
         setBusy(false);
         setTurnStartedAt(null);
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
+        permResolveRef.current = null;
+        pendingToolCallsRef.current.clear();
       }
     },
     [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe, updateGatewayMeta],
@@ -2410,6 +2481,7 @@ function App({
           theme={theme}
           onDecide={(d) => {
             perm.resolve(d);
+            permResolveRef.current = null;
             setPerm(null);
           }}
         />

--- a/src/util/sse.test.ts
+++ b/src/util/sse.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readSSE } from "./sse.js";
+
+describe("readSSE", () => {
+  it("exits gracefully when signal aborts during pending read", async () => {
+    const controller = new AbortController();
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // Abort before enqueueing any data so reader.read() is pending.
+        setTimeout(() => controller.abort(), 10);
+      },
+    });
+    const gen = readSSE(stream, controller.signal);
+    const result = await gen.next();
+    assert.strictEqual(result.done, true);
+  });
+
+  it("yields events when stream completes normally", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("data: hello\n\n"));
+        c.close();
+      },
+    });
+    const gen = readSSE(stream);
+    const results: string[] = [];
+    for await (const ev of gen) {
+      results.push(ev);
+    }
+    assert.deepStrictEqual(results, ["hello"]);
+  });
+});

--- a/src/util/sse.ts
+++ b/src/util/sse.ts
@@ -13,6 +13,16 @@ export async function* readSSE(
   const reader = stream.getReader();
   const decoder = new TextDecoder("utf-8");
   let buffer = "";
+
+  const onAbort = () => {
+    try {
+      reader.cancel(new DOMException("aborted", "AbortError"));
+    } catch {
+      /* reader may already be closed */
+    }
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+
   try {
     while (true) {
       if (signal?.aborted) throw new DOMException("aborted", "AbortError");
@@ -34,6 +44,7 @@ export async function* readSSE(
     const tail = extractData(buffer.trim());
     if (tail !== null) yield tail;
   } finally {
+    signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
   }
 }


### PR DESCRIPTION
## Summary

Implements graceful interrupt for the agent turn. When kimiflare is thinking, streaming, or executing tools, pressing **Ctrl+C** or **Escape** aborts the current operation and returns control to the prompt — without crashing the TUI.

## Root cause of the previous bug

The SSE reader (`src/util/sse.ts`) had a race where `signal.aborted` was only checked *before* `reader.read()`. If the abort fired while `reader.read()` was already pending, the promise never resolved and the agent loop hung forever. A previous fix added a global `process.on('SIGINT')` handler, but that conflicted with Ink's own handler and corrupted terminal state.

## Changes

### `src/util/sse.ts`
- Adds an abort listener that calls `reader.cancel()`, forcing `reader.read()` to resolve with `{ done: true }` so the generator exits instead of hanging.
- Wrapped in `try/catch` because `reader.cancel()` may throw if the reader is already closed.

### `src/agent/loop.ts`
- Adds `opts.signal.aborted` check immediately after the streaming loop. Prevents saving a partial/empty assistant message when the user interrupts during streaming.

### `src/app.tsx`
- **`permResolveRef`**: Stores the pending permission resolver. On interrupt, resolves with `"deny"` and dismisses the modal.
- **`pendingToolCallsRef`**: Tracks tool calls that have been finalized but not yet completed. On abort, injects synthetic `"(interrupted)"` tool results into `messagesRef.current` so the conversation history remains valid (OpenAI API requires 1:1 mapping between `tool_calls` and tool messages).
- **Ctrl+C handler**: If a permission modal is open, resolves deny first. If busy, aborts the controller. If idle (and no permission was pending), exits gracefully.
- **Escape handler**: Only triggers interrupt when no modal/dialog is open (`perm`, help menu, theme picker, command wizard, etc.).
- **`finally` blocks**: Stop streaming spinner, clear `permResolveRef` and `pendingToolCallsRef`.

### Tests
- `src/util/sse.test.ts`: Verifies that `readSSE` exits gracefully when the signal aborts during a pending read.
- `src/agent/loop.test.ts`: Verifies that `runAgentTurn` throws `AbortError` when the signal aborts during streaming or before tool execution, and that no invalid message state is left behind.

### Docs
- `README.md`: Updated shortcut description from "Ctrl+C — Interrupt current turn (press again to exit)" to "Ctrl+C / Esc — Interrupt current turn when busy; exit when idle".

## Guardrail compliance

| Rule | Score | Notes |
|------|-------|-------|
| CRIT-1 TypeScript | 2 | Compiles cleanly |
| CRIT-2 Tests | 2 | New tests for SSE and loop abort |
| CRIT-3 Build | 2 | No new deps |
| HP-2 Agent Loop | 2 | Synthetic tool results prevent history corruption |
| HP-4 Data Integrity | 2 | Session saves valid history |
| HP-5 TUI Stability | 2 | Conditional Escape, no modal collision |
| STD-1 Documentation | 2 | README updated |
| STD-3 Error Handling | 2 | `reader.cancel()` wrapped |
| STD-4 Test Quality | 2 | Tests verify behavior |

## Historical context

This re-implements the feature from commits `3307c8f` → `c6e9c1f` → `bf46eb8`, which were reverted in `d10c104` because a global `process.on('SIGINT')` handler conflicted with Ink's handler and caused screen flashing. This PR avoids that mistake by using Ink's `useInput` exclusively and never touching `process.on('SIGINT')` in TUI mode.
