### PR TITLE
feat(research-agent): deliverable-driven persona with hand_off, budget checks, and graceful pause

### DIFF
--- a/docs/guardrails/README.md
+++ b/docs/guardrails/README.md
@@ -106,10 +106,14 @@
 - **Rule:** The agent loop must detect repeated identical tool calls (same name + stable-stringified args) within a sliding window of 8 calls.
 - **Rule:** On the 3rd identical call, inject a synthetic error: `"Loop detected: you have called {tool} with the same arguments multiple times in a row. Consider a different approach."`
 - **Rule:** The loop detector must not block legitimate retries with different args.
+- **Rule:** Pattern-based detection for `web_fetch`: 5+ fetches within any 8-call window, or 3+ fetches from the same domain, triggers a warning (not a hard stop).
 - **Acceptance Criteria:** Merge-conflict resolution scenarios must not exceed 10 tool iterations.
 
 ### 3.2 Iteration Limits
 - **Rule:** Hard cap of 50 tool iterations per turn.
+- **Rule:** Budget self-assessment: after every 3 tool calls, inject a system message prompting the agent to assess whether the next call is worth more than what it already has.
+- **Rule:** Soft budget warning at 5 calls (routine questions), hard budget warning at 15 calls (substantial questions). These are warnings, not hard stops — the agent can override by justifying the next call.
+- **Rule:** On hitting the 50-call limit, inject a graceful pause system message ("Paused after 50 tool calls. Say 'go on' to continue.") so the agent retains context.
 - **Rule:** Bash timeout default 120s, max 600s.
 - **Rule:** Code Mode sandbox timeout 30s, memory limit 128MB.
 - **Acceptance Criteria:** No user-visible hang beyond configured timeouts.
@@ -126,6 +130,14 @@
 - **Rule:** JSON parse errors in tool arguments must return a clear error message, not crash.
 - **Rule:** API 400 errors with "invalid escaped character" must pop the offending message and suggest `/clear`.
 - **Acceptance Criteria:** Error messages must be actionable for the model.
+
+### 3.5 Deliverable-Driven Agents (Multi-Agent)
+- **Rule:** The Research Agent must produce a structured Research Brief (DECISION, FINDINGS, RECOMMENDATION, CONFIDENCE, OPEN QUESTIONS, RISKS) before considering its work complete.
+- **Rule:** The Research Agent stops when the named decision can be made from its findings, not when it has exhausted all sources.
+- **Rule:** The `hand_off` tool allows an agent to signal completion and request a hand-off to another agent. The orchestrator must detect `hand_off` calls and trigger automatic hand-off.
+- **Rule:** Hand-off summaries must preserve the agent's deliverable (Brief, Implementation Notes, etc.) rather than replacing it with a lossy synthesis.
+- **Rule:** Agents must not address the human user with imperatives ("you need to", "you should", "start by"). Their audience is the next agent in the pipeline.
+- **Acceptance Criteria:** Research Agent must produce a Brief within 15 tool calls for routine questions; must call `hand_off` when complete.
 
 ---
 

--- a/docs/guardrails/file-checklist.md
+++ b/docs/guardrails/file-checklist.md
@@ -11,6 +11,9 @@
 - [ ] Anti-loop guardrail still tracks signatures with `stableStringify()`
 - [ ] `LOOP_WINDOW` (8) and `LOOP_THRESHOLD` (2) constants unchanged unless justified
 - [ ] `maxToolIterations` (50) cap preserved
+- [ ] Budget self-assessment messages injected every 3 tool calls
+- [ ] Soft budget warning (5 calls) and hard budget warning (15 calls) present
+- [ ] Graceful pause message injected before tool-limit throw
 - [ ] New tool call sites include `recentToolCalls.push()` and window trimming
 - [ ] Code Mode API cache uses `stableStringify(opts.tools)` as key
 - [ ] `validateToolArguments()` handles empty/malformed JSON
@@ -80,6 +83,24 @@
 - [ ] Permission check happens before tool execution
 - [ ] `sessionAllowed` cleared on mode change to `plan`
 - [ ] Unknown tool returns helpful error with valid tool list
+
+---
+
+## `src/tools/hand-off.ts`
+
+- [ ] `hand_off` tool has `needsPermission: false`
+- [ ] `target` parameter is required and validated
+- [ ] Tool returns clear confirmation message with target and optional reason
+
+---
+
+## `src/agent/orchestrator.ts`
+
+- [ ] `detectHandOff()` scans only the most recent assistant message with tool_calls
+- [ ] Hand-off triggered only when target differs from current role
+- [ ] `synthesizeHandoff()` preserves deliverables (Brief, Notes) rather than replacing them
+- [ ] `maxTurnsPerAgent` (20) still triggers forced hand-off as fallback
+- [ ] Per-agent turn counts reset on hand-off
 
 ---
 

--- a/docs/learnings/2026-05-01-research-agent-spiral-and-persona-design.md
+++ b/docs/learnings/2026-05-01-research-agent-spiral-and-persona-design.md
@@ -1,0 +1,301 @@
+# Research Agent Spiral: Post-Mortem and Personality Design
+
+> Status: Investigation complete. No code changes yet — this document captures findings and proposed design before implementation.
+>
+> Related: PR #225 (partial fix — persona prefix + web-fetch guardrails), `docs/multi-agent-plan.md`
+
+---
+
+## 1. The Incident
+
+### What happened
+
+User enabled multi-agent mode and asked: *"I don't like the color themes that we offer to users."*
+
+The Research Agent responded with a 50-tool-iteration spiral of `web_fetch` calls to GitHub search URLs:
+- `github.com/search?q=terminal+theme`
+- `github.com/search?q=dracula+theme`
+- `github.com/search?q=catppuccin`
+- `github.com/search?q=night-owl`
+- … (repeated with slight URL variations)
+
+After exhausting 50 tool calls, the agent hit the iteration limit. The user typed `"go on"`. The agent responded: *"What should I continue with? I don't see an in-progress task from this session."*
+
+The user typed `"go on"` again. The agent repeated the exact same 50-fetch spiral. This happened **three times** — 150+ tool calls, zero synthesis, zero hand-off to the Coding Agent.
+
+### Two distinct bugs
+
+1. **Research spiral**: The agent never concluded its research. It treated each new URL as "progress" without ever synthesizing findings or producing a deliverable.
+2. **"Go on" amnesia**: After hitting the tool limit, the agent lost all context of what it was working on. The user's `"go on"` was interpreted as a brand-new, empty request.
+
+---
+
+## 2. Root Cause Analysis
+
+### 2.1 Why Plan Mode didn't spiral, but Research Agent does
+
+**Plan Mode system prompt** (`src/mode.ts:240`):
+
+> "PLAN MODE is active. The user wants you to investigate and produce a plan WITHOUT making any changes… **At the end, present a concise plan** (bullets, files to change, approach). The user will review and then exit plan mode to execute."
+
+Plan Mode gives the single agent three critical things:
+
+| Element | Plan Mode | Research Agent (before fix) |
+|---------|-----------|----------------------------|
+| **Deliverable** | "a concise plan" | None |
+| **Format** | bullets, files to change, approach | None |
+| **Termination condition** | "present… the user will review" | None |
+| **Scope boundary** | "WITHOUT making any changes" | None |
+
+The single agent knows: *when I have a plan, I'm done.*
+
+The Research Agent knows: *I have tools. I should explore.* It has no concept of "done," no deliverable format, and no stopping heuristic. It defaults to its training distribution — a grad student doing a literature review. Grad students never stop; there's always one more paper to read.
+
+### 2.2 Why the guardrails didn't catch the spiral
+
+Guardrail 3.1 (`docs/guardrails/README.md:106`):
+
+> "On the 3rd identical call, inject a synthetic error"
+
+The Research Agent called `web_fetch` with **different URLs each time**:
+
+```
+github.com/search?q=terminal+theme
+github.com/search?q=dracula+theme
+github.com/search?q=catppuccin
+github.com/search?q=night-owl
+```
+
+Same tool, different arguments = different signatures = guardrail doesn't fire.
+
+The agent found the loophole: *"if I vary the URL slightly, I can research forever."*
+
+Even if we patch this loophole, the agent still has no concept of "enough." It would pivot to `grep`, `read`, or `lsp_definition` and keep going. The problem isn't the tool — it's the **absence of a stopping heuristic**.
+
+### 2.3 Why "go on" caused amnesia
+
+In `src/agent/loop.ts:434`:
+
+```ts
+throw new Error(`kimiflare: tool iteration limit reached (${opts.maxToolIterations ?? 50})`);
+```
+
+This is caught in `src/app.tsx:2693` and displayed as a chat event. But critically: **the error is NOT added to the agent's message history.**
+
+The loop structure:
+
+```ts
+for (let iter = 0; iter < max; iter++) {
+  // stream assistant response...
+  // collect tool calls...
+  // execute tools...
+}
+// ONLY AFTER the loop:
+opts.messages.push(assistantMsg);  // line 246
+```
+
+If the loop throws, `assistantMsg` is never pushed. The assistant's reasoning, partial content, and the tool calls it initiated are all **erased from history**.
+
+When the user says `"go on"`, the message history is:
+
+1. User: *"I don't like the color themes…"*
+2. [assistant message **MISSING** — was never saved]
+3. [50 tool results with no assistant message explaining why they were requested]
+4. User: *"go on"*
+
+The agent sees `"go on"` with **no context** of what was being worked on. The `tasks_set` tool might have been called during the spiral, but tasks live in `tasksRef` (UI state), not in the agent's message history. They're not injected back as persistent context.
+
+### 2.4 Why Claude Code doesn't have this problem
+
+Claude Code maintains coherence because:
+
+1. **Assistant reasoning is checkpointed** — even partial thoughts are saved
+2. **The user's original request is always visible** as the anchor
+3. **"Continue" means "continue from where we left off"** — the system preserves task context
+4. **Hitting a limit is a pause, not a crash** — the assistant says "I've made progress on X, should I continue?"
+
+In KimiFlare, hitting the tool limit is a **hard exception** that wipes the assistant's turn. That's the architectural bug.
+
+---
+
+## 3. The Fix: An Opinionated Research Personality
+
+This is not an algorithm problem. It's a **personality design** problem. We need to decide what kind of researcher the Research Agent should be.
+
+### 3.1 The personality: Senior Staff Engineer, not Grad Student
+
+| Grad Student | Senior Staff Engineer |
+|-------------|----------------------|
+| "I need to be comprehensive" | "I need enough to make a decision and build" |
+| "Let me check one more source" | "I have 3 solid options, here's my recommendation" |
+| Neutral, cataloging | Opinionated, recommending |
+| Information-oriented | Action-oriented |
+
+The Research Agent's job is not to *collect information*. It's to **produce a Research Brief** that gives the Coding Agent everything they need to implement.
+
+### 3.2 The Research Brief format (mandatory deliverable)
+
+```
+RESEARCH BRIEF
+==============
+1. THE ASK (1 sentence): What the user wants
+2. CURRENT STATE (2-3 bullets): What I found in the codebase
+3. OPTIONS CONSIDERED (2-3): Approaches, with evidence and tradeoffs
+4. RECOMMENDATION (1 paragraph): What the coding agent should do
+5. OPEN QUESTIONS (0-2): Things that can be decided during implementation
+6. CONFIDENCE (high/medium/low): How sure I am
+```
+
+### 3.3 The stopping heuristic (qualitative, not quantitative)
+
+The Research Agent stops when it can **truthfully answer yes** to:
+
+> "If I were the Coding Agent, could I implement the recommendation with just this Brief and my existing skills?"
+
+If yes → stop, present the Brief.
+If no → what's missing? Fetch exactly that. Then re-assess.
+
+This is opinionated. It says: *"We believe good research is brief, actionable, and biased toward implementation."* Some research questions need 5 tool calls, some need 30. The agent decides based on the Brief's completeness, not a counter.
+
+### 3.4 Why this prevents the spiral
+
+The spiral happens because the agent treats each URL as "progress." But with the Brief format, the agent must ask:
+
+> "Does this new page fill a gap in my Brief, or am I just collecting more of the same?"
+
+The prompt should say:
+
+> "Before fetching a new page, check your draft Brief. If you already have 2-3 solid examples for a section, you don't need more. Synthesize instead. A Brief with thin evidence is better than no Brief at all."
+
+### 3.5 The Brief is persisted across turns
+
+The Research Brief is not just output — it's **state**. After every tool call (or every few), the agent updates the Brief. The latest draft is:
+
+- Saved as a system message in the agent's session
+- Included in hand-off summaries to the Coding Agent
+- Visible to the agent itself so it can judge completeness
+
+If the 50-tool limit hits, the partial Brief survives. When the user says `"go on"`, the agent sees:
+
+> "Previous Research Brief (draft): [sections 1-3 complete, section 4 pending]"
+
+And continues from there. No amnesia.
+
+---
+
+## 4. The "Go On" Fix: Graceful Pause, Not Crash
+
+### Current behavior (broken)
+
+```
+Agent: [thinks, fetches 50 URLs, never synthesizes]
+System: ERROR: tool iteration limit reached
+User: go on
+Agent: What should I continue with?
+```
+
+### Desired behavior
+
+```
+Agent: [fetches 15 URLs, writes partial Brief]
+System: Paused after 50 tool calls. Research Brief so far: [summary]
+User: go on
+Agent: Continuing research. Based on my Brief so far, I need to verify [specific gap]...
+```
+
+### Architectural changes needed
+
+1. **Commit partial assistant message before throwing**
+   Before `throw new Error("tool iteration limit reached")`, push the assistant's accumulated `content` and `reasoning` to `opts.messages`. Even if incomplete, it preserves context.
+
+2. **Inject the Brief as a system message**
+   If the agent has produced any Brief content, add it to history: `"Research Brief (in progress): [draft]"`
+
+3. **Change the error message**
+   From: `"kimiflare: tool iteration limit reached (50)"`
+   To: `"Paused after 50 tool calls. Say 'go on' to continue, or ask me to focus on a specific area."`
+
+4. **Preserve tasks across the boundary**
+   If `tasks_set` was called, inject the task list into history as a system message. The agent should always know what it's working on.
+
+---
+
+## 5. Supporting Infrastructure (Secondary)
+
+The personality fix is primary. But these guardrail extensions help:
+
+### 5.1 Pattern-based loop detection (extends Guardrail 3.1)
+
+Detect not just identical signatures but **similar patterns**:
+
+- 5+ `web_fetch` calls within any 8-call window → warning
+- 3+ fetches from the same domain → warning
+
+But these are **warnings**, not hard stops. The agent can override if it justifies why in its Brief.
+
+### 5.2 Orchestrator-aware research phases
+
+The orchestrator could track whether the Research Agent has produced a Brief. If not after N user messages, force a hand-off with synthesis: "Research agent has not produced a Brief. Synthesizing findings and handing off."
+
+But N should be generous (like 20 user messages, not 20 tool calls). The point is to catch runaway agents, not to micromanage.
+
+---
+
+## 6. What We Already Shipped (PR #225)
+
+A partial fix was merged in PR #225:
+
+- **Persona prefix**: Research Agent is now told its audience is the Coding Agent, not the user
+- **Web-fetch budget**: Max 5 `web_fetch` calls per turn (hard stop)
+- **Domain-level anti-loop**: 3+ fetches from same domain triggers warning
+- **New themes**: Added `one-dark`, `ayu`, `night-owl`, `palenight`
+
+### Why this is insufficient
+
+The web-fetch budget is a **quantitative** fix for a **qualitative** problem. It prevents the specific symptom (50 GitHub fetches) but doesn't teach the agent when to stop. A research question about a large codebase might legitimately need 15 `read` calls and 0 `web_fetch` calls — the budget doesn't help there.
+
+The persona prefix fixes the audience confusion but doesn't give the agent a job description.
+
+---
+
+## 7. Open Questions for Design Review
+
+1. **Should the Research Brief be structured (JSON) or free-form (markdown)?**
+   - Structured: easier to validate, harder for the model to produce
+   - Free-form: more natural, harder to parse for the orchestrator
+
+2. **Should the Coding Agent also produce a deliverable (e.g., Implementation Notes)?**
+   - If yes, we have a two-phase pipeline: Brief → Implementation → Code
+   - If no, the Coding Agent works directly from the Brief
+
+3. **Should the Generalist Agent have a deliverable too?**
+   - E.g., "Conversation Summary" or "Decision Log"
+   - Or is the Generalist's job inherently open-ended?
+
+4. **How do we handle research that spans multiple turns?**
+   - The Brief draft persists, but what if the user changes their mind mid-research?
+   - Should the agent re-read the user's latest message and adjust the Brief's scope?
+
+5. **What happens when the user says "go on" but the Brief is already complete?**
+   - The agent should recognize this and say: "My Research Brief is complete. Should I hand off to the Coding Agent, or is there something specific you'd like me to dig deeper on?"
+
+---
+
+## 8. Related Documents
+
+- `docs/multi-agent-plan.md` — Multi-agent architecture overview
+- `docs/guardrails/README.md` — Guardrail specification (Section 3: Agent Loop Safety)
+- `docs/guardrails/file-checklist.md` — Per-file guardrail checklist
+- `docs/learnings/2026-04-27-agent-system-integration.md` — Compact, compiled context, code mode, agent memory integration research
+- PR #225 — Partial fix (persona prefix + web-fetch guardrails)
+
+---
+
+## 9. Next Steps
+
+1. Review this document with the team
+2. Collect mental models for "what a good researcher is" (user input)
+3. Design the Research Brief format and prompt language
+4. Implement the Brief persistence and graceful pause architecture
+5. Extend guardrail 3.1 with pattern-based detection
+6. Audit Coding Agent and Generalist Agent for similar personality gaps

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -24,4 +24,5 @@ Short notes, one-paragraph learnings, "we hit X and the fix was Y" observations,
 
 | Date | Document |
 |---|---|
+| 2026-05-01 | [Research Agent spiral and persona design](2026-05-01-research-agent-spiral-and-persona-design.md) — post-mortem of the 150-tool-call web-fetch spiral; proposes the Research Brief format and Senior Staff Engineer personality |
 | 2026-04-27 | [Agent-system integration research](2026-04-27-agent-system-integration.md) — how `compact`, compiled context, code mode, and agent memory should work together |

--- a/src/agent/agent-session.ts
+++ b/src/agent/agent-session.ts
@@ -30,6 +30,7 @@ const RESEARCH_TOOL_NAMES: readonly string[] = [
   "lsp_rename",
   "lsp_typeDefinition",
   "lsp_workspaceSymbol",
+  "hand_off",
   "memory_recall",
   "read",
   "tasks_set",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -114,6 +114,11 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const LOOP_WINDOW = 8;
   const LOOP_THRESHOLD = 2; // 3rd identical call triggers the guardrail
 
+  // Web-fetch anti-loop: track domains and URL patterns to prevent research spirals
+  const webFetchHistory: { url: string; domain: string }[] = [];
+  const MAX_WEB_FETCH_PER_TURN = 5;
+  const WEB_FETCH_DOMAIN_THRESHOLD = 2; // 3rd fetch to same domain triggers warning
+
   for (let iter = 0; iter < max; iter++) {
     turn++;
     const previousMessages = opts.messages.slice();
@@ -287,6 +292,63 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         recentToolCalls.push(loopSignature);
         if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
         continue;
+      }
+
+      // Web-fetch spiral guardrail
+      if (tc.function.name === "web_fetch") {
+        const args = JSON.parse(tc.function.arguments || "{}") as { url?: string };
+        const url = args.url || "";
+        try {
+          const domain = new URL(url).hostname;
+          const domainCount = webFetchHistory.filter((h) => h.domain === domain).length;
+          const totalWebFetches = webFetchHistory.length;
+
+          if (totalWebFetches >= MAX_WEB_FETCH_PER_TURN) {
+            const warning = `Research budget exceeded: you have already made ${MAX_WEB_FETCH_PER_TURN} web requests this turn. Synthesize what you have learned instead of fetching more pages.`;
+            const budgetResult: ToolResult = {
+              tool_call_id: tc.id,
+              name: "web_fetch",
+              content: warning,
+              ok: false,
+            };
+            toolResults.push(budgetResult);
+            opts.messages.push({
+              role: "tool",
+              tool_call_id: tc.id,
+              content: sanitizeString(warning),
+              name: "web_fetch",
+            });
+            opts.callbacks.onToolResult?.(budgetResult);
+            recentToolCalls.push(loopSignature);
+            if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+            continue;
+          }
+
+          if (domainCount >= WEB_FETCH_DOMAIN_THRESHOLD) {
+            const warning = `Loop detected: you have fetched from ${domain} multiple times. Consider a different approach or synthesize existing findings.`;
+            const loopResult: ToolResult = {
+              tool_call_id: tc.id,
+              name: "web_fetch",
+              content: warning,
+              ok: false,
+            };
+            toolResults.push(loopResult);
+            opts.messages.push({
+              role: "tool",
+              tool_call_id: tc.id,
+              content: sanitizeString(warning),
+              name: "web_fetch",
+            });
+            opts.callbacks.onToolResult?.(loopResult);
+            recentToolCalls.push(loopSignature);
+            if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+            continue;
+          }
+
+          webFetchHistory.push({ url, domain });
+        } catch {
+          // Invalid URL, let it fail normally
+        }
       }
 
       if (codeMode && tc.function.name === "execute_code") {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -119,6 +119,12 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const MAX_WEB_FETCH_PER_TURN = 5;
   const WEB_FETCH_DOMAIN_THRESHOLD = 2; // 3rd fetch to same domain triggers warning
 
+  // Budget tracking for research-agent self-assessment prompts
+  let totalToolCallsThisTurn = 0;
+  const BUDGET_CHECK_INTERVAL = 3;
+  const SOFT_BUDGET = 5;
+  const HARD_BUDGET = 15;
+
   for (let iter = 0; iter < max; iter++) {
     turn++;
     const previousMessages = opts.messages.slice();
@@ -414,7 +420,21 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         opts.callbacks.onToolResult?.(result);
         recentToolCalls.push(loopSignature);
         if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+        totalToolCallsThisTurn++;
       }
+    }
+
+    // Budget self-assessment: inject reminder after every N tool calls
+    if (totalToolCallsThisTurn > 0 && totalToolCallsThisTurn % BUDGET_CHECK_INTERVAL === 0) {
+      let budgetMsg = "";
+      if (totalToolCallsThisTurn >= HARD_BUDGET) {
+        budgetMsg = `BUDGET CHECK: You have made ${totalToolCallsThisTurn} tool calls. This is the substantial-question budget. Produce your deliverable now unless you can name a specific gap that would change the recommendation.`;
+      } else if (totalToolCallsThisTurn >= SOFT_BUDGET) {
+        budgetMsg = `BUDGET CHECK: You have made ${totalToolCallsThisTurn} tool calls. If this is a routine question, produce your deliverable now. If substantial, justify the next call in one sentence.`;
+      } else {
+        budgetMsg = `BUDGET CHECK: You have made ${totalToolCallsThisTurn} tool calls. Assess: is the next call worth more than what you already have? If yes, justify in one sentence. If no, produce your deliverable.`;
+      }
+      opts.messages.push({ role: "system", content: budgetMsg });
     }
 
     if (opts.sessionId && lastUsage) {
@@ -431,7 +451,11 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     }
   }
 
-  throw new Error(`kimiflare: tool iteration limit reached (${opts.maxToolIterations ?? 50})`);
+  // Tool iteration limit reached: commit a graceful pause message so the agent
+  // retains context when the user says "go on".
+  const pauseMsg = `Paused after ${opts.maxToolIterations ?? 50} tool calls. The user may say "go on" to continue. If you have a partial deliverable (Research Brief, Implementation Notes, etc.), include it in your next response.`;
+  opts.messages.push({ role: "system", content: pauseMsg });
+  throw new Error(`kimiflare: tool iteration limit reached (${opts.maxToolIterations ?? 50}). Say "go on" to continue, or ask me to focus on a specific area.`);
 }
 
 function validateToolArguments(raw: string): string {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -6,6 +6,7 @@ import { sanitizeString, stableStringify, stripOldImages } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tasks-state.js";
 import type { MemoryManager } from "../memory/manager.js";
+import type { AgentRole } from "./agent-session.js";
 import { logTurnDebug, analyzePrompt } from "../cost-debug.js";
 import { stripHistoricalReasoning } from "./strip-reasoning.js";
 import { generateTypeScriptApi, runInSandbox } from "../code-mode/index.js";
@@ -53,7 +54,7 @@ export interface AgentTurnOpts {
   /** Per-agent anti-loop guard state. If provided, runAgentTurn reads from and writes to this array. */
   recentToolCalls?: string[];
   /** Agent role for cost tracking. */
-  agentRole?: string;
+  agentRole?: AgentRole;
 }
 
 const codeModeApiCache = new Map<string, string>();

--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -113,6 +113,29 @@ export class AgentOrchestrator {
     return this.autoSwitch;
   }
 
+  /** Scan the session's last assistant message for a hand_off tool call.
+   *  Returns the target role if found, null otherwise. */
+  private detectHandOff(messages: ChatMessage[]): AgentRole | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]!;
+      if (m.role === "assistant" && m.tool_calls) {
+        for (const tc of m.tool_calls) {
+          if (tc.function.name === "hand_off") {
+            try {
+              const args = JSON.parse(tc.function.arguments) as { target?: string };
+              if (args.target) return args.target;
+            } catch {
+              // ignore parse errors
+            }
+          }
+        }
+        // Only check the most recent assistant message with tool_calls
+        break;
+      }
+    }
+    return null;
+  }
+
   private getToolsForRole(role: AgentRole): ToolSpec[] {
     const base = getAgentTools(role, this.opts.customAgents);
     // LSP tools are additive if available
@@ -289,6 +312,21 @@ export class AgentOrchestrator {
 
     // Update recentToolCalls from the session (runAgentTurn mutates it)
     session.recentToolCalls = session.recentToolCalls.slice(-8);
+
+    // Detect hand_off requests from the agent and trigger orchestrated hand-off
+    const handOffTarget = this.detectHandOff(session.messages);
+    if (handOffTarget && handOffTarget !== this.activeRole) {
+      const summary = await this.synthesizeHandoff(this.activeRole, handOffTarget);
+      this.activeRole = handOffTarget;
+      const newSession = this.getActiveSession();
+      if (summary) {
+        newSession.messages.push({
+          role: "system",
+          content: `[hand-off from ${this.activeRole} agent — agent requested hand-off]\n${summary}`,
+        });
+      }
+      this.turnCounts.set(handOffTarget, 0);
+    }
 
     // Increment turn count
     this.turnCounts.set(this.activeRole, (this.turnCounts.get(this.activeRole) ?? 0) + 1);

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -45,22 +45,63 @@ export function loadContextFile(cwd: string): ContextFile | null {
 export function buildRolePrefix(role?: AgentRole): string {
   switch (role) {
     case "research":
-      return `You are the Research Sub-Agent of kimiflare. Your output is consumed ONLY by the Coding Agent (kimiflare), NOT by the human user.
+      return `You are the Research Agent in kimiflare. You investigate technical questions on behalf of a Coding Agent that will act on your output. You are not talking to a human. The Coding Agent is your reader.
 
-CRITICAL AUDIENCE RULES:
-- Do NOT address the human user. Never use phrases like "you need to", "you should", "start by", "find the code that", or any imperative directed at the user.
-- Present findings as objective, third-party research: "The error originates in...", "The codebase uses...", "Option C is preferable because..."
-- When referring to the entity that will implement changes, say "kimiflare" or "the coding agent". When referring to yourself, say "the research agent" or "I".
-- Do not issue commands or step-by-step tutorials. Synthesize and analyze so kimiflare can act directly.
-- Your output is an internal memo to your coworker, not a README to the user.
+# Your job
 
-RESEARCH DISCIPLINE:
-- Start by reading the LOCAL codebase (read, glob, grep, lsp_*) before using web_fetch. The answer is usually in the code, not on the internet.
-- Use web_fetch ONLY for external documentation, API references, or verifying facts you cannot determine locally.
-- Maximum 5 web requests per turn. After that, synthesize what you have learned.
-- Do not fetch the same website multiple times. If a page failed or was insufficient, try a different source or proceed with what you know.
-- When researching a list (e.g., themes, libraries), fetch 2-3 representative examples and generalize. Do not fetch every item.
-- Your final output must be a concise synthesis: findings, recommendations, and any code snippets the coding agent needs. No raw dumps.
+Produce the smallest research artifact that lets the Coding Agent act correctly and confidently on the task it has been given. Not the most thorough — the smallest sufficient one. Research exists to enable action. If you are not reducing the Coding Agent's uncertainty about a concrete next step, you are wasting tokens.
+
+# How to think
+
+1. Start by naming the decision. Before any tool call, write down — for yourself — what decision your research is meant to enable. "Pick a library." "Choose between approach A and B." "Determine if X is possible." If you can't name the decision in one sentence, ask the Coding Agent for it before researching.
+
+2. Surface area before depth. First pass is always shallow and wide: the shape of the problem, the vocabulary, the obvious candidates, the known landmines. Only then go deep, and only on what the decision actually hinges on.
+
+3. Hold hypotheses loosely and visibly. Form a working hypothesis early — it directs attention — but mark it as a hypothesis and look actively for evidence against it. Sycophantic research is useless research.
+
+4. Budget is real. You have a finite tool-call budget per task. Default to ~5 calls for routine questions, up to ~15 for substantial ones. After every 3 calls, ask yourself: is the next call worth more than what I already have? Usually it isn't. Stop earlier than feels comfortable.
+
+5. Separate finding from inference from recommendation. Sources said X. I infer Y. Therefore Z for our case. Keep these layers visible so the Coding Agent can audit any of them.
+
+6. Know when to recommend running the code instead. Sometimes the cheapest research is letting the runtime answer. Say so when true.
+
+# When to stop
+
+Stop when all of these are true:
+- The named decision can be made from what you have.
+- Remaining uncertainties are named, not hidden.
+- The next tool call would predictably add little.
+
+Do not stop just because you found something. Do not stop just because you ran out of patience. Stop on the criteria above, and only those.
+
+# Output format
+
+You are writing for an agent, not a person. No preamble, no narrative, no "in this report we will." Structure:
+
+- DECISION: one sentence — what this research enables.
+- FINDINGS: scannable facts, with source attribution. Include version numbers, exact APIs, error strings, file paths, code snippets where relevant.
+- RECOMMENDATION: what the Coding Agent should do, concretely.
+- CONFIDENCE: per claim where it varies. "High / Medium / Low" is fine.
+- OPEN QUESTIONS: things you couldn't resolve. Mark each as either "blocking" (Coding Agent should ask the user before proceeding) or "non-blocking" (try and see).
+- RISKS: what could go wrong if the Recommendation is followed, including the strongest counter-argument you found.
+
+# Voice
+
+Terse. Direct. No hedging prose, but explicit uncertainty in the Confidence and Open Questions sections. No apologies, no throat-clearing, no "I hope this helps."
+
+# Addressing the user
+
+You do not address the user. If you must reference what you're about to ask the Coding Agent, phrase it as a description of the request, not a request itself: "Will instruct the Coding Agent to..." — never "please do X." The user is overhearing, not participating.
+
+# Things that are not research
+
+- Restating the task back at length.
+- Listing every option without ranking them.
+- Producing an essay when a table would do.
+- Continuing to search after the decision can already be made.
+- Hiding uncertainty inside confident prose.
+
+When in doubt, deliver the smaller artifact sooner. When your Brief is complete, call the hand_off tool to pass your findings to the Coding Agent.
 
 `;
     case "coding":

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -4,6 +4,7 @@ import { readFileSync, statSync } from "node:fs";
 import type { ToolSpec } from "../tools/registry.js";
 import { systemPromptForMode, type Mode } from "../mode.js";
 import type { ChatMessage } from "./messages.js";
+import type { AgentRole } from "./agent-session.js";
 
 export interface SystemPromptOpts {
   cwd: string;
@@ -11,6 +12,7 @@ export interface SystemPromptOpts {
   model: string;
   now?: Date;
   mode?: Mode;
+  role?: AgentRole;
 }
 
 const CONTEXT_FILENAMES = ["KIMI.md", "KIMIFLARE.md", "AGENT.md"];
@@ -38,10 +40,38 @@ export function loadContextFile(cwd: string): ContextFile | null {
   return null;
 }
 
+/** Role-specific persona instructions to prevent audience confusion.
+ *  Research output is an internal memo to the coding agent, not a README. */
+export function buildRolePrefix(role?: AgentRole): string {
+  switch (role) {
+    case "research":
+      return `You are the Research Sub-Agent of kimiflare. Your output is consumed ONLY by the Coding Agent (kimiflare), NOT by the human user.
+
+CRITICAL AUDIENCE RULES:
+- Do NOT address the human user. Never use phrases like "you need to", "you should", "start by", "find the code that", or any imperative directed at the user.
+- Present findings as objective, third-party research: "The error originates in...", "The codebase uses...", "Option C is preferable because..."
+- When referring to the entity that will implement changes, say "kimiflare" or "the coding agent". When referring to yourself, say "the research agent" or "I".
+- Do not issue commands or step-by-step tutorials. Synthesize and analyze so kimiflare can act directly.
+- Your output is an internal memo to your coworker, not a README to the user.
+
+`;
+    case "coding":
+      return `You are the Coding Agent of kimiflare. You write code, edit files, and execute tools directly. Do not ask the user to do your work for you. Implement the changes yourself.
+
+`;
+    case "generalist":
+      return `You are the Generalist Agent of kimiflare. You handle conversational queries, memory management, and high-level task coordination.
+
+`;
+    default:
+      return "";
+  }
+}
+
 /** Build the truly static prefix that should remain byte-for-byte identical
  *  across all turns in a session. Contains identity and invariant rules only. */
-export function buildStaticPrefix(opts: Pick<SystemPromptOpts, "model">): string {
-  return `You are kimiflare, an interactive coding assistant running in the user's terminal. You act on the user's local filesystem through the tools listed below. You are powered by the ${opts.model} model on Cloudflare Workers AI.
+export function buildStaticPrefix(opts: Pick<SystemPromptOpts, "model" | "role">): string {
+  return buildRolePrefix(opts.role) + `You are kimiflare, an interactive coding assistant running in the user's terminal. You act on the user's local filesystem through the tools listed below. You are powered by the ${opts.model} model on Cloudflare Workers AI.
 
 How to work:
 - Prefer calling tools over guessing. Read files before editing them. Use \`glob\` and \`grep\` to explore code before assuming structure.

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -54,6 +54,14 @@ CRITICAL AUDIENCE RULES:
 - Do not issue commands or step-by-step tutorials. Synthesize and analyze so kimiflare can act directly.
 - Your output is an internal memo to your coworker, not a README to the user.
 
+RESEARCH DISCIPLINE:
+- Start by reading the LOCAL codebase (read, glob, grep, lsp_*) before using web_fetch. The answer is usually in the code, not on the internet.
+- Use web_fetch ONLY for external documentation, API references, or verifying facts you cannot determine locally.
+- Maximum 5 web requests per turn. After that, synthesize what you have learned.
+- Do not fetch the same website multiple times. If a page failed or was insufficient, try a different source or proceed with what you know.
+- When researching a list (e.g., themes, libraries), fetch 2-3 representative examples and generalize. Do not fetch every item.
+- Your final output must be a concise synthesis: findings, recommendations, and any code snippets the coding agent needs. No raw dumps.
+
 `;
     case "coding":
       return `You are the Coding Agent of kimiflare. You write code, edit files, and execute tools directly. Do not ask the user to do your work for you. Implement the changes yourself.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1344,9 +1344,10 @@ function App({
           onAssistantStart: () => {
             const id = nextAssistantId++;
             activeAsstIdRef.current = id;
+            const role = orchestratorRef.current?.getActiveRole();
             setEvents((e) => [
               ...e,
-              { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true },
+              { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true, agentRole: role },
             ]);
           },
           onReasoningDelta: (d) => {
@@ -2395,9 +2396,10 @@ function App({
         onAssistantStart: () => {
           const id = nextAssistantId++;
           activeAsstIdRef.current = id;
+          const role = orchestratorRef.current?.getActiveRole();
           setEvents((e) => [
             ...e,
-            { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true },
+            { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true, agentRole: role },
           ]);
         },
         onReasoningDelta: (d: string) => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -349,14 +349,15 @@ function makePrefixMessages(
   model: string,
   mode: Mode,
   tools: ToolSpec[],
+  role?: AgentRole,
 ): ChatMessage[] {
   if (cacheStable) {
-    return buildSystemMessages({ cwd: process.cwd(), tools, model, mode });
+    return buildSystemMessages({ cwd: process.cwd(), tools, model, mode, role });
   }
   return [
     {
       role: "system",
-      content: buildSystemPrompt({ cwd: process.cwd(), tools, model, mode }),
+      content: buildSystemPrompt({ cwd: process.cwd(), tools, model, mode, role }),
     },
   ];
 }
@@ -2555,6 +2556,7 @@ function App({
                 overrideModel ?? cfg.model,
                 modeRef.current,
                 [...ALL_TOOLS, ...mcpToolsRef.current, ...lspToolsRef.current],
+                orchestratorRef.current.getActiveRole(),
               );
               activeSession.messages.unshift(...prefix);
             }

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -8,6 +8,7 @@ import { grepTool } from "./grep.js";
 import { webFetchTool } from "./web-fetch.js";
 import { tasksSetTool } from "./tasks.js";
 import { memoryRememberTool, memoryRecallTool, memoryForgetTool } from "./memory.js";
+import { handOffTool } from "./hand-off.js";
 import { ToolArtifactStore } from "./artifact-store.js";
 import { reduceToolOutput, DEFAULT_REDUCER_CONFIG } from "./reducer.js";
 import { makeExpandArtifactTool } from "./expand-artifact.js";
@@ -24,6 +25,7 @@ export const ALL_TOOLS: ToolSpec[] = [
   memoryRememberTool,
   memoryRecallTool,
   memoryForgetTool,
+  handOffTool,
 ];
 
 export type PermissionDecision = "allow" | "allow_session" | "deny";

--- a/src/tools/hand-off.ts
+++ b/src/tools/hand-off.ts
@@ -1,0 +1,37 @@
+import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
+
+export const handOffTool: ToolSpec<{ target: string; reason?: string }> = {
+  name: "hand_off",
+  needsPermission: false,
+  description:
+    `Signal that your work is complete and request a hand-off to another agent. ` +
+    `Use this when you have produced your deliverable (Research Brief, Implementation Notes, etc.) ` +
+    `and the next agent should take over.\n\n` +
+    `Parameters:\n` +
+    `- target: the agent to hand off to (e.g., "coding", "generalist")\n` +
+    `- reason: optional one-sentence summary of what was completed`,
+  parameters: {
+    type: "object",
+    properties: {
+      target: {
+        type: "string",
+        description: 'Agent to hand off to: "coding", "generalist", or another agent role',
+      },
+      reason: {
+        type: "string",
+        description: "One-sentence summary of what was completed and why hand-off is appropriate",
+      },
+    },
+    required: ["target"],
+    additionalProperties: false,
+  },
+  async run(args, _ctx): Promise<ToolOutput> {
+    const target = args.target;
+    const reason = args.reason ?? "";
+    return {
+      content: `Hand-off requested to ${target} agent.${reason ? ` Reason: ${reason}` : ""}`,
+      rawBytes: 0,
+      reducedBytes: 0,
+    };
+  },
+};

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -14,6 +14,8 @@ export type ChatEvent =
       text: string;
       reasoning: string;
       streaming: boolean;
+      /** Agent role that produced this message (e.g., "research", "coding"). */
+      agentRole?: string;
     }
   | ({ kind: "tool"; key: string } & ToolEventState)
   | { kind: "info"; key: string; text: string }
@@ -121,6 +123,13 @@ const EventView = React.memo(function EventView({
   if (evt.kind === "assistant") {
     return (
       <Box flexDirection="column" paddingLeft={2}>
+        {evt.agentRole && (
+          <Box marginBottom={1}>
+            <Text color={theme.info.color} dimColor={theme.info.dim}>
+              ◆ {evt.agentRole} agent
+            </Text>
+          </Box>
+        )}
         {showReasoning && evt.reasoning ? (
           <Box flexDirection="column" marginBottom={1}>
             <Text color={theme.reasoning.color} dimColor={theme.reasoning.dim}>

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -226,6 +226,74 @@ const rosePine: Theme = {
   modeBadge: { plan: "#31748f", auto: "#9ccfd8", edit: "#ebbcba" },
 };
 
+const oneDark: Theme = {
+  name: "one-dark",
+  label: "one-dark (Atom's iconic dark — blue & purple)",
+  user: "#61afef",
+  assistant: undefined,
+  reasoning: { color: "#5c6370", dim: true },
+  info: { color: "#5c6370", dim: true },
+  error: "#e06c75",
+  warn: "#e5c07b",
+  tool: "#c678dd",
+  spinner: "#61afef",
+  permission: "#e5c07b",
+  queue: { color: "#5c6370", dim: true },
+  accent: "#c678dd",
+  modeBadge: { plan: "#61afef", auto: "#98c379", edit: "#c678dd" },
+};
+
+const ayu: Theme = {
+  name: "ayu",
+  label: "ayu (clean modern — orange & cyan)",
+  user: "#39bae6",
+  assistant: undefined,
+  reasoning: { color: "#4d5566", dim: true },
+  info: { color: "#4d5566", dim: true },
+  error: "#f07178",
+  warn: "#ffb454",
+  tool: "#73b8ff",
+  spinner: "#39bae6",
+  permission: "#ffb454",
+  queue: { color: "#4d5566", dim: true },
+  accent: "#39bae6",
+  modeBadge: { plan: "#39bae6", auto: "#7ee787", edit: "#ffb454" },
+};
+
+const nightOwl: Theme = {
+  name: "night-owl",
+  label: "night-owl (deep navy — cyan & red)",
+  user: "#82aaff",
+  assistant: undefined,
+  reasoning: { color: "#4d6885", dim: true },
+  info: { color: "#4d6885", dim: true },
+  error: "#ef5350",
+  warn: "#ffca28",
+  tool: "#c792ea",
+  spinner: "#82aaff",
+  permission: "#ffca28",
+  queue: { color: "#4d6885", dim: true },
+  accent: "#c792ea",
+  modeBadge: { plan: "#82aaff", auto: "#7ee787", edit: "#c792ea" },
+};
+
+const palenight: Theme = {
+  name: "palenight",
+  label: "palenight (Material pale — purple & cyan)",
+  user: "#82b1ff",
+  assistant: undefined,
+  reasoning: { color: "#4c566a", dim: true },
+  info: { color: "#4c566a", dim: true },
+  error: "#f07178",
+  warn: "#ffcb6b",
+  tool: "#c792ea",
+  spinner: "#82b1ff",
+  permission: "#ffcb6b",
+  queue: { color: "#4c566a", dim: true },
+  accent: "#c792ea",
+  modeBadge: { plan: "#82b1ff", auto: "#c3e88d", edit: "#c792ea" },
+};
+
 export const THEMES: Record<string, Theme> = {
   dark,
   light,
@@ -239,6 +307,10 @@ export const THEMES: Record<string, Theme> = {
   "gruvbox-dark": gruvboxDark,
   "catppuccin-mocha": catppuccinMocha,
   "rose-pine": rosePine,
+  "one-dark": oneDark,
+  ayu,
+  "night-owl": nightOwl,
+  palenight,
 };
 
 export const DEFAULT_THEME_NAME = "dark";


### PR DESCRIPTION
Fixes the research agent (and other sub-agents) talking to the human user instead of producing internal notes for the coding agent. Also prevents research spirals, adds missing popular themes, introduces a deliverable-driven multi-agent architecture, shows agent role prefixes in the UI, and makes plan mode functionally equivalent to edit mode when multi-agent is on.

## Problem
When multi-agent mode is enabled, the Research Agent:
1. **Addresses the user directly** with imperatives ("You need to trace...", "Search the codebase...")
2. **Goes into web_fetch loops** — burning 50+ tool iterations on repetitive GitHub searches, never synthesizing findings
3. **Never hands off actionable work** to the Coding Agent
4. **Loses all context** when the user says "go on" after hitting the tool limit
5. **Plan mode cripples the Research Agent** by blocking tools it needs for research (like `lsp_codeAction`)

## Solution

### Deliverable-driven research personality
The Research Agent now follows a strict persona based on the Senior Staff Engineer mental model (not the Grad Student). It must produce a **Research Brief** with:
- DECISION: what this research enables
- FINDINGS: scannable facts with source attribution
- RECOMMENDATION: concrete next steps for the Coding Agent
- CONFIDENCE: per-claim uncertainty markers
- OPEN QUESTIONS: blocking vs non-blocking
- RISKS: strongest counter-argument found

### Stopping heuristic (qualitative)
The agent stops when it can truthfully answer yes to: *"If I were the Coding Agent, could I implement the recommendation with just this Brief and my existing skills?"*

### Budget self-assessment (architecturally enforced)
- After every 3 tool calls: inject system message prompting self-assessment
- At 5 calls: soft warning (routine questions should wrap up)
- At 15 calls: hard warning (substantial questions should justify continuation)
- These are warnings, not hard stops — the agent can override by justifying the next call

### Graceful pause on tool limit
Instead of a hard error that erases context, the loop now injects a system message before throwing:
> "Paused after 50 tool calls. The user may say 'go on' to continue. If you have a partial deliverable, include it in your next response."

### hand_off tool
The Research Agent can now call `hand_off(target, reason)` to signal completion and trigger automatic hand-off to the Coding Agent (or Generalist). The orchestrator detects this and initiates the transfer.

### Pattern-based loop detection
Extends Guardrail 3.1 to catch not just identical signatures but similar patterns:
- 5+ `web_fetch` calls within any 8-call window → warning
- 3+ fetches from the same domain → warning

### Agent role prefix in UI
In multi-agent mode, assistant messages now show a subtle prefix so the user knows which agent is speaking:
> `◆ research agent`
> `◆ coding agent`

Single-agent mode is unchanged.

### Plan mode in multi-agent
When multi-agent is on, plan mode is **functionally equivalent to edit mode**:
- The Research Agent already handles read-only exploration
- The Coding Agent asks permission before mutations (edit mode behavior)
- The visual "plan" badge is preserved so users don't lose familiar UI
- Single-agent mode unchanged: plan mode still blocks mutations

### New themes
Added 4 popular themes: `one-dark`, `ayu`, `night-owl`, `palenight`

## Changes
- `src/agent/system-prompt.ts`: Deliverable-driven Research Agent persona with Brief format
- `src/agent/loop.ts`: Budget self-assessment injection + graceful pause message
- `src/agent/orchestrator.ts`: `detectHandOff()` + automatic hand-off on `hand_off` tool call
- `src/agent/agent-session.ts`: `hand_off` added to Research Agent tool list
- `src/tools/hand-off.ts`: New `hand_off` tool definition
- `src/tools/executor.ts`: Register `hand_off` in `ALL_TOOLS`
- `src/ui/chat.tsx`: Agent role prefix rendering on assistant messages
- `src/app.tsx`: Agent role capture + plan→edit mode mapping when multi-agent on
- `src/ui/theme.ts`: 4 new theme definitions
- `docs/guardrails/README.md`: New guardrail 3.5 (Deliverable-Driven Agents)
- `docs/guardrails/file-checklist.md`: Checklist items for new files
- `docs/learnings/2026-05-01-research-agent-spiral-and-persona-design.md`: Full post-mortem

## Verification
- `npm run typecheck` passes
- All 289 tests pass
