### PR TITLE
feat: @ file mention picker with inline filtering and navigation

### DIFF
--- a/KIMI.md
+++ b/KIMI.md
@@ -39,6 +39,12 @@
 - Classification is lazy (runs on first `cost` invocation), deterministic heuristic with optional LLM fallback.
 - Results cached in `usage.json`; no runtime cost when disabled.
 
+**@ File Mention Picker (opt-in)**
+- Enable with `filePicker: true` in config or `KIMIFLARE_FILE_PICKER=1`.
+- Type `@` in the chat input to open a file picker with inline filtering and keyboard navigation.
+- Searches the current working directory, respecting `.gitignore` and common ignore patterns.
+- No runtime cost when disabled.
+
 **Do / Don't**
 - Do keep agent responses terse; don't re-summarize tool output the user already sees inline.
 - Do call `tasks_set` at the start of multi-step work and update it as steps complete; skip for trivial one-offs.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build": "tsup",
     "dev": "tsx src/index.tsx",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test src/**/*.test.ts src/**/*.test.tsx",
     "start": "node bin/kimiflare.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, writeFileSync, rmdirSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildFilePickerIgnoreList,
+  filterPickerItems,
+  shouldOpenMentionPicker,
+} from "./app.js";
+import type { FilePickerItem } from "./ui/file-picker.js";
+
+describe("buildFilePickerIgnoreList", () => {
+  it("always includes hardcoded patterns", () => {
+    const list = buildFilePickerIgnoreList("/fake");
+    assert.ok(list.includes("**/node_modules/**"));
+    assert.ok(list.includes("**/.git/**"));
+    assert.ok(list.includes("**/dist/**"));
+  });
+
+  it("reads .gitignore and converts patterns", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kp-test-"));
+    writeFileSync(join(dir, ".gitignore"), "*.log\nbuild/\n/dist\n", "utf-8");
+    const list = buildFilePickerIgnoreList(dir);
+    assert.ok(list.includes("**/*.log"));
+    assert.ok(list.includes("**/build/**"));
+    assert.ok(list.includes("dist"));
+    unlinkSync(join(dir, ".gitignore"));
+    rmdirSync(dir);
+  });
+
+  it("skips oversized .gitignore files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kp-test-"));
+    // Write > 1 MB so the size guard triggers
+    writeFileSync(join(dir, ".gitignore"), "a\n".repeat(600_000), "utf-8");
+    const list = buildFilePickerIgnoreList(dir);
+    // Should return only hardcoded patterns, not crash
+    assert.ok(list.includes("**/node_modules/**"));
+    assert.ok(!list.includes("**/a"));
+    unlinkSync(join(dir, ".gitignore"));
+    rmdirSync(dir);
+  });
+
+  it("ignores comments and negation patterns", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kp-test-"));
+    writeFileSync(join(dir, ".gitignore"), "# comment\n!important\n", "utf-8");
+    const list = buildFilePickerIgnoreList(dir);
+    assert.ok(!list.includes("# comment"));
+    assert.ok(!list.includes("!important"));
+    unlinkSync(join(dir, ".gitignore"));
+    rmdirSync(dir);
+  });
+});
+
+describe("filterPickerItems", () => {
+  const items: FilePickerItem[] = [
+    { name: "src/app.tsx", isDirectory: false },
+    { name: "src", isDirectory: true },
+    { name: "README.md", isDirectory: false },
+  ];
+
+  it("filters by substring case-insensitively", () => {
+    const result = filterPickerItems(items, "app");
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]!.name, "src/app.tsx");
+  });
+
+  it("returns all items when query is empty", () => {
+    const result = filterPickerItems(items, "");
+    assert.strictEqual(result.length, 3);
+  });
+
+  it("caps results at 50", () => {
+    const many = Array.from({ length: 100 }, (_, i) => ({
+      name: `file${i}.ts`,
+      isDirectory: false,
+    }));
+    const result = filterPickerItems(many, "");
+    assert.strictEqual(result.length, 50);
+  });
+});
+
+describe("shouldOpenMentionPicker", () => {
+  it("opens when @ is typed at start", () => {
+    assert.strictEqual(shouldOpenMentionPicker("@", 1, null), true);
+  });
+
+  it("opens when @ follows whitespace", () => {
+    assert.strictEqual(shouldOpenMentionPicker("hello @", 7, null), true);
+  });
+
+  it("does not open when @ follows a non-whitespace character", () => {
+    assert.strictEqual(shouldOpenMentionPicker("hello@", 6, null), false);
+  });
+
+  it("does not open immediately after cancel at same offset", () => {
+    assert.strictEqual(shouldOpenMentionPicker("hello ", 6, 6), false);
+  });
+
+  it("does not open when cursor is at 0", () => {
+    assert.strictEqual(shouldOpenMentionPicker("", 0, null), false);
+  });
+});

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -34,7 +34,7 @@ import { ResumePicker } from "./ui/resume-picker.js";
 import { ThemePicker } from "./ui/theme-picker.js";
 import { TaskList } from "./ui/task-list.js";
 import type { Task } from "./tasks-state.js";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { ToolRender } from "./tools/registry.js";
 import { CustomTextInput } from "./ui/text-input.js";
@@ -92,7 +92,9 @@ import { readFileSync } from "node:fs";
  * All hardcoded patterns use the `** /` prefix so they match at any depth
  * (e.g. `** /node_modules/ *` catches both root and nested node_modules).
  */
-function buildFilePickerIgnoreList(cwd: string): string[] {
+const MAX_GITIGNORE_SIZE = 1 * 1024 * 1024; // 1 MB
+
+export function buildFilePickerIgnoreList(cwd: string): string[] {
   const hardcoded = [
     // Dependencies
     "**/node_modules/**",
@@ -168,6 +170,11 @@ function buildFilePickerIgnoreList(cwd: string): string[] {
   const gitignorePatterns: string[] = [];
   try {
     const gitignorePath = join(cwd, ".gitignore");
+    const stats = statSync(gitignorePath);
+    if (stats.size > MAX_GITIGNORE_SIZE) {
+      // Guardrail 1.4: skip oversized .gitignore files
+      return hardcoded;
+    }
     const content = readFileSync(gitignorePath, "utf-8");
     for (const line of content.split(/\r?\n/)) {
       const trimmed = line.trim();
@@ -203,6 +210,24 @@ function buildFilePickerIgnoreList(cwd: string): string[] {
   return [...hardcoded, ...gitignorePatterns];
 }
 
+export function filterPickerItems(items: FilePickerItem[], query: string): FilePickerItem[] {
+  const q = query.toLowerCase();
+  return items.filter((item) => item.name.toLowerCase().includes(q)).slice(0, 50);
+}
+
+export function shouldOpenMentionPicker(
+  input: string,
+  cursorOffset: number,
+  pickerCancelOffset: number | null,
+): boolean {
+  if (pickerCancelOffset === cursorOffset) return false;
+  if (cursorOffset > 0 && input[cursorOffset - 1] === "@") {
+    const beforeAt = cursorOffset - 2;
+    return beforeAt < 0 || /\s/.test(input[beforeAt]!);
+  }
+  return false;
+}
+
 interface Cfg {
   accountId: string;
   apiToken: string;
@@ -231,6 +256,7 @@ interface Cfg {
   lspEnabled?: boolean;
   lspServers?: Record<string, { command: string[]; env?: Record<string, string>; enabled?: boolean; rootPatterns?: string[] }>;
   costAttribution?: boolean;
+  filePicker?: boolean;
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
@@ -407,6 +433,7 @@ function App({
 
   const [mode, setMode] = useState<Mode>("edit");
   const [codeMode, setCodeMode] = useState<boolean>(initialCfg?.codeMode ?? false);
+  const filePickerEnabled = initialCfg?.filePicker ?? false;
   const [effort, setEffort] = useState<ReasoningEffort>(
     initialCfg?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
   );
@@ -479,10 +506,7 @@ function App({
 
   const filteredPickerItems = React.useMemo(() => {
     if (!mentionState) return [];
-    const q = mentionState.query.toLowerCase();
-    return pickerItems
-      .filter((item) => item.name.toLowerCase().includes(q))
-      .slice(0, 50);
+    return filterPickerItems(pickerItems, mentionState.query);
   }, [pickerItems, mentionState]);
 
   // Detect @ mention opening/closing
@@ -513,23 +537,22 @@ function App({
       return;
     }
 
-    // Look for @ just before cursor
-    if (cursorOffset > 0 && input[cursorOffset - 1] === "@") {
-      const beforeAt = cursorOffset - 2;
-      if (beforeAt < 0 || /\s/.test(input[beforeAt]!)) {
-        setPickerAnchor(cursorOffset - 1);
-        setPickerSelected(0);
-        // Load files lazily on first open
-        if (pickerItems.length === 0) {
-          const cwd = process.cwd();
-          void fg("**/*", {
-            cwd,
-            ignore: buildFilePickerIgnoreList(cwd),
-            dot: false,
-            absolute: false,
-            onlyFiles: false,
-            markDirectories: true,
-          } as fg.Options).then((entries) => {
+    // Look for @ just before cursor (only when feature flag is enabled)
+    if (filePickerEnabled && shouldOpenMentionPicker(input, cursorOffset, pickerCancelRef.current)) {
+      setPickerAnchor(cursorOffset - 1);
+      setPickerSelected(0);
+      // Load files lazily on first open
+      if (pickerItems.length === 0) {
+        const cwd = process.cwd();
+        void fg("**/*", {
+          cwd,
+          ignore: buildFilePickerIgnoreList(cwd),
+          dot: false,
+          absolute: false,
+          onlyFiles: false,
+          markDirectories: true,
+        } as fg.Options)
+          .then((entries) => {
             const strings = (entries as string[]).slice(0, 300);
             const items: FilePickerItem[] = strings.map((e) => ({
               name: e.endsWith("/") ? e.slice(0, -1) : e,
@@ -542,11 +565,13 @@ function App({
               return a.name.localeCompare(b.name);
             });
             setPickerItems(items);
+          })
+          .catch(() => {
+            setPickerItems([]);
           });
-        }
       }
     }
-  }, [input, cursorOffset, pickerAnchor, pickerItems.length]);
+  }, [input, cursorOffset, pickerAnchor, pickerItems.length, filePickerEnabled]);
 
   // Clamp selected index when filtered list changes
   useEffect(() => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -88,78 +88,83 @@ import { readFileSync } from "node:fs";
  * Build a comprehensive ignore list for the @ file mention picker.
  * Combines common noise patterns (dependencies, build output, caches, etc.)
  * with patterns read from the project's .gitignore file.
+ *
+ * All hardcoded patterns use the `** /` prefix so they match at any depth
+ * (e.g. `** /node_modules/ *` catches both root and nested node_modules).
  */
 function buildFilePickerIgnoreList(cwd: string): string[] {
-  // Hardcoded common patterns that are almost never useful to mention
   const hardcoded = [
     // Dependencies
-    "node_modules/**",
-    "vendor/**",
-    ".bundle/**",
-    "bower_components/**",
+    "**/node_modules/**",
+    "**/vendor/**",
+    "**/.bundle/**",
+    "**/bower_components/**",
     // Version control
-    ".git/**",
-    ".svn/**",
-    ".hg/**",
+    "**/.git/**",
+    "**/.svn/**",
+    "**/.hg/**",
     // Build / output directories
-    "dist/**",
-    "build/**",
-    "out/**",
-    "public/**",
-    ".next/**",
-    ".nuxt/**",
-    ".svelte-kit/**",
-    ".vercel/**",
-    ".netlify/**",
-    "target/**",
-    "bin/**",
-    "obj/**",
-    "Debug/**",
-    "Release/**",
-    ".gradle/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/out/**",
+    "**/public/**",
+    "**/.next/**",
+    "**/.nuxt/**",
+    "**/.svelte-kit/**",
+    "**/.vercel/**",
+    "**/.netlify/**",
+    "**/target/**",
+    "**/bin/**",
+    "**/obj/**",
+    "**/Debug/**",
+    "**/Release/**",
+    "**/.gradle/**",
     // Caches
-    ".cache/**",
-    ".parcel-cache/**",
-    ".turbo/**",
-    ".eslintcache",
-    ".stylelintcache",
-    ".rpt2_cache/**",
-    ".rts2_cache/**",
+    "**/.cache/**",
+    "**/.parcel-cache/**",
+    "**/.turbo/**",
+    "**/.eslintcache",
+    "**/.stylelintcache",
+    "**/.rpt2_cache/**",
+    "**/.rts2_cache/**",
     // Temporary
-    "tmp/**",
-    "temp/**",
-    "*.tmp",
+    "**/tmp/**",
+    "**/temp/**",
+    "**/*.tmp",
     // Coverage
-    "coverage/**",
-    ".nyc_output/**",
+    "**/coverage/**",
+    "**/.nyc_output/**",
     // OS files
-    ".DS_Store",
-    "Thumbs.db",
+    "**/.DS_Store",
+    "**/Thumbs.db",
     // Logs
-    "*.log",
-    "logs/**",
+    "**/*.log",
+    "**/logs/**",
     // Lock files (auto-generated, usually huge)
-    "package-lock.json",
-    "yarn.lock",
-    "pnpm-lock.yaml",
-    "bun.lockb",
-    "Cargo.lock",
-    "Gemfile.lock",
-    "composer.lock",
-    "Pipfile.lock",
-    "poetry.lock",
-    "go.sum",
+    "**/package-lock.json",
+    "**/yarn.lock",
+    "**/pnpm-lock.yaml",
+    "**/bun.lockb",
+    "**/Cargo.lock",
+    "**/Gemfile.lock",
+    "**/composer.lock",
+    "**/Pipfile.lock",
+    "**/poetry.lock",
+    "**/go.sum",
     // Minified / source maps
-    "*.min.js",
-    "*.min.css",
-    "*.map",
+    "**/*.min.js",
+    "**/*.min.css",
+    "**/*.map",
     // kimiflare internal
-    ".kimiflare/**",
+    "**/.kimiflare/**",
     // IDE (usually not relevant to mention)
-    ".idea/**",
+    "**/.idea/**",
   ];
 
-  // Try to read .gitignore for project-specific ignores
+  // Try to read .gitignore for project-specific ignores.
+  // Gitignore patterns are relative to the repo root and may match at any
+  // depth. We approximate that by prefixing with `** /`. Patterns that
+  // already start with `*` or `/` are handled carefully.
   const gitignorePatterns: string[] = [];
   try {
     const gitignorePath = join(cwd, ".gitignore");
@@ -167,13 +172,28 @@ function buildFilePickerIgnoreList(cwd: string): string[] {
     for (const line of content.split(/\r?\n/)) {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith("#")) continue;
-      // Convert directory patterns to glob recursive patterns
-      if (trimmed.endsWith("/")) {
-        gitignorePatterns.push(trimmed + "**");
+
+      // Skip negation patterns — fast-glob ignore doesn't support them
+      if (trimmed.startsWith("!")) continue;
+
+      let pattern = trimmed;
+      const isAnchored = pattern.startsWith("/");
+      const isDir = pattern.endsWith("/");
+
+      // Remove leading slash for processing
+      if (isAnchored) pattern = pattern.slice(1);
+      // Remove trailing slash for processing
+      if (isDir) pattern = pattern.slice(0, -1);
+
+      // Skip patterns that are already wildcards or empty
+      if (!pattern) continue;
+
+      if (isAnchored) {
+        // Anchored patterns only match at root, so keep them relative to cwd
+        gitignorePatterns.push(isDir ? pattern + "/**" : pattern);
       } else {
-        gitignorePatterns.push(trimmed);
-        // Also add a directory variant in case it's a dir
-        gitignorePatterns.push(trimmed + "/**");
+        // Unanchored patterns match at any depth — prepend `**/`
+        gitignorePatterns.push(isDir ? "**/" + pattern + "/**" : "**/" + pattern);
       }
     }
   } catch {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -82,6 +82,106 @@ import { saveProjectLspConfig, type ResolvedLspConfig } from "./util/lsp-config.
 import { maybeLspNudge } from "./util/lsp-nudge.js";
 import fg from "fast-glob";
 import { FilePicker, type FilePickerItem } from "./ui/file-picker.js";
+import { readFileSync } from "node:fs";
+
+/**
+ * Build a comprehensive ignore list for the @ file mention picker.
+ * Combines common noise patterns (dependencies, build output, caches, etc.)
+ * with patterns read from the project's .gitignore file.
+ */
+function buildFilePickerIgnoreList(cwd: string): string[] {
+  // Hardcoded common patterns that are almost never useful to mention
+  const hardcoded = [
+    // Dependencies
+    "node_modules/**",
+    "vendor/**",
+    ".bundle/**",
+    "bower_components/**",
+    // Version control
+    ".git/**",
+    ".svn/**",
+    ".hg/**",
+    // Build / output directories
+    "dist/**",
+    "build/**",
+    "out/**",
+    "public/**",
+    ".next/**",
+    ".nuxt/**",
+    ".svelte-kit/**",
+    ".vercel/**",
+    ".netlify/**",
+    "target/**",
+    "bin/**",
+    "obj/**",
+    "Debug/**",
+    "Release/**",
+    ".gradle/**",
+    // Caches
+    ".cache/**",
+    ".parcel-cache/**",
+    ".turbo/**",
+    ".eslintcache",
+    ".stylelintcache",
+    ".rpt2_cache/**",
+    ".rts2_cache/**",
+    // Temporary
+    "tmp/**",
+    "temp/**",
+    "*.tmp",
+    // Coverage
+    "coverage/**",
+    ".nyc_output/**",
+    // OS files
+    ".DS_Store",
+    "Thumbs.db",
+    // Logs
+    "*.log",
+    "logs/**",
+    // Lock files (auto-generated, usually huge)
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "Pipfile.lock",
+    "poetry.lock",
+    "go.sum",
+    // Minified / source maps
+    "*.min.js",
+    "*.min.css",
+    "*.map",
+    // kimiflare internal
+    ".kimiflare/**",
+    // IDE (usually not relevant to mention)
+    ".idea/**",
+  ];
+
+  // Try to read .gitignore for project-specific ignores
+  const gitignorePatterns: string[] = [];
+  try {
+    const gitignorePath = join(cwd, ".gitignore");
+    const content = readFileSync(gitignorePath, "utf-8");
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      // Convert directory patterns to glob recursive patterns
+      if (trimmed.endsWith("/")) {
+        gitignorePatterns.push(trimmed + "**");
+      } else {
+        gitignorePatterns.push(trimmed);
+        // Also add a directory variant in case it's a dir
+        gitignorePatterns.push(trimmed + "/**");
+      }
+    }
+  } catch {
+    // No .gitignore found — that's fine
+  }
+
+  return [...hardcoded, ...gitignorePatterns];
+}
 
 interface Cfg {
   accountId: string;
@@ -404,16 +504,7 @@ function App({
           const cwd = process.cwd();
           void fg("**/*", {
             cwd,
-            ignore: [
-              "node_modules/**",
-              ".git/**",
-              "dist/**",
-              ".kimiflare/**",
-              "coverage/**",
-              ".next/**",
-              "build/**",
-              "out/**",
-            ],
+            ignore: buildFilePickerIgnoreList(cwd),
             dot: false,
             absolute: false,
             onlyFiles: false,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -80,6 +80,8 @@ import { CommandList } from "./ui/command-list.js";
 import { LspWizard } from "./ui/lsp-wizard.js";
 import { saveProjectLspConfig, type ResolvedLspConfig } from "./util/lsp-config.js";
 import { maybeLspNudge } from "./util/lsp-nudge.js";
+import fg from "fast-glob";
+import { FilePicker, type FilePickerItem } from "./ui/file-picker.js";
 
 interface Cfg {
   accountId: string;
@@ -306,6 +308,12 @@ function App({
   const [hasUpdate, setHasUpdate] = useState(initialUpdateResult?.hasUpdate ?? false);
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
 
+  // File mention picker state
+  const [cursorOffset, setCursorOffset] = useState(0);
+  const [pickerItems, setPickerItems] = useState<FilePickerItem[]>([]);
+  const [pickerSelected, setPickerSelected] = useState(0);
+  const [pickerAnchor, setPickerAnchor] = useState<number | null>(null);
+
   const cacheStableRef = useRef(initialCfg?.cacheStablePrompts !== false);
   const messagesRef = useRef<ChatMessage[]>(
     makePrefixMessages(cacheStableRef.current, cfg?.model ?? DEFAULT_MODEL, "edit", ALL_TOOLS),
@@ -340,6 +348,125 @@ function App({
   const pendingTextRef = useRef<Map<number, { text: string; reasoning: string }>>(new Map());
   const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const customCommandsRef = useRef<CustomCommand[]>([]);
+  const pickerCancelRef = useRef<number | null>(null);
+
+  // ── File mention picker logic ────────────────────────────────────────────
+  const mentionState = React.useMemo(() => {
+    if (pickerAnchor === null) return null;
+    const query = input.slice(pickerAnchor + 1, cursorOffset);
+    return { query, anchor: pickerAnchor };
+  }, [input, cursorOffset, pickerAnchor]);
+
+  const filteredPickerItems = React.useMemo(() => {
+    if (!mentionState) return [];
+    const q = mentionState.query.toLowerCase();
+    return pickerItems
+      .filter((item) => item.name.toLowerCase().includes(q))
+      .slice(0, 50);
+  }, [pickerItems, mentionState]);
+
+  // Detect @ mention opening/closing
+  useEffect(() => {
+    if (pickerAnchor !== null) {
+      // If cursor moved before anchor, close picker
+      if (cursorOffset < pickerAnchor) {
+        setPickerAnchor(null);
+        return;
+      }
+      // If the @ was deleted, close picker
+      if (input[pickerAnchor] !== "@") {
+        setPickerAnchor(null);
+        return;
+      }
+      // If user typed a space inside the mention query, close picker
+      const query = input.slice(pickerAnchor + 1, cursorOffset);
+      if (query.includes(" ")) {
+        setPickerAnchor(null);
+        return;
+      }
+      return;
+    }
+
+    // Prevent immediate reopen after cancel at the same cursor position
+    if (pickerCancelRef.current === cursorOffset) {
+      pickerCancelRef.current = null;
+      return;
+    }
+
+    // Look for @ just before cursor
+    if (cursorOffset > 0 && input[cursorOffset - 1] === "@") {
+      const beforeAt = cursorOffset - 2;
+      if (beforeAt < 0 || /\s/.test(input[beforeAt]!)) {
+        setPickerAnchor(cursorOffset - 1);
+        setPickerSelected(0);
+        // Load files lazily on first open
+        if (pickerItems.length === 0) {
+          const cwd = process.cwd();
+          void fg("**/*", {
+            cwd,
+            ignore: [
+              "node_modules/**",
+              ".git/**",
+              "dist/**",
+              ".kimiflare/**",
+              "coverage/**",
+              ".next/**",
+              "build/**",
+              "out/**",
+            ],
+            dot: false,
+            absolute: false,
+            onlyFiles: false,
+            markDirectories: true,
+          } as fg.Options).then((entries) => {
+            const strings = (entries as string[]).slice(0, 300);
+            const items: FilePickerItem[] = strings.map((e) => ({
+              name: e.endsWith("/") ? e.slice(0, -1) : e,
+              isDirectory: e.endsWith("/"),
+            }));
+            // Sort directories first, then alphabetically
+            items.sort((a, b) => {
+              if (a.isDirectory && !b.isDirectory) return -1;
+              if (!a.isDirectory && b.isDirectory) return 1;
+              return a.name.localeCompare(b.name);
+            });
+            setPickerItems(items);
+          });
+        }
+      }
+    }
+  }, [input, cursorOffset, pickerAnchor, pickerItems.length]);
+
+  // Clamp selected index when filtered list changes
+  useEffect(() => {
+    if (pickerAnchor !== null) {
+      setPickerSelected((prev) => Math.min(prev, Math.max(0, filteredPickerItems.length - 1)));
+    }
+  }, [filteredPickerItems.length, pickerAnchor]);
+
+  const handlePickerUp = useCallback(() => {
+    setPickerSelected((i) => Math.max(0, i - 1));
+  }, []);
+
+  const handlePickerDown = useCallback(() => {
+    setPickerSelected((i) => Math.min(filteredPickerItems.length - 1, i + 1));
+  }, [filteredPickerItems.length]);
+
+  const handlePickerSelect = useCallback(() => {
+    if (!mentionState || filteredPickerItems.length === 0) return;
+    const item = filteredPickerItems[pickerSelected];
+    if (!item) return;
+    const insert = item.name + (item.isDirectory ? "/" : " ");
+    const newInput = input.slice(0, mentionState.anchor) + insert + input.slice(cursorOffset);
+    setInput(newInput);
+    setCursorOffset(mentionState.anchor + insert.length);
+    setPickerAnchor(null);
+  }, [mentionState, filteredPickerItems, pickerSelected, input, cursorOffset]);
+
+  const handlePickerCancel = useCallback(() => {
+    pickerCancelRef.current = cursorOffset;
+    setPickerAnchor(null);
+  }, [cursorOffset]);
 
   useEffect(() => {
     if (!cfg) return;
@@ -2533,6 +2660,14 @@ function App({
             gatewayMeta={gatewayMeta}
             codeMode={codeMode}
           />
+          {pickerAnchor !== null && (
+            <FilePicker
+              items={filteredPickerItems}
+              selectedIndex={pickerSelected}
+              theme={theme}
+              query={mentionState?.query ?? ""}
+            />
+          )}
           <Box marginTop={1}>
             <Text color={theme.accent}>› </Text>
             <CustomTextInput
@@ -2540,6 +2675,13 @@ function App({
               onChange={setInput}
               onSubmit={submit}
               enablePaste
+              cursorOffset={cursorOffset}
+              onCursorChange={setCursorOffset}
+              pickerActive={pickerAnchor !== null}
+              onPickerUp={handlePickerUp}
+              onPickerDown={handlePickerDown}
+              onPickerSelect={handlePickerSelect}
+              onPickerCancel={handlePickerCancel}
               onHistoryUp={() => {
                 if (history.length === 0) return;
                 if (historyIndex === -1) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,8 @@ export interface KimiConfig {
   lspServers?: Record<string, LspServerConfig>;
   /** Enable cost attribution by task type. Default: false. Once stable for 2 releases, consider defaulting to true. */
   costAttribution?: boolean;
+  /** Enable @ file mention picker in chat input. Default: false. */
+  filePicker?: boolean;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
@@ -156,6 +158,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envPlumbingModel = process.env.KIMIFLARE_PLUMBING_MODEL;
   const envCodeMode = readBooleanEnv("KIMIFLARE_CODE_MODE");
   const envCostAttribution = readBooleanEnv("KIMI_COST_ATTRIBUTION");
+  const envFilePicker = readBooleanEnv("KIMIFLARE_FILE_PICKER");
 
   if (envAccount && envToken) {
     return {
@@ -183,6 +186,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       plumbingModel: envPlumbingModel,
       codeMode: envCodeMode,
       costAttribution: envCostAttribution ?? false,
+      filePicker: envFilePicker ?? false,
     };
   }
 
@@ -217,6 +221,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         plumbingModel: envPlumbingModel ?? parsed.plumbingModel,
         codeMode: envCodeMode ?? parsed.codeMode,
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? false,
+        filePicker: envFilePicker ?? parsed.filePicker ?? false,
       };
     }
   } catch {

--- a/src/ui/file-picker.test.tsx
+++ b/src/ui/file-picker.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import React from "react";
+import { renderToString } from "ink";
+import { FilePicker, type FilePickerItem } from "./file-picker.js";
+import { resolveTheme } from "./theme.js";
+
+const theme = resolveTheme(undefined);
+
+function renderPicker(items: FilePickerItem[], selectedIndex: number, query = ""): string {
+  return renderToString(
+    <FilePicker items={items} selectedIndex={selectedIndex} theme={theme} query={query} />,
+  );
+}
+
+describe("FilePicker", () => {
+  it("renders empty state", () => {
+    const out = renderPicker([], 0);
+    assert.ok(out.includes("No matches"));
+  });
+
+  it("renders items with selection indicator", () => {
+    const items: FilePickerItem[] = [
+      { name: "src", isDirectory: true },
+      { name: "README.md", isDirectory: false },
+    ];
+    const out = renderPicker(items, 0);
+    assert.ok(out.includes("› src/"));
+    assert.ok(out.includes("  README.md"));
+  });
+
+  it("renders query header when filtering", () => {
+    const items: FilePickerItem[] = [{ name: "app.tsx", isDirectory: false }];
+    const out = renderPicker(items, 0, "app");
+    assert.ok(out.includes('Files matching "app"'));
+  });
+
+  it("shows 'and N more' when items exceed visible limit", () => {
+    const items: FilePickerItem[] = Array.from({ length: 15 }, (_, i) => ({
+      name: `file${i}.ts`,
+      isDirectory: false,
+    }));
+    const out = renderPicker(items, 14);
+    assert.ok(out.includes("more above"));
+  });
+
+  it("uses stable keys by item name", () => {
+    // This is a design test: keys must be based on name alone so filtering
+    // does not shift identities.
+    const items: FilePickerItem[] = [
+      { name: "a.ts", isDirectory: false },
+      { name: "b.ts", isDirectory: false },
+    ];
+    const out = renderPicker(items, 1);
+    assert.ok(out.includes("› b.ts"));
+  });
+});

--- a/src/ui/file-picker.tsx
+++ b/src/ui/file-picker.tsx
@@ -51,7 +51,7 @@ export function FilePicker({ items, selectedIndex, theme, query }: Props) {
           const isSelected = actualIndex === selectedIndex;
           const label = item.isDirectory ? `${item.name}/` : item.name;
           return (
-            <Text key={item.name + actualIndex} color={isSelected ? theme.accent : undefined} bold={isSelected}>
+            <Text key={item.name} color={isSelected ? theme.accent : undefined} bold={isSelected}>
               {isSelected ? "› " : "  "}
               {label}
             </Text>

--- a/src/ui/file-picker.tsx
+++ b/src/ui/file-picker.tsx
@@ -17,8 +17,15 @@ interface Props {
 const VISIBLE_LIMIT = 12;
 
 export function FilePicker({ items, selectedIndex, theme, query }: Props) {
-  const visible = items.slice(0, VISIBLE_LIMIT);
-  const hasMore = items.length > VISIBLE_LIMIT;
+  // Scroll the visible window so the selected item is always in view.
+  // Keep the selected item at the bottom edge when scrolling down.
+  let startIndex = 0;
+  if (selectedIndex >= VISIBLE_LIMIT) {
+    startIndex = selectedIndex - VISIBLE_LIMIT + 1;
+  }
+  const visible = items.slice(startIndex, startIndex + VISIBLE_LIMIT);
+  const hasMoreAbove = startIndex > 0;
+  const hasMoreBelow = items.length > startIndex + VISIBLE_LIMIT;
 
   return (
     <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
@@ -34,19 +41,25 @@ export function FilePicker({ items, selectedIndex, theme, query }: Props) {
             No matches
           </Text>
         )}
+        {hasMoreAbove && (
+          <Text color={theme.info.color} dimColor>
+            … {startIndex} more above
+          </Text>
+        )}
         {visible.map((item, i) => {
-          const isSelected = i === selectedIndex;
+          const actualIndex = startIndex + i;
+          const isSelected = actualIndex === selectedIndex;
           const label = item.isDirectory ? `${item.name}/` : item.name;
           return (
-            <Text key={item.name + i} color={isSelected ? theme.accent : undefined} bold={isSelected}>
+            <Text key={item.name + actualIndex} color={isSelected ? theme.accent : undefined} bold={isSelected}>
               {isSelected ? "› " : "  "}
               {label}
             </Text>
           );
         })}
-        {hasMore && (
+        {hasMoreBelow && (
           <Text color={theme.info.color} dimColor>
-            … and {items.length - VISIBLE_LIMIT} more
+            … {items.length - (startIndex + VISIBLE_LIMIT)} more below
           </Text>
         )}
       </Box>

--- a/src/ui/file-picker.tsx
+++ b/src/ui/file-picker.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { Theme } from "./theme.js";
+
+export interface FilePickerItem {
+  name: string;
+  isDirectory: boolean;
+}
+
+interface Props {
+  items: FilePickerItem[];
+  selectedIndex: number;
+  theme: Theme;
+  query: string;
+}
+
+const VISIBLE_LIMIT = 12;
+
+export function FilePicker({ items, selectedIndex, theme, query }: Props) {
+  const visible = items.slice(0, VISIBLE_LIMIT);
+  const hasMore = items.length > VISIBLE_LIMIT;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        {query ? `Files matching "${query}"` : "Mention a file"}
+      </Text>
+      <Text color={theme.info.color} dimColor={false}>
+        Arrow keys to navigate, Enter to select, Esc to cancel.
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {visible.length === 0 && (
+          <Text color={theme.info.color} dimColor>
+            No matches
+          </Text>
+        )}
+        {visible.map((item, i) => {
+          const isSelected = i === selectedIndex;
+          const label = item.isDirectory ? `${item.name}/` : item.name;
+          return (
+            <Text key={item.name + i} color={isSelected ? theme.accent : undefined} bold={isSelected}>
+              {isSelected ? "› " : "  "}
+              {label}
+            </Text>
+          );
+        })}
+        {hasMore && (
+          <Text color={theme.info.color} dimColor>
+            … and {items.length - VISIBLE_LIMIT} more
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -159,6 +159,7 @@ const CATEGORIES: Category[] = [
     commands: [
       { command: "/init", description: "scan this repo and write a KIMI.md" },
       { command: "/logout", description: "clear credentials" },
+      { command: "filePicker", description: "enable with KIMIFLARE_FILE_PICKER=1 or filePicker: true in config", selectable: false },
     ],
   },
 ];

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -78,9 +78,11 @@ export function CustomTextInput({
 
   useEffect(() => {
     if (!focus) return;
-    if (controlledCursor !== undefined) return;
-    setInternalCursor((prev) => (prev > value.length ? value.length : prev));
-  }, [value, focus, controlledCursor]);
+    const next = cursorOffset > value.length ? value.length : cursorOffset;
+    if (next !== cursorOffset) {
+      setCursorOffset(next);
+    }
+  }, [value, focus, cursorOffset]);
 
   useInput(
     (input, key) => {

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -93,23 +93,6 @@ export function CustomTextInput({
       if (key.ctrl && input === "o") return;
       if (key.tab) return;
 
-      if (key.return) {
-        let full = value;
-        let hasPastes = false;
-        if (enablePaste && pastesRef.current.size > 0) {
-          for (const [placeholder, fullText] of pastesRef.current) {
-            if (full.includes(placeholder)) {
-              full = full.split(placeholder).join(fullText);
-              hasPastes = true;
-            }
-          }
-        }
-        onSubmit(full, hasPastes ? value : undefined);
-        pastesRef.current.clear();
-        setCursorOffset(0);
-        return;
-      }
-
       if (pickerActive) {
         if (key.upArrow) {
           onPickerUp?.();
@@ -127,6 +110,23 @@ export function CustomTextInput({
           onPickerCancel?.();
           return;
         }
+      }
+
+      if (key.return) {
+        let full = value;
+        let hasPastes = false;
+        if (enablePaste && pastesRef.current.size > 0) {
+          for (const [placeholder, fullText] of pastesRef.current) {
+            if (full.includes(placeholder)) {
+              full = full.split(placeholder).join(fullText);
+              hasPastes = true;
+            }
+          }
+        }
+        onSubmit(full, hasPastes ? value : undefined);
+        pastesRef.current.clear();
+        setCursorOffset(0);
+        return;
       }
 
       if (key.upArrow) {

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -12,6 +12,13 @@ interface Props {
   focus?: boolean;
   mask?: string;
   enablePaste?: boolean;
+  cursorOffset?: number;
+  onCursorChange?: (offset: number) => void;
+  pickerActive?: boolean;
+  onPickerUp?: () => void;
+  onPickerDown?: () => void;
+  onPickerSelect?: () => void;
+  onPickerCancel?: () => void;
 }
 
 const PASTE_CHAR_THRESHOLD = 200;
@@ -53,14 +60,27 @@ export function CustomTextInput({
   focus = true,
   mask,
   enablePaste = false,
+  cursorOffset: controlledCursor,
+  onCursorChange,
+  pickerActive = false,
+  onPickerUp,
+  onPickerDown,
+  onPickerSelect,
+  onPickerCancel,
 }: Props) {
-  const [cursorOffset, setCursorOffset] = useState(value.length);
+  const [internalCursor, setInternalCursor] = useState(value.length);
+  const cursorOffset = controlledCursor ?? internalCursor;
+  const setCursorOffset = (offset: number) => {
+    setInternalCursor(offset);
+    onCursorChange?.(offset);
+  };
   const pastesRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     if (!focus) return;
-    setCursorOffset((prev) => (prev > value.length ? value.length : prev));
-  }, [value, focus]);
+    if (controlledCursor !== undefined) return;
+    setInternalCursor((prev) => (prev > value.length ? value.length : prev));
+  }, [value, focus, controlledCursor]);
 
   useInput(
     (input, key) => {
@@ -86,6 +106,25 @@ export function CustomTextInput({
         pastesRef.current.clear();
         setCursorOffset(0);
         return;
+      }
+
+      if (pickerActive) {
+        if (key.upArrow) {
+          onPickerUp?.();
+          return;
+        }
+        if (key.downArrow) {
+          onPickerDown?.();
+          return;
+        }
+        if (key.return) {
+          onPickerSelect?.();
+          return;
+        }
+        if (key.escape) {
+          onPickerCancel?.();
+          return;
+        }
       }
 
       if (key.upArrow) {


### PR DESCRIPTION
## Summary
Adds an inline file picker triggered by typing `@` in the chat input. Users can navigate with arrow keys, filter by typing, and select a file or folder to insert its path.

## Features
- Type `@` (after whitespace or at start of input) to open the picker
- Arrow keys (↑/↓) to navigate results
- Type to filter file/folder names by substring match
- Enter to insert the selected path (directories get trailing `/`, files get trailing space)
- Escape to cancel without inserting
- Loads up to 300 project files recursively, ignoring common build dirs (`node_modules`, `.git`, `dist`, etc.)
- Displays up to 12 visible items with `… and N more` indicator

## Files Changed
- `src/ui/text-input.tsx` — controlled cursor + picker key routing
- `src/ui/file-picker.tsx` — new dropdown UI component
- `src/app.tsx` — mention detection, file loading, filtering, insertion logic

## Testing
- `npm run typecheck` ✅
- `npm run build` ✅

Co-authored-by: kimiflare <kimiflare@proton.me>