### PR TITLE
fix(cost): show big-picture week breakdown in ongoing TUI sessions

### DIFF
--- a/src/cost-attribution/renderer.ts
+++ b/src/cost-attribution/renderer.ts
@@ -73,7 +73,8 @@ export function renderTerminal(report: CostAttributionReport): string {
       const day = new Date(s.date).toLocaleDateString("en-US", { weekday: "short" });
       const cat = s.category;
       const sum = s.summary ? ` — ${s.summary}` : "";
-      lines.push(`  ${fmtCost(s.cost).padStart(6)}  ${day}  ${cat}${sum}`);
+      const cur = s.isCurrentSession ? " (current)" : "";
+      lines.push(`  ${fmtCost(s.cost).padStart(6)}  ${day}  ${cat}${sum}${cur}`);
     }
   }
 

--- a/src/cost-attribution/report.ts
+++ b/src/cost-attribution/report.ts
@@ -19,6 +19,7 @@ export interface BuildReportOptions {
   previousSessions?: SessionUsage[]; // for week-over-week comparison
   reconciliation?: ReconciliationResult;
   categoryFilter?: TaskCategory;
+  currentSessionId?: string; // highlight this session in top sessions
 }
 
 function dateInRange(date: string, start: string, end: string): boolean {
@@ -77,6 +78,7 @@ export function buildReport(opts: BuildReportOptions): CostAttributionReport {
       cost: s.cost,
       category: (s.category ?? "other") as TaskCategory,
       summary: s.summary,
+      isCurrentSession: opts.currentSessionId ? s.id === opts.currentSessionId : undefined,
     }));
 
   // Per-agent metrics

--- a/src/cost-attribution/tui-report.ts
+++ b/src/cost-attribution/tui-report.ts
@@ -45,26 +45,7 @@ function filterSessions(sessions: SessionUsage[], start: string, end: string): S
 export async function getCategoryReportText(sessionId?: string): Promise<string | null> {
   const log = await loadLog();
 
-  if (sessionId) {
-    const session = log.sessions.find((s) => s.id === sessionId);
-    if (!session) return null;
-    if (!session.category) {
-      const result = await classifyFromSessionFile(sessionId);
-      session.category = result.category;
-      session.confidence = result.confidence;
-      session.classifiedBy = result.classifiedBy;
-      session.summary = result.summary;
-      session.classifiedAt = new Date().toISOString();
-    }
-    const report = buildReport({
-      startDate: session.date,
-      endDate: session.date,
-      sessions: [session],
-    });
-    return renderTerminal(report);
-  }
-
-  // Default: last 7 days
+  // Default: last 7 days (big picture, same as `kimiflare cost --week`)
   const startDate = daysAgo(7);
   const endDate = today();
   const prevStart = daysAgo(14);
@@ -72,6 +53,19 @@ export async function getCategoryReportText(sessionId?: string): Promise<string 
 
   const sessions = filterSessions(log.sessions, startDate, endDate);
   const prevSessions = filterSessions(log.sessions, prevStart, prevEnd);
+
+  // Eagerly classify the current session so it appears correctly in the breakdown
+  if (sessionId) {
+    const session = log.sessions.find((s) => s.id === sessionId);
+    if (session && !session.category) {
+      const result = await classifyFromSessionFile(sessionId);
+      session.category = result.category;
+      session.confidence = result.confidence;
+      session.classifiedBy = result.classifiedBy;
+      session.summary = result.summary;
+      session.classifiedAt = new Date().toISOString();
+    }
+  }
 
   for (const s of sessions) {
     if (!s.category) {
@@ -89,6 +83,7 @@ export async function getCategoryReportText(sessionId?: string): Promise<string 
     endDate,
     sessions,
     previousSessions: prevSessions,
+    currentSessionId: sessionId,
   });
 
   return renderTerminal(report);

--- a/src/cost-attribution/types.ts
+++ b/src/cost-attribution/types.ts
@@ -78,6 +78,7 @@ export interface TopSessionEntry {
   cost: number;
   category: TaskCategory;
   summary?: string;
+  isCurrentSession?: boolean;
 }
 
 export interface ReconciliationResult {


### PR DESCRIPTION
When `/cost` was run inside an ongoing TUI session, `getCategoryReportText` isolated the report to a single session, dropping the week-over-week comparison and broader context. It also returned `null` if the session wasn't yet in `usage.json`, silently omitting the category breakdown entirely.

## Changes

- **tui-report.ts**: Always build the default 7-day report; eagerly classify the current session when `sessionId` is provided instead of isolating to a single-session view.
- **report.ts**: Add `currentSessionId` to `BuildReportOptions`; flag the matching session in `topSessions`.
- **types.ts**: Add `isCurrentSession` to `TopSessionEntry`.
- **renderer.ts**: Render `(current)` marker next to the ongoing session in the top sessions list.

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓

Fixes the issue where the cost breakdown feature doesn't show big picture cost when run in an ongoing session.

Co-authored-by: kimiflare <kimiflare@proton.me>