### PR TITLE
fix: prevent perf_hooks memory leak in long-running TUI sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "ink-text-input": "^6.0.0",
         "isolated-vm": "^6.1.2",
         "react": "^19.2.0",
-        "react-devtools-core": "^6.1.2",
         "turndown": "^7.2.0",
         "vscode-languageserver-protocol": "^3.17.5"
       },
@@ -38,7 +37,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -3036,7 +3035,7 @@
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -3047,6 +3046,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -3366,6 +3366,7 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "ink-text-input": "^6.0.0",
     "isolated-vm": "^6.1.2",
     "react": "^19.2.0",
-    "react-devtools-core": "^6.1.2",
     "turndown": "^7.2.0",
     "vscode-languageserver-protocol": "^3.17.5"
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -445,6 +445,20 @@ function App({
     });
   }, [cfg, setEvents]);
 
+  // Periodically clear performance marks to prevent perf_hooks buffer overflow
+  // in long-running sessions (react-devtools-core causes marks on every render).
+  useEffect(() => {
+    const id = setInterval(() => {
+      try {
+        performance.clearMarks();
+        performance.clearMeasures();
+      } catch {
+        // ignore — not all Node versions expose these globally
+      }
+    }, 300_000); // every 5 minutes
+    return () => clearInterval(id);
+  }, []);
+
   const reloadCustomCommands = useCallback(async () => {
     const { commands, warnings } = await loadCustomCommands(process.cwd());
     customCommandsRef.current = commands;


### PR DESCRIPTION
## Problem

In very long-running TUI sessions, Node emits:

```
MaxPerformanceEntryBufferExceededWarning: Possible perf_hooks memory leak detected. 1000001 measure entries added to the global performance entry buffer.
```

The app continues to work, but the warning is noisy and indicates unbounded memory growth.

## Root Cause

`react-devtools-core` is an optional peer dependency of `ink`. Because it was listed in `package.json` dependencies, React detects it at runtime and enables DevTools integration, which calls `performance.mark()` on every component render. In a session with constant TUI updates (spinners, streaming text, status bar refreshes), those marks accumulate in Node's global performance entry buffer (default limit 1,000,000).

## Changes

1. **Remove `react-devtools-core` from dependencies** — kimiflare doesn't use React DevTools, so this stops the marks at the source.
2. **Add defensive periodic cleanup** — a `useEffect` in `App` clears `performance.mark()` and `performance.measure()` every 5 minutes, so any other source of marks can't grow unbounded.

## Guardrail Check

- **5.1 TUI/UX Stability** — fixes unbounded memory growth in long sessions (acceptance criteria: *100-turn session must not cause TUI lag or memory growth*).
- **9.4 Graceful Degradation** — reduces optional dependency surface; core TUI works without DevTools.
- **1.2 ESM & Import Conventions** — no new imports needed (`performance` is global in Node 20+).
- **1.3 Runtime Error Prevention** — cleanup wrapped in `try/catch` and returned cleanup function clears the interval.

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅

Co-authored-by: kimiflare <kimiflare@proton.me>