### PR TITLE
feat: / slash command picker with inline filtering and navigation

### DIFF
--- a/KIMI.md
+++ b/KIMI.md
@@ -45,6 +45,10 @@
 - Searches the current working directory, respecting `.gitignore` and common ignore patterns.
 - No runtime cost when disabled.
 
+**/ Slash Command Picker**
+- Type `/` at the start of the chat input to open a picker with all built-in and custom slash commands.
+- Filters as you type (fuzzy match); arrow keys navigate, Enter inserts the command name (does not auto-submit), Esc cancels.
+
 **Do / Don't**
 - Do keep agent responses terse; don't re-summarize tool output the user already sees inline.
 - Do call `tasks_set` at the start of multi-step work and update it as steps complete; skip for trivial one-offs.

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -7,6 +7,8 @@ import {
   buildFilePickerIgnoreList,
   filterPickerItems,
   shouldOpenMentionPicker,
+  shouldOpenSlashPicker,
+  insertSlashCommand,
 } from "./app.js";
 import type { FilePickerItem } from "./ui/file-picker.js";
 
@@ -99,5 +101,68 @@ describe("shouldOpenMentionPicker", () => {
 
   it("does not open when cursor is at 0", () => {
     assert.strictEqual(shouldOpenMentionPicker("", 0, null), false);
+  });
+});
+
+describe("shouldOpenSlashPicker", () => {
+  it("opens when / is the first char", () => {
+    assert.strictEqual(shouldOpenSlashPicker("/", 1, null), true);
+  });
+
+  it("opens when / follows leading whitespace", () => {
+    assert.strictEqual(shouldOpenSlashPicker("  /", 3, null), true);
+  });
+
+  it("does not open when / is mid-message", () => {
+    assert.strictEqual(shouldOpenSlashPicker("hello /", 7, null), false);
+    assert.strictEqual(shouldOpenSlashPicker("path/to", 5, null), false);
+  });
+
+  it("does not open immediately after cancel at same offset", () => {
+    assert.strictEqual(shouldOpenSlashPicker("/", 1, 1), false);
+  });
+
+  it("does not open when cursor is at 0", () => {
+    assert.strictEqual(shouldOpenSlashPicker("", 0, null), false);
+  });
+
+  it("does not open when char before cursor isn't /", () => {
+    assert.strictEqual(shouldOpenSlashPicker("hello", 5, null), false);
+  });
+});
+
+describe("insertSlashCommand", () => {
+  it("inserts and appends a trailing space when input ends at the token", () => {
+    const { value, cursor } = insertSlashCommand("/mod", 0, "model");
+    assert.strictEqual(value, "/model ");
+    assert.strictEqual(cursor, "/model ".length);
+  });
+
+  it("preserves args past the typed command token", () => {
+    // user typed `/m|od rest` (cursor mid-token) and picked "model"
+    const { value, cursor } = insertSlashCommand("/mod rest", 0, "model");
+    assert.strictEqual(value, "/model rest");
+    assert.strictEqual(cursor, "/model ".length);
+  });
+
+  it("does not duplicate spaces if a space already follows the token", () => {
+    const { value } = insertSlashCommand("/m foo", 0, "model");
+    assert.strictEqual(value, "/model foo");
+  });
+
+  it("works with leading whitespace before the slash", () => {
+    const { value, cursor } = insertSlashCommand("  /he arg", 2, "help");
+    assert.strictEqual(value, "  /help arg");
+    assert.strictEqual(cursor, "  /help ".length);
+  });
+
+  it("collapses multi-space tails to a single separator", () => {
+    const { value } = insertSlashCommand("/m  foo", 0, "model");
+    assert.strictEqual(value, "/model foo");
+  });
+
+  it("normalizes tab/newline tails to a single space", () => {
+    const { value } = insertSlashCommand("/m\tfoo", 0, "model");
+    assert.strictEqual(value, "/model foo");
   });
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -73,7 +73,8 @@ import { spawn } from "node:child_process";
 import { platform } from "node:os";
 import { loadCustomCommands } from "./commands/loader.js";
 import { renderCommand } from "./commands/renderer.js";
-import type { CustomCommand } from "./commands/types.js";
+import type { CustomCommand, SlashItem } from "./commands/types.js";
+import { BUILTIN_COMMANDS, BUILTIN_COMMAND_NAMES } from "./commands/builtins.js";
 import { saveCustomCommand, deleteCustomCommand } from "./commands/save.js";
 import type { SaveCustomCommandOptions } from "./commands/save.js";
 import { CommandWizard } from "./ui/command-wizard.js";
@@ -84,6 +85,8 @@ import { saveProjectLspConfig, type ResolvedLspConfig } from "./util/lsp-config.
 import { maybeLspNudge } from "./util/lsp-nudge.js";
 import fg from "fast-glob";
 import { FilePicker, type FilePickerItem } from "./ui/file-picker.js";
+import { SlashPicker } from "./ui/slash-picker.js";
+import { fuzzyFilter } from "./util/fuzzy.js";
 import { readFileSync } from "node:fs";
 
 /**
@@ -229,6 +232,46 @@ export function shouldOpenMentionPicker(
   }
   return false;
 }
+
+/**
+ * Slash picker triggers when:
+ *   - the char immediately before the cursor is "/"
+ *   - everything before that "/" is whitespace-only
+ * This matches handleSlash() dispatch (it only runs on inputs where the
+ * trimmed text starts with "/"), so the picker can't surface commands
+ * that won't actually fire.
+ */
+export function shouldOpenSlashPicker(
+  input: string,
+  cursorOffset: number,
+  cancelOffset: number | null,
+): boolean {
+  if (cancelOffset === cursorOffset) return false;
+  if (cursorOffset === 0 || input[cursorOffset - 1] !== "/") return false;
+  return /^\s*$/.test(input.slice(0, cursorOffset - 1));
+}
+
+/**
+ * Insert a picked slash-command name into the input, replacing the entire
+ * command token (from `/` through the next whitespace or EOL). Preserves
+ * any args the user already typed past the cursor and ensures exactly one
+ * separating space.
+ */
+export function insertSlashCommand(
+  input: string,
+  anchor: number,
+  name: string,
+): { value: string; cursor: number } {
+  let tokenEnd = anchor + 1;
+  while (tokenEnd < input.length && !/\s/.test(input[tokenEnd]!)) tokenEnd++;
+  const head = input.slice(0, anchor + 1) + name;
+  const tail = " " + input.slice(tokenEnd).replace(/^\s+/, "");
+  return { value: head + tail, cursor: head.length + 1 };
+}
+
+type ActivePicker =
+  | { kind: "file"; anchor: number; selected: number }
+  | { kind: "slash"; anchor: number; selected: number };
 
 interface Cfg {
   accountId: string;
@@ -392,12 +435,6 @@ function findImagePaths(text: string): string[] {
   return paths;
 }
 
-const BUILTIN_COMMAND_NAMES = new Set([
-  "exit", "quit", "clear", "reasoning", "cost", "model", "thinking", "effort",
-  "theme", "mode", "plan", "auto", "edit", "resume", "compact", "init",
-  "update", "mcp", "logout", "help", "memory", "gateway", "hello", "community",
-  "agent",
-]);
 
 const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
   low: "low — fastest; lightest reasoning. Best for simple Q&A, small edits, quick coordination.",
@@ -466,11 +503,12 @@ function App({
   const [hasUpdate, setHasUpdate] = useState(initialUpdateResult?.hasUpdate ?? false);
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
 
-  // File mention picker state
+  // Picker state — single popup at a time (file mention or slash command).
   const [cursorOffset, setCursorOffset] = useState(0);
-  const [pickerItems, setPickerItems] = useState<FilePickerItem[]>([]);
-  const [pickerSelected, setPickerSelected] = useState(0);
-  const [pickerAnchor, setPickerAnchor] = useState<number | null>(null);
+  const [activePicker, setActivePicker] = useState<ActivePicker | null>(null);
+  const [filePickerItems, setFilePickerItems] = useState<FilePickerItem[]>([]);
+  const filePickerLoadedRef = useRef(false);
+  const [customCommandsVersion, setCustomCommandsVersion] = useState(0);
 
   const cacheStableRef = useRef(initialCfg?.cacheStablePrompts !== false);
   const messagesRef = useRef<ChatMessage[]>(
@@ -510,52 +548,70 @@ function App({
   const customCommandsRef = useRef<CustomCommand[]>([]);
   const pickerCancelRef = useRef<number | null>(null);
 
-  // ── File mention picker logic ────────────────────────────────────────────
-  const mentionState = React.useMemo(() => {
+  // ── Picker logic (file mention `@` and slash command `/`) ──────────────
+  // Depend on stable fields (kind, anchor) — not the activePicker reference,
+  // which churns on every arrow-key press.
+  const pickerAnchor = activePicker?.anchor ?? null;
+  const pickerKind = activePicker?.kind ?? null;
+  const pickerQuery = React.useMemo(() => {
     if (pickerAnchor === null) return null;
-    const query = input.slice(pickerAnchor + 1, cursorOffset);
-    return { query, anchor: pickerAnchor };
+    return input.slice(pickerAnchor + 1, cursorOffset);
   }, [input, cursorOffset, pickerAnchor]);
 
-  const filteredPickerItems = React.useMemo(() => {
-    if (!mentionState) return [];
-    return filterPickerItems(pickerItems, mentionState.query);
-  }, [pickerItems, mentionState]);
+  const filteredFileItems = React.useMemo(() => {
+    if (pickerKind !== "file" || pickerQuery === null) return [];
+    return filterPickerItems(filePickerItems, pickerQuery);
+  }, [pickerKind, filePickerItems, pickerQuery]);
 
-  // Detect @ mention opening/closing
+  // Custom commands that shadow built-ins are warned about and won't run, so
+  // don't surface them in the picker either. customCommandsVersion is bumped
+  // by every customCommandsRef mutation — keep that invariant intact.
+  const allSlashCommands = React.useMemo<SlashItem[]>(() => {
+    const customs: SlashItem[] = customCommandsRef.current
+      .filter((c) => !BUILTIN_COMMAND_NAMES.has(c.name.toLowerCase()))
+      .map((c) => ({
+        name: c.name,
+        description: c.description ?? "",
+        source: c.source,
+      }));
+    return [...BUILTIN_COMMANDS, ...customs];
+  }, [customCommandsVersion]);
+
+  const filteredSlashItems = React.useMemo(() => {
+    if (pickerKind !== "slash" || pickerQuery === null) return [];
+    return fuzzyFilter(allSlashCommands, pickerQuery, (c) => c.name).slice(0, 50);
+  }, [pickerKind, allSlashCommands, pickerQuery]);
+
   useEffect(() => {
-    if (pickerAnchor !== null) {
-      // If cursor moved before anchor, close picker
-      if (cursorOffset < pickerAnchor) {
-        setPickerAnchor(null);
+    if (activePicker !== null) {
+      const trigger = activePicker.kind === "file" ? "@" : "/";
+      if (cursorOffset < activePicker.anchor) {
+        setActivePicker(null);
         return;
       }
-      // If the @ was deleted, close picker
-      if (input[pickerAnchor] !== "@") {
-        setPickerAnchor(null);
+      if (input[activePicker.anchor] !== trigger) {
+        setActivePicker(null);
         return;
       }
-      // If user typed a space inside the mention query, close picker
-      const query = input.slice(pickerAnchor + 1, cursorOffset);
-      if (query.includes(" ")) {
-        setPickerAnchor(null);
+      // Whitespace ends the token (start of args for slash, end of mention for @).
+      const query = input.slice(activePicker.anchor + 1, cursorOffset);
+      if (/\s/.test(query)) {
+        setActivePicker(null);
         return;
       }
       return;
     }
 
-    // Prevent immediate reopen after cancel at the same cursor position
+    // Drop sticky-cancel once the cursor moves away from the cancel offset.
     if (pickerCancelRef.current === cursorOffset) {
       pickerCancelRef.current = null;
       return;
     }
 
-    // Look for @ just before cursor (only when feature flag is enabled)
     if (filePickerEnabled && shouldOpenMentionPicker(input, cursorOffset, pickerCancelRef.current)) {
-      setPickerAnchor(cursorOffset - 1);
-      setPickerSelected(0);
-      // Load files lazily on first open
-      if (pickerItems.length === 0) {
+      setActivePicker({ kind: "file", anchor: cursorOffset - 1, selected: 0 });
+      if (!filePickerLoadedRef.current) {
+        filePickerLoadedRef.current = true;
         const cwd = process.cwd();
         void fg("**/*", {
           cwd,
@@ -571,51 +627,116 @@ function App({
               name: e.endsWith("/") ? e.slice(0, -1) : e,
               isDirectory: e.endsWith("/"),
             }));
-            // Sort directories first, then alphabetically
             items.sort((a, b) => {
               if (a.isDirectory && !b.isDirectory) return -1;
               if (!a.isDirectory && b.isDirectory) return 1;
               return a.name.localeCompare(b.name);
             });
-            setPickerItems(items);
+            setFilePickerItems(items);
           })
           .catch(() => {
-            setPickerItems([]);
+            setFilePickerItems([]);
           });
       }
+      return;
     }
-  }, [input, cursorOffset, pickerAnchor, pickerItems.length, filePickerEnabled]);
 
-  // Clamp selected index when filtered list changes
-  useEffect(() => {
-    if (pickerAnchor !== null) {
-      setPickerSelected((prev) => Math.min(prev, Math.max(0, filteredPickerItems.length - 1)));
+    if (shouldOpenSlashPicker(input, cursorOffset, pickerCancelRef.current)) {
+      setActivePicker({ kind: "slash", anchor: cursorOffset - 1, selected: 0 });
+      return;
     }
-  }, [filteredPickerItems.length, pickerAnchor]);
+  }, [input, cursorOffset, activePicker, filePickerEnabled]);
+
+  // Clamp selected index when filtered list shrinks below the current selection.
+  useEffect(() => {
+    if (activePicker?.kind !== "file") return;
+    const max = Math.max(0, filteredFileItems.length - 1);
+    if (activePicker.selected > max) {
+      setActivePicker({ ...activePicker, selected: max });
+    }
+  }, [filteredFileItems.length, activePicker]);
+
+  useEffect(() => {
+    if (activePicker?.kind !== "slash") return;
+    const max = Math.max(0, filteredSlashItems.length - 1);
+    if (activePicker.selected > max) {
+      setActivePicker({ ...activePicker, selected: max });
+    }
+  }, [filteredSlashItems.length, activePicker]);
 
   const handlePickerUp = useCallback(() => {
-    setPickerSelected((i) => Math.max(0, i - 1));
+    setActivePicker((p) => {
+      if (!p) return null;
+      const next = Math.max(0, p.selected - 1);
+      return next === p.selected ? p : { ...p, selected: next };
+    });
   }, []);
 
   const handlePickerDown = useCallback(() => {
-    setPickerSelected((i) => Math.min(filteredPickerItems.length - 1, i + 1));
-  }, [filteredPickerItems.length]);
+    setActivePicker((p) => {
+      if (!p) return null;
+      const max = p.kind === "file"
+        ? Math.max(0, filteredFileItems.length - 1)
+        : Math.max(0, filteredSlashItems.length - 1);
+      const next = Math.min(max, p.selected + 1);
+      return next === p.selected ? p : { ...p, selected: next };
+    });
+  }, [filteredFileItems.length, filteredSlashItems.length]);
 
   const handlePickerSelect = useCallback(() => {
-    if (!mentionState || filteredPickerItems.length === 0) return;
-    const item = filteredPickerItems[pickerSelected];
+    if (!activePicker) return;
+    if (activePicker.kind === "file") {
+      const item = filteredFileItems[activePicker.selected];
+      if (!item) return;
+      const insert = item.name + (item.isDirectory ? "/" : " ");
+      const newInput = input.slice(0, activePicker.anchor) + insert + input.slice(cursorOffset);
+      setInput(newInput);
+      setCursorOffset(activePicker.anchor + insert.length);
+      setActivePicker(null);
+      return;
+    }
+    // slash
+    const item = filteredSlashItems[activePicker.selected];
     if (!item) return;
-    const insert = item.name + (item.isDirectory ? "/" : " ");
-    const newInput = input.slice(0, mentionState.anchor) + insert + input.slice(cursorOffset);
-    setInput(newInput);
-    setCursorOffset(mentionState.anchor + insert.length);
-    setPickerAnchor(null);
-  }, [mentionState, filteredPickerItems, pickerSelected, input, cursorOffset]);
+    const { value, cursor } = insertSlashCommand(input, activePicker.anchor, item.name);
+    setInput(value);
+    setCursorOffset(cursor);
+    setActivePicker(null);
+  }, [activePicker, filteredFileItems, filteredSlashItems, input, cursorOffset]);
 
   const handlePickerCancel = useCallback(() => {
     pickerCancelRef.current = cursorOffset;
-    setPickerAnchor(null);
+    setActivePicker(null);
   }, [cursorOffset]);
+
+  // Close any open picker when a modal takes over the input. Without this,
+  // picker state would survive the modal and re-render on close.
+  useEffect(() => {
+    const modalActive =
+      showThemePicker ||
+      showHelpMenu ||
+      commandWizard !== null ||
+      commandPicker !== null ||
+      commandToDelete !== null ||
+      showCommandList ||
+      showLspWizard ||
+      resumeSessions !== null ||
+      perm !== null;
+    if (modalActive && activePicker !== null) {
+      setActivePicker(null);
+    }
+  }, [
+    showThemePicker,
+    showHelpMenu,
+    commandWizard,
+    commandPicker,
+    commandToDelete,
+    showCommandList,
+    showLspWizard,
+    resumeSessions,
+    perm,
+    activePicker,
+  ]);
 
   useEffect(() => {
     if (!cfg) return;
@@ -710,6 +831,7 @@ function App({
 
     void loadCustomCommands(process.cwd()).then(({ commands, warnings }) => {
       customCommandsRef.current = commands;
+      setCustomCommandsVersion((v) => v + 1);
       for (const w of warnings) {
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `commands: ${w}` }]);
       }
@@ -740,6 +862,7 @@ function App({
   const reloadCustomCommands = useCallback(async () => {
     const { commands, warnings } = await loadCustomCommands(process.cwd());
     customCommandsRef.current = commands;
+    setCustomCommandsVersion((v) => v + 1);
     for (const w of warnings) {
       setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `commands: ${w}` }]);
     }
@@ -3007,12 +3130,20 @@ function App({
             gatewayMeta={gatewayMeta}
             codeMode={codeMode}
           />
-          {pickerAnchor !== null && (
+          {activePicker?.kind === "file" && (
             <FilePicker
-              items={filteredPickerItems}
-              selectedIndex={pickerSelected}
+              items={filteredFileItems}
+              selectedIndex={activePicker.selected}
               theme={theme}
-              query={mentionState?.query ?? ""}
+              query={pickerQuery ?? ""}
+            />
+          )}
+          {activePicker?.kind === "slash" && (
+            <SlashPicker
+              items={filteredSlashItems}
+              selectedIndex={activePicker.selected}
+              theme={theme}
+              query={pickerQuery ?? ""}
             />
           )}
           <Box marginTop={1}>
@@ -3024,7 +3155,7 @@ function App({
               enablePaste
               cursorOffset={cursorOffset}
               onCursorChange={setCursorOffset}
-              pickerActive={pickerAnchor !== null}
+              pickerActive={activePicker !== null}
               onPickerUp={handlePickerUp}
               onPickerDown={handlePickerDown}
               onPickerSelect={handlePickerSelect}

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -1,0 +1,39 @@
+import type { SlashItem } from "./types.js";
+
+/**
+ * Built-in slash commands shown in the `/`-trigger picker. Each entry's
+ * `name` must match a branch in `handleSlash` (src/app.tsx) — keep this
+ * list in sync when adding/removing handled commands.
+ */
+export const BUILTIN_COMMANDS: SlashItem[] = [
+  { name: "help", description: "Show keybindings and command list", source: "builtin" },
+  { name: "model", description: "Show current model", source: "builtin" },
+  { name: "mode", argHint: "edit|plan|auto", description: "Switch agent mode", source: "builtin" },
+  { name: "plan", description: "Switch to plan mode", source: "builtin" },
+  { name: "auto", description: "Switch to auto mode", source: "builtin" },
+  { name: "edit", description: "Switch to edit mode", source: "builtin" },
+  { name: "thinking", argHint: "low|medium|high", description: "Set reasoning effort", source: "builtin" },
+  { name: "effort", argHint: "low|medium|high", description: "Alias for /thinking", source: "builtin" },
+  { name: "reasoning", description: "Toggle reasoning visibility", source: "builtin" },
+  { name: "theme", description: "Open theme picker", source: "builtin" },
+  { name: "agent", argHint: "[on|off|status]", description: "Multi-agent mode controls", source: "builtin" },
+  { name: "memory", argHint: "[on|off|clear|search ...]", description: "Manage memory", source: "builtin" },
+  { name: "cost", argHint: "[on|off]", description: "Show cost report or toggle attribution", source: "builtin" },
+  { name: "gateway", argHint: "[status|off|<id>|cache-ttl|skip-cache|...]", description: "Manage AI Gateway", source: "builtin" },
+  { name: "mcp", argHint: "[list|reload]", description: "Manage MCP servers", source: "builtin" },
+  { name: "lsp", argHint: "[config|list|reload|scope]", description: "Manage language servers", source: "builtin" },
+  { name: "command", argHint: "[create|edit|delete|list]", description: "Manage custom slash commands", source: "builtin" },
+  { name: "resume", description: "Pick a past conversation to resume", source: "builtin" },
+  { name: "compact", description: "Summarize old turns to free context", source: "builtin" },
+  { name: "clear", description: "Clear current conversation", source: "builtin" },
+  { name: "init", description: "Scan repo and write KIMI.md", source: "builtin" },
+  { name: "update", description: "Check for updates", source: "builtin" },
+  { name: "hello", description: "Send a voice note to the creator", source: "builtin" },
+  { name: "logout", description: "Clear stored credentials", source: "builtin" },
+  { name: "exit", description: "Exit kimiflare", source: "builtin" },
+  { name: "quit", description: "Alias for /exit", source: "builtin" },
+];
+
+export const BUILTIN_COMMAND_NAMES = new Set(
+  BUILTIN_COMMANDS.map((c) => c.name.toLowerCase()),
+);

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -25,3 +25,12 @@ export type LoadResult = {
   commands: CustomCommand[];
   warnings: string[];
 };
+
+export type SlashItemSource = "builtin" | CommandSource;
+
+export type SlashItem = {
+  name: string;
+  description: string;
+  argHint?: string;
+  source: SlashItemSource;
+};

--- a/src/ui/slash-picker.test.tsx
+++ b/src/ui/slash-picker.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import React from "react";
+import { renderToString } from "ink";
+import { SlashPicker } from "./slash-picker.js";
+import type { SlashItem } from "../commands/types.js";
+import { resolveTheme } from "./theme.js";
+
+const theme = resolveTheme(undefined);
+
+function render(items: SlashItem[], selectedIndex: number, query = ""): string {
+  return renderToString(
+    <SlashPicker items={items} selectedIndex={selectedIndex} theme={theme} query={query} />,
+  );
+}
+
+const sample: SlashItem[] = [
+  { name: "model", description: "Show current model", source: "builtin" },
+  { name: "mode", argHint: "edit|plan|auto", description: "Switch agent mode", source: "builtin" },
+  { name: "memory", description: "Manage memory", source: "builtin" },
+];
+
+describe("SlashPicker", () => {
+  it("renders empty state", () => {
+    const out = render([], 0);
+    assert.ok(out.includes("No matches"));
+  });
+
+  it("renders items with selection indicator and arg hint", () => {
+    const out = render(sample, 1);
+    assert.ok(out.includes("/model"));
+    assert.ok(out.includes("› /mode edit|plan|auto"));
+    assert.ok(out.includes("Switch agent mode"));
+  });
+
+  it("renders query header when filtering", () => {
+    const out = render([sample[0]!], 0, "mod");
+    assert.ok(out.includes('Commands matching "/mod"'));
+  });
+
+  it("shows project/global source badge for custom commands", () => {
+    const items: SlashItem[] = [
+      { name: "fix", description: "Quick fixer", source: "project" },
+      { name: "review", description: "Quick reviewer", source: "global" },
+    ];
+    const out = render(items, 0);
+    assert.ok(out.includes("[project]"));
+    assert.ok(out.includes("[global]"));
+  });
+
+  it("does not render a badge for built-ins", () => {
+    const out = render([sample[0]!], 0);
+    assert.ok(!out.includes("[builtin]"));
+  });
+
+  it("keeps a separator between long labels and the description", () => {
+    const items: SlashItem[] = [
+      { name: "mode", argHint: "edit|plan|auto", description: "Switch agent mode", source: "builtin" },
+    ];
+    const out = render(items, 0);
+    // Label is 20 chars; need at least one space before "Switch".
+    assert.ok(/\/mode edit\|plan\|auto\s+Switch agent mode/.test(out), out);
+  });
+
+  it("shows 'more above' / 'more below' on overflow", () => {
+    const items: SlashItem[] = Array.from({ length: 12 }, (_, i) => ({
+      name: `cmd${i}`,
+      description: `desc ${i}`,
+      source: "builtin" as const,
+    }));
+    const out = render(items, 11);
+    assert.ok(out.includes("more above"));
+  });
+});

--- a/src/ui/slash-picker.tsx
+++ b/src/ui/slash-picker.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { SlashItem } from "../commands/types.js";
+import type { Theme } from "./theme.js";
+
+interface Props {
+  items: SlashItem[];
+  selectedIndex: number;
+  theme: Theme;
+  query: string;
+}
+
+const VISIBLE_LIMIT = 7;
+const NAME_COL_MIN_WIDTH = 18;
+const NAME_DESC_GAP = 2;
+
+function sourceBadge(source: SlashItem["source"]): string {
+  if (source === "builtin") return "";
+  if (source === "project") return "project";
+  return "global";
+}
+
+function commandLabel(item: SlashItem): string {
+  return `/${item.name}${item.argHint ? ` ${item.argHint}` : ""}`;
+}
+
+export function SlashPicker({ items, selectedIndex, theme, query }: Props) {
+  let startIndex = 0;
+  if (selectedIndex >= VISIBLE_LIMIT) {
+    startIndex = selectedIndex - VISIBLE_LIMIT + 1;
+  }
+  const visible = items.slice(startIndex, startIndex + VISIBLE_LIMIT);
+  const hasMoreAbove = startIndex > 0;
+  const hasMoreBelow = items.length > startIndex + VISIBLE_LIMIT;
+  // Pad to the longest visible label so descriptions align across rows.
+  const longestLabel = visible.reduce((m, it) => Math.max(m, commandLabel(it).length), 0);
+  const nameColWidth = Math.max(NAME_COL_MIN_WIDTH, longestLabel + NAME_DESC_GAP);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        {query ? `Commands matching "/${query}"` : "Slash commands"}
+      </Text>
+      <Text color={theme.info.color}>
+        Arrow keys to navigate, Enter to select, Esc to cancel.
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {visible.length === 0 && (
+          <Text color={theme.info.color} dimColor>
+            No matches
+          </Text>
+        )}
+        {hasMoreAbove && (
+          <Text color={theme.info.color} dimColor>
+            … {startIndex} more above
+          </Text>
+        )}
+        {visible.map((item, i) => {
+          const actualIndex = startIndex + i;
+          const isSelected = actualIndex === selectedIndex;
+          const nameCol = commandLabel(item).padEnd(nameColWidth);
+          const badge = sourceBadge(item.source);
+          return (
+            <Text key={item.name} color={isSelected ? theme.accent : undefined} bold={isSelected}>
+              {isSelected ? "› " : "  "}
+              {nameCol}
+              <Text color={theme.info.color} dimColor>
+                {item.description}
+                {badge && `  [${badge}]`}
+              </Text>
+            </Text>
+          );
+        })}
+        {hasMoreBelow && (
+          <Text color={theme.info.color} dimColor>
+            … {items.length - (startIndex + VISIBLE_LIMIT)} more below
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/util/fuzzy.test.ts
+++ b/src/util/fuzzy.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { fuzzyMatch, fuzzyFilter } from "./fuzzy.js";
+
+describe("fuzzyMatch", () => {
+  it("matches empty query with score 0", () => {
+    assert.deepStrictEqual(fuzzyMatch("", "anything"), { matches: true, score: 0 });
+  });
+
+  it("rejects when query longer than text", () => {
+    assert.strictEqual(fuzzyMatch("abcdef", "abc").matches, false);
+  });
+
+  it("matches when chars appear in order", () => {
+    assert.strictEqual(fuzzyMatch("mdl", "model").matches, true);
+  });
+
+  it("rejects when chars are out of order", () => {
+    assert.strictEqual(fuzzyMatch("ldm", "model").matches, false);
+  });
+
+  it("scores exact prefix better than gappy match", () => {
+    const exact = fuzzyMatch("mod", "model");
+    const gappy = fuzzyMatch("mod", "memory off direct");
+    assert.ok(exact.matches && gappy.matches);
+    assert.ok(exact.score < gappy.score, `exact(${exact.score}) should beat gappy(${gappy.score})`);
+  });
+
+  it("rewards word-boundary matches", () => {
+    const boundary = fuzzyMatch("c", "cost");
+    const mid = fuzzyMatch("o", "cost");
+    assert.ok(boundary.score < mid.score);
+  });
+
+  it("is case-insensitive", () => {
+    assert.strictEqual(fuzzyMatch("MoD", "model").matches, true);
+  });
+
+  // Letters and digits are not swapped to match — keep matching simple.
+  it("does NOT swap letters/digits to match", () => {
+    assert.strictEqual(fuzzyMatch("2k", "k2").matches, false);
+  });
+});
+
+describe("fuzzyFilter", () => {
+  const items = ["model", "mode", "memory", "help", "compact"];
+  const id = (s: string) => s;
+
+  it("returns all items unchanged for empty query", () => {
+    assert.deepStrictEqual(fuzzyFilter(items, "", id), items);
+    assert.deepStrictEqual(fuzzyFilter(items, "   ", id), items);
+  });
+
+  it("filters out non-matching items", () => {
+    const out = fuzzyFilter(items, "mod", id);
+    assert.ok(out.includes("model"));
+    assert.ok(out.includes("mode"));
+    assert.ok(!out.includes("help"));
+  });
+
+  it("ranks tighter matches above gappier ones", () => {
+    const out = fuzzyFilter(items, "mo", id);
+    // model/mode (consecutive at boundary) should both rank above memory (gap)
+    const idxModel = out.indexOf("model");
+    const idxMode = out.indexOf("mode");
+    const idxMemory = out.indexOf("memory");
+    assert.ok(idxModel < idxMemory);
+    assert.ok(idxMode < idxMemory);
+  });
+
+  it("requires all space-separated tokens to match", () => {
+    const out = fuzzyFilter(items, "mo ry", id);
+    assert.deepStrictEqual(out, ["memory"]);
+  });
+});

--- a/src/util/fuzzy.ts
+++ b/src/util/fuzzy.ts
@@ -1,0 +1,81 @@
+/**
+ * Fuzzy matching utilities (trimmed port of pi-mono's fuzzy.ts).
+ * Match if all query characters appear in `text` in order (not necessarily
+ * consecutive). Lower score = better match.
+ */
+
+export interface FuzzyMatch {
+  matches: boolean;
+  score: number;
+}
+
+export function fuzzyMatch(query: string, text: string): FuzzyMatch {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+
+  if (q.length === 0) return { matches: true, score: 0 };
+  if (q.length > t.length) return { matches: false, score: 0 };
+
+  let qi = 0;
+  let score = 0;
+  let lastMatch = -1;
+  let consecutive = 0;
+
+  for (let i = 0; i < t.length && qi < q.length; i++) {
+    if (t[i] !== q[qi]) continue;
+
+    const isWordBoundary = i === 0 || /[\s\-_./:]/.test(t[i - 1]!);
+
+    if (lastMatch === i - 1) {
+      consecutive++;
+      score -= consecutive * 5;
+    } else {
+      consecutive = 0;
+      if (lastMatch >= 0) score += (i - lastMatch - 1) * 2;
+    }
+
+    if (isWordBoundary) score -= 10;
+    score += i * 0.1;
+
+    lastMatch = i;
+    qi++;
+  }
+
+  if (qi < q.length) return { matches: false, score: 0 };
+  return { matches: true, score };
+}
+
+/**
+ * Filter and sort items by fuzzy match quality (best matches first).
+ * Empty / whitespace-only query returns the input unchanged.
+ * Space-separated tokens must all match.
+ */
+export function fuzzyFilter<T>(
+  items: T[],
+  query: string,
+  getText: (item: T) => string,
+): T[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return items;
+
+  const tokens = trimmed.split(/\s+/);
+  const scored: { item: T; score: number }[] = [];
+
+  for (const item of items) {
+    const text = getText(item);
+    let total = 0;
+    let allMatch = true;
+    for (const token of tokens) {
+      const m = fuzzyMatch(token, text);
+      if (!m.matches) {
+        allMatch = false;
+        break;
+      }
+      total += m.score;
+    }
+    if (allMatch) scored.push({ item, score: total });
+  }
+
+  scored.sort((a, b) => a.score - b.score);
+  return scored.map((s) => s.item);
+}


### PR DESCRIPTION
Hey — companion to the `@` file picker from #217. Type `/` at the start of the input and a popup shows all built-in and custom slash commands with descriptions; keep typing to fuzzy-filter, arrow keys to navigate, Enter to insert (no auto-submit), Esc to cancel.

A few design notes:

- Took the trigger and matching cues from pi-mono's editor autocomplete — opens only when everything before the `/` is whitespace, so it can't surface commands that wouldn't actually fire through `handleSlash`.
- Refactored the existing `@` picker state into a single discriminated `activePicker` (`{ kind: "file" | "slash"; ... } | null`) since `CustomTextInput` only has one picker channel anyway. Cleaner than two parallel anchors.
- Built-ins are now a metadata array (name, description, optional argHint, source) in `src/commands/builtins.ts`, replacing the bare Set that lived in `app.tsx`. Caught some pre-existing drift along the way: `/lsp` and `/command` had handlers but weren't in the Set; `/community` was in the Set with no handler. All fixed.
- Custom commands keep their `project` / `global` source distinction in the picker (shown as a faint badge). Customs that shadow built-ins are filtered out, matching what the help menu already does.
- Picker closes when a modal takes over the input (theme picker, command wizard, permission dialog, etc.) so it doesn't pop back open when the modal closes.
- Fuzzy matcher is a small local port of pi-mono's `fuzzy.ts` (~80 lines, no deps). Dropped the alphanumeric-swap fallback — overkill for command names.

Landed it behind a `slashPicker` opt-in flag first to dogfood for a bit, then flipped to default-on after testing.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 308/308 pass, including new tests for `shouldOpenSlashPicker`, `insertSlashCommand` (incl. multi-space/tab tail normalization), `SlashPicker` rendering, and `fuzzyMatch`/`fuzzyFilter`
- [x] `npm run build`
- [x] Manual: `/`, type `mod`, arrow + Enter → inserts `/model `; mid-token `/m|od rest` + pick → `/model rest`; Esc closes (sticky cancel); modal boundary test; `hello /` doesn't open it