### PR TITLE
feat: /remote — autonomous coding on Cloudflare

### DIFF
--- a/docs/remote-architecture.md
+++ b/docs/remote-architecture.md
@@ -1,0 +1,1386 @@
+# `/remote` Feature — Architecture Document & Implementation Plan
+
+**Status:** Design complete, awaiting implementation.  
+**Decisions confirmed:** OAuth Device Flow (C), Worker Relay (B), Rich Base + Auto-Setup (C), Persistent Baseline + Copy (A), TUI + CLI + Web (C).
+
+---
+
+## Table of Contents
+
+1. [Codebase Findings](#1-codebase-findings)
+2. [End-to-End Sequence Diagram](#2-end-to-end-sequence-diagram)
+3. [Worker Design](#3-worker-design)
+4. [Artifacts Repo Lifecycle](#4-artifacts-repo-lifecycle)
+5. [Sandbox Lifecycle](#5-sandbox-lifecycle)
+6. [Secret and Credential Flow](#6-secret-and-credential-flow)
+7. [GitHub Integration](#7-github-integration)
+8. [Local CLI Changes](#8-local-cli-changes)
+9. [Failure Modes and Recovery](#9-failure-modes-and-recovery)
+10. [Observability](#10-observability)
+11. [Cost Model Per Session](#11-cost-model-per-session)
+12. [Pre-Mortem](#12-pre-mortem)
+13. [Phased Implementation Plan](#13-phased-implementation-plan)
+
+---
+
+## 1. Codebase Findings
+
+### 1.1 Current Agent Loop
+
+**Files:** `src/agent/loop.ts`, `src/agent/orchestrator.ts`, `src/agent/agent-session.ts`
+
+The agent loop is well-factored and largely reusable for a headless remote variant.
+
+- `runAgentTurn(opts: AgentTurnOpts)` (`src/agent/loop.ts:62`) is the core turn runner. It takes a prompt, messages array, tools, executor, callbacks, and an `AbortSignal`. It streams LLM events and executes tools in a loop until `maxToolIterations` (default 50) is hit.
+- `AgentOrchestrator` (`src/agent/orchestrator.ts:51`) sits above `runAgentTurn` for multi-agent mode. It manages per-role `AgentSession` objects (message buffers, artifact stores) and handles hand-offs between `research` / `coding` / `generalist` agents.
+- `AgentSession` (`src/agent/agent-session.ts:11`) is a plain object: `{ role, messages, recentToolCalls, artifactStore }`.
+
+**Reusability assessment:**
+- ✅ `runAgentTurn` can run headless with no TUI changes — it only calls callbacks.
+- ✅ `AgentOrchestrator` can run headless — same callback pattern.
+- ⚠️ The callback interface (`AgentCallbacks`, `src/agent/loop.ts:14`) is TUI-oriented (`onTextDelta`, `onReasoningDelta`, `onToolCallStart`, etc.). For `/remote`, we need a **structured progress serializer** that converts these callbacks into JSON lines for the Worker to relay. This is a thin adapter, not a refactor.
+- ⚠️ `codeMode` (`src/agent/loop.ts:51`) and `memoryManager` are optional; the remote agent can disable them in v1.
+
+**Key excerpt — the seam where headless mode diverges:**
+
+```ts
+// src/tools/executor.ts:91
+async run(
+  call: ToolInvocation,
+  askPermission: PermissionAsker,  // <-- this is the seam
+  ctx: ToolContext,
+  onFileChange?: (path: string, content: string) => void,
+): Promise<ToolResult> {
+  // ...
+  if (tool.needsPermission) {
+    const sessionKey = this.permissionKey(tool, args);
+    if (!this.sessionAllowed.has(sessionKey)) {
+      const decision = await askPermission({ tool, args, sessionKey });
+      // ...
+    }
+  }
+}
+```
+
+In local `auto` mode, `askPermission` immediately resolves `"allow"` (`src/app.tsx:1528`). The remote agent will do the same — no permission gating changes needed in `ToolExecutor`, just a headless `askPermission` that always returns `"allow"`.
+
+### 1.2 Config and Credential Handling
+
+**File:** `src/config.ts`
+
+Config lives at `~/.config/kimiflare/config.json` (XDG-compliant, falls back to `~/.kimiflare/config.json` for legacy).
+
+```ts
+// src/config.ts:25
+export interface KimiConfig {
+  accountId: string;
+  apiToken: string;
+  model: string;
+  aiGatewayId?: string;
+  // ... many other fields
+}
+```
+
+Credentials are **BYOK-only today**: the user puts their Cloudflare `accountId` and `apiToken` into the config file. There is no OAuth, no hosted auth, no secret manager integration.
+
+**How `/remote` secrets fit:**
+- `remoteWorkerUrl`: new optional config field pointing to the user's deployed orchestrator Worker.
+- `githubToken`: new optional config field (PAT or fine-grained PAT) for PR creation.
+- These should follow the exact same pattern: read from config file, overridable by env vars (`KIMIFLARE_REMOTE_WORKER_URL`, `KIMIFLARE_GITHUB_TOKEN`).
+
+### 1.3 CLI Command Framework
+
+**Files:** `src/commands/builtins.ts`, `src/app.tsx` ( `handleSlash` )
+
+Slash commands are dispatched in a single `handleSlash` callback inside the Ink `App` component. There is no separate command router — commands are hard-coded in `handleSlash` and matched by string prefix.
+
+**Excerpt of the most similar existing command (`/cost`):**
+
+```ts
+// src/app.tsx:1766
+if (c === "/cost") {
+  if (!cfg) return true;
+  if (arg === "on") {
+    const next = { ...cfg, costAttribution: true };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cost attribution enabled" }]);
+    return true;
+  }
+  // ...
+}
+```
+
+**Pattern for `/remote`:**
+1. Add `{ name: "remote", argHint: "[status|cancel <id>]", description: "...", source: "builtin" }` to `BUILTIN_COMMANDS` in `src/commands/builtins.ts`.
+2. Add a branch in `handleSlash` in `src/app.tsx`.
+3. If the user types `/remote` with no args, open a prompt collector (similar to how `/init` builds a prompt and calls `runAgentTurn`, but instead calls the Worker).
+
+### 1.4 GitHub Repo Identification
+
+**Finding:** kimiflare has **no explicit GitHub repo detection today**. It operates entirely on `process.cwd()`. There is no `git remote` inspection, no `GITHUB_REPO` env var, no config field for repo identity.
+
+**Implication for `/remote`:** We must add repo identification. The most natural place is:
+- At `/remote` invocation, inspect `git remote get-url origin` in `process.cwd()`.
+- Parse out `owner/repo`.
+- Cache it in the local session file (or config) so the user doesn't re-enter it.
+- This is new infrastructure; `/remote` invents it, but it should be minimal and automatic.
+
+### 1.5 Local State Directory
+
+**Files:** `src/sessions.ts`, `src/util/state.ts`, `src/usage-tracker.ts`
+
+Local state is organized under `~/.config/kimiflare/`:
+
+```ts
+// src/sessions.ts:36
+function sessionsDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "sessions");
+}
+
+// src/usage-tracker.ts:71
+function usageDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "usage");
+}
+
+// src/util/state.ts:9
+function statePath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "state.json");
+}
+```
+
+Sessions are JSON files named `{timestamp}-{sanitized-prompt}.json`. They contain messages, session state, artifact stores, and multi-agent state.
+
+**Integration point for `/remote`:**
+- Add a `remote/` subdirectory under `~/.config/kimiflare/` for remote session tracking.
+- Each remote session gets a JSON file: `{sessionId}.json` with fields: `sessionId`, `prompt`, `repo`, `workerUrl`, `status`, `branch`, `prUrl`, `createdAt`, `updatedAt`.
+- This mirrors the existing session persistence pattern exactly.
+
+### 1.6 Tool Execution / File Edit Pipeline
+
+**File:** `src/tools/executor.ts`
+
+`ToolExecutor.run()` is the universal entrypoint. It:
+1. Looks up the tool by name.
+2. Parses JSON args.
+3. Checks `tool.needsPermission` against `sessionAllowed` set.
+4. If not allowed, calls `askPermission` (the seam).
+5. Runs `tool.run(args, ctx)`.
+6. Normalizes and reduces output via `reduceToolOutput()`.
+7. Returns `ToolResult`.
+
+**Headless variant:** The remote agent inside the Sandbox will instantiate `ToolExecutor` with `ALL_TOOLS` (or a subset), and pass an `askPermission` that always resolves `"allow"`. No changes to `ToolExecutor` or individual tools are required.
+
+**The only Sandbox-specific consideration:** Some tools assume a local filesystem (`read`, `write`, `edit`, `bash`, `glob`, `grep`). Inside the Sandbox, `process.cwd()` will be `/workspace` and the repo will be cloned there. These tools will work unchanged because they operate on `ctx.cwd`.
+
+### 1.7 Streaming and Output Rendering
+
+**File:** `src/agent/loop.ts` ( `AgentCallbacks` )
+
+Local streaming uses a rich callback interface:
+
+```ts
+// src/agent/loop.ts:14
+export interface AgentCallbacks {
+  onAssistantStart?: () => void;
+  onReasoningDelta?: (text: string) => void;
+  onTextDelta?: (text: string) => void;
+  onToolCallStart?: (index: number, id: string, name: string) => void;
+  onToolCallArgs?: (index: number, delta: string) => void;
+  onToolCallFinalized?: (call: ToolCall) => void;
+  onUsage?: (usage: Usage) => void;
+  onUsageFinal?: (usage: Usage, gatewayMeta?: GatewayMeta) => void;
+  onGatewayMeta?: (meta: GatewayMeta) => void;
+  onAssistantFinal?: (msg: ChatMessage) => void;
+  onToolResult?: (result: ToolResult) => void;
+  onTasks?: (tasks: Task[]) => void;
+  askPermission: PermissionAsker;
+}
+```
+
+For `/remote`, the Sandbox agent will use the same callbacks but serialize them to **NDJSON progress events** that the Worker relays over SSE/WebSocket. Example event types:
+
+```ts
+type RemoteProgressEvent =
+  | { type: "turn_start"; turn: number }
+  | { type: "text_delta"; text: string }
+  | { type: "tool_call"; name: string; args: string }
+  | { type: "tool_result"; name: string; ok: boolean; content: string }
+  | { type: "usage"; promptTokens: number; completionTokens: number }
+  | { type: "tasks"; tasks: Task[] }
+  | { type: "turn_end" }
+  | { type: "done"; finishReason: string }
+  | { type: "error"; message: string };
+```
+
+The local CLI will render these as a simplified TUI stream (no diff modals, no permission prompts — just a tail of agent activity).
+
+### 1.8 Build, Test, and Release Tooling
+
+**Files:** `package.json`, `tsup.config.ts`
+
+- **Build:** `tsup` bundles `src/index.tsx` → `dist/index.js` (ESM, Node 20 target). Runtime deps (`ink`, `react`, `commander`, etc.) are externalized.
+- **CLI shim:** `bin/kimiflare.mjs` is a small wrapper that imports `../dist/index.js`.
+- **Test:** `tsx --test src/**/*.test.ts src/**/*.test.tsx` (Node native test runner).
+- **Release:** `npm run build` then `npm publish`. No Docker, no CI/CD config in repo.
+
+**Implication:** The `/remote` feature adds two new artifacts that do not fit the existing npm package:
+1. A **Cloudflare Worker** (orchestrator) — needs its own `wrangler.toml`, `package.json`, and build step.
+2. A **Sandbox container image** — needs a `Dockerfile` and a build/push workflow.
+
+These should live in a new `remote/` directory at repo root, with their own build scripts. The main `package.json` gets a `build:remote` script that delegates. Release process should include pushing the container image to a registry (GHCR or Docker Hub) and deploying the Worker via `wrangler deploy`.
+
+---
+
+## 2. End-to-End Sequence Diagram
+
+### 2.1 Session Start
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────┐     ┌─────────────┐
+│ Local CLI   │     │ Orchestrator    │     │ Artifacts       │     │ Sandbox     │     │ GitHub      │
+│ (kimiflare) │     │ Worker          │     │ (Git server)    │     │ Container   │     │ API         │
+└──────┬──────┘     └────────┬────────┘     └────────┬────────┘     └──────┬──────┘     └──────┬──────┘
+       │                     │                       │                     │                     │
+       │  1. POST /remote/start                      │                     │                     │
+       │  { prompt, repo, branch, githubToken,       │                     │                     │
+       │   accountId, apiToken, model, config }      │                     │                     │
+       │ ───────────────────────────────────────────>│                     │                     │
+       │                     │                       │                     │                     │
+       │                     │  2. Generate sessionId  │                     │                     │
+       │                     │  (uuid, 8-char prefix)  │                     │                     │
+       │                     │                       │                     │                     │
+       │                     │  3. Create Artifacts repo                     │                     │
+       │                     │  POST /repos  { name: "kf-<sessionId>" }      │                     │
+       │                     │ ──────────────────────>│                     │                     │
+       │                     │  { repoUrl, writeToken }                       │                     │
+       │                     │ <──────────────────────│                     │                     │
+       │                     │                       │                     │                     │
+       │                     │  4. Sync baseline     │                     │                     │
+       │                     │  (clone from GitHub or copy from cached baseline)
+       │                     │ ──────────────────────>│                     │                     │
+       │                     │                       │                     │                     │
+       │                     │  5. Create Sandbox    │                     │                     │
+       │                     │  sandbox.create({ id: sessionId, image: "kimiflare/remote-agent" })
+       │                     │ ───────────────────────────────────────────────────────────────>│
+       │                     │                       │                     │                     │
+       │                     │  6. Start agent process in Sandbox            │                     │
+       │                     │  exec("node", ["/opt/kimiflare/remote-agent.mjs"], {            │
+       │                     │    env: { SESSION_ID, ARTIFACTS_URL, ARTIFACTS_TOKEN,           │
+       │                     │           WORKER_RELAY_URL, REPO_OWNER, REPO_NAME,              │
+       │                     │           GITHUB_BRANCH, PROMPT, MODEL, ... } })                │
+       │                     │ ───────────────────────────────────────────────────────────────>│
+       │                     │                       │                     │                     │
+       │                     │  7. Stream SSE back to CLI                    │                     │
+       │  { sessionId, status: "running", streamUrl }  │                     │                     │
+       │ <───────────────────────────────────────────│                     │                     │
+       │                     │                       │                     │                     │
+       │  8. CLI opens SSE to streamUrl                │                     │                     │
+       │ ────────────────────────────────────────────>│                     │                     │
+       │  [progress events: turn_start, text_delta, tool_call, tool_result, usage, ...]        │
+       │ <───────────────────────────────────────────│                     │                     │
+       │                     │                       │                     │                     │
+```
+
+### 2.2 Agent Execution (Inside Sandbox)
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│ Sandbox Agent   │     │ Orchestrator    │     │ Workers AI      │     │ Artifacts       │
+│ Process         │     │ Worker          │     │ (Kimi K2.6)     │     │ Repo            │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │                       │
+         │  1. POST /relay       │                       │                       │
+         │  { model, messages, tools, temperature }      │                       │
+         │ ─────────────────────>│                       │                       │
+         │                       │  2. Forward to Workers AI                     │
+         │                       │  (holds real API token)                       │
+         │                       │ ─────────────────────>│                       │
+         │                       │  [SSE stream: reasoning, text, tool_calls]    │
+         │                       │ <─────────────────────│                       │
+         │                       │                       │                       │
+         │  3. Stream response back                      │                       │
+         │ <─────────────────────│                       │                       │
+         │                       │                       │                       │
+         │  4. Execute tools (read, write, edit, bash, git)                      │
+         │  → All operate on /workspace (cloned Artifacts repo)                  │
+         │                       │                       │                       │
+         │  5. git commit after each successful tool batch                       │
+         │  → Commits land in the Artifacts repo (not GitHub yet)                │
+         │                       │                       │                       │
+         │  6. Stream progress events to Worker via POST /progress               │
+         │  { sessionId, events: [...] }               │                       │
+         │ ─────────────────────>│                       │                       │
+         │                       │  7. Relay to CLI SSE stream                   │
+         │                       │                       │                       │
+         │                       │                       │                       │
+```
+
+### 2.3 Finalize (PR Creation)
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│ Sandbox Agent   │     │ Orchestrator    │     │ Artifacts       │     │ GitHub          │
+│ Process         │     │ Worker          │     │ Repo            │     │ API             │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │                       │
+         │  1. Agent finishes    │                       │                       │
+         │  → Final git commit + push to Artifacts       │                       │
+         │                       │                       │                       │
+         │  2. POST /finalize    │                       │                       │
+         │  { sessionId, summary, commitCount }          │                       │
+         │ ─────────────────────>│                       │                       │
+         │                       │                       │                       │
+         │                       │  3. Push branch from Artifacts to GitHub      │
+         │                       │  git push https://<githubToken>@github.com/... │
+         │                       │ ──────────────────────────────────────────────>│
+         │                       │                       │                       │
+         │                       │  4. Open PR via GitHub API                    │
+         │                       │  POST /repos/{owner}/{repo}/pulls             │
+         │                       │  { title, body, head: "kimiflare/remote/<sessionId>", base: "main" }
+         │                       │ ──────────────────────────────────────────────>│
+         │                       │  { html_url, number } │                       │
+         │                       │ <──────────────────────────────────────────────│
+         │                       │                       │                       │
+         │                       │  5. Update session state: status="done"       │
+         │                       │  Store PR URL, branch name, summary           │
+         │                       │                       │                       │
+         │  6. Stream final event to CLI                 │                       │
+         │  { type: "done", prUrl, branch, summary }     │                       │
+         │ <─────────────────────│                       │                       │
+         │                       │                       │                       │
+```
+
+### 2.4 What Runs Where
+
+| Component | Location | Responsibilities |
+|-----------|----------|------------------|
+| **Local CLI** | User's laptop | Collect prompt, auth with Worker, stream progress, persist session metadata, subcommands for status/cancel/list |
+| **Orchestrator Worker** | Cloudflare Edge | Session lifecycle, Artifacts repo management, Sandbox creation/management, GitHub API calls, LLM relay, progress streaming, finalize/PR creation |
+| **Sandbox Container** | Cloudflare Sandbox | Run headless kimiflare agent, execute tools on `/workspace`, call LLM via Worker relay, commit to Artifacts repo |
+| **Artifacts Repo** | Cloudflare Artifacts | Per-session Git repo holding the agent's work. Durable across Sandbox restarts. |
+| **GitHub** | GitHub.com | Source of truth for baseline code, destination for PRs |
+
+---
+
+## 3. Worker Design
+
+### 3.1 Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/remote/start` | Bearer token (CLI → Worker shared secret) | Start a new remote session. Returns `{ sessionId, streamUrl }`. |
+| `GET` | `/remote/stream/:sessionId` | None (URL contains random token) | SSE endpoint for progress events. Opened by local CLI. |
+| `POST` | `/remote/cancel/:sessionId` | Bearer token | Cancel a running session. Signals Sandbox to terminate. |
+| `GET` | `/remote/status/:sessionId` | None (or Bearer token) | JSON snapshot of session state (for CLI subcommands and web page). |
+| `POST` | `/relay` | Internal (Sandbox → Worker, IP-restricted or mTLS) | LLM relay endpoint. Sandbox agent sends prompts here; Worker forwards to Workers AI. |
+| `POST` | `/progress/:sessionId` | Internal (Sandbox → Worker) | Sandbox agent posts batched progress events. Worker relays to SSE stream. |
+| `POST` | `/finalize/:sessionId` | Internal (Sandbox → Worker) | Agent signals completion. Worker pushes branch to GitHub and opens PR. |
+| `GET` | `/remote/web/:sessionId` | None | Static HTML page that consumes the SSE stream. For mobile/status checking. |
+
+### 3.2 Worker Authentication (Local CLI → Worker)
+
+The Worker must verify that the local CLI is authorized to start sessions.
+
+**Mechanism:** Shared secret + optional OAuth.
+
+1. **Shared Secret (v1):** User generates a random secret (`wrangler secret put REMOTE_AUTH_SECRET`) and stores it in both the Worker and their local config (`remoteAuthSecret`). The CLI sends it as `Authorization: Bearer <secret>` on every request.
+2. **OAuth Extension (v2):** For managed cloud, the Worker can accept a JWT issued by a kimiflare auth service. BYOK users continue using the shared secret.
+
+**Why not just the GitHub token?** The GitHub token is for GitHub API calls, not for Worker authentication. Separating them means a leaked GitHub token can't be used to spawn arbitrary Sandbox sessions.
+
+### 3.3 Worker → Artifacts
+
+The Worker uses the **Artifacts Workers Binding API** (not REST) for performance.
+
+```ts
+// wrangler.toml
+[[artifacts]]
+binding = "ARTIFACTS"
+```
+
+```ts
+// In the Worker
+const repo = await env.ARTIFACTS.createRepo({
+  name: `kf-${sessionId}`,
+});
+// repo.url, repo.writeToken, repo.readToken
+```
+
+For baseline sync, the Worker may need to read from an existing baseline repo. The binding provides read/write token generation scoped to specific repos.
+
+### 3.4 Worker → Sandbox
+
+The Worker uses the **Sandbox SDK binding**.
+
+```ts
+// wrangler.toml
+[[sandbox]]
+binding = "SANDBOX"
+```
+
+```ts
+// In the Worker
+const sandbox = await env.SANDBOX.create({
+  id: sessionId,  // deterministic for routing
+  image: "kimiflare/remote-agent:latest",
+  env: {
+    SESSION_ID: sessionId,
+    ARTIFACTS_URL: repo.url,
+    ARTIFACTS_TOKEN: repo.writeToken,
+    WORKER_RELAY_URL: `https://${workerHost}/relay`,
+    // ... other config
+  },
+});
+```
+
+**Sandbox ID strategy:** Derived directly from `sessionId` (e.g., `sandbox.id = sessionId`). This ensures stable routing: if the Worker needs to send a command to an existing Sandbox, it uses the same ID.
+
+### 3.5 State Management
+
+**Durable Object (DO) per session.**
+
+Each `/remote` session gets its own Durable Object instance keyed by `sessionId`.
+
+**Why Durable Object?**
+- SSE streams require a persistent WebSocket-like connection. DOs maintain in-memory state and can hold the SSE `ReadableStream`.
+- DOs survive Worker restarts and colocate compute with state.
+- DOs provide atomic state updates and alarm-based timeouts.
+
+**DO State Schema:**
+
+```ts
+interface SessionState {
+  sessionId: string;
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
+  prompt: string;
+  repo: { owner: string; name: string };
+  branch: string;
+  artifactsRepo: { name: string; url: string; writeToken: string };
+  sandboxId: string;
+  githubToken: string;  // encrypted at rest (DO storage is encrypted)
+  progressEvents: RemoteProgressEvent[];  // last 1000, for replay
+  prUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  maxTurns: number;
+  currentTurn: number;
+}
+```
+
+**Why not KV or D1?**
+- KV is eventually consistent and has 60s propagation — unacceptable for real-time progress.
+- D1 is SQL but doesn't support SSE streaming or alarms natively.
+- DO is the right abstraction for session-oriented state + streaming.
+
+---
+
+## 4. Artifacts Repo Lifecycle
+
+### 4.1 Naming Convention
+
+Per-session repo name: `kf-<sessionId>`
+
+- `sessionId` is a UUID v4, 36 chars. Prefix `kf-` makes it 39 chars.
+- Artifacts limits: 3–63 chars, lowercase, a-z and hyphens only.
+- UUID v4 contains hyphens, which are allowed. All lowercase.
+- Collision probability: effectively zero (UUID v4).
+
+### 4.2 Baseline Repo
+
+**Persistent baseline:** `kf-baseline-<owner>-<repo>`
+
+- Created lazily on first `/remote` invocation for a given GitHub repo.
+- The Worker refreshes it from GitHub `main` before each session batch:
+  1. Check if baseline exists.
+  2. If not, create it and clone from GitHub.
+  3. If it exists, fetch latest from GitHub and fast-forward.
+- The baseline is updated in-place; it is not immutable.
+
+**Why a baseline?**
+- Artifacts-to-Artifacts copy is fast (same data center, no egress).
+- GitHub clone bandwidth is saved.
+- For `/parallel N`, all N sessions copy from the same baseline — instant.
+
+### 4.3 Per-Session Repo Creation
+
+For each session:
+1. Worker creates a new Artifacts repo: `kf-<sessionId>`.
+2. Worker clones the baseline repo into the new repo.
+3. Worker creates a new branch: `kimiflare/remote/<sessionId>`.
+4. The Sandbox agent works on this branch.
+
+### 4.4 Token Strategy
+
+| Token | Minted By | Lifetime | Scope |
+|-------|-----------|----------|-------|
+| **Artifacts write token** | Worker (via binding) | Per-session, 24h | Single repo: `kf-<sessionId>` |
+| **Artifacts read token** | Worker (via binding) | Per-session, 24h | Single repo: `kf-<sessionId>` or baseline |
+| **GitHub token** | User (OAuth or PAT) | OAuth: 8h access + refresh; PAT: until revoked | User's repos (PR + push) |
+| **Workers AI token** | Worker (via binding or secret) | Per-request | Workers AI inference |
+
+**Token flow:**
+- Artifacts write token → injected into Sandbox env → agent uses it to `git push` to the session repo.
+- GitHub token → **never** enters Sandbox. Held only by Worker. Used in finalize step to push branch to GitHub and open PR.
+- Workers AI token → held by Worker. Sandbox calls `/relay`; Worker attaches the token.
+
+### 4.5 Cleanup Policy
+
+- **Session repos:** Deleted 7 days after session completion (success or error). Configurable via `REMOTE_REPO_TTL_DAYS` env var on Worker.
+- **Baseline repos:** Kept indefinitely. Refreshed on demand. If unused for 30 days, Worker may delete and recreate lazily.
+- **Cleanup mechanism:** DO alarm scheduled at session completion. Alarm fires after TTL; Worker calls `env.ARTIFACTS.deleteRepo(name)`.
+
+---
+
+## 5. Sandbox Lifecycle
+
+### 5.1 Container Image
+
+**Base:** `node:20-bookworm` (Debian 12, full build toolchain)
+
+**Pre-installed:**
+- `node` (20.x) + `npm`
+- `git`
+- `python3` + `pip`
+- `build-essential` (gcc, g++, make)
+- `curl`, `wget`, `jq`
+- `rustup` (Rust toolchain)
+- `golang` (Go compiler)
+
+**Image layers:**
+1. Base Debian + system packages
+2. Node + npm
+3. Language runtimes (Python, Rust, Go)
+4. Pre-built kimiflare remote agent (`remote/agent/remote-agent.mjs`)
+
+**Size:** ~1.5GB uncompressed. Cloudflare caches images after first pull, so cold start is ~10–30s, warm start is ~2–5s.
+
+**Registry:** GitHub Container Registry (`ghcr.io/sinameraji/kimiflare-remote-agent`).
+
+### 5.2 Sandbox ID Strategy
+
+```ts
+sandboxId = sessionId;  // deterministic 1:1 mapping
+```
+
+This means:
+- The Worker can always address a Sandbox by its session ID.
+- If a DO needs to send a command to a Sandbox, it uses `env.SANDBOX.get(sessionId)`.
+- No separate ID namespace to manage.
+
+### 5.3 Agent Launch
+
+The Worker starts the agent via `sandbox.exec()`:
+
+```ts
+await sandbox.exec("node", ["/opt/kimiflare/remote-agent.mjs"], {
+  env: {
+    SESSION_ID: sessionId,
+    ARTIFACTS_URL: artifactsRepo.url,
+    ARTIFACTS_TOKEN: artifactsRepo.writeToken,
+    WORKER_RELAY_URL: `https://${workerHost}/relay`,
+    PROGRESS_URL: `https://${workerHost}/progress/${sessionId}`,
+    FINALIZE_URL: `https://${workerHost}/finalize/${sessionId}`,
+    REPO_OWNER: repo.owner,
+    REPO_NAME: repo.name,
+    GITHUB_BRANCH: `kimiflare/remote/${sessionId}`,
+    PROMPT: prompt,
+    MODEL: model,
+    MAX_TURNS: String(maxTurns),
+    REASONING_EFFORT: reasoningEffort,
+  },
+  cwd: "/workspace",
+});
+```
+
+The agent process is long-running. It:
+1. Clones the Artifacts repo into `/workspace`.
+2. Checks out the session branch.
+3. Runs the agent loop (`runAgentTurn` in headless mode).
+4. Commits after each tool batch.
+5. Posts progress events to `PROGRESS_URL`.
+6. On completion, posts to `FINALIZE_URL`.
+
+### 5.4 stdout/stderr/progress Streaming
+
+The Sandbox agent writes progress events as **NDJSON lines** to stdout. The Sandbox SDK captures stdout and streams it to the Worker.
+
+```ts
+// Inside Sandbox agent
+console.log(JSON.stringify({ type: "turn_start", turn: 1 }));
+console.log(JSON.stringify({ type: "text_delta", text: "I'll start by..." }));
+console.log(JSON.stringify({ type: "tool_call", name: "read", args: "{\"path\":\"README.md\"}" }));
+// ...
+```
+
+The Worker parses these lines and relays them to the SSE stream connected to the local CLI.
+
+**Why NDJSON to stdout instead of HTTP posts?**
+- Simpler: no HTTP client needed inside the agent.
+- The Sandbox SDK already captures stdout; we just need to parse it.
+- For `/parallel N`, HTTP posts from N Sandboxes could overwhelm the Worker. stdout streaming is pull-based (Worker reads at its own pace).
+
+**Alternative (HTTP posts):** If stdout parsing proves unreliable, the agent can POST batched events to `PROGRESS_URL`. This is a fallback, not the primary path.
+
+### 5.5 Sandbox Sleep Behavior
+
+Cloudflare Sandboxes sleep after a period of inactivity (exact timeout TBD by Cloudflare, typically 5–15 minutes).
+
+**Impact on long-running agents:**
+- If the agent is actively running (CPU usage > 0), the Sandbox stays warm.
+- If the agent is waiting for an LLM response (which can take 30–60s), the Sandbox may sleep.
+- **Mitigation:** The agent sends a heartbeat (empty NDJSON line or `{"type":"heartbeat"}`) every 60s while idle. This keeps the Sandbox warm.
+- **Resume:** If the Sandbox does sleep, the Worker detects it on next stdout read and calls `sandbox.wake()` (or the SDK auto-wakes on next exec). The agent process resumes from where it left off — no state loss because all state is in the Artifacts repo and the DO.
+
+### 5.6 Idle Timeout and Forced Shutdown
+
+| Timeout | Value | Action |
+|---------|-------|--------|
+| **Max session duration** | 4 hours | DO alarm fires; Worker cancels Sandbox, sets status="error", notifies user. |
+| **Idle timeout** | 30 minutes | If no stdout output for 30m, Worker assumes agent is stuck; cancels Sandbox. |
+| **Tool iteration limit** | 50 (configurable) | Agent loop self-terminates after 50 turns. |
+| **Token budget** | 1M tokens (configurable) | Agent loop self-terminates if cumulative usage exceeds budget. |
+
+---
+
+## 6. Secret and Credential Flow
+
+### 6.1 Worker Secrets
+
+Stored via `wrangler secret put`:
+
+| Secret | Description |
+|--------|-------------|
+| `REMOTE_AUTH_SECRET` | Shared secret for CLI → Worker auth. |
+| `CF_API_TOKEN` | Cloudflare API token for Workers AI relay. |
+| `GITHUB_APP_CLIENT_SECRET` | For OAuth device flow (if using GitHub App). |
+| `GITHUB_WEBHOOK_SECRET` | For GitHub webhook verification (optional). |
+
+### 6.2 Sandbox Environment Variables
+
+Injected by Worker at Sandbox creation:
+
+| Env Var | Value | Sensitive? |
+|---------|-------|------------|
+| `ARTIFACTS_URL` | Session repo Git URL | No |
+| `ARTIFACTS_TOKEN` | Short-lived write token | **Yes** — scoped to single repo |
+| `WORKER_RELAY_URL` | `https://worker/relay` | No |
+| `PROGRESS_URL` | `https://worker/progress/:id` | No |
+| `FINALIZE_URL` | `https://worker/finalize/:id` | No |
+| `SESSION_ID` | UUID | No |
+| `REPO_OWNER` | GitHub owner | No |
+| `REPO_NAME` | GitHub repo name | No |
+| `GITHUB_BRANCH` | `kimiflare/remote/<id>` | No |
+| `PROMPT` | User prompt | No |
+| `MODEL` | Model ID | No |
+| `MAX_TURNS` | Max iterations | No |
+| `REASONING_EFFORT` | low/medium/high | No |
+
+**Notably absent:** `CF_API_TOKEN` (Workers AI token) and `GITHUB_TOKEN` (GitHub PAT). These never enter the Sandbox.
+
+### 6.3 GitHub Token
+
+- Held only by the Worker (in DO storage, encrypted at rest).
+- Used exclusively in the finalize step: `git push` to GitHub + `POST /repos/{owner}/{repo}/pulls`.
+- Never logged, never sent to client, never injected into Sandbox.
+
+### 6.4 Workers AI Token
+
+- Held only by the Worker.
+- The `/relay` endpoint attaches it to the outgoing Workers AI request.
+- The Sandbox agent sends `{ model, messages, tools }` to `/relay`; the Worker adds auth and forwards.
+- The Worker can enforce per-session rate limits and max-spend here.
+
+### 6.5 Artifacts Write Token
+
+- Minted by Worker via Artifacts binding.
+- Scoped to a single repo (`kf-<sessionId>`).
+- Lifetime: 24 hours.
+- Injected into Sandbox env for `git push`.
+- If leaked, attacker can only push to the session repo (which is deleted after 7 days anyway).
+
+---
+
+## 7. GitHub Integration
+
+### 7.1 Repo Identification
+
+At `/remote` invocation:
+1. Local CLI runs `git remote get-url origin` in `process.cwd()`.
+2. Parses URL to extract `owner/repo` (supports HTTPS and SSH formats).
+3. If parsing fails, prompts user to enter `owner/repo` manually.
+4. Caches result in local config (`githubRepo: "owner/repo"`) for future sessions.
+
+**BYOK vs Managed Cloud:**
+- BYOK: User's local CLI inspects their local git repo. Worker URL is configurable (`remoteWorkerUrl` in config).
+- Managed Cloud: Same flow, but `remoteWorkerUrl` points to our hosted Worker.
+
+### 7.2 Branch Naming Convention
+
+```
+kimiflare/remote/<sessionId>
+```
+
+- Prefix `kimiflare/remote/` makes it easy to identify and filter.
+- `sessionId` is the UUID, ensuring uniqueness.
+- Example: `kimiflare/remote/a1b2c3d4-e5f6-7890-abcd-ef1234567890`
+
+### 7.3 How Commits Land on GitHub
+
+**Worker pushes after agent finishes (not agent directly).**
+
+Rationale:
+- The GitHub token never enters the Sandbox.
+- The Worker can handle push failures (retry, fallback, notify user).
+- The Worker can rewrite the branch (e.g., squash commits) before pushing.
+- If push fails, the work is not lost — it's still in the Artifacts repo.
+
+**Flow:**
+1. Agent finishes, commits final changes to Artifacts repo.
+2. Agent POSTs `/finalize/:sessionId`.
+3. Worker clones the Artifacts repo (or uses a local copy), checks out the session branch.
+4. Worker force-pushes the branch to GitHub: `git push --force-with-lease origin kimiflare/remote/<sessionId>`.
+5. Worker opens PR via GitHub API.
+
+### 7.4 PR Body Template
+
+```markdown
+## 🤖 Kimiflare Remote Session
+
+**Session ID:** `a1b2c3d4-e5f6-7890-abcd-ef1234567890`
+**Prompt:**
+> Add OAuth device flow authentication to the CLI
+
+**Summary:**
+- Added `src/auth/github.ts` with device flow implementation
+- Updated `src/config.ts` to store GitHub tokens
+- Added `kimiflare auth github` subcommand
+- All changes include tests
+
+**Commits:** 12
+**Turns:** 23 / 50
+**Tokens used:** ~45,000
+**Status:** ✅ Completed
+
+**View live log:** [Session status page](https://worker.example.com/remote/web/a1b2c3d4-e5f6-7890-abcd-ef1234567890)
+
+---
+*This PR was generated by [kimiflare](https://github.com/sinameraji/kimiflare) in remote mode.*
+```
+
+---
+
+## 8. Local CLI Changes
+
+### 8.1 The `/remote` Command
+
+**In TUI (`src/app.tsx`):**
+
+```ts
+if (c === "/remote") {
+  if (!cfg?.remoteWorkerUrl) {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "remote worker not configured. Set remoteWorkerUrl in config." }]);
+    return true;
+  }
+  if (!arg) {
+    // Open prompt collector (similar to /init)
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "Enter your remote prompt:" }]);
+    // User types prompt, hits enter
+    // → calls startRemoteSession(prompt)
+    return true;
+  }
+  // /remote status, /remote cancel handled by subcommands
+  return true;
+}
+```
+
+**Subcommands (`src/index.tsx` via Commander):**
+
+```ts
+program
+  .command("remote")
+  .description("Manage remote sessions")
+  .addCommand(
+    new Command("list")
+      .description("List remote sessions")
+      .action(async () => { /* ... */ })
+  )
+  .addCommand(
+    new Command("status")
+      .description("Show remote session status")
+      .argument("[session-id]", "Session ID (defaults to most recent)")
+      .action(async (sessionId) => { /* ... */ })
+  )
+  .addCommand(
+    new Command("cancel")
+      .description("Cancel a remote session")
+      .argument("<session-id>", "Session ID")
+      .action(async (sessionId) => { /* ... */ })
+  )
+  .addCommand(
+    new Command("auth")
+      .description("Authenticate with GitHub")
+      .addCommand(
+        new Command("github")
+          .description("Authenticate via OAuth device flow")
+          .action(async () => { /* ... */ })
+      )
+  );
+```
+
+### 8.2 Status Streaming
+
+When the user types `/remote <prompt>`:
+1. CLI POSTs to Worker `/remote/start`.
+2. Worker returns `{ sessionId, streamUrl }`.
+3. CLI opens SSE connection to `streamUrl`.
+4. CLI renders a simplified stream:
+   - No diff modals, no permission prompts.
+   - Shows: turn number, current action, tool calls, token usage.
+   - Similar to `tail -f` but structured.
+
+**Rendering example:**
+```
+🚀 Remote session a1b2c3d4 started
+   Repo: sinameraji/kimiflare
+   Branch: kimiflare/remote/a1b2c3d4
+
+Turn 1/50  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  0 tokens
+  → read README.md
+  → read package.json
+
+Turn 2/50  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  1,234 tokens
+  → write src/auth/github.ts
+  → bash npm run typecheck
+
+...
+
+✅ Done — PR opened: https://github.com/sinameraji/kimiflare/pull/123
+```
+
+### 8.3 Detach Behavior
+
+- User closes laptop → SSE connection drops.
+- Worker continues running the session (DO + Sandbox are independent of CLI connection).
+- User reopens terminal, runs `kimiflare remote status` (no ID needed — defaults to most recent).
+- CLI fetches current state from Worker and prints summary.
+- If session is still running, CLI can re-open the SSE stream at the current position (Worker supports `Last-Event-ID` for replay).
+
+### 8.4 Local Session Persistence
+
+Remote sessions are stored in `~/.config/kimiflare/remote/`:
+
+```ts
+interface RemoteSessionFile {
+  sessionId: string;
+  prompt: string;
+  repo: string;  // "owner/repo"
+  workerUrl: string;
+  status: "pending" | "running" | "done" | "error" | "cancelled";
+  branch?: string;
+  prUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt?: string;
+}
+```
+
+---
+
+## 9. Failure Modes and Recovery
+
+### 9.1 Sandbox Crashes Mid-Task
+
+**Detection:** Worker stops receiving stdout from Sandbox. DO idle timeout alarm fires.
+
+**Recovery:**
+1. Worker sets status="error".
+2. Worker attempts to restart the Sandbox with the same `sessionId`.
+3. On restart, the agent process checks the Artifacts repo for existing commits.
+4. If commits exist, agent resumes from the last commit (replays the last turn's context from the DO).
+5. If resumption fails, Worker notifies user with error message and Artifacts repo URL (work is not lost).
+
+**Max retries:** 3. After 3 crashes, session is marked "error" and user is notified.
+
+### 9.2 Agent Gets Stuck in a Loop
+
+**Detection:**
+- `maxToolIterations` (default 50) reached.
+- `maxTokens` (default 1M) exceeded.
+- Idle timeout (30 min with no output).
+- DO alarm for max session duration (4 hours).
+
+**Recovery:**
+- Agent loop self-terminates, commits current work, calls `/finalize`.
+- Worker opens PR with whatever work was completed.
+- PR body notes: "Session terminated after N turns — work may be incomplete."
+
+### 9.3 GitHub Push Fails
+
+**Scenarios:**
+- Token expired → Worker refreshes OAuth token (if using device flow) or reports error (if PAT).
+- Branch conflict → Worker force-pushes (`--force-with-lease`) after warning.
+- Network error → Retry with exponential backoff (3 attempts).
+- Repo not found → Report error to user.
+
+**Work preservation:** The Artifacts repo is durable. Even if GitHub push fails, the work exists in Artifacts. The user can manually pull from Artifacts or retry finalize.
+
+### 9.4 User Cancels
+
+**Flow:**
+1. User runs `kimiflare remote cancel <sessionId>`.
+2. CLI POSTs `/remote/cancel/:sessionId`.
+3. Worker signals Sandbox to terminate (`sandbox.kill()` or `sandbox.exec("kill", [pid])`).
+4. Worker sets status="cancelled".
+5. Worker does NOT open a PR (unless user explicitly requests "cancel and save").
+
+### 9.5 Worker Crash / DO Loss
+
+**Mitigation:**
+- DOs are backed by persistent storage. If the DO crashes, it recovers from storage on next request.
+- SSE streams are re-establishable. CLI reconnects automatically.
+- Sandbox continues running independently of Worker (it only needs the Worker for `/relay` and `/progress`). If Worker is down, Sandbox buffers progress events and retries.
+
+---
+
+## 10. Observability
+
+### 10.1 Logging Strategy
+
+| Layer | Destination | Contents |
+|-------|-------------|----------|
+| **Agent logs** | stdout (Sandbox) → Worker → DO storage | Every tool call, LLM request, commit, error. Stored in DO for 7 days. |
+| **Worker logs** | Cloudflare Workers Logs | HTTP requests, session lifecycle, errors, token usage. |
+| **Sandbox stdout** | Worker (via SDK) → DO storage | Raw NDJSON progress events. |
+
+### 10.2 Debugging a Failed Session
+
+**Developer (you) flow:**
+1. Get `sessionId` from user or Worker logs.
+2. Query DO directly: `wrangler d1 execute` or custom admin endpoint.
+3. Retrieve stored progress events and agent logs from DO storage.
+4. Check Artifacts repo: `git clone https://artifacts.cloudflare.com/.../kf-<sessionId>`.
+5. Check Worker logs in Cloudflare dashboard.
+
+**User flow:**
+1. Run `kimiflare remote status <sessionId>` — shows error message and last known state.
+2. Visit web status page — shows full event history.
+3. If PR was opened, PR body links to session page.
+
+### 10.3 Metrics
+
+Worker emits metrics to Cloudflare Analytics (or optional external service):
+
+- `remote_sessions_started_total`
+- `remote_sessions_completed_total` (label: `status=done|error|cancelled`)
+- `remote_session_duration_seconds` (histogram)
+- `remote_turns_per_session` (histogram)
+- `remote_tokens_per_session` (histogram)
+- `relay_requests_total` (label: `model`, `status`)
+- `sandbox_crashes_total` (label: `sessionId`)
+
+---
+
+## 11. Cost Model Per Session
+
+### 11.1 Components
+
+| Component | Unit | Rate | Typical Session |
+|-----------|------|------|-----------------|
+| **Sandbox CPU** | CPU-seconds | $0.0001 / CPU-s | 30 min × 1 CPU = 1,800s → $0.18 |
+| **Sandbox Memory** | GB-seconds | $0.0001 / GB-s | 30 min × 2 GB = 3,600 GB-s → $0.36 |
+| **Sandbox Egress** | GB | $0.09 / GB | ~0.1 GB (progress events) → $0.009 |
+| **Artifacts Storage** | GB-month | $0.023 / GB-month | 0.1 GB × 7 days → ~$0.0005 |
+| **Artifacts Ops** | Requests | $0.004 / 1,000 | ~500 requests → $0.002 |
+| **Workers Invocations** | Requests | $0.50 / 1M | ~1,000 invocations → $0.0005 |
+| **Workers AI (Kimi K2.6)** | Tokens | $0.95/M input, $4.00/M output | ~50K input + 20K output → $0.13 |
+| **Durable Object** | Requests + Storage | $0.12/M requests, $0.12/GB-month | ~1,000 requests + negligible storage → $0.0001 |
+
+### 11.2 Per-Session Estimate
+
+**Typical session (30 min, 50K input tokens, 20K output tokens):**
+
+| Cost Item | Amount |
+|-----------|--------|
+| Sandbox CPU | $0.18 |
+| Sandbox Memory | $0.36 |
+| Sandbox Egress | $0.01 |
+| Artifacts | $0.00 |
+| Workers | $0.00 |
+| Workers AI | $0.13 |
+| Durable Object | $0.00 |
+| **Total** | **~$0.68** |
+
+**Long session (2 hours, 200K input, 80K output):**
+
+| Cost Item | Amount |
+|-----------|--------|
+| Sandbox CPU | $0.72 |
+| Sandbox Memory | $1.44 |
+| Sandbox Egress | $0.02 |
+| Workers AI | $0.52 |
+| **Total** | **~$2.70** |
+
+### 11.3 Per-1,000-Sessions Estimate
+
+| Scenario | Cost |
+|----------|------|
+| 1,000 typical sessions | **~$680** |
+| 1,000 long sessions | **~$2,700** |
+
+### 11.4 Cost Controls
+
+- Per-session token budget (default 1M tokens).
+- Per-session max duration (default 4 hours).
+- Worker relay can enforce per-account daily spend limits.
+- User-visible cost estimate before starting session: "Estimated cost: $0.50–$2.00".
+
+---
+
+## 12. Pre-Mortem
+
+### 12.1 Failure 1: Sandbox Sleep Breaks Long-Running Agents
+
+**Scenario:** Agent runs for 45 minutes. Sandbox sleeps during a long LLM inference. Agent process state is lost or corrupted on resume.
+
+**Early signal:** Sessions consistently failing after ~30–40 minutes with "Sandbox disconnected" errors.
+
+**Mitigation (build in v1):**
+- Agent sends heartbeat every 60s while waiting for LLM response.
+- Agent commits state to Artifacts repo after every turn (not just every batch).
+- On restart, agent reads last commit from Artifacts and resumes from there.
+- DO tracks "last known good turn" and can inject it into restarted agent.
+
+### 12.2 Failure 2: Worker Relay Becomes Bottleneck at Scale
+
+**Scenario:** `/parallel N` launches 10 Sandboxes. All 10 stream LLM requests through the single Worker relay. Worker hits CPU/memory limits, causing latency spikes and dropped SSE connections.
+
+**Early signal:** Relay response times increase linearly with active sessions. P99 latency > 5s.
+
+**Mitigation (build in v1):**
+- Relay endpoint is stateless — can scale horizontally across multiple Worker instances.
+- Use Cloudflare AI Gateway for caching and rate limiting (reduces duplicate requests).
+- Stream relay responses directly (don't buffer in Worker).
+- If relay is overloaded, return 429 to Sandbox; Sandbox retries with backoff.
+
+### 12.3 Failure 3: GitHub OAuth Token Refresh Fails Mid-Session
+
+**Scenario:** Session runs for 6 hours. OAuth access token expires after 8 hours, but refresh token is invalid (user revoked access, or GitHub App was uninstalled). Finalize step fails to push branch or open PR.
+
+**Early signal:** High rate of "finalize failed: 401 Unauthorized" errors in Worker logs.
+
+**Mitigation (build in v1):**
+- Worker validates GitHub token at session start (quick API call to `/user`).
+- If token expires during session, Worker attempts refresh once. If refresh fails, Worker:
+  - Keeps the Artifacts repo alive (work is not lost).
+  - Notifies user via CLI and web page: "Session complete, but PR creation failed. Token expired. Run `kimiflare remote auth github` to refresh, then `kimiflare remote finalize <sessionId>` to retry."
+- Store refresh token in DO (encrypted) so retry doesn't require user intervention.
+
+---
+
+## 13. Phased Implementation Plan
+
+### Phase 0: Spike — Validate Cloudflare APIs (1 day)
+
+**Goal:** Confirm the Artifacts binding, Sandbox SDK, and DO SSE streaming work as expected before building the full system.
+
+**Files/modules:**
+- `remote/spike/` (temporary directory, deleted after spike)
+
+**New dependencies:**
+- `wrangler` (dev dependency for Worker deployment)
+- `@cloudflare/artifacts` (if there's a types package)
+- `@cloudflare/sandbox` (if there's a types package)
+
+**Acceptance criteria:**
+- [ ] Worker script deployed to `*.workers.dev`.
+- [ ] Worker creates an Artifacts repo via binding.
+- [ ] Worker creates a Sandbox, runs `echo "hello"`, and captures stdout.
+- [ ] Worker streams 10 SSE events to a `curl` client.
+- [ ] Document any API mismatches or gotchas.
+
+---
+
+### Phase 1: End-to-End Pipe — Hello World PR (1–2 days)
+
+**Goal:** The smallest slice that produces a real PR on GitHub. The agent inside the Sandbox just runs `echo "hello" >> README.md && git commit && git push`.
+
+**Files/modules created:**
+- `remote/worker/` — Orchestrator Worker
+  - `src/index.ts` — Hono or raw fetch handler, routes
+  - `src/session-do.ts` — Durable Object class
+  - `src/github.ts` — GitHub API client (push branch, open PR)
+  - `src/artifacts.ts` — Artifacts binding wrapper
+  - `src/sandbox.ts` — Sandbox binding wrapper
+  - `wrangler.toml`
+- `remote/agent/` — Headless agent (minimal)
+  - `src/remote-agent.ts` — Entrypoint: clone repo, run hardcoded bash, commit, call finalize
+- `remote/Dockerfile` — Container image
+
+**Files/modules touched:**
+- `src/commands/builtins.ts` — Add `/remote` to built-ins
+- `src/app.tsx` — Add `/remote` handler (prompt collector, call Worker)
+- `src/config.ts` — Add `remoteWorkerUrl`, `githubToken` fields
+
+**New dependencies:**
+- `hono` (Worker HTTP framework, optional)
+- `octokit` (GitHub API client, optional — can use raw fetch)
+
+**Acceptance criteria:**
+- [ ] User types `/remote test prompt` in local TUI.
+- [ ] CLI calls Worker, gets session ID and SSE URL.
+- [ ] Worker creates Artifacts repo, creates Sandbox, starts agent.
+- [ ] Agent clones repo, modifies README.md, commits, calls `/finalize`.
+- [ ] Worker pushes branch to GitHub and opens a PR.
+- [ ] CLI shows progress stream and final "PR opened" message.
+
+---
+
+### Phase 2: Real Agent Loop in Sandbox (1–2 days)
+
+**Goal:** Replace the hardcoded bash script with the actual kimiflare agent loop (`runAgentTurn`).
+
+**Files/modules created:**
+- `remote/agent/src/agent-loop.ts` — Headless wrapper around `runAgentTurn`
+- `remote/agent/src/progress-reporter.ts` — Serializes `AgentCallbacks` to NDJSON
+- `remote/agent/src/headless-permission.ts` — `PermissionAsker` that always returns `"allow"`
+
+**Files/modules touched:**
+- `src/agent/loop.ts` — Ensure it can run without TUI (it already can, but verify)
+- `src/tools/executor.ts` — No changes expected
+- `remote/agent/src/remote-agent.ts` — Integrate real agent loop
+
+**Acceptance criteria:**
+- [ ] Agent inside Sandbox receives a real prompt (e.g., "Add a comment to README.md").
+- [ ] Agent calls LLM via Worker relay.
+- [ ] Agent executes tools (read, write, bash) on `/workspace`.
+- [ ] Agent commits after each tool batch.
+- [ ] Progress events stream to CLI in real-time.
+- [ ] Session completes and opens PR with actual changes.
+
+---
+
+### Phase 3: Worker Relay + Progress Streaming (1 day)
+
+**Goal:** Implement the LLM relay and robust progress streaming.
+
+**Files/modules created/touched:**
+- `remote/worker/src/relay.ts` — `/relay` endpoint
+- `remote/worker/src/progress.ts` — `/progress/:sessionId` endpoint
+- `remote/worker/src/stream.ts` — SSE stream management in DO
+
+**Acceptance criteria:**
+- [ ] Sandbox agent calls `/relay` for LLM inference; Worker forwards to Workers AI.
+- [ ] Worker streams LLM response back to Sandbox without buffering.
+- [ ] Sandbox agent posts progress events to `/progress`.
+- [ ] Worker relays progress events to CLI SSE stream.
+- [ ] CLI can disconnect and reconnect without losing events (Last-Event-ID support).
+
+---
+
+### Phase 4: GitHub OAuth + Local CLI Subcommands (1–2 days)
+
+**Goal:** Replace PAT with OAuth device flow and add CLI subcommands.
+
+**Files/modules created:**
+- `src/auth/github.ts` — OAuth device flow implementation
+- `src/remote/cli.ts` — `kimiflare remote list|status|cancel` subcommands
+- `src/remote/session-store.ts` — Local remote session persistence
+
+**Files/modules touched:**
+- `src/index.tsx` — Add `remote` subcommand group
+- `src/config.ts` — Add `githubOAuthToken`, `githubRefreshToken`, `githubTokenExpiry` fields
+
+**Acceptance criteria:**
+- [ ] `kimiflare auth github` initiates device flow.
+- [ ] User completes auth in browser; CLI stores tokens.
+- [ ] `kimiflare remote list` shows active/completed sessions.
+- [ ] `kimiflare remote status` shows most recent session (no ID needed).
+- [ ] `kimiflare remote cancel <id>` cancels a running session.
+
+---
+
+### Phase 5: Baseline Repo + Auto-Setup (1 day)
+
+**Goal:** Add persistent baseline repo and auto-setup for project dependencies.
+
+**Files/modules created/touched:**
+- `remote/worker/src/baseline.ts` — Baseline repo sync logic
+- `remote/agent/src/setup.ts` — Auto-detect project type and run setup
+
+**Acceptance criteria:**
+- [ ] Worker maintains a baseline repo per GitHub repo.
+- [ ] New sessions copy from baseline instead of cloning GitHub.
+- [ ] Sandbox agent detects `package.json` → runs `npm install`.
+- [ ] Sandbox agent detects `Cargo.toml` → runs `cargo fetch`.
+- [ ] Sandbox agent detects `requirements.txt` → runs `pip install`.
+
+---
+
+### Phase 6: Web Status Page + Polish (1 day)
+
+**Goal:** Add the web status page and final polish.
+
+**Files/modules created:**
+- `remote/worker/src/web.html` — Static HTML status page (embedded in Worker)
+- `remote/worker/src/web.ts` — `/remote/web/:sessionId` endpoint
+
+**Files/modules touched:**
+- `src/app.tsx` — Add `/remote` picker in TUI (like `/resume`)
+- `src/ui/remote-status.tsx` — Remote session status component
+
+**Acceptance criteria:**
+- [ ] `https://worker.example.com/remote/web/<sessionId>` shows live status.
+- [ ] Page works on mobile.
+- [ ] Page auto-refreshes (SSE or polling fallback).
+- [ ] PR body links to status page.
+- [ ] TUI `/remote` with no args opens session picker.
+
+---
+
+### Phase 7: Failure Recovery + Observability (1 day)
+
+**Goal:** Add retries, crash recovery, and logging.
+
+**Files/modules created/touched:**
+- `remote/worker/src/recovery.ts` — Sandbox restart and resume logic
+- `remote/worker/src/alarms.ts` — DO alarms for timeouts
+- `remote/worker/src/metrics.ts` — Analytics metrics emission
+
+**Acceptance criteria:**
+- [ ] Sandbox crash triggers automatic restart (up to 3 retries).
+- [ ] Agent resumes from last commit after restart.
+- [ ] Max session duration alarm (4h) terminates stuck sessions.
+- [ ] Idle timeout alarm (30m) terminates frozen sessions.
+- [ ] Worker logs include session lifecycle events.
+- [ ] Metrics dashboard shows sessions started/completed/failed.
+
+---
+
+### Phase 8: `/parallel` Foundation (1 day)
+
+**Goal:** Ensure the architecture supports multiple concurrent sessions without single-instance assumptions.
+
+**Files/modules touched:**
+- `remote/worker/src/session-do.ts` — Verify DO isolation
+- `remote/worker/src/parallel.ts` — Batch session creation endpoint
+
+**Acceptance criteria:**
+- [ ] Worker can create 5 sessions simultaneously.
+- [ ] Each session gets its own DO, Sandbox, and Artifacts repo.
+- [ ] Progress streams are independent.
+- [ ] Baseline repo is copied to all 5 sessions efficiently.
+- [ ] No shared mutable state between sessions.
+
+---
+
+### Total Timeline
+
+| Phase | Duration | Cumulative |
+|-------|----------|------------|
+| 0. Spike | 1 day | 1 day |
+| 1. Hello World PR | 1–2 days | 2–3 days |
+| 2. Real Agent Loop | 1–2 days | 3–5 days |
+| 3. Relay + Streaming | 1 day | 4–6 days |
+| 4. OAuth + CLI | 1–2 days | 5–8 days |
+| 5. Baseline + Auto-Setup | 1 day | 6–9 days |
+| 6. Web Page + Polish | 1 day | 7–10 days |
+| 7. Recovery + Observability | 1 day | 8–11 days |
+| 8. `/parallel` Foundation | 1 day | 9–12 days |
+
+**Estimated total: 2–2.5 weeks** for one developer working full-time.
+
+---
+
+## Appendix A: Directory Structure
+
+```
+kimiflare/
+├── src/                          # Existing local CLI
+│   ├── agent/
+│   ├── tools/
+│   ├── ui/
+│   ├── auth/
+│   │   └── github.ts             # NEW: OAuth device flow
+│   ├── remote/
+│   │   ├── cli.ts                # NEW: remote subcommands
+│   │   ├── session-store.ts      # NEW: local session persistence
+│   │   └── worker-client.ts      # NEW: HTTP client for Worker
+│   ├── commands/builtins.ts      # MODIFIED: add /remote
+│   ├── app.tsx                   # MODIFIED: add /remote handler
+│   ├── config.ts                 # MODIFIED: add remote fields
+│   └── index.tsx                 # MODIFIED: add remote subcommands
+├── remote/                       # NEW: Cloudflare infrastructure
+│   ├── worker/
+│   │   ├── src/
+│   │   │   ├── index.ts          # fetch handler / router
+│   │   │   ├── session-do.ts     # Durable Object
+│   │   │   ├── github.ts         # GitHub API client
+│   │   │   ├── artifacts.ts      # Artifacts binding wrapper
+│   │   │   ├── sandbox.ts        # Sandbox binding wrapper
+│   │   │   ├── relay.ts          # LLM relay endpoint
+│   │   │   ├── progress.ts       # Progress ingestion
+│   │   │   ├── stream.ts         # SSE stream management
+│   │   │   ├── baseline.ts       # Baseline repo sync
+│   │   │   ├── recovery.ts       # Crash recovery
+│   │   │   ├── alarms.ts         # DO alarms
+│   │   │   ├── metrics.ts        # Analytics
+│   │   │   └── web.ts            # Web status page
+│   │   ├── wrangler.toml
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   ├── agent/
+│   │   ├── src/
+│   │   │   ├── remote-agent.ts   # Entrypoint
+│   │   │   ├── agent-loop.ts     # Headless runAgentTurn wrapper
+│   │   │   ├── progress-reporter.ts
+│   │   │   ├── headless-permission.ts
+│   │   │   └── setup.ts          # Auto-setup detection
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   └── Dockerfile                # Sandbox container image
+├── docs/
+│   ├── remote-architecture.md    # This document
+│   └── remote-feature-findings-and-decisions.md
+├── package.json                  # MODIFIED: add build:remote script
+└── tsup.config.ts                # Unchanged
+```
+
+---
+
+## Appendix B: Config Schema Additions
+
+```ts
+// src/config.ts
+export interface KimiConfig {
+  // ... existing fields ...
+
+  // Remote feature
+  remoteWorkerUrl?: string;
+  remoteEnabled?: boolean;
+
+  // GitHub auth (OAuth device flow)
+  githubOAuthToken?: string;
+  githubRefreshToken?: string;
+  githubTokenExpiry?: number;  // Unix timestamp
+
+  // GitHub repo (auto-detected, cached)
+  githubRepo?: string;  // "owner/repo"
+}
+```
+
+**Environment variable overrides:**
+- `KIMIFLARE_REMOTE_WORKER_URL`
+- `KIMIFLARE_GITHUB_REPO`
+- `KIMIFLARE_REMOTE_ENABLED`
+
+---
+
+*Document version: 1.0*  
+*Last updated: 2026-05-03*

--- a/docs/remote-feature-findings-and-decisions.md
+++ b/docs/remote-feature-findings-and-decisions.md
@@ -1,0 +1,386 @@
+# `/remote` Feature — Codebase Findings & Design Decisions
+
+> Research and planning deliverable. No implementation code yet.
+
+---
+
+## 1. Codebase Findings
+
+### 1.1 Current Agent Loop
+
+**Files:** `src/agent/loop.ts`, `src/agent/orchestrator.ts`, `src/agent/agent-session.ts`
+
+The agent loop is **well-factored and largely reusable** for a headless remote variant.
+
+- `runAgentTurn(opts: AgentTurnOpts)` (`src/agent/loop.ts:62`) is the core turn runner. It takes a prompt, messages array, tools, executor, callbacks, and an `AbortSignal`. It streams LLM events and executes tools in a loop until `maxToolIterations` (default 50) is hit.
+- `AgentOrchestrator` (`src/agent/orchestrator.ts:51`) sits above `runAgentTurn` for multi-agent mode. It manages per-role `AgentSession` objects (message buffers, artifact stores) and handles hand-offs between `research` / `coding` / `generalist` agents.
+- `AgentSession` (`src/agent/agent-session.ts:11`) is a plain object: `{ role, messages, recentToolCalls, artifactStore }`.
+
+**Reusability assessment:**
+- ✅ `runAgentTurn` can run headless with no TUI changes — it only calls callbacks.
+- ✅ `AgentOrchestrator` can run headless — same callback pattern.
+- ⚠️ The callback interface (`AgentCallbacks`, `src/agent/loop.ts:14`) is TUI-oriented (`onTextDelta`, `onReasoningDelta`, `onToolCallStart`, etc.). For `/remote`, we need a **structured progress serializer** that converts these callbacks into JSON lines for the Worker to relay. This is a thin adapter, not a refactor.
+- ⚠️ `codeMode` (`src/agent/loop.ts:51`) and `memoryManager` are optional; the remote agent can disable them in v1.
+
+**Key excerpt — the seam where headless mode diverges:**
+
+```ts
+// src/tools/executor.ts:91
+async run(
+  call: ToolInvocation,
+  askPermission: PermissionAsker,  // <-- this is the seam
+  ctx: ToolContext,
+  onFileChange?: (path: string, content: string) => void,
+): Promise<ToolResult> {
+  // ...
+  if (tool.needsPermission) {
+    const sessionKey = this.permissionKey(tool, args);
+    if (!this.sessionAllowed.has(sessionKey)) {
+      const decision = await askPermission({ tool, args, sessionKey });
+      // ...
+    }
+  }
+}
+```
+
+In local `auto` mode, `askPermission` immediately resolves `"allow"` (`src/app.tsx:1528`). The remote agent will do the same — no permission gating changes needed in `ToolExecutor`, just a headless `askPermission` that always returns `"allow"`.
+
+### 1.2 Config and Credential Handling
+
+**File:** `src/config.ts`
+
+Config lives at `~/.config/kimiflare/config.json` (XDG-compliant, falls back to `~/.kimiflare/config.json` for legacy).
+
+```ts
+// src/config.ts:25
+export interface KimiConfig {
+  accountId: string;
+  apiToken: string;
+  model: string;
+  aiGatewayId?: string;
+  // ... many other fields
+}
+```
+
+Credentials are **BYOK-only today**: the user puts their Cloudflare `accountId` and `apiToken` into the config file. There is no OAuth, no hosted auth, no secret manager integration.
+
+**How `/remote` secrets fit:**
+- `remoteWorkerUrl`: new optional config field pointing to the user's deployed orchestrator Worker.
+- `githubToken`: new optional config field (PAT or fine-grained PAT) for PR creation.
+- These should follow the exact same pattern: read from config file, overridable by env vars (`KIMIFLARE_REMOTE_WORKER_URL`, `KIMIFLARE_GITHUB_TOKEN`).
+
+### 1.3 CLI Command Framework
+
+**Files:** `src/commands/builtins.ts`, `src/app.tsx` ( `handleSlash` )
+
+Slash commands are dispatched in a single `handleSlash` callback inside the Ink `App` component. There is no separate command router — commands are hard-coded in `handleSlash` and matched by string prefix.
+
+**Excerpt of the most similar existing command (`/cost`):**
+
+```ts
+// src/app.tsx:1766
+if (c === "/cost") {
+  if (!cfg) return true;
+  if (arg === "on") {
+    const next = { ...cfg, costAttribution: true };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cost attribution enabled" }]);
+    return true;
+  }
+  if (arg === "off") { /* ... */ }
+  void getCostReport(sessionIdRef.current ?? undefined)
+    .then(async (report) => { /* ... */ })
+    .catch((err) => { /* ... */ });
+  return true;
+}
+```
+
+**Pattern for `/remote`:**
+1. Add `{ name: "remote", argHint: "[status|cancel <id>]", description: "...", source: "builtin" }` to `BUILTIN_COMMANDS` in `src/commands/builtins.ts`.
+2. Add a branch in `handleSlash` in `src/app.tsx`.
+3. If the user types `/remote` with no args, open a prompt collector (similar to how `/init` builds a prompt and calls `runAgentTurn`, but instead calls the Worker).
+
+### 1.4 GitHub Repo Identification
+
+**Finding:** kimiflare has **no explicit GitHub repo detection today**. It operates entirely on `process.cwd()`. There is no `git remote` inspection, no `GITHUB_REPO` env var, no config field for repo identity.
+
+**Implication for `/remote`:** We must add repo identification. The most natural place is:
+- At `/remote` invocation, inspect `git remote get-url origin` in `process.cwd()`.
+- Parse out `owner/repo`.
+- Cache it in the local session file (or config) so the user doesn't re-enter it.
+- This is new infrastructure; `/remote` invents it, but it should be minimal and automatic.
+
+### 1.5 Local State Directory
+
+**Files:** `src/sessions.ts`, `src/util/state.ts`, `src/usage-tracker.ts`
+
+Local state is organized under `~/.config/kimiflare/`:
+
+```ts
+// src/sessions.ts:36
+function sessionsDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "sessions");
+}
+
+// src/usage-tracker.ts:71
+function usageDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "usage");
+}
+
+// src/util/state.ts:9
+function statePath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "state.json");
+}
+```
+
+Sessions are JSON files named `{timestamp}-{sanitized-prompt}.json`. They contain messages, session state, artifact stores, and multi-agent state.
+
+**Integration point for `/remote`:**
+- Add a `remote/` subdirectory under `~/.config/kimiflare/` for remote session tracking.
+- Each remote session gets a JSON file: `{sessionId}.json` with fields: `sessionId`, `prompt`, `repo`, `workerUrl`, `status`, `branch`, `prUrl`, `createdAt`, `updatedAt`.
+- This mirrors the existing session persistence pattern exactly.
+
+### 1.6 Tool Execution / File Edit Pipeline
+
+**File:** `src/tools/executor.ts`
+
+`ToolExecutor.run()` is the universal entrypoint. It:
+1. Looks up the tool by name.
+2. Parses JSON args.
+3. Checks `tool.needsPermission` against `sessionAllowed` set.
+4. If not allowed, calls `askPermission` (the seam).
+5. Runs `tool.run(args, ctx)`.
+6. Normalizes and reduces output via `reduceToolOutput()`.
+7. Returns `ToolResult`.
+
+**Headless variant:** The remote agent inside the Sandbox will instantiate `ToolExecutor` with `ALL_TOOLS` (or a subset), and pass an `askPermission` that always resolves `"allow"`. No changes to `ToolExecutor` or individual tools are required.
+
+**The only Sandbox-specific consideration:** Some tools assume a local filesystem (`read`, `write`, `edit`, `bash`, `glob`, `grep`). Inside the Sandbox, `process.cwd()` will be `/workspace` and the repo will be cloned there. These tools will work unchanged because they operate on `ctx.cwd`.
+
+### 1.7 Streaming and Output Rendering
+
+**File:** `src/agent/loop.ts` ( `AgentCallbacks` )
+
+Local streaming uses a rich callback interface:
+
+```ts
+// src/agent/loop.ts:14
+export interface AgentCallbacks {
+  onAssistantStart?: () => void;
+  onReasoningDelta?: (text: string) => void;
+  onTextDelta?: (text: string) => void;
+  onToolCallStart?: (index: number, id: string, name: string) => void;
+  onToolCallArgs?: (index: number, delta: string) => void;
+  onToolCallFinalized?: (call: ToolCall) => void;
+  onUsage?: (usage: Usage) => void;
+  onUsageFinal?: (usage: Usage, gatewayMeta?: GatewayMeta) => void;
+  onGatewayMeta?: (meta: GatewayMeta) => void;
+  onAssistantFinal?: (msg: ChatMessage) => void;
+  onToolResult?: (result: ToolResult) => void;
+  onTasks?: (tasks: Task[]) => void;
+  askPermission: PermissionAsker;
+}
+```
+
+For `/remote`, the Sandbox agent will use the same callbacks but serialize them to **NDJSON progress events** that the Worker relays over SSE/WebSocket. Example event types:
+
+```ts
+type RemoteProgressEvent =
+  | { type: "turn_start"; turn: number }
+  | { type: "text_delta"; text: string }
+  | { type: "tool_call"; name: string; args: string }
+  | { type: "tool_result"; name: string; ok: boolean; content: string }
+  | { type: "usage"; promptTokens: number; completionTokens: number }
+  | { type: "tasks"; tasks: Task[] }
+  | { type: "turn_end" }
+  | { type: "done"; finishReason: string }
+  | { type: "error"; message: string };
+```
+
+The local CLI will render these as a simplified TUI stream (no diff modals, no permission prompts — just a tail of agent activity).
+
+### 1.8 Build, Test, and Release Tooling
+
+**Files:** `package.json`, `tsup.config.ts`
+
+- **Build:** `tsup` bundles `src/index.tsx` → `dist/index.js` (ESM, Node 20 target). Runtime deps (`ink`, `react`, `commander`, etc.) are externalized.
+- **CLI shim:** `bin/kimiflare.mjs` is a small wrapper that imports `../dist/index.js`.
+- **Test:** `tsx --test src/**/*.test.ts src/**/*.test.tsx` (Node native test runner).
+- **Release:** `npm run build` then `npm publish`. No Docker, no CI/CD config in repo.
+
+**Implication:** The `/remote` feature adds two new artifacts that do not fit the existing npm package:
+1. A **Cloudflare Worker** (orchestrator) — needs its own `wrangler.toml`, `package.json`, and build step.
+2. A **Sandbox container image** — needs a `Dockerfile` and a build/push workflow.
+
+These should live in a new `remote/` directory at repo root, with their own build scripts. The main `package.json` gets a `build:remote` script that delegates. Release process should include pushing the container image to a registry (GHCR or Docker Hub) and deploying the Worker via `wrangler deploy`.
+
+---
+
+## 2. Design Decisions Needed
+
+Below are the genuine choices where the codebase provides no answer and your judgment is required. Each has 2–3 options with tradeoffs and my recommendation.
+
+---
+
+### Decision 1: GitHub Authentication Model
+
+`/remote` must push a branch and open a PR. How does the user authenticate kimiflare against their GitHub repo?
+
+**Option A — Personal Access Token (PAT)**
+- User generates a fine-grained PAT (or classic PAT) with `contents:write` and `pull_requests:write` scopes.
+- Stores it in `~/.config/kimiflare/config.json` as `githubToken` (or env `KIMIFLARE_GITHUB_TOKEN`).
+- The local CLI sends it to the Worker on session start. The Worker holds it and uses it for push + PR creation.
+- **Pros:** Simplest to implement, no hosted infrastructure, works for BYOK immediately.
+- **Cons:** Token has broad scope; if leaked, attacker has write access to all repos the token can access. User must manually rotate.
+
+**Option B — GitHub App**
+- We (or the user) create a GitHub App. User installs it on their repo.
+- The App gives us an installation token with scoped permissions.
+- **Pros:** Fine-grained per-repo permissions, no long-lived PAT, org-friendly.
+- **Cons:** Requires a GitHub App creation flow (either we host one or users create their own). For BYOK self-hosters, creating a GitHub App is a significant onboarding hurdle. Adds OAuth/App authentication logic to the Worker.
+
+**Option C — OAuth Device Flow**
+- User runs `kimiflare auth github`, gets a device code, completes auth in browser.
+- GitHub returns a short-lived access token + refresh token.
+- **Pros:** Best UX, no manual token copying, standard GitHub flow.
+- **Cons:** Requires a hosted OAuth callback endpoint (or device flow support). For BYOK, the user would need to set up a GitHub OAuth App. Adds the most complexity to v1.
+
+**My recommendation:** Option A (PAT) for v1. It unblocks the entire feature with a single config field. We can add Option B (GitHub App) in v2 for orgs and managed-cloud users. Option C is overkill until we have a hosted service.
+
+**Your pick?**
+
+---
+
+### Decision 2: Sandbox → Workers AI Inference Path
+
+The agent running inside the Cloudflare Sandbox needs to call Kimi K2.6 on Workers AI. How?
+
+**Option A — Direct HTTP from Sandbox to Workers AI**
+- The Worker mints a short-lived Workers AI API token and injects it into the Sandbox as an env var (`CF_API_TOKEN`).
+- The agent inside the Sandbox makes HTTPS calls directly to `https://api.cloudflare.com/client/v4/accounts/{accountId}/ai/run/{model}`.
+- **Pros:** Simplest, no relay latency, Sandbox egress proxy can control outbound domains.
+- **Cons:** The API token is visible to the agent process inside the Sandbox. A malicious prompt could exfiltrate it (though the Sandbox egress proxy can block non-CF domains).
+
+**Option B — Relay through the Orchestrator Worker**
+- The Sandbox agent streams LLM requests to a `/relay` endpoint on the orchestrator Worker.
+- The Worker holds the real API token, forwards the request to Workers AI, and streams the response back.
+- **Pros:** API token never enters the Sandbox. The Worker can enforce rate limits, logging, and request inspection.
+- **Cons:** Adds ~20–50ms latency per request. The Worker becomes a bandwidth bottleneck for large streaming responses. More complex — needs a streaming relay implementation.
+
+**Option C — Workers AI Binding via Sandbox SDK Egress Proxy**
+- Use the Sandbox SDK's egress proxy / credential injection feature to transparently route Workers AI calls without exposing the token to the agent process.
+- **Pros:** Best of both worlds — token is hidden, no relay latency.
+- **Cons:** Depends on the exact Sandbox SDK surface. From the docs, the Sandbox SDK supports environment variable injection and egress proxying, but it's unclear if it supports transparent credential injection for arbitrary HTTP headers. May require experimentation.
+
+**My recommendation:** Option A for v1, with egress proxy locked to `api.cloudflare.com` only. The token is scoped to Workers AI (not the user's Cloudflare account broadly) and can be rotated easily. Option B adds too much complexity and cost for v1. Option C is the ideal end state but needs a spike to validate.
+
+**Your pick?**
+
+---
+
+### Decision 3: Container Image Strategy
+
+What runs inside the Sandbox? The agent needs Node.js, git, and likely Python/build tools for the repos it will edit.
+
+**Option A — Fixed Universal Image**
+- A single `kimiflare/remote-agent` image based on `node:20-slim` (or `ubuntu:22.04` + Node).
+- Pre-installs: `node`, `npm`, `git`, `python3`, `make`, `gcc`, `g++`, `curl`, `jq`.
+- The kimiflare source is baked into the image at build time (or fetched from npm/GitHub at Sandbox startup).
+- **Pros:** Fast startup (image is cached), predictable, no per-repo configuration.
+- **Cons:** Bloated (~500MB–1GB), may lack project-specific dependencies (e.g., Rust toolchain, specific Python versions).
+
+**Option B — Project-Specific Dockerfile**
+- User can place a `Dockerfile.remote` (or similar) in their repo root.
+- The Worker builds or references this image for the Sandbox.
+- **Pros:** Perfect dependency match for the project.
+- **Cons:** Slower startup (build step or large custom image pull), massive support burden (users will write broken Dockerfiles), adds complexity to the Worker (image registry management).
+
+**Option C — Hybrid: Fixed Base + Runtime Install**
+- Fixed base image with Node + git + common tools.
+- At Sandbox startup, run a user-provided setup script (e.g., `.kimiflare/remote-setup.sh`) to install additional deps.
+- **Pros:** Faster than full custom image, more flexible than fixed.
+- **Cons:** Setup script runs on every session startup (slow), still requires user to write scripts.
+
+**My recommendation:** Option A for v1. The image should be based on `node:20-bookworm` (Debian-based, more build tools available than `-slim`) and include a pre-built kimiflare agent binary. For v2, we can add a `remote.setupScript` config option for lightweight customization.
+
+**Your pick?**
+
+---
+
+### Decision 4: Baseline Repo Strategy (Artifacts)
+
+For each `/remote` session, we need a Git repo in Artifacts that contains the user's code. How do we get it there?
+
+**Option A — Persistent Baseline + Per-Session Fork**
+- Maintain a single baseline Artifacts repo (e.g., `kimiflare-baseline-{owner}-{repo}`) that mirrors the user's GitHub `main`.
+- The Worker updates the baseline periodically (or on demand) by cloning from GitHub.
+- For each session, the Worker "forks" the baseline into a new Artifacts repo (or creates a new repo and pushes the baseline's contents).
+- **Pros:** Very fast session startup (no GitHub clone bandwidth), bandwidth-efficient.
+- **Cons:** Adds baseline lifecycle complexity (when to update? what if main diverges during a session?). Artifacts "fork" behavior needs validation — the docs mention repo creation but not explicit fork semantics.
+
+**Option B — Fresh Clone Per Session**
+- For each session, the Worker creates a new empty Artifacts repo and runs `git clone --depth 1 https://github.com/{owner}/{repo}.git` inside the Sandbox (or Worker) into it.
+- **Pros:** Simplest, always up-to-date with `main`, no baseline to maintain.
+- **Cons:** Slower session startup (clones entire repo from GitHub each time), uses more GitHub bandwidth, Artifacts storage grows faster.
+
+**Option C — Shallow Clone + Reference**
+- Create a new Artifacts repo per session, but do a shallow clone (`--depth 1`) from GitHub directly into the Sandbox's `/workspace`, then push to the session's Artifacts repo.
+- **Pros:** Reasonable middle ground.
+- **Cons:** Still clones from GitHub every session.
+
+**My recommendation:** Option B for v1. It is the simplest and most reliable. The baseline optimization (Option A) is premature — we don't know typical repo sizes yet. If repos are large, we can add baseline caching in v2 without changing the architecture.
+
+**Your pick?**
+
+---
+
+### Decision 5: Local CLI Detach / Reattach UX
+
+After typing `/remote <prompt>`, the user sees a status stream. They close their laptop. Later, they want to know what happened.
+
+**Option A — Subcommand Only (`kimiflare remote status|cancel|list`)**
+- Add `kimiflare remote <subcommand>` to the Commander CLI in `src/index.tsx`.
+- `kimiflare remote list` — shows active/completed remote sessions.
+- `kimiflare remote status <session-id>` — polls the Worker for current status and prints a summary.
+- `kimiflare remote cancel <session-id>` — sends cancel signal.
+- **Pros:** Clean separation from the TUI, works from any terminal, easy to script.
+- **Cons:** User must remember the session ID or run `list` first.
+
+**Option B — TUI Integration (`/remote status`)**
+- Inside the running kimiflare TUI, `/remote` with no args opens a picker showing active remote sessions (like `/resume` shows past local sessions).
+- Selecting one shows a live stream of its progress.
+- **Pros:** Consistent with existing UX patterns (`/resume`, pickers).
+- **Cons:** Only works while the TUI is running. If the user closed their terminal, they can't reattach via TUI.
+
+**Option C — Both**
+- TUI shows `/remote` picker for in-session discovery.
+- Subcommands exist for out-of-band access.
+- **Pros:** Best of both worlds.
+- **Cons:** More code to write and maintain.
+
+**My recommendation:** Option C, but implement Option A first (subcommands) because it's the only way to check status after closing the terminal. The TUI picker can be added in a later phase as a polish item.
+
+**Your pick?**
+
+---
+
+## 3. What I Was Unable to Verify from Cloudflare Docs
+
+I fetched the Artifacts and Sandbox overview pages, but the HTML-heavy docs site made deep extraction difficult. I was loop-detected before I could read:
+
+- The exact Artifacts REST API for repo creation and token minting.
+- The Sandbox SDK TypeScript API surface for `exec()`, file operations, and environment variable injection.
+- Whether Artifacts supports true "fork" semantics or only repo creation + push.
+- The Sandbox egress proxy configuration details.
+
+**Mitigation:** Your architecture description in the prompt is detailed and I will treat it as the source of truth for API surfaces. During implementation, we will validate against the actual SDK types and docs. The phased plan (below, pending your answers) includes a "spike" phase for Worker + Sandbox + Artifacts integration to surface any API mismatches early.
+
+---
+
+## Next Step
+
+Please reply with your picks for Decisions 1–5 (or just the ones you care about — I have defaults for all). I will then produce the full architecture document (11 sections) and the phased implementation plan.

--- a/docs/remote-local-testing.md
+++ b/docs/remote-local-testing.md
@@ -1,0 +1,233 @@
+# Testing `/remote` Locally
+
+## What You Can Test Right Now (No Cloudflare Account Needed)
+
+### 1. Build the remote agent bundle
+
+```bash
+npm run build:remote-agent
+```
+
+This should produce `remote/agent/dist/remote-agent.mjs` without errors.
+
+### 2. Run the local CLI commands
+
+```bash
+# The help text should show the new commands
+kimiflare --help
+
+# The remote subcommand should be available
+kimiflare remote --help
+
+# List sessions (will be empty initially)
+kimiflare remote list
+```
+
+### 3. Test GitHub OAuth device flow
+
+```bash
+kimiflare auth github
+```
+
+This will:
+1. Print a verification URL and user code
+2. Open your browser (or print the URL)
+3. Poll GitHub for the token
+4. Save it to `~/.config/kimiflare/config.json`
+
+**Note:** This requires a GitHub OAuth App. The PR includes a default client ID, but you can override it:
+
+```bash
+KIMIFLARE_GITHUB_CLIENT_ID=your_client_id kimiflare auth github
+```
+
+### 4. Verify config persistence
+
+```bash
+cat ~/.config/kimiflare/config.json
+```
+
+You should see `githubOAuthToken`, `githubRefreshToken`, `githubTokenExpiry` fields.
+
+### 5. Test repo auto-detection
+
+In a git repo with a GitHub remote:
+
+```bash
+cd /path/to/your/repo
+kimiflare
+# Then type: /remote test
+```
+
+It will detect the repo from `git remote get-url origin` and either:
+- Start the session (if `remoteWorkerUrl` is configured)
+- Tell you to configure `remoteWorkerUrl` (expected if you haven't deployed the Worker)
+
+### 6. Run the test suite
+
+```bash
+npm test
+```
+
+All 310 tests should pass, including any new tests.
+
+---
+
+## What Requires Cloudflare Infrastructure
+
+The end-to-end flow needs:
+
+| Component | Why it needs Cloudflare |
+|-----------|------------------------|
+| **Worker** | Uses Durable Objects, Artifacts binding, Sandbox binding |
+| **Sandbox** | Cloudflare Sandbox is a managed container runtime |
+| **Artifacts** | Cloudflare Artifacts is a managed Git server |
+| **LLM Relay** | Calls Workers AI API via the Worker |
+
+**You cannot run the full end-to-end flow locally.** The Worker bindings are Cloudflare-specific.
+
+---
+
+## Mock Mode for Local Development
+
+For development without Cloudflare infra, you can run a mock Worker:
+
+```bash
+# Terminal 1: Start the mock Worker
+node scripts/mock-remote-worker.js
+
+# Terminal 2: Configure CLI to use mock
+kimiflare config remoteWorkerUrl http://localhost:8787
+kimiflare config remoteAuthSecret dev-secret
+
+# Terminal 3: Start a session
+kimiflare
+/remote "Add a README"
+```
+
+The mock Worker simulates:
+- Session creation
+- SSE progress streaming (sends fake events)
+- Status queries
+- Cancellation
+
+It does **not**:
+- Run actual code
+- Call Workers AI
+- Create GitHub PRs
+
+See `scripts/mock-remote-worker.js` below.
+
+---
+
+## Deploying to Cloudflare (Required for Real Testing)
+
+### Step 1: Deploy the Worker
+
+```bash
+cd remote/worker
+
+# Install dependencies
+npm install
+
+# Set secrets
+wrangler secret put REMOTE_AUTH_SECRET
+# Enter a strong random string
+
+wrangler secret put CF_API_TOKEN
+# Enter your Cloudflare API token (needs Workers AI + Account read)
+
+# Deploy
+wrangler deploy
+```
+
+### Step 2: Build and push the container image
+
+```bash
+# Build the agent bundle
+npm run build:remote-agent
+
+# Build the Docker image
+cd remote
+docker build -t ghcr.io/sinameraji/kimiflare-remote-agent:latest .
+
+# Push (requires GitHub Container Registry auth)
+docker push ghcr.io/sinameraji/kimiflare-remote-agent:latest
+```
+
+**Note:** The Worker references `ghcr.io/sinameraji/kimiflare-remote-agent:latest`. Change this in `remote/worker/src/session-do.ts` if you use a different registry.
+
+### Step 3: Configure the CLI
+
+```bash
+# Set your deployed Worker URL
+kimiflare config remoteWorkerUrl https://kimiflare-remote.your-account.workers.dev
+
+# Set the same secret you used in wrangler
+kimiflare config remoteAuthSecret your-secret-here
+
+# Authenticate with GitHub
+kimiflare auth github
+```
+
+### Step 4: Run a real session
+
+```bash
+cd /path/to/your/repo
+kimiflare
+/remote "Refactor the auth module"
+```
+
+You'll see:
+1. "Starting remote session..."
+2. Live progress streaming in the TUI
+3. "✅ Done — PR: https://github.com/..." when finished
+
+---
+
+## Troubleshooting
+
+### "Remote worker not configured"
+
+Set `remoteWorkerUrl` in your config:
+
+```bash
+kimiflare config remoteWorkerUrl https://your-worker.workers.dev
+```
+
+### "GitHub not authenticated"
+
+Run the OAuth flow:
+
+```bash
+kimiflare auth github
+```
+
+### "Could not detect GitHub repo"
+
+Either:
+- Run from a git repo with a GitHub remote
+- Or set it explicitly: `kimiflare config githubRepo owner/repo`
+
+### Worker deployment fails
+
+Check that your Cloudflare account has:
+- Workers enabled
+- Durable Objects available
+- Artifacts beta access (if required)
+- Sandbox beta access (if required)
+
+---
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `kimiflare auth github` | Authenticate with GitHub |
+| `kimiflare remote list` | List all remote sessions |
+| `kimiflare remote status [id]` | Show session status |
+| `kimiflare remote cancel <id>` | Cancel a running session |
+| `kimiflare config remoteWorkerUrl <url>` | Set Worker URL |
+| `kimiflare config remoteAuthSecret <secret>` | Set auth secret |
+| `kimiflare config githubRepo owner/repo` | Set default repo |
+| `/remote <prompt>` | Start session from TUI |

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build": "tsup",
     "build:remote": "npm run build:worker && npm run build:remote-agent",
     "build:worker": "cd remote/worker && npm run typecheck",
-    "build:remote-agent": "cd remote/agent && npm run typecheck",
+    "build:remote-agent": "cd remote/agent && npx tsup",
     "dev": "tsx src/index.tsx",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts src/**/*.test.tsx",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   },
   "scripts": {
     "build": "tsup",
+    "build:remote": "npm run build:worker && npm run build:remote-agent",
+    "build:worker": "cd remote/worker && npm run typecheck",
+    "build:remote-agent": "cd remote/agent && npm run typecheck",
     "dev": "tsx src/index.tsx",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts src/**/*.test.tsx",

--- a/remote/.dockerignore
+++ b/remote/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+worker/node_modules
+agent/node_modules
+*.log
+.git
+.gitignore
+README.md
+.env

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -1,0 +1,56 @@
+# kimiflare remote agent sandbox image
+# Based on node:20-bookworm for rich build toolchain support
+
+FROM node:20-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    wget \
+    jq \
+    build-essential \
+    python3 \
+    python3-pip \
+    python3-venv \
+    golang-go \
+    rustc \
+    cargo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust via rustup (system rustc may be outdated)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Set up workspace
+WORKDIR /workspace
+
+# Pre-install common package managers
+RUN npm install -g pnpm yarn
+
+# Copy and install remote agent dependencies
+COPY remote/agent/package.json /opt/kimiflare/package.json
+WORKDIR /opt/kimiflare
+RUN npm install
+
+# Copy remote agent source
+COPY remote/agent/src /opt/kimiflare/src
+COPY src/agent /opt/kimiflare/src/agent
+COPY src/tools /opt/kimiflare/src/tools
+COPY src/tasks-state.ts /opt/kimiflare/src/tasks-state.ts
+COPY src/mode.ts /opt/kimiflare/src/mode.ts
+COPY src/util /opt/kimiflare/src/util
+COPY src/memory /opt/kimiflare/src/memory
+COPY src/pricing.ts /opt/kimiflare/src/pricing.ts
+COPY src/storage-limits.ts /opt/kimiflare/src/storage-limits.ts
+COPY src/cost-debug.ts /opt/kimiflare/src/cost-debug.ts
+COPY src/usage-tracker.ts /opt/kimiflare/src/usage-tracker.ts
+COPY tsconfig.json /opt/kimiflare/tsconfig.json
+
+# Build the remote agent
+RUN npx tsc --outDir dist --module esnext --moduleResolution bundler --target es2022 --esModuleInterop --skipLibCheck
+
+# Entrypoint
+ENV NODE_ENV=production
+WORKDIR /workspace
+ENTRYPOINT ["node", "/opt/kimiflare/dist/remote-agent.js"]

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -1,9 +1,9 @@
 # kimiflare remote agent sandbox image
-# Based on node:20-bookworm for rich build toolchain support
+# This image runs the pre-built remote agent bundle inside a Cloudflare Sandbox.
 
 FROM node:20-bookworm
 
-# Install system dependencies
+# Install system dependencies for common build toolchains
 RUN apt-get update && apt-get install -y \
     git \
     curl \
@@ -22,35 +22,16 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Set up workspace
-WORKDIR /workspace
-
 # Pre-install common package managers
 RUN npm install -g pnpm yarn
 
-# Copy and install remote agent dependencies
-COPY remote/agent/package.json /opt/kimiflare/package.json
-WORKDIR /opt/kimiflare
-RUN npm install
+# Set up workspace
+WORKDIR /workspace
 
-# Copy remote agent source
-COPY remote/agent/src /opt/kimiflare/src
-COPY src/agent /opt/kimiflare/src/agent
-COPY src/tools /opt/kimiflare/src/tools
-COPY src/tasks-state.ts /opt/kimiflare/src/tasks-state.ts
-COPY src/mode.ts /opt/kimiflare/src/mode.ts
-COPY src/util /opt/kimiflare/src/util
-COPY src/memory /opt/kimiflare/src/memory
-COPY src/pricing.ts /opt/kimiflare/src/pricing.ts
-COPY src/storage-limits.ts /opt/kimiflare/src/storage-limits.ts
-COPY src/cost-debug.ts /opt/kimiflare/src/cost-debug.ts
-COPY src/usage-tracker.ts /opt/kimiflare/src/usage-tracker.ts
-COPY tsconfig.json /opt/kimiflare/tsconfig.json
+# Copy pre-built remote agent bundle
+# This bundle is built by `npm run build:remote-agent` before building the image
+COPY dist/remote-agent.mjs /opt/kimiflare/remote-agent.mjs
 
-# Build the remote agent
-RUN npx tsc --outDir dist --module esnext --moduleResolution bundler --target es2022 --esModuleInterop --skipLibCheck
-
-# Entrypoint
 ENV NODE_ENV=production
 WORKDIR /workspace
-ENTRYPOINT ["node", "/opt/kimiflare/dist/remote-agent.js"]
+ENTRYPOINT ["node", "/opt/kimiflare/remote-agent.mjs"]

--- a/remote/README.md
+++ b/remote/README.md
@@ -1,0 +1,147 @@
+# kimiflare `/remote` Feature
+
+Run autonomous coding tasks on Cloudflare infrastructure. The agent works in a Sandbox container, commits to an Artifacts repo, and opens a PR on GitHub when done.
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────┐
+│ Local CLI   │────▶│ Orchestrator    │────▶│ Artifacts       │◀────│ Sandbox     │
+│ (kimiflare) │◀────│ Worker (DO)     │     │ (Git server)    │────▶│ Container   │
+└─────────────┘     └─────────────────┘     └─────────────────┘     └─────────────┘
+                           │                                               │
+                           ▼                                               ▼
+                    ┌─────────────┐                               ┌─────────────┐
+                    │ GitHub API  │                               │ Workers AI  │
+                    │ (PR, push)  │                               │ (LLM relay) │
+                    └─────────────┘                               └─────────────┘
+```
+
+## Quick Start
+
+### 1. Deploy the Worker
+
+```bash
+cd remote/worker
+# Set secrets
+wrangler secret put REMOTE_AUTH_SECRET
+wrangler secret put CF_API_TOKEN
+# Deploy
+wrangler deploy
+```
+
+### 2. Build and push the container image
+
+```bash
+# Build the remote agent bundle
+npm run build:remote-agent
+
+# Build and push the Docker image
+cd remote
+docker build -t ghcr.io/sinameraji/kimiflare-remote-agent:latest .
+docker push ghcr.io/sinameraji/kimiflare-remote-agent:latest
+```
+
+### 3. Configure the CLI
+
+```bash
+# Set your Worker URL
+kimiflare config remoteWorkerUrl https://kimiflare-remote.your-account.workers.dev
+
+# Authenticate with GitHub
+kimiflare auth github
+
+# Set shared secret (must match Worker secret)
+kimiflare config remoteAuthSecret your-secret-here
+```
+
+### 4. Run a remote session
+
+```bash
+# In your project directory
+kimiflare
+
+# In the TUI
+/remote Add OAuth device flow authentication
+```
+
+## Components
+
+### `remote/worker/` — Orchestrator Worker
+
+Cloudflare Worker with Durable Objects that manages:
+- Session lifecycle
+- Artifacts repo creation/deletion
+- Sandbox creation/management
+- GitHub API integration
+- LLM relay (Workers AI)
+- Progress streaming (SSE)
+
+### `remote/agent/` — Headless Agent
+
+Node.js application that runs inside the Sandbox:
+- Clones the Artifacts repo
+- Runs the kimiflare agent loop in headless mode
+- Auto-approves all tool calls
+- Commits after each tool batch
+- Streams progress as NDJSON
+
+### `src/remote/` — Local CLI Integration
+
+- `worker-client.ts` — HTTP client for the Worker
+- `session-store.ts` — Local session persistence
+- `cli.ts` — `kimiflare remote list|status|cancel` subcommands
+
+### `src/auth/github.ts` — GitHub OAuth
+
+Device flow implementation for CLI authentication.
+
+## Environment Variables
+
+### Worker Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `REMOTE_AUTH_SECRET` | Shared secret for CLI → Worker auth |
+| `CF_API_TOKEN` | Cloudflare API token for Workers AI relay |
+
+### CLI Config
+
+| Config Key | Description |
+|------------|-------------|
+| `remoteWorkerUrl` | URL of your deployed Worker |
+| `remoteAuthSecret` | Shared secret (must match Worker) |
+| `githubOAuthToken` | GitHub OAuth token (set via `kimiflare auth github`) |
+| `githubRepo` | Cached repo identifier (`owner/repo`) |
+
+## Development
+
+### Local testing
+
+The Worker and Sandbox bindings require Cloudflare infrastructure. For local development:
+1. Use `wrangler dev` for the Worker
+2. Use `wrangler sandbox` (if available) for Sandbox testing
+3. Or mock the bindings for unit tests
+
+### Building
+
+```bash
+# Main project
+npm run build
+
+# Remote agent bundle
+npm run build:remote-agent
+
+# Worker (typecheck only — deployed via wrangler)
+npm run build:worker
+```
+
+## Cost Estimate
+
+Per typical session (~30 min, 50K input tokens):
+- Sandbox CPU/memory: ~$0.55
+- Workers AI: ~$0.13
+- Workers/Artifacts: ~$0.01
+- **Total: ~$0.70**
+
+See `docs/remote-architecture.md` for detailed cost breakdown.

--- a/remote/agent/package.json
+++ b/remote/agent/package.json
@@ -3,11 +3,16 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "commander": "^12.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",
+    "tsup": "^8.3.5",
     "typescript": "^5.7.2"
   }
 }

--- a/remote/agent/package.json
+++ b/remote/agent/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kimiflare/remote-agent",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/remote/agent/src/headless-permission.ts
+++ b/remote/agent/src/headless-permission.ts
@@ -1,0 +1,7 @@
+import type { PermissionAsker, PermissionDecision } from "../../../src/tools/executor.js";
+
+/**
+ * Headless permission handler that auto-approves all tool calls.
+ * Used inside the Sandbox where there is no interactive user.
+ */
+export const headlessPermissionAsker: PermissionAsker = async () => "allow";

--- a/remote/agent/src/progress-reporter.ts
+++ b/remote/agent/src/progress-reporter.ts
@@ -1,0 +1,98 @@
+import type { AgentCallbacks, AgentTurnOpts } from "../../../src/agent/loop.js";
+import type { ToolCall, Usage } from "../../../src/agent/messages.js";
+import type { ToolResult } from "../../../src/tools/executor.js";
+import type { Task } from "../../../src/tasks-state.js";
+
+export type RemoteProgressEvent =
+  | { type: "turn_start"; turn: number }
+  | { type: "text_delta"; text: string }
+  | { type: "reasoning_delta"; text: string }
+  | { type: "tool_call_start"; index: number; id: string; name: string }
+  | { type: "tool_call_args"; index: number; delta: string }
+  | { type: "tool_call_finalized"; call: ToolCall }
+  | { type: "tool_result"; result: ToolResult }
+  | { type: "usage"; usage: Usage }
+  | { type: "tasks"; tasks: Task[] }
+  | { type: "turn_end"; turn: number }
+  | { type: "done"; finishReason: string | null }
+  | { type: "error"; message: string }
+  | { type: "heartbeat" };
+
+function emit(event: RemoteProgressEvent): void {
+  console.log(JSON.stringify(event));
+}
+
+export function createProgressReporter(): AgentCallbacks {
+  let currentTurn = 0;
+
+  return {
+    onAssistantStart: () => {
+      currentTurn++;
+      emit({ type: "turn_start", turn: currentTurn });
+    },
+    onReasoningDelta: (text: string) => {
+      emit({ type: "reasoning_delta", text });
+    },
+    onTextDelta: (text: string) => {
+      emit({ type: "text_delta", text });
+    },
+    onToolCallStart: (index: number, id: string, name: string) => {
+      emit({ type: "tool_call_start", index, id, name });
+    },
+    onToolCallArgs: (index: number, delta: string) => {
+      emit({ type: "tool_call_args", index, delta });
+    },
+    onToolCallFinalized: (call: ToolCall) => {
+      emit({ type: "tool_call_finalized", call });
+    },
+    onToolResult: (result: ToolResult) => {
+      emit({ type: "tool_result", result });
+    },
+    onUsage: (usage: Usage) => {
+      emit({ type: "usage", usage });
+    },
+    onUsageFinal: (usage: Usage) => {
+      emit({ type: "usage", usage });
+    },
+    onAssistantFinal: () => {
+      emit({ type: "turn_end", turn: currentTurn });
+    },
+    onTasks: (tasks: Task[]) => {
+      emit({ type: "tasks", tasks });
+    },
+    askPermission: async () => "allow",
+  };
+}
+
+export async function postProgress(
+  url: string,
+  sessionId: string,
+  events: RemoteProgressEvent[],
+): Promise<void> {
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId, events }),
+    });
+  } catch {
+    // Non-fatal: progress posting is best-effort
+  }
+}
+
+export async function postFinalize(
+  url: string,
+  sessionId: string,
+  summary: string,
+  commitCount: number,
+): Promise<void> {
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId, summary, commitCount }),
+    });
+  } catch {
+    // Non-fatal
+  }
+}

--- a/remote/agent/src/progress-reporter.ts
+++ b/remote/agent/src/progress-reporter.ts
@@ -69,15 +69,24 @@ export async function postProgress(
   sessionId: string,
   events: RemoteProgressEvent[],
 ): Promise<void> {
-  try {
-    await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sessionId, events }),
-    });
-  } catch {
-    // Non-fatal: progress posting is best-effort
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId, events }),
+      });
+      if (res.ok) return;
+    } catch {
+      // Retry
+    }
+    await sleep(1000 * (attempt + 1));
   }
+  // Non-fatal: progress posting is best-effort
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function postFinalize(

--- a/remote/agent/src/remote-agent.ts
+++ b/remote/agent/src/remote-agent.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * kimiflare Remote Agent
+ * Headless agent that runs inside a Cloudflare Sandbox.
+ */
+
+import { execSync } from "node:child_process";
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { runAgentTurn } from "../../../src/agent/loop.js";
+import { buildSystemPrompt } from "../../../src/agent/system-prompt.js";
+import { ToolExecutor, ALL_TOOLS } from "../../../src/tools/executor.js";
+import type { ChatMessage } from "../../../src/agent/messages.js";
+import { createProgressReporter, postFinalize } from "./progress-reporter.js";
+
+const SESSION_ID = process.env.SESSION_ID ?? "unknown";
+const ARTIFACTS_URL = process.env.ARTIFACTS_URL ?? "";
+const ARTIFACTS_TOKEN = process.env.ARTIFACTS_TOKEN ?? "";
+const WORKER_RELAY_URL = process.env.WORKER_RELAY_URL ?? "";
+const PROGRESS_URL = process.env.PROGRESS_URL ?? "";
+const FINALIZE_URL = process.env.FINALIZE_URL ?? "";
+const REPO_OWNER = process.env.REPO_OWNER ?? "";
+const REPO_NAME = process.env.REPO_NAME ?? "";
+const GITHUB_BRANCH = process.env.GITHUB_BRANCH ?? `kimiflare/remote/${SESSION_ID}`;
+const PROMPT = process.env.PROMPT ?? "Do something useful";
+const MODEL = process.env.MODEL ?? "@cf/moonshotai/kimi-k2.6";
+const MAX_TURNS = parseInt(process.env.MAX_TURNS ?? "50", 10);
+const REASONING_EFFORT = (process.env.REASONING_EFFORT ?? "medium") as "low" | "medium" | "high";
+const ACCOUNT_ID = process.env.ACCOUNT_ID ?? "";
+const API_TOKEN = process.env.API_TOKEN ?? "";
+
+const WORKSPACE = "/workspace";
+
+function logInfo(msg: string): void {
+  console.log(JSON.stringify({ type: "info", message: msg }));
+}
+
+function logError(msg: string): void {
+  console.log(JSON.stringify({ type: "error", message: msg }));
+}
+
+function setupGit(): void {
+  execSync("git config --global user.email 'kimiflare@proton.me'");
+  execSync("git config --global user.name 'kimiflare'");
+}
+
+function cloneRepo(): void {
+  if (!ARTIFACTS_URL || !ARTIFACTS_TOKEN) {
+    throw new Error("ARTIFACTS_URL and ARTIFACTS_TOKEN must be set");
+  }
+  const authUrl = ARTIFACTS_URL.replace("https://", `https://token:${ARTIFACTS_TOKEN}@`);
+  execSync(`git clone ${authUrl} ${WORKSPACE}`, { stdio: "inherit" });
+}
+
+function createBranch(): void {
+  execSync(`git checkout -b ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+}
+
+function gitCommit(message: string): void {
+  try {
+    execSync("git add -A", { cwd: WORKSPACE });
+    execSync(`git commit -m "${message}" --no-verify`, { cwd: WORKSPACE });
+  } catch {
+    // No changes to commit
+  }
+}
+
+function pushRepo(): void {
+  if (!ARTIFACTS_URL || !ARTIFACTS_TOKEN) return;
+  const authUrl = ARTIFACTS_URL.replace("https://", `https://token:${ARTIFACTS_TOKEN}@`);
+  execSync(`git push ${authUrl} ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+}
+
+async function runRemoteAgent(): Promise<void> {
+  logInfo(`Starting remote session ${SESSION_ID}`);
+  logInfo(`Model: ${MODEL}`);
+  logInfo(`Max turns: ${MAX_TURNS}`);
+
+  setupGit();
+
+  if (!existsSync(WORKSPACE)) {
+    mkdirSync(WORKSPACE, { recursive: true });
+  }
+
+  // Check if workspace is empty
+  const workspaceFiles = execSync("ls -A", { cwd: WORKSPACE, encoding: "utf8" });
+  if (workspaceFiles.trim().length === 0) {
+    logInfo("Cloning repository...");
+    cloneRepo();
+  }
+
+  createBranch();
+  logInfo(`Created branch ${GITHUB_BRANCH}`);
+
+  // Detect project type and run setup
+  await runProjectSetup();
+
+  const tools = ALL_TOOLS;
+  const executor = new ToolExecutor(tools);
+  const callbacks = createProgressReporter();
+
+  const messages: ChatMessage[] = [
+    {
+      role: "system",
+      content: buildSystemPrompt({
+        cwd: WORKSPACE,
+        tools,
+        model: MODEL,
+        mode: "auto",
+      }),
+    },
+    {
+      role: "user",
+      content: PROMPT,
+    },
+  ];
+
+  const controller = new AbortController();
+
+  // Heartbeat to keep Sandbox warm
+  const heartbeat = setInterval(() => {
+    console.log(JSON.stringify({ type: "heartbeat" }));
+  }, 60000);
+
+  try {
+    await runAgentTurn({
+      accountId: ACCOUNT_ID,
+      apiToken: API_TOKEN,
+      model: MODEL,
+      messages,
+      tools,
+      executor,
+      cwd: WORKSPACE,
+      signal: controller.signal,
+      callbacks,
+      maxToolIterations: MAX_TURNS,
+      reasoningEffort: REASONING_EFFORT,
+      coauthor: { name: "kimiflare", email: "kimiflare@proton.me" },
+      sessionId: SESSION_ID,
+    });
+
+    logInfo("Agent loop completed");
+    gitCommit(`feat: ${PROMPT.slice(0, 50)}`);
+    pushRepo();
+    logInfo("Pushed to Artifacts repo");
+
+    await postFinalize(FINALIZE_URL, SESSION_ID, PROMPT, 1);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError(`Agent error: ${message}`);
+    gitCommit(`wip: ${PROMPT.slice(0, 50)} (interrupted)`);
+    pushRepo();
+    throw err;
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+async function runProjectSetup(): Promise<void> {
+  const packageJsonPath = join(WORKSPACE, "package.json");
+  const cargoTomlPath = join(WORKSPACE, "Cargo.toml");
+  const requirementsPath = join(WORKSPACE, "requirements.txt");
+  const setupScriptPath = join(WORKSPACE, ".kimiflare", "remote-setup.sh");
+
+  if (existsSync(setupScriptPath)) {
+    logInfo("Running custom setup script...");
+    execSync(`bash ${setupScriptPath}`, { cwd: WORKSPACE, stdio: "inherit" });
+    return;
+  }
+
+  if (existsSync(packageJsonPath)) {
+    logInfo("Detected Node.js project, running npm install...");
+    execSync("npm install", { cwd: WORKSPACE, stdio: "inherit" });
+    return;
+  }
+
+  if (existsSync(cargoTomlPath)) {
+    logInfo("Detected Rust project, running cargo fetch...");
+    execSync("cargo fetch", { cwd: WORKSPACE, stdio: "inherit" });
+    return;
+  }
+
+  if (existsSync(requirementsPath)) {
+    logInfo("Detected Python project, running pip install...");
+    execSync("pip install -r requirements.txt", { cwd: WORKSPACE, stdio: "inherit" });
+    return;
+  }
+
+  logInfo("No project setup detected");
+}
+
+runRemoteAgent().then(
+  () => {
+    logInfo("Remote agent finished successfully");
+    process.exit(0);
+  },
+  (err) => {
+    logError(`Remote agent failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  },
+);

--- a/remote/agent/src/remote-agent.ts
+++ b/remote/agent/src/remote-agent.ts
@@ -88,10 +88,18 @@ async function runRemoteAgent(): Promise<void> {
   if (workspaceFiles.trim().length === 0) {
     logInfo("Cloning repository...");
     cloneRepo();
+  } else {
+    logInfo("Workspace already populated, skipping clone");
   }
 
-  createBranch();
-  logInfo(`Created branch ${GITHUB_BRANCH}`);
+  // Create or checkout branch
+  try {
+    execSync(`git checkout -b ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+    logInfo(`Created branch ${GITHUB_BRANCH}`);
+  } catch {
+    execSync(`git checkout ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+    logInfo(`Checked out existing branch ${GITHUB_BRANCH}`);
+  }
 
   // Detect project type and run setup
   await runProjectSetup();
@@ -117,6 +125,12 @@ async function runRemoteAgent(): Promise<void> {
   ];
 
   const controller = new AbortController();
+
+  // Handle SIGTERM gracefully
+  process.on("SIGTERM", () => {
+    logInfo("Received SIGTERM, shutting down gracefully...");
+    controller.abort();
+  });
 
   // Heartbeat to keep Sandbox warm
   const heartbeat = setInterval(() => {

--- a/remote/agent/tsconfig.json
+++ b/remote/agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "../../src/**/*"]
+}

--- a/remote/agent/tsup.config.ts
+++ b/remote/agent/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/remote-agent.ts"],
+  format: ["esm"],
+  target: "node20",
+  platform: "node",
+  clean: true,
+  sourcemap: true,
+  dts: false,
+  splitting: false,
+  shims: false,
+  minify: false,
+  bundle: true,
+  external: [],
+  // Include source files from the main project
+  esbuildOptions(options) {
+    options.resolveExtensions = [".ts", ".js", ".tsx"];
+  },
+});

--- a/remote/worker/package.json
+++ b/remote/worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@kimiflare/remote-worker",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241022.0",
+    "typescript": "^5.7.2",
+    "wrangler": "^3.84.0"
+  }
+}

--- a/remote/worker/src/github.ts
+++ b/remote/worker/src/github.ts
@@ -1,0 +1,92 @@
+const GITHUB_API_BASE = "https://api.github.com";
+
+export interface GitHubRepo {
+  owner: string;
+  name: string;
+}
+
+export async function pushBranch(
+  token: string,
+  repo: GitHubRepo,
+  branch: string,
+  artifactsUrl: string,
+  artifactsToken: string,
+): Promise<void> {
+  // Clone the artifacts repo, then push to GitHub
+  // This is done by creating a temporary git remote and pushing
+  const authArtifactsUrl = artifactsUrl.replace("https://", `https://token:${artifactsToken}@`);
+  const authGithubUrl = `https://x-access-token:${token}@github.com/${repo.owner}/${repo.name}.git`;
+
+  // In practice, this would be done inside the Worker using a git library or subprocess
+  // For now, we'll use the GitHub API to create a PR with the branch
+  // The actual push would need to happen via a git client
+
+  // Note: Cloudflare Workers don't have git CLI available.
+  // We need to use the GitHub API to create a PR, but the branch must already exist on GitHub.
+  // Alternative: use a git WASM implementation or delegate push to the Sandbox.
+
+  // For v1, we'll have the Sandbox push directly to GitHub using a short-lived token
+  // This is a pragmatic compromise — the token is scoped and short-lived.
+}
+
+export async function createPullRequest(
+  token: string,
+  repo: GitHubRepo,
+  branch: string,
+  title: string,
+  body: string,
+): Promise<{ html_url: string; number: number }> {
+  const res = await fetch(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}/pulls`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title,
+      body,
+      head: branch,
+      base: "main",
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub PR creation failed: ${res.status} ${text}`);
+  }
+
+  const data = await res.json() as { html_url: string; number: number };
+  return data;
+}
+
+export async function getDefaultBranch(
+  token: string,
+  repo: GitHubRepo,
+): Promise<string> {
+  const res = await fetch(`${GITHUB_API_BASE}/repos/${repo.owner}/${repo.name}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to get repo info: ${res.status}`);
+  }
+
+  const data = await res.json() as { default_branch: string };
+  return data.default_branch;
+}
+
+export async function validateToken(token: string): Promise<boolean> {
+  const res = await fetch(`${GITHUB_API_BASE}/user`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+  return res.ok;
+}

--- a/remote/worker/src/index.ts
+++ b/remote/worker/src/index.ts
@@ -4,8 +4,16 @@ import { SessionDO } from "./session-do.js";
 
 const app = new Hono<{ Bindings: Env }>();
 
-// Auth middleware
-app.use("/remote/*", async (c, next) => {
+// Auth middleware — only for CLI-facing endpoints
+app.use("/remote/start", async (c, next) => {
+  const auth = c.req.header("Authorization");
+  const expected = `Bearer ${c.env.REMOTE_AUTH_SECRET}`;
+  if (auth !== expected) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+app.use("/remote/cancel/*", async (c, next) => {
   const auth = c.req.header("Authorization");
   const expected = `Bearer ${c.env.REMOTE_AUTH_SECRET}`;
   if (auth !== expected) {
@@ -122,6 +130,20 @@ app.post("/relay", async (c) => {
   }));
 
   return res;
+});
+
+// CORS for web status page and SSE streams
+app.use("/remote/stream/*", async (c, next) => {
+  c.header("Access-Control-Allow-Origin", "*");
+  c.header("Access-Control-Allow-Methods", "GET");
+  c.header("Access-Control-Allow-Headers", "Content-Type");
+  await next();
+});
+app.use("/remote/web/*", async (c, next) => {
+  c.header("Access-Control-Allow-Origin", "*");
+  c.header("Access-Control-Allow-Methods", "GET");
+  c.header("Access-Control-Allow-Headers", "Content-Type");
+  await next();
 });
 
 // Web status page

--- a/remote/worker/src/index.ts
+++ b/remote/worker/src/index.ts
@@ -1,0 +1,199 @@
+import { Hono } from "hono";
+import type { Env } from "./types.js";
+import { SessionDO } from "./session-do.js";
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Auth middleware
+app.use("/remote/*", async (c, next) => {
+  const auth = c.req.header("Authorization");
+  const expected = `Bearer ${c.env.REMOTE_AUTH_SECRET}`;
+  if (auth !== expected) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+
+// Start a remote session
+app.post("/remote/start", async (c) => {
+  const body = await c.req.json();
+  const sessionId = crypto.randomUUID();
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/start", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  const data = await res.json();
+  return c.json({ ...data, sessionId });
+});
+
+// Stream progress (SSE)
+app.get("/remote/stream/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/stream", {
+    method: "GET",
+  }));
+
+  return res;
+});
+
+// Cancel session
+app.post("/remote/cancel/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/cancel", {
+    method: "POST",
+  }));
+
+  return res;
+});
+
+// Get session status
+app.get("/remote/status/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/status", {
+    method: "GET",
+  }));
+
+  return res;
+});
+
+// Receive progress from Sandbox
+app.post("/progress/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const body = await c.req.json();
+  const res = await doStub.fetch(new Request("http://internal/progress", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  return res;
+});
+
+// Finalize session (from Sandbox)
+app.post("/finalize/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const body = await c.req.json();
+  const res = await doStub.fetch(new Request("http://internal/finalize", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  return res;
+});
+
+// LLM relay (from Sandbox)
+app.post("/relay", async (c) => {
+  // The relay endpoint is called by the Sandbox.
+  // We identify the session from a header or the request body.
+  const sessionId = c.req.header("X-Session-Id");
+  if (!sessionId) {
+    return c.json({ error: "Missing X-Session-Id header" }, 400);
+  }
+
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const body = await c.req.json();
+  const res = await doStub.fetch(new Request("http://internal/relay", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  return res;
+});
+
+// Web status page
+app.get("/remote/web/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const streamUrl = `/remote/stream/${sessionId}`;
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kimiflare remote — ${sessionId}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background: #0d1117; color: #c9d1d9; }
+    h1 { font-size: 1.25rem; color: #58a6ff; }
+    .event { padding: 0.5rem; margin: 0.25rem 0; border-radius: 6px; background: #161b22; font-family: monospace; font-size: 0.875rem; }
+    .event.turn_start { border-left: 3px solid #58a6ff; }
+    .event.tool_call { border-left: 3px solid #f0883e; }
+    .event.tool_result { border-left: 3px solid #3fb950; }
+    .event.error { border-left: 3px solid #f85149; }
+    .event.done { border-left: 3px solid #3fb950; background: #23863620; }
+    .status { padding: 1rem; background: #161b22; border-radius: 8px; margin-bottom: 1rem; }
+    .status.running { border: 1px solid #58a6ff; }
+    .status.done { border: 1px solid #3fb950; }
+    .status.error { border: 1px solid #f85149; }
+  </style>
+</head>
+<body>
+  <h1>�� kimiflare remote</h1>
+  <div id="status" class="status running">Connecting...</div>
+  <div id="events"></div>
+  <script>
+    const sessionId = "${sessionId}";
+    const streamUrl = "${streamUrl}";
+    const eventsDiv = document.getElementById("events");
+    const statusDiv = document.getElementById("status");
+    const evtSource = new EventSource(streamUrl);
+
+    evtSource.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      const div = document.createElement("div");
+      div.className = "event " + data.type;
+      div.textContent = JSON.stringify(data);
+      eventsDiv.appendChild(div);
+      window.scrollTo(0, document.body.scrollHeight);
+
+      if (data.type === "done") {
+        statusDiv.textContent = "✅ Done" + (data.prUrl ? " — PR: " + data.prUrl : "");
+        statusDiv.className = "status done";
+        evtSource.close();
+      } else if (data.type === "error") {
+        statusDiv.textContent = "❌ Error: " + data.message;
+        statusDiv.className = "status error";
+      } else if (data.type === "cancelled") {
+        statusDiv.textContent = "🚫 Cancelled";
+        statusDiv.className = "status error";
+      }
+    };
+
+    evtSource.onerror = () => {
+      statusDiv.textContent = "⚠️ Connection lost — reconnecting...";
+    };
+  </script>
+</body>
+</html>`;
+
+  return c.html(html);
+});
+
+// Health check
+app.get("/health", (c) => c.json({ ok: true }));
+
+export default app;
+export { SessionDO };

--- a/remote/worker/src/session-do.ts
+++ b/remote/worker/src/session-do.ts
@@ -127,11 +127,65 @@ export class SessionDO implements DurableObject {
     // Start heartbeat
     this.startHeartbeat();
 
+    // Start agent in background (don't await — it runs for minutes/hours)
+    this.runAgentInSandbox(sandbox);
+
     return Response.json({
       sessionId,
       streamUrl: `/remote/stream/${sessionId}`,
       status: "running",
     });
+  }
+
+  private async runAgentInSandbox(sandbox: import("./types.js").SandboxInstance): Promise<void> {
+    try {
+      const result = await sandbox.exec("node", ["/opt/kimiflare/dist/remote-agent.js"]);
+
+      // Stream stdout
+      const reader = result.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const event = JSON.parse(trimmed) as RemoteProgressEvent;
+            if (this.sessionState) {
+              this.sessionState.progressEvents.push(event);
+              if (this.sessionState.progressEvents.length > MAX_EVENTS) {
+                this.sessionState.progressEvents.shift();
+              }
+              this.broadcast(event);
+
+              if (event.type === "turn_start" && typeof (event as Record<string, unknown>).turn === "number") {
+                this.sessionState.currentTurn = (event as Record<string, unknown>).turn as number;
+              }
+            }
+          } catch {
+            // Not JSON — treat as raw log
+            this.broadcast({ type: "log", text: trimmed });
+          }
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.sessionState) {
+        this.sessionState.status = "error";
+        this.sessionState.errorMessage = message;
+        this.sessionState.finishedAt = Date.now();
+        await this.saveState();
+      }
+      this.broadcast({ type: "error", message });
+    }
   }
 
   private handleStream(): Response {

--- a/remote/worker/src/session-do.ts
+++ b/remote/worker/src/session-do.ts
@@ -1,0 +1,399 @@
+import type { SessionState, RemoteProgressEvent, Env } from "./types.js";
+import { createPullRequest, getDefaultBranch } from "./github.js";
+
+const MAX_EVENTS = 1000;
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export class SessionDO implements DurableObject {
+  private state: DurableObjectState;
+  private env: Env;
+  private sessionState: SessionState | null = null;
+  private clients: Set<ReadableStreamDefaultController<string>> = new Set();
+  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // Restore state from storage if available
+    if (!this.sessionState) {
+      const stored = await this.state.storage.get<SessionState>("state");
+      if (stored) this.sessionState = stored;
+    }
+
+    if (path.endsWith("/start") && request.method === "POST") {
+      return this.handleStart(request);
+    }
+    if (path.endsWith("/stream") && request.method === "GET") {
+      return this.handleStream();
+    }
+    if (path.endsWith("/cancel") && request.method === "POST") {
+      return this.handleCancel();
+    }
+    if (path.endsWith("/status") && request.method === "GET") {
+      return this.handleStatus();
+    }
+    if (path.endsWith("/progress") && request.method === "POST") {
+      return this.handleProgress(request);
+    }
+    if (path.endsWith("/finalize") && request.method === "POST") {
+      return this.handleFinalize(request);
+    }
+    if (path.endsWith("/relay") && request.method === "POST") {
+      return this.handleRelay(request);
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  private async handleStart(request: Request): Promise<Response> {
+    const body = await request.json() as {
+      prompt: string;
+      repo: { owner: string; name: string };
+      githubToken: string;
+      accountId: string;
+      apiToken: string;
+      model?: string;
+      maxTurns?: number;
+      reasoningEffort?: string;
+    };
+
+    const sessionId = this.state.id.toString();
+    const branch = `kimiflare/remote/${sessionId}`;
+
+    // Create Artifacts repo
+    const artifactsRepo = await this.env.ARTIFACTS.createRepo({
+      name: `kf-${sessionId}`,
+    });
+
+    // Create Sandbox
+    const sandbox = await this.env.SANDBOX.create({
+      id: sessionId,
+      image: "ghcr.io/sinameraji/kimiflare-remote-agent:latest",
+      env: {
+        SESSION_ID: sessionId,
+        ARTIFACTS_URL: artifactsRepo.url,
+        ARTIFACTS_TOKEN: artifactsRepo.writeToken,
+        WORKER_RELAY_URL: `https://${request.headers.get("host")}/relay`,
+        PROGRESS_URL: `https://${request.headers.get("host")}/progress`,
+        FINALIZE_URL: `https://${request.headers.get("host")}/finalize`,
+        REPO_OWNER: body.repo.owner,
+        REPO_NAME: body.repo.name,
+        GITHUB_BRANCH: branch,
+        PROMPT: body.prompt,
+        MODEL: body.model ?? "@cf/moonshotai/kimi-k2.6",
+        MAX_TURNS: String(body.maxTurns ?? 50),
+        REASONING_EFFORT: body.reasoningEffort ?? "medium",
+        ACCOUNT_ID: body.accountId,
+        API_TOKEN: body.apiToken,
+      },
+    });
+
+    this.sessionState = {
+      sessionId,
+      status: "running",
+      prompt: body.prompt,
+      repo: body.repo,
+      branch,
+      artifactsRepo: {
+        name: artifactsRepo.name,
+        url: artifactsRepo.url,
+        writeToken: artifactsRepo.writeToken,
+      },
+      sandboxId: sandbox.id,
+      githubToken: body.githubToken,
+      progressEvents: [],
+      maxTurns: body.maxTurns ?? 50,
+      currentTurn: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      startedAt: Date.now(),
+      accountId: body.accountId,
+      apiToken: body.apiToken,
+      model: body.model,
+      reasoningEffort: body.reasoningEffort,
+    };
+
+    await this.saveState();
+
+    // Set alarm for max session duration (4 hours)
+    await this.state.storage.setAlarm(Date.now() + 4 * 60 * 60 * 1000);
+
+    // Start heartbeat
+    this.startHeartbeat();
+
+    return Response.json({
+      sessionId,
+      streamUrl: `/remote/stream/${sessionId}`,
+      status: "running",
+    });
+  }
+
+  private handleStream(): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<string>({
+      start: (controller) => {
+        this.clients.add(controller);
+        // Send existing events
+        if (this.sessionState) {
+          for (const ev of this.sessionState.progressEvents) {
+            controller.enqueue(`data: ${JSON.stringify(ev)}\n\n`);
+          }
+        }
+      },
+      cancel: () => {
+        // Find and remove this controller
+        for (const client of this.clients) {
+          try {
+            client.close();
+          } catch {
+            // ignore
+          }
+        }
+        this.clients.clear();
+      },
+    });
+
+    return new Response(stream as unknown as ReadableStream<Uint8Array>, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  private async handleCancel(): Promise<Response> {
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    this.sessionState.status = "cancelled";
+    this.sessionState.finishedAt = Date.now();
+    await this.saveState();
+
+    // Kill sandbox
+    try {
+      const sandbox = await this.env.SANDBOX.get(this.sessionState.sandboxId!);
+      await sandbox.kill();
+    } catch {
+      // ignore
+    }
+
+    this.broadcast({ type: "cancelled" });
+    return Response.json({ status: "cancelled" });
+  }
+
+  private handleStatus(): Response {
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    // Don't expose sensitive tokens
+    const { githubToken, artifactsRepo, apiToken, ...safe } = this.sessionState;
+    return Response.json({
+      ...safe,
+      artifactsRepo: artifactsRepo ? { name: artifactsRepo.name, url: artifactsRepo.url } : undefined,
+    });
+  }
+
+  private async handleProgress(request: Request): Promise<Response> {
+    const body = await request.json() as { events: RemoteProgressEvent[] };
+
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    for (const ev of body.events) {
+      this.sessionState.progressEvents.push(ev);
+      if (this.sessionState.progressEvents.length > MAX_EVENTS) {
+        this.sessionState.progressEvents.shift();
+      }
+      this.broadcast(ev);
+
+      if (ev.type === "turn_start" && typeof ev.turn === "number") {
+        this.sessionState.currentTurn = ev.turn;
+      }
+    }
+
+    this.sessionState.updatedAt = Date.now();
+    await this.saveState();
+
+    return Response.json({ ok: true });
+  }
+
+  private async handleFinalize(request: Request): Promise<Response> {
+    const body = await request.json() as { summary: string; commitCount: number };
+
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    this.sessionState.status = "done";
+    this.sessionState.finishedAt = Date.now();
+
+    // Create PR
+    try {
+      const defaultBranch = await getDefaultBranch(
+        this.sessionState.githubToken!,
+        this.sessionState.repo,
+      );
+
+      const pr = await createPullRequest(
+        this.sessionState.githubToken!,
+        this.sessionState.repo,
+        this.sessionState.branch,
+        `feat: ${this.sessionState.prompt.slice(0, 60)}`,
+        buildPrBody(this.sessionState, body.summary, body.commitCount),
+      );
+
+      this.sessionState.prUrl = pr.html_url;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.sessionState.errorMessage = message;
+      this.sessionState.status = "error";
+    }
+
+    await this.saveState();
+    this.broadcast({ type: "done", prUrl: this.sessionState.prUrl });
+
+    // Schedule cleanup alarm
+    await this.state.storage.setAlarm(Date.now() + SESSION_TTL_MS);
+
+    return Response.json({
+      status: this.sessionState.status,
+      prUrl: this.sessionState.prUrl,
+    });
+  }
+
+  private async handleRelay(request: Request): Promise<Response> {
+    const body = await request.json() as {
+      model: string;
+      messages: unknown[];
+      tools?: unknown[];
+      temperature?: number;
+      maxCompletionTokens?: number;
+      reasoningEffort?: string;
+    };
+
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const accountId = this.sessionState.accountId;
+    const apiToken = this.env.CF_API_TOKEN;
+
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${body.model}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: body.messages,
+          tools: body.tools,
+          temperature: body.temperature,
+          max_tokens: body.maxCompletionTokens,
+          reasoning_effort: body.reasoningEffort,
+        }),
+      },
+    );
+
+    // Stream the response back
+    return new Response(res.body, {
+      status: res.status,
+      headers: {
+        "Content-Type": res.headers.get("Content-Type") ?? "application/json",
+      },
+    });
+  }
+
+  private broadcast(event: RemoteProgressEvent): void {
+    const data = `data: ${JSON.stringify(event)}\n\n`;
+    for (const client of this.clients) {
+      try {
+        client.enqueue(data);
+      } catch {
+        // Client disconnected
+      }
+    }
+  }
+
+  private async saveState(): Promise<void> {
+    if (this.sessionState) {
+      await this.state.storage.put("state", this.sessionState);
+    }
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatInterval) return;
+    this.heartbeatInterval = setInterval(() => {
+      this.broadcast({ type: "heartbeat" });
+    }, 30000);
+  }
+
+  async alarm(): Promise<void> {
+    if (!this.sessionState) return;
+
+    // If session is still running, it's a timeout
+    if (this.sessionState.status === "running") {
+      this.sessionState.status = "error";
+      this.sessionState.errorMessage = "Session timed out after 4 hours";
+      this.sessionState.finishedAt = Date.now();
+      await this.saveState();
+      this.broadcast({ type: "error", message: this.sessionState.errorMessage });
+
+      // Kill sandbox
+      try {
+        const sandbox = await this.env.SANDBOX.get(this.sessionState.sandboxId!);
+        await sandbox.kill();
+      } catch {
+        // ignore
+      }
+    }
+
+    // Clean up artifacts repo after TTL
+    if (this.sessionState.artifactsRepo) {
+      try {
+        await this.env.ARTIFACTS.deleteRepo(this.sessionState.artifactsRepo.name);
+      } catch {
+        // ignore
+      }
+    }
+
+    // Clean up storage
+    await this.state.storage.deleteAll();
+  }
+}
+
+function buildPrBody(
+  state: SessionState,
+  summary: string,
+  commitCount: number,
+): string {
+  return `## 🤖 Kimiflare Remote Session
+
+**Session ID:** \`${state.sessionId}\`
+**Prompt:**
+> ${state.prompt}
+
+**Summary:**
+${summary}
+
+**Commits:** ${commitCount}
+**Turns:** ${state.currentTurn} / ${state.maxTurns}
+**Status:** ${state.status === "done" ? "✅ Completed" : "⚠️ Incomplete"}
+
+**View live log:** [Session status page](https://placeholder/remote/web/${state.sessionId})
+
+---
+*This PR was generated by [kimiflare](https://github.com/sinameraji/kimiflare) in remote mode.*
+`;
+}

--- a/remote/worker/src/types.ts
+++ b/remote/worker/src/types.ts
@@ -1,0 +1,56 @@
+export interface RemoteProgressEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface SessionState {
+  sessionId: string;
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
+  prompt: string;
+  repo: { owner: string; name: string };
+  branch: string;
+  artifactsRepo?: { name: string; url: string; writeToken: string };
+  sandboxId?: string;
+  githubToken?: string;
+  progressEvents: RemoteProgressEvent[];
+  prUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  maxTurns: number;
+  currentTurn: number;
+  accountId?: string;
+  apiToken?: string;
+  model?: string;
+  reasoningEffort?: string;
+}
+
+export interface Env {
+  SESSION_DO: DurableObjectNamespace;
+  ARTIFACTS: ArtifactsBinding;
+  SANDBOX: SandboxBinding;
+  OAUTH_KV: KVNamespace;
+  REMOTE_AUTH_SECRET: string;
+  CF_API_TOKEN: string;
+  GITHUB_APP_CLIENT_SECRET?: string;
+}
+
+// Cloudflare Artifacts binding (simplified — actual types may vary)
+export interface ArtifactsBinding {
+  createRepo(opts: { name: string }): Promise<{ name: string; url: string; writeToken: string; readToken: string }>;
+  deleteRepo(name: string): Promise<void>;
+}
+
+// Cloudflare Sandbox binding (simplified — actual types may vary)
+export interface SandboxBinding {
+  create(opts: { id: string; image: string; env?: Record<string, string> }): Promise<SandboxInstance>;
+  get(id: string): Promise<SandboxInstance>;
+}
+
+export interface SandboxInstance {
+  id: string;
+  exec(command: string, args?: string[], opts?: { env?: Record<string, string>; cwd?: string }): Promise<{ stdout: ReadableStream; stderr: ReadableStream }>;
+  kill(): Promise<void>;
+}

--- a/remote/worker/tsconfig.json
+++ b/remote/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/remote/worker/wrangler.toml
+++ b/remote/worker/wrangler.toml
@@ -1,0 +1,28 @@
+name = "kimiflare-remote"
+main = "src/index.ts"
+compatibility_date = "2024-10-22"
+compatibility_flags = ["nodejs_compat"]
+
+# Durable Objects
+[[durable_objects.bindings]]
+name = "SESSION_DO"
+class_name = "SessionDO"
+
+# Artifacts binding
+[[artifacts]]
+binding = "ARTIFACTS"
+
+# Sandbox binding
+[[sandbox]]
+binding = "SANDBOX"
+
+# KV for OAuth state (optional, can use DO instead)
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = ""
+
+[vars]
+# Set via wrangler secret put:
+# REMOTE_AUTH_SECRET
+# CF_API_TOKEN
+# GITHUB_APP_CLIENT_SECRET

--- a/scripts/mock-remote-worker.js
+++ b/scripts/mock-remote-worker.js
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/**
+ * Mock remote Worker for local development.
+ * Simulates the orchestrator endpoints without needing Cloudflare infra.
+ *
+ * Usage:
+ *   node scripts/mock-remote-worker.js
+ *
+ * Then configure the CLI:
+ *   kimiflare config remoteWorkerUrl http://localhost:8787
+ *   kimiflare config remoteAuthSecret dev-secret
+ */
+
+import { createServer } from "node:http";
+
+const PORT = 8787;
+const AUTH_SECRET = "dev-secret";
+
+const sessions = new Map();
+
+function requireAuth(req, res) {
+  const auth = req.headers["authorization"];
+  if (auth !== `Bearer ${AUTH_SECRET}`) {
+    res.writeHead(401, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Unauthorized" }));
+    return false;
+  }
+  return true;
+}
+
+function sendSSE(res, data) {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const path = url.pathname;
+
+  // CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  // Health check
+  if (path === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, mock: true }));
+    return;
+  }
+
+  // Start session
+  if (path === "/remote/start" && req.method === "POST") {
+    if (!requireAuth(req, res)) return;
+
+    const body = await readBody(req);
+    const sessionId = `mock-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    sessions.set(sessionId, {
+      sessionId,
+      status: "running",
+      prompt: body.prompt,
+      repo: body.repo,
+      branch: `kimiflare/remote/${sessionId}`,
+      progressEvents: [],
+      maxTurns: body.maxTurns ?? 50,
+      currentTurn: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      startedAt: Date.now(),
+    });
+
+    // Simulate progress in background
+    simulateSession(sessionId);
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        sessionId,
+        streamUrl: `/remote/stream/${sessionId}`,
+        status: "running",
+      }),
+    );
+    return;
+  }
+
+  // Stream progress (SSE)
+  if (path.startsWith("/remote/stream/") && req.method === "GET") {
+    const sessionId = path.split("/").pop();
+    const session = sessions.get(sessionId);
+
+    if (!session) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Session not found" }));
+      return;
+    }
+
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+
+    // Send existing events
+    for (const ev of session.progressEvents) {
+      sendSSE(res, ev);
+    }
+
+    // Keep connection alive and send new events
+    const interval = setInterval(() => {
+      const s = sessions.get(sessionId);
+      if (!s || s.status === "done" || s.status === "error") {
+        clearInterval(interval);
+        if (s?.status === "done") {
+          sendSSE(res, { type: "done", prUrl: s.prUrl });
+        } else if (s?.status === "error") {
+          sendSSE(res, { type: "error", message: s.errorMessage });
+        }
+        res.end();
+        return;
+      }
+
+      // Send heartbeat
+      sendSSE(res, { type: "heartbeat" });
+    }, 5000);
+
+    req.on("close", () => {
+      clearInterval(interval);
+    });
+
+    return;
+  }
+
+  // Cancel session
+  if (path.startsWith("/remote/cancel/") && req.method === "POST") {
+    if (!requireAuth(req, res)) return;
+
+    const sessionId = path.split("/").pop();
+    const session = sessions.get(sessionId);
+
+    if (!session) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Session not found" }));
+      return;
+    }
+
+    session.status = "cancelled";
+    session.finishedAt = Date.now();
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "cancelled" }));
+    return;
+  }
+
+  // Get session status
+  if (path.startsWith("/remote/status/") && req.method === "GET") {
+    const sessionId = path.split("/").pop();
+    const session = sessions.get(sessionId);
+
+    if (!session) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Session not found" }));
+      return;
+    }
+
+    const { githubToken, apiToken, ...safe } = session;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(safe));
+    return;
+  }
+
+  // Receive progress from Sandbox
+  if (path.startsWith("/progress/") && req.method === "POST") {
+    const sessionId = path.split("/").pop();
+    const session = sessions.get(sessionId);
+
+    if (!session) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Session not found" }));
+      return;
+    }
+
+    const body = await readBody(req);
+    for (const ev of body.events ?? []) {
+      session.progressEvents.push(ev);
+      if (ev.type === "turn_start" && typeof ev.turn === "number") {
+        session.currentTurn = ev.turn;
+      }
+    }
+    session.updatedAt = Date.now();
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  // Finalize session
+  if (path.startsWith("/finalize/") && req.method === "POST") {
+    const sessionId = path.split("/").pop();
+    const session = sessions.get(sessionId);
+
+    if (!session) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Session not found" }));
+      return;
+    }
+
+    const body = await readBody(req);
+    session.status = "done";
+    session.finishedAt = Date.now();
+    session.prUrl = `https://github.com/${session.repo.owner}/${session.repo.name}/pull/1`;
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "done", prUrl: session.prUrl }));
+    return;
+  }
+
+  // LLM relay
+  if (path === "/relay" && req.method === "POST") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error: "Mock relay: LLM calls are not supported in mock mode",
+      }),
+    );
+    return;
+  }
+
+  // Web status page
+  if (path.startsWith("/remote/web/") && req.method === "GET") {
+    const sessionId = path.split("/").pop();
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>kimiflare remote (MOCK) — ${sessionId}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background: #0d1117; color: #c9d1d9; }
+    h1 { font-size: 1.25rem; color: #58a6ff; }
+    .mock-banner { background: #f0883e; color: #000; padding: 0.5rem; border-radius: 6px; margin-bottom: 1rem; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <div class="mock-banner">⚠️ MOCK MODE — This is a local development server</div>
+  <h1>kimiflare remote</h1>
+  <p>Session: ${sessionId}</p>
+  <p>Status: Mock session</p>
+</body>
+</html>`;
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(html);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Not found" }));
+});
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk) => (data += chunk));
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch {
+        resolve({});
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+async function simulateSession(sessionId) {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+
+  const events = [
+    { type: "turn_start", turn: 1 },
+    { type: "text_delta", text: "I'll help you with that. Let me start by examining the codebase..." },
+    { type: "tool_call_start", index: 0, id: "call_1", name: "read" },
+    { type: "tool_call_args", index: 0, delta: '{"path": "README.md"}' },
+    { type: "tool_call_finalized", call: { id: "call_1", name: "read", arguments: { path: "README.md" } } },
+    { type: "tool_result", result: { ok: true, value: "# Project\n\nA sample project." } },
+    { type: "text_delta", text: "I see the project structure. Now I'll make the changes..." },
+    { type: "turn_end", turn: 1 },
+    { type: "turn_start", turn: 2 },
+    { type: "tool_call_start", index: 0, id: "call_2", name: "write" },
+    { type: "tool_call_finalized", call: { id: "call_2", name: "write", arguments: { path: "README.md", content: "# Updated Project\n\nNow with more features!" } } },
+    { type: "tool_result", result: { ok: true } },
+    { type: "turn_end", turn: 2 },
+  ];
+
+  for (const ev of events) {
+    await sleep(500 + Math.random() * 1000);
+    session.progressEvents.push(ev);
+    if (ev.type === "turn_start" && typeof ev.turn === "number") {
+      session.currentTurn = ev.turn;
+    }
+  }
+
+  await sleep(1000);
+  session.status = "done";
+  session.finishedAt = Date.now();
+  session.prUrl = `https://github.com/${session.repo.owner}/${session.repo.name}/pull/1`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+server.listen(PORT, () => {
+  console.log(`🧪 Mock remote Worker running at http://localhost:${PORT}`);
+  console.log(`   Auth secret: ${AUTH_SECRET}`);
+  console.log("");
+  console.log("Configure the CLI:");
+  console.log(`  kimiflare config remoteWorkerUrl http://localhost:${PORT}`);
+  console.log(`  kimiflare config remoteAuthSecret ${AUTH_SECRET}`);
+  console.log("");
+  console.log("Then start a session:");
+  console.log("  kimiflare");
+  console.log('  /remote "Do something useful"');
+});

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2430,7 +2430,11 @@ function App({
 
             // Stream progress
             try {
-              for await (const ev of streamRemoteProgress(cfg.remoteWorkerUrl!, data.sessionId)) {
+              for await (const ev of streamRemoteProgress(
+                cfg.remoteWorkerUrl!,
+                data.sessionId,
+                activeControllerRef.current?.signal,
+              )) {
                 const event = ev as Record<string, unknown>;
                 if (event.type === "text_delta") {
                   setEvents((e) => [

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -28,6 +28,8 @@ import { LspManager } from "./lsp/manager.js";
 import { makeLspTools } from "./tools/lsp.js";
 import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
+import { startRemoteSession, streamRemoteProgress } from "./remote/worker-client.js";
+import { saveRemoteSession } from "./remote/session-store.js";
 import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
@@ -63,6 +65,7 @@ import {
   type SessionSummary,
 } from "./sessions.js";
 import { unlink } from "node:fs/promises";
+import { execSync } from "node:child_process";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
 import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
 import type { GatewayUsageLookup, DailyUsage } from "./usage-tracker.js";
@@ -343,6 +346,25 @@ function openBrowser(url: string): void {
   const cmd = platform() === "darwin" ? "open" : platform() === "win32" ? "start" : "xdg-open";
   const child = spawn(cmd, [url], { detached: true, stdio: "ignore" });
   child.unref();
+}
+
+function detectGitHubRepo(cachedRepo?: string): { owner: string; name: string } | null {
+  if (cachedRepo) {
+    const parts = cachedRepo.split("/");
+    if (parts.length === 2) return { owner: parts[0]!, name: parts[1]! };
+  }
+  try {
+    const remoteUrl = execSync("git remote get-url origin", { cwd: process.cwd(), encoding: "utf8" }).trim();
+    // Parse HTTPS: https://github.com/owner/repo.git
+    // Parse SSH: git@github.com:owner/repo.git
+    const httpsMatch = remoteUrl.match(/github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/);
+    if (httpsMatch) return { owner: httpsMatch[1]!, name: httpsMatch[2]! };
+    const sshMatch = remoteUrl.match(/github\.com:([^\/]+)\/([^\/]+?)(?:\.git)?$/);
+    if (sshMatch) return { owner: sshMatch[1]!, name: sshMatch[2]! };
+  } catch {
+    // not a git repo or no origin remote
+  }
+  return null;
 }
 
 interface PendingPermission {
@@ -2342,6 +2364,123 @@ function App({
           ...e,
           { kind: "info", key: mkKey(), text: "usage: /command create | edit | delete | list" },
         ]);
+        return true;
+      }
+      if (c === "/remote") {
+        if (!cfg?.remoteWorkerUrl) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: "Remote worker not configured. Set remoteWorkerUrl in ~/.config/kimiflare/config.json" },
+          ]);
+          return true;
+        }
+        if (!cfg?.githubOAuthToken) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: "GitHub not authenticated. Run `kimiflare auth github` first." },
+          ]);
+          return true;
+        }
+        if (arg === "status" || arg === "cancel") {
+          // Handled by CLI subcommands; in TUI just show info
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `Use \`kimiflare remote ${arg}\` from your shell.` },
+          ]);
+          return true;
+        }
+        // Start remote session with the rest of the input as prompt
+        const prompt = rest.join(" ").trim();
+        if (!prompt) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: "usage: /remote <prompt>" },
+          ]);
+          return true;
+        }
+
+        const repo = detectGitHubRepo(cfg.githubRepo);
+        if (!repo) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: "Could not detect GitHub repo. Set githubRepo in config (owner/repo)." },
+          ]);
+          return true;
+        }
+
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
+        ]);
+
+        startRemoteSession({ prompt, repo, cfg })
+          .then(async (data) => {
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: `Remote session started: ${data.sessionId}` },
+              { kind: "info", key: mkKey(), text: `Streaming from ${data.streamUrl}` },
+            ]);
+
+            // Stream progress
+            try {
+              for await (const ev of streamRemoteProgress(cfg.remoteWorkerUrl!, data.sessionId)) {
+                const event = ev as Record<string, unknown>;
+                if (event.type === "text_delta") {
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "info", key: mkKey(), text: String(event.text ?? "") },
+                  ]);
+                } else if (event.type === "tool_call") {
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "info", key: mkKey(), text: `→ ${String(event.name ?? "")}` },
+                  ]);
+                } else if (event.type === "done") {
+                  const prUrl = event.prUrl as string | undefined;
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "info", key: mkKey(), text: prUrl ? `✅ Done — PR: ${prUrl}` : "✅ Done" },
+                  ]);
+                  await saveRemoteSession({
+                    sessionId: data.sessionId,
+                    prompt,
+                    repo: `${repo.owner}/${repo.name}`,
+                    workerUrl: cfg.remoteWorkerUrl!,
+                    status: "done",
+                    prUrl,
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                  });
+                } else if (event.type === "error") {
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "error", key: mkKey(), text: `Remote error: ${String(event.message ?? "")}` },
+                  ]);
+                  await saveRemoteSession({
+                    sessionId: data.sessionId,
+                    prompt,
+                    repo: `${repo.owner}/${repo.name}`,
+                    workerUrl: cfg.remoteWorkerUrl!,
+                    status: "error",
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                  });
+                }
+              }
+            } catch (err) {
+              setEvents((e) => [
+                ...e,
+                { kind: "error", key: mkKey(), text: `Stream error: ${err instanceof Error ? err.message : String(err)}` },
+              ]);
+            }
+          })
+          .catch((err) => {
+            setEvents((e) => [
+              ...e,
+              { kind: "error", key: mkKey(), text: `Failed to start remote session: ${err instanceof Error ? err.message : String(err)}` },
+            ]);
+          });
+
         return true;
       }
       if (c === "/help") {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -314,6 +314,13 @@ interface Cfg {
   autoSwitchConfirm?: boolean;
   maxTurnsPerAgent?: number;
   customAgents?: { name: string; tools: string[]; model?: string; systemPrompt?: string; reasoningEffort?: ReasoningEffort }[];
+  remoteWorkerUrl?: string;
+  remoteEnabled?: boolean;
+  remoteAuthSecret?: string;
+  githubOAuthToken?: string;
+  githubRefreshToken?: string;
+  githubTokenExpiry?: number;
+  githubRepo?: string;
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -30,6 +30,8 @@ import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
 import { startRemoteSession, streamRemoteProgress } from "./remote/worker-client.js";
 import { saveRemoteSession } from "./remote/session-store.js";
+import { deployForTui } from "./remote/tui-deploy.js";
+import { authGitHubForTui } from "./remote/tui-auth.js";
 import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
@@ -51,6 +53,7 @@ import {
   configPath,
   DEFAULT_MODEL,
   DEFAULT_REASONING_EFFORT,
+  loadConfig,
   saveConfig,
   type ReasoningEffort,
 } from "./config.js";
@@ -2374,31 +2377,14 @@ function App({
         return true;
       }
       if (c === "/remote") {
-        if (!cfg?.remoteWorkerUrl) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: "Remote worker not deployed yet." },
-            { kind: "info", key: mkKey(), text: "Run: kimiflare remote deploy" },
-            { kind: "info", key: mkKey(), text: "(One-time setup — takes ~2 minutes)" },
-          ]);
-          return true;
-        }
-        if (!cfg?.githubOAuthToken) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: "GitHub not authenticated. Run `kimiflare auth github` first." },
-          ]);
-          return true;
-        }
         if (arg === "status" || arg === "cancel") {
-          // Handled by CLI subcommands; in TUI just show info
           setEvents((e) => [
             ...e,
             { kind: "info", key: mkKey(), text: `Use \`kimiflare remote ${arg}\` from your shell.` },
           ]);
           return true;
         }
-        // Start remote session with the rest of the input as prompt
+
         const prompt = rest.join(" ").trim();
         if (!prompt) {
           setEvents((e) => [
@@ -2408,91 +2394,155 @@ function App({
           return true;
         }
 
-        const repo = detectGitHubRepo(cfg.githubRepo);
+        const repo = detectGitHubRepo(cfg?.githubRepo);
         if (!repo) {
           setEvents((e) => [
             ...e,
-            { kind: "info", key: mkKey(), text: "Could not detect GitHub repo. Set githubRepo in config (owner/repo)." },
+            { kind: "info", key: mkKey(), text: "Could not detect GitHub repo. Run from a repo with a GitHub remote, or set githubRepo in config." },
           ]);
           return true;
         }
 
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
-        ]);
-
-        startRemoteSession({ prompt, repo, cfg })
-          .then(async (data) => {
+        // Run the full remote flow: deploy → auth → session
+        (async () => {
+          // -- Auto-deploy if needed --
+          if (!cfg?.remoteWorkerUrl) {
             setEvents((e) => [
               ...e,
-              { kind: "info", key: mkKey(), text: `Remote session started: ${data.sessionId}` },
-              { kind: "info", key: mkKey(), text: `Streaming from ${data.streamUrl}` },
+              { kind: "info", key: mkKey(), text: "Remote infrastructure not deployed yet. Setting up now (~2 min)..." },
+            ]);
+
+            try {
+              for await (const step of deployForTui()) {
+                setEvents((e) => [
+                  ...e,
+                  { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
+                ]);
+                if (step.done) break;
+              }
+            } catch {
+              setEvents((e) => [
+                ...e,
+                { kind: "error", key: mkKey(), text: "Deploy failed. Fix the issue above and try /remote again." },
+              ]);
+              return;
+            }
+
+            // Reload config after deploy
+            const { loadConfig: reloadConfig } = await import("./config.js");
+            const newCfg = await reloadConfig();
+            if (newCfg) setCfg(newCfg);
+          }
+
+          const currentCfg = cfg ?? (await loadConfig());
+          if (!currentCfg?.remoteWorkerUrl) {
+            setEvents((e) => [
+              ...e,
+              { kind: "error", key: mkKey(), text: "Deploy seemed to succeed but config wasn't saved. Try again." },
+            ]);
+            return;
+          }
+
+          // -- Auto-auth with GitHub if needed --
+          if (!currentCfg.githubOAuthToken) {
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: "GitHub not authenticated. Starting OAuth device flow..." },
+            ]);
+
+            try {
+              for await (const step of authGitHubForTui()) {
+                setEvents((e) => [
+                  ...e,
+                  { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
+                ]);
+                if (step.done) break;
+              }
+            } catch {
+              setEvents((e) => [
+                ...e,
+                { kind: "error", key: mkKey(), text: "GitHub auth failed. Try `kimiflare auth github` from shell." },
+              ]);
+              return;
+            }
+
+            // Reload config after auth
+            const { loadConfig: reloadConfig } = await import("./config.js");
+            const newCfg = await reloadConfig();
+            if (newCfg) setCfg(newCfg);
+          }
+
+          const finalCfg = (await loadConfig()) ?? currentCfg;
+
+          // -- Start remote session --
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
+          ]);
+
+          try {
+            const data = await startRemoteSession({ prompt, repo, cfg: finalCfg });
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: `Session started: ${data.sessionId}` },
             ]);
 
             // Stream progress
-            try {
-              for await (const ev of streamRemoteProgress(
-                cfg.remoteWorkerUrl!,
-                data.sessionId,
-                activeControllerRef.current?.signal,
-              )) {
-                const event = ev as Record<string, unknown>;
-                if (event.type === "text_delta") {
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "info", key: mkKey(), text: String(event.text ?? "") },
-                  ]);
-                } else if (event.type === "tool_call") {
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "info", key: mkKey(), text: `→ ${String(event.name ?? "")}` },
-                  ]);
-                } else if (event.type === "done") {
-                  const prUrl = event.prUrl as string | undefined;
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "info", key: mkKey(), text: prUrl ? `✅ Done — PR: ${prUrl}` : "✅ Done" },
-                  ]);
-                  await saveRemoteSession({
-                    sessionId: data.sessionId,
-                    prompt,
-                    repo: `${repo.owner}/${repo.name}`,
-                    workerUrl: cfg.remoteWorkerUrl!,
-                    status: "done",
-                    prUrl,
-                    createdAt: new Date().toISOString(),
-                    updatedAt: new Date().toISOString(),
-                  });
-                } else if (event.type === "error") {
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "error", key: mkKey(), text: `Remote error: ${String(event.message ?? "")}` },
-                  ]);
-                  await saveRemoteSession({
-                    sessionId: data.sessionId,
-                    prompt,
-                    repo: `${repo.owner}/${repo.name}`,
-                    workerUrl: cfg.remoteWorkerUrl!,
-                    status: "error",
-                    createdAt: new Date().toISOString(),
-                    updatedAt: new Date().toISOString(),
-                  });
-                }
+            for await (const ev of streamRemoteProgress(
+              finalCfg.remoteWorkerUrl!,
+              data.sessionId,
+              activeControllerRef.current?.signal,
+            )) {
+              const event = ev as Record<string, unknown>;
+              if (event.type === "text_delta") {
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: String(event.text ?? "") },
+                ]);
+              } else if (event.type === "tool_call") {
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: `→ ${String(event.name ?? "")}` },
+                ]);
+              } else if (event.type === "done") {
+                const prUrl = event.prUrl as string | undefined;
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: prUrl ? `Done — PR: ${prUrl}` : "Done" },
+                ]);
+                await saveRemoteSession({
+                  sessionId: data.sessionId,
+                  prompt,
+                  repo: `${repo.owner}/${repo.name}`,
+                  workerUrl: finalCfg.remoteWorkerUrl!,
+                  status: "done",
+                  prUrl,
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                });
+              } else if (event.type === "error") {
+                setEvents((e) => [
+                  ...e,
+                  { kind: "error", key: mkKey(), text: `Remote error: ${String(event.message ?? "")}` },
+                ]);
+                await saveRemoteSession({
+                  sessionId: data.sessionId,
+                  prompt,
+                  repo: `${repo.owner}/${repo.name}`,
+                  workerUrl: finalCfg.remoteWorkerUrl!,
+                  status: "error",
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                });
               }
-            } catch (err) {
-              setEvents((e) => [
-                ...e,
-                { kind: "error", key: mkKey(), text: `Stream error: ${err instanceof Error ? err.message : String(err)}` },
-              ]);
             }
-          })
-          .catch((err) => {
+          } catch (err) {
             setEvents((e) => [
               ...e,
-              { kind: "error", key: mkKey(), text: `Failed to start remote session: ${err instanceof Error ? err.message : String(err)}` },
+              { kind: "error", key: mkKey(), text: `Failed: ${err instanceof Error ? err.message : String(err)}` },
             ]);
-          });
+          }
+        })();
 
         return true;
       }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2377,7 +2377,9 @@ function App({
         if (!cfg?.remoteWorkerUrl) {
           setEvents((e) => [
             ...e,
-            { kind: "info", key: mkKey(), text: "Remote worker not configured. Set remoteWorkerUrl in ~/.config/kimiflare/config.json" },
+            { kind: "info", key: mkKey(), text: "Remote worker not deployed yet." },
+            { kind: "info", key: mkKey(), text: "Run: kimiflare remote deploy" },
+            { kind: "info", key: mkKey(), text: "(One-time setup — takes ~2 minutes)" },
           ]);
           return true;
         }

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -1,0 +1,115 @@
+import { writeFile } from "node:fs/promises";
+import { loadConfig, saveConfig, configPath } from "../config.js";
+
+const GITHUB_CLIENT_ID = "Ov23liM7lJX1xE2V1sVK"; // GitHub OAuth App client ID
+const GITHUB_DEVICE_AUTH_URL = "https://github.com/login/device/code";
+const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface AccessTokenResponse {
+  access_token: string;
+  token_type: string;
+  scope: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+export async function githubDeviceFlow(): Promise<void> {
+  console.log("Initiating GitHub device flow...\n");
+
+  // Step 1: Request device code
+  const deviceRes = await fetch(GITHUB_DEVICE_AUTH_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: GITHUB_CLIENT_ID,
+      scope: "repo",
+    }),
+  });
+
+  if (!deviceRes.ok) {
+    throw new Error(`Failed to request device code: ${deviceRes.status}`);
+  }
+
+  const deviceData = await deviceRes.json() as DeviceCodeResponse;
+  console.log(`Please visit: ${deviceData.verification_uri}`);
+  console.log(`Enter code: ${deviceData.user_code}\n`);
+
+  // Step 2: Poll for access token
+  const startTime = Date.now();
+  const expiresIn = deviceData.expires_in * 1000;
+  const interval = deviceData.interval * 1000;
+
+  while (Date.now() - startTime < expiresIn) {
+    await sleep(interval);
+
+    const tokenRes = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: GITHUB_CLIENT_ID,
+        device_code: deviceData.device_code,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+    });
+
+    if (!tokenRes.ok) continue;
+
+    const tokenData = await tokenRes.json() as AccessTokenResponse & { error?: string };
+
+    if (tokenData.error === "authorization_pending") {
+      continue;
+    }
+    if (tokenData.error === "slow_down") {
+      await sleep(interval * 2);
+      continue;
+    }
+    if (tokenData.error) {
+      throw new Error(`OAuth error: ${tokenData.error}`);
+    }
+
+    if (tokenData.access_token) {
+      // Save tokens
+      const cfg = (await loadConfig()) ?? {
+        accountId: "",
+        apiToken: "",
+        model: "@cf/moonshotai/kimi-k2.6",
+      };
+
+      const expiry = tokenData.expires_in
+        ? Date.now() + tokenData.expires_in * 1000
+        : undefined;
+
+      const next = {
+        ...cfg,
+        githubOAuthToken: tokenData.access_token,
+        githubRefreshToken: tokenData.refresh_token,
+        githubTokenExpiry: expiry,
+      };
+
+      await saveConfig(next);
+      console.log("✅ GitHub authentication successful!");
+      console.log(`Token saved to ${configPath()}`);
+      return;
+    }
+  }
+
+  throw new Error("Device flow expired. Please try again.");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/auth/github.ts
+++ b/src/auth/github.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import { loadConfig, saveConfig, configPath } from "../config.js";
 
-const GITHUB_CLIENT_ID = "Ov23liM7lJX1xE2V1sVK"; // GitHub OAuth App client ID
+const GITHUB_CLIENT_ID = process.env.KIMIFLARE_GITHUB_CLIENT_ID ?? "Ov23liM7lJX1xE2V1sVK";
 const GITHUB_DEVICE_AUTH_URL = "https://github.com/login/device/code";
 const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
 

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -28,6 +28,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "clear", description: "Clear current conversation", source: "builtin" },
   { name: "init", description: "Scan repo and write KIMI.md", source: "builtin" },
   { name: "update", description: "Check for updates", source: "builtin" },
+  { name: "remote", argHint: "[status|cancel <id>]", description: "Start or manage a remote session", source: "builtin" },
   { name: "hello", description: "Send a voice note to the creator", source: "builtin" },
   { name: "logout", description: "Clear stored credentials", source: "builtin" },
   { name: "exit", description: "Exit kimiflare", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,24 @@ export interface KimiConfig {
   maxTurnsPerAgent?: number;
   /** User-defined custom agents with their own tool sets and models. */
   customAgents?: CustomAgentConfig[];
+
+  // ── Remote feature ──────────────────────────────────────────────────
+  /** URL of the remote orchestrator Worker. */
+  remoteWorkerUrl?: string;
+  /** Enable remote mode. Default: false. */
+  remoteEnabled?: boolean;
+  /** Shared secret for authenticating with the remote Worker. */
+  remoteAuthSecret?: string;
+
+  // ── GitHub auth (OAuth device flow) ─────────────────────────────────
+  /** GitHub OAuth access token. */
+  githubOAuthToken?: string;
+  /** GitHub OAuth refresh token. */
+  githubRefreshToken?: string;
+  /** GitHub OAuth token expiry (Unix timestamp). */
+  githubTokenExpiry?: number;
+  /** Cached GitHub repo identifier (owner/repo). */
+  githubRepo?: string;
 }
 
 export interface CustomAgentConfig {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,8 @@ import type { ChatMessage } from "./agent/messages.js";
 import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 import { getAppVersion } from "./util/version.js";
+import { createRemoteCommand } from "./remote/cli.js";
+import { githubDeviceFlow } from "./auth/github.js";
 
 const program = new Command();
 program
@@ -46,6 +48,24 @@ program
     const { runCostCommand } = await import("./cost-attribution/cli.js");
     await runCostCommand({ ...cmdOpts, config: cfg });
   });
+
+program.addCommand(createRemoteCommand());
+
+program
+  .command("auth")
+  .description("Authenticate with external services")
+  .addCommand(
+    new Command("github")
+      .description("Authenticate with GitHub via OAuth device flow")
+      .action(async () => {
+        try {
+          await githubDeviceFlow();
+        } catch (err) {
+          console.error(`Authentication failed: ${err instanceof Error ? err.message : String(err)}`);
+          process.exit(1);
+        }
+      }),
+  );
 
 program.action(async () => {
   await main();

--- a/src/remote/cli.ts
+++ b/src/remote/cli.ts
@@ -5,9 +5,33 @@ import {
   loadRemoteSession,
   getMostRecentRemoteSession,
 } from "./session-store.js";
+import { runDeployWizard, checkDeployStatus } from "./deploy.js";
 
 export function createRemoteCommand(): Command {
   const remote = new Command("remote").description("Manage remote sessions");
+
+  remote
+    .command("deploy")
+    .description("Deploy the remote Worker and container image to Cloudflare")
+    .action(async () => {
+      await runDeployWizard();
+    });
+
+  remote
+    .command("setup")
+    .description("Check remote deployment status and prerequisites")
+    .action(async () => {
+      const status = await checkDeployStatus();
+      console.log("Remote deployment status:\n");
+      console.log(`  wrangler CLI:      ${status.wranglerInstalled ? "✅" : "❌"} installed`);
+      console.log(`  wrangler auth:     ${status.wranglerAuthenticated ? "✅" : "❌"} logged in`);
+      console.log(`  Docker:            ${status.dockerInstalled ? "✅" : "❌"} installed`);
+      console.log(`  Docker registry:   ${status.dockerAuthenticated ? "✅" : "❌"} authenticated`);
+      console.log(`  Worker deployed:   ${status.workerDeployed ? "✅" : "❌"} ${status.workerUrl ?? ""}`);
+      console.log(`  Image pushed:      ${status.imagePushed ? "✅" : "❌"}`);
+      console.log(`  Secrets set:       ${status.secretsSet ? "✅" : "❌"}`);
+      console.log("\nRun `kimiflare remote deploy` to deploy.");
+    });
 
   remote
     .command("list")

--- a/src/remote/cli.ts
+++ b/src/remote/cli.ts
@@ -5,7 +5,7 @@ import {
   loadRemoteSession,
   getMostRecentRemoteSession,
 } from "./session-store.js";
-import { runDeployWizard, checkDeployStatus } from "./deploy.js";
+import { runDeploy, checkDeployStatus } from "./deploy.js";
 
 export function createRemoteCommand(): Command {
   const remote = new Command("remote").description("Manage remote sessions");
@@ -14,7 +14,7 @@ export function createRemoteCommand(): Command {
     .command("deploy")
     .description("Deploy the remote Worker and container image to Cloudflare")
     .action(async () => {
-      await runDeployWizard();
+      await runDeploy();
     });
 
   remote
@@ -23,13 +23,10 @@ export function createRemoteCommand(): Command {
     .action(async () => {
       const status = await checkDeployStatus();
       console.log("Remote deployment status:\n");
-      console.log(`  wrangler CLI:      ${status.wranglerInstalled ? "✅" : "❌"} installed`);
-      console.log(`  wrangler auth:     ${status.wranglerAuthenticated ? "✅" : "❌"} logged in`);
-      console.log(`  Docker:            ${status.dockerInstalled ? "✅" : "❌"} installed`);
-      console.log(`  Docker registry:   ${status.dockerAuthenticated ? "✅" : "❌"} authenticated`);
-      console.log(`  Worker deployed:   ${status.workerDeployed ? "✅" : "❌"} ${status.workerUrl ?? ""}`);
-      console.log(`  Image pushed:      ${status.imagePushed ? "✅" : "❌"}`);
-      console.log(`  Secrets set:       ${status.secretsSet ? "✅" : "❌"}`);
+      console.log(`  wrangler CLI:    ${status.wrangler ? "yes" : "no"}`);
+      console.log(`  wrangler auth:   ${status.wranglerAuth ? "yes" : "no"}`);
+      console.log(`  Docker:          ${status.docker ? "yes" : "no"}`);
+      console.log(`  Worker URL:      ${status.workerUrl ?? "not deployed"}`);
       console.log("\nRun `kimiflare remote deploy` to deploy.");
     });
 

--- a/src/remote/cli.ts
+++ b/src/remote/cli.ts
@@ -1,0 +1,107 @@
+import { Command } from "commander";
+import { loadConfig, saveConfig } from "../config.js";
+import {
+  listRemoteSessions,
+  loadRemoteSession,
+  getMostRecentRemoteSession,
+} from "./session-store.js";
+
+export function createRemoteCommand(): Command {
+  const remote = new Command("remote").description("Manage remote sessions");
+
+  remote
+    .command("list")
+    .description("List remote sessions")
+    .action(async () => {
+      const sessions = await listRemoteSessions();
+      if (sessions.length === 0) {
+        console.log("No remote sessions found.");
+        return;
+      }
+      console.log(`Remote sessions (${sessions.length} total):\n`);
+      for (const s of sessions.slice(0, 20)) {
+        const date = new Date(s.createdAt).toLocaleString();
+        const statusIcon = s.status === "done" ? "✅" : s.status === "error" ? "❌" : s.status === "running" ? "🔄" : "⏹️";
+        console.log(`  ${statusIcon} ${s.sessionId.slice(0, 8)}…  ${s.status.padEnd(10)}  ${date}  ${s.prompt.slice(0, 50)}`);
+        if (s.prUrl) {
+          console.log(`     PR: ${s.prUrl}`);
+        }
+      }
+    });
+
+  remote
+    .command("status")
+    .description("Show remote session status")
+    .argument("[session-id]", "Session ID (defaults to most recent)")
+    .action(async (sessionId?: string) => {
+      const session = sessionId
+        ? await loadRemoteSession(sessionId)
+        : await getMostRecentRemoteSession();
+
+      if (!session) {
+        console.log(sessionId ? `Session ${sessionId} not found.` : "No remote sessions found.");
+        return;
+      }
+
+      const cfg = await loadConfig();
+      const workerUrl = cfg?.remoteWorkerUrl;
+      if (!workerUrl) {
+        console.log("Remote worker not configured.");
+        return;
+      }
+
+      try {
+        const res = await fetch(`${workerUrl}/remote/status/${session.sessionId}`, {
+          headers: {
+            Authorization: `Bearer ${cfg.remoteAuthSecret ?? ""}`,
+          },
+        });
+        if (!res.ok) {
+          console.log(`Failed to fetch status: ${res.status}`);
+          return;
+        }
+        const data = await res.json();
+        console.log(`Session: ${data.sessionId}`);
+        console.log(`Status:  ${data.status}`);
+        console.log(`Prompt:  ${data.prompt}`);
+        console.log(`Repo:    ${data.repo?.owner}/${data.repo?.name}`);
+        console.log(`Branch:  ${data.branch}`);
+        console.log(`Turns:   ${data.currentTurn} / ${data.maxTurns}`);
+        if (data.prUrl) console.log(`PR:      ${data.prUrl}`);
+        if (data.errorMessage) console.log(`Error:   ${data.errorMessage}`);
+      } catch (err) {
+        console.log(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  remote
+    .command("cancel")
+    .description("Cancel a remote session")
+    .argument("<session-id>", "Session ID")
+    .action(async (sessionId: string) => {
+      const cfg = await loadConfig();
+      const workerUrl = cfg?.remoteWorkerUrl;
+      if (!workerUrl) {
+        console.log("Remote worker not configured.");
+        return;
+      }
+
+      try {
+        const res = await fetch(`${workerUrl}/remote/cancel/${sessionId}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${cfg.remoteAuthSecret ?? ""}`,
+          },
+        });
+        if (!res.ok) {
+          console.log(`Failed to cancel: ${res.status}`);
+          return;
+        }
+        console.log(`Session ${sessionId} cancelled.`);
+      } catch (err) {
+        console.log(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  return remote;
+}

--- a/src/remote/deploy.ts
+++ b/src/remote/deploy.ts
@@ -1,220 +1,170 @@
-import { execSync, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadConfig, saveConfig, type KimiConfig } from "../config.js";
+import { randomBytes } from "node:crypto";
+import { loadConfig, saveConfig } from "../config.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REMOTE_DIR = join(__dirname, "..", "..", "..", "remote");
 const WORKER_DIR = join(REMOTE_DIR, "worker");
 
-interface DeployStatus {
-  wranglerInstalled: boolean;
-  wranglerAuthenticated: boolean;
-  dockerInstalled: boolean;
-  dockerAuthenticated: boolean;
-  workerDeployed: boolean;
-  workerUrl?: string;
-  imagePushed: boolean;
-  secretsSet: boolean;
+function generateSecret(): string {
+  return randomBytes(32).toString("hex");
 }
 
-export async function checkDeployStatus(): Promise<DeployStatus> {
-  const status: DeployStatus = {
-    wranglerInstalled: false,
-    wranglerAuthenticated: false,
-    dockerInstalled: false,
-    dockerAuthenticated: false,
-    workerDeployed: false,
-    imagePushed: false,
-    secretsSet: false,
+function run(cmd: string, cwd?: string, input?: string): void {
+  execSync(cmd, {
+    cwd,
+    stdio: input ? ["pipe", "inherit", "inherit"] : "inherit",
+    input,
+  });
+}
+
+function runOutput(cmd: string, cwd?: string): string {
+  return execSync(cmd, { cwd, encoding: "utf8", stdio: ["inherit", "pipe", "inherit"] }).trim();
+}
+
+export async function runDeploy(): Promise<void> {
+  console.log("kimiflare remote deploy\n");
+
+  // -- 1. Prerequisites --
+  try {
+    run("wrangler --version");
+  } catch {
+    console.error("wrangler not found. Install: npm install -g wrangler");
+    console.error("Then run: wrangler login");
+    process.exit(1);
+  }
+
+  try {
+    run("wrangler whoami");
+  } catch {
+    console.error("wrangler not authenticated. Run: wrangler login");
+    process.exit(1);
+  }
+
+  try {
+    run("docker --version");
+  } catch {
+    console.error("Docker not found. Install: https://docs.docker.com/get-docker/");
+    process.exit(1);
+  }
+
+  // -- 2. Build agent bundle --
+  console.log("Building remote agent bundle...");
+  run("npm run build:remote-agent", join(REMOTE_DIR, ".."));
+  console.log("Bundle built\n");
+
+  // -- 3. Deploy Worker --
+  console.log("Deploying Worker...");
+  run("wrangler deploy", WORKER_DIR);
+  console.log("Worker deployed\n");
+
+  // Extract Worker URL from wrangler output or config
+  let workerUrl: string | undefined;
+  try {
+    const info = runOutput("wrangler info", WORKER_DIR);
+    const match = info.match(/https:\/\/[^\s]+\.workers\.dev/);
+    if (match) workerUrl = match[0];
+  } catch { /* ignore */ }
+
+  if (!workerUrl) {
+    console.error("Could not auto-detect Worker URL from wrangler.");
+    console.error("Check your Cloudflare dashboard for the deployed Worker URL.");
+    process.exit(1);
+  }
+  console.log(`Worker URL: ${workerUrl}\n`);
+
+  // -- 4. Auto-generate and set secrets --
+  const authSecret = generateSecret();
+
+  // Try to get CF_API_TOKEN from env or existing config
+  const cfg = await loadConfig();
+  const cfToken = process.env.CF_API_TOKEN ?? cfg?.apiToken;
+
+  if (!cfToken) {
+    console.error("CF_API_TOKEN not found.");
+    console.error("Set it via: export CF_API_TOKEN=your_token");
+    console.error("Or add apiToken to ~/.config/kimiflare/config.json");
+    process.exit(1);
+  }
+
+  console.log("Setting Worker secrets...");
+  run(`wrangler secret put REMOTE_AUTH_SECRET`, WORKER_DIR, authSecret);
+  run(`wrangler secret put CF_API_TOKEN`, WORKER_DIR, cfToken);
+  console.log("Secrets set\n");
+
+  // -- 5. Build and push container --
+  const imageTag = "ghcr.io/sinameraji/kimiflare-remote-agent:latest";
+
+  console.log("Building container image...");
+  run(`docker build -t ${imageTag} .`, REMOTE_DIR);
+  console.log("Image built\n");
+
+  console.log(`Pushing ${imageTag}...`);
+  try {
+    run(`docker push ${imageTag}`, REMOTE_DIR);
+    console.log("Image pushed\n");
+  } catch {
+    console.error("Failed to push image.");
+    console.error("Make sure you're logged into ghcr.io:");
+    console.error("docker login ghcr.io -u USERNAME -p GITHUB_TOKEN");
+    process.exit(1);
+  }
+
+  // -- 6. Save config --
+  const nextCfg = {
+    ...(cfg ?? { accountId: "", apiToken: "", model: "@cf/moonshotai/kimi-k2.6" }),
+    remoteWorkerUrl: workerUrl,
+    remoteAuthSecret: authSecret,
   };
+  await saveConfig(nextCfg);
+  console.log("Saved remoteWorkerUrl and remoteAuthSecret to config\n");
 
-  // Check wrangler
+  // -- 7. Done --
+  console.log("Remote infrastructure ready!\n");
+  console.log("Next step: authenticate with GitHub");
+  console.log("  kimiflare auth github\n");
+  console.log("Then start coding remotely:");
+  console.log("  kimiflare");
+  console.log('  /remote "Your prompt here"');
+}
+
+export async function checkDeployStatus(): Promise<{
+  wrangler: boolean;
+  wranglerAuth: boolean;
+  docker: boolean;
+  workerUrl?: string;
+}> {
+  let wrangler = false;
+  let wranglerAuth = false;
+  let docker = false;
+  let workerUrl: string | undefined;
+
   try {
-    execSync("wrangler --version", { stdio: "ignore" });
-    status.wranglerInstalled = true;
-  } catch {
-    // not installed
-  }
+    run("wrangler --version");
+    wrangler = true;
+  } catch { /* ignore */ }
 
-  if (status.wranglerInstalled) {
+  if (wrangler) {
     try {
-      execSync("wrangler whoami", { stdio: "ignore" });
-      status.wranglerAuthenticated = true;
-    } catch {
-      // not authenticated
-    }
+      run("wrangler whoami");
+      wranglerAuth = true;
+    } catch { /* ignore */ }
   }
 
-  // Check docker
   try {
-    execSync("docker --version", { stdio: "ignore" });
-    status.dockerInstalled = true;
-  } catch {
-    // not installed
-  }
+    run("docker --version");
+    docker = true;
+  } catch { /* ignore */ }
 
-  if (status.dockerInstalled) {
-    try {
-      // Check if logged into ghcr.io
-      const info = execSync("docker info --format '{{.IndexServerAddress}}'", { encoding: "utf8" });
-      status.dockerAuthenticated = info.includes("ghcr.io") || info.includes("docker.io");
-    } catch {
-      // not authenticated
-    }
-  }
-
-  // Check if worker is already deployed
   const cfg = await loadConfig();
   if (cfg?.remoteWorkerUrl) {
     try {
       const res = await fetch(`${cfg.remoteWorkerUrl}/health`, { signal: AbortSignal.timeout(5000) });
-      if (res.ok) {
-        status.workerDeployed = true;
-        status.workerUrl = cfg.remoteWorkerUrl;
-      }
-    } catch {
-      // not reachable
-    }
+      if (res.ok) workerUrl = cfg.remoteWorkerUrl;
+    } catch { /* ignore */ }
   }
 
-  return status;
-}
-
-export async function runDeployWizard(): Promise<void> {
-  console.log("🚀 kimiflare remote deployment wizard\n");
-
-  const status = await checkDeployStatus();
-
-  // Step 1: Prerequisites
-  console.log("Checking prerequisites...\n");
-
-  if (!status.wranglerInstalled) {
-    console.log("❌ wrangler CLI not found. Install it:");
-    console.log("   npm install -g wrangler");
-    console.log("   Then run: wrangler login\n");
-    return;
-  }
-  console.log("✅ wrangler installed");
-
-  if (!status.wranglerAuthenticated) {
-    console.log("❌ wrangler not authenticated. Run:");
-    console.log("   wrangler login\n");
-    return;
-  }
-  console.log("✅ wrangler authenticated");
-
-  if (!status.dockerInstalled) {
-    console.log("❌ Docker not found. Install Docker Desktop:");
-    console.log("   https://docs.docker.com/get-docker/\n");
-    return;
-  }
-  console.log("✅ Docker installed");
-
-  // Step 2: Build agent bundle
-  console.log("\n📦 Building remote agent bundle...");
-  try {
-    execSync("npm run build:remote-agent", {
-      cwd: join(REMOTE_DIR, ".."),
-      stdio: "inherit",
-    });
-    console.log("✅ Agent bundle built\n");
-  } catch (err) {
-    console.error("❌ Failed to build agent bundle:", err instanceof Error ? err.message : String(err));
-    return;
-  }
-
-  // Step 3: Deploy Worker
-  console.log("🌐 Deploying Worker...");
-  try {
-    execSync("wrangler deploy", {
-      cwd: WORKER_DIR,
-      stdio: "inherit",
-    });
-    console.log("✅ Worker deployed\n");
-  } catch (err) {
-    console.error("❌ Failed to deploy Worker:", err instanceof Error ? err.message : String(err));
-    return;
-  }
-
-  // Get Worker URL from wrangler
-  let workerUrl: string | undefined;
-  try {
-    const output = execSync("wrangler info", { cwd: WORKER_DIR, encoding: "utf8" });
-    // Try to extract URL from wrangler output
-    const match = output.match(/https:\/\/[^\s]+\.workers\.dev/);
-    if (match) workerUrl = match[0];
-  } catch {
-    // ignore
-  }
-
-  if (!workerUrl) {
-    console.log("⚠️  Could not auto-detect Worker URL.");
-    console.log("   Check your Cloudflare dashboard or wrangler output.\n");
-  } else {
-    console.log(`✅ Worker URL: ${workerUrl}\n`);
-  }
-
-  // Step 4: Set secrets
-  console.log("🔐 Setting Worker secrets...");
-  console.log("   You'll need to enter these interactively.\n");
-
-  console.log("   Setting REMOTE_AUTH_SECRET...");
-  console.log("   (Enter a strong random string, or press Enter to generate one)");
-  // We can't easily do interactive input here, so we document it
-  console.log("   Run: cd remote/worker && wrangler secret put REMOTE_AUTH_SECRET\n");
-
-  console.log("   Setting CF_API_TOKEN...");
-  console.log("   (Create at https://dash.cloudflare.com/profile/api-tokens with Workers AI + Account read)");
-  console.log("   Run: cd remote/worker && wrangler secret put CF_API_TOKEN\n");
-
-  // Step 5: Build and push container
-  console.log("🐳 Building container image...");
-  const imageTag = "ghcr.io/sinameraji/kimiflare-remote-agent:latest";
-  try {
-    execSync(`docker build -t ${imageTag} .`, {
-      cwd: REMOTE_DIR,
-      stdio: "inherit",
-    });
-    console.log("✅ Image built\n");
-  } catch (err) {
-    console.error("❌ Failed to build image:", err instanceof Error ? err.message : String(err));
-    return;
-  }
-
-  console.log(`📤 Pushing image to ${imageTag}...`);
-  console.log("   (Make sure you're logged into ghcr.io: docker login ghcr.io -u USERNAME)");
-  try {
-    execSync(`docker push ${imageTag}`, {
-      cwd: REMOTE_DIR,
-      stdio: "inherit",
-    });
-    console.log("✅ Image pushed\n");
-  } catch (err) {
-    console.error("❌ Failed to push image:", err instanceof Error ? err.message : String(err));
-    console.log("   You may need to authenticate with GitHub Container Registry first.\n");
-    return;
-  }
-
-  // Step 6: Save config
-  if (workerUrl) {
-    const cfg = (await loadConfig()) ?? {
-      accountId: "",
-      apiToken: "",
-      model: "@cf/moonshotai/kimi-k2.6",
-    };
-    await saveConfig({
-      ...cfg,
-      remoteWorkerUrl: workerUrl,
-    });
-    console.log(`💾 Saved remoteWorkerUrl to config\n`);
-  }
-
-  console.log("🎉 Deployment complete!");
-  console.log("\nNext steps:");
-  console.log("  1. Set the Worker secrets (see above)");
-  console.log("  2. Authenticate with GitHub: kimiflare auth github");
-  console.log("  3. Set the auth secret in config: kimiflare config remoteAuthSecret YOUR_SECRET");
-  console.log("  4. Start a session: kimiflare → /remote <prompt>\n");
+  return { wrangler, wranglerAuth, docker, workerUrl };
 }

--- a/src/remote/deploy.ts
+++ b/src/remote/deploy.ts
@@ -1,0 +1,220 @@
+import { execSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfig, saveConfig, type KimiConfig } from "../config.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REMOTE_DIR = join(__dirname, "..", "..", "..", "remote");
+const WORKER_DIR = join(REMOTE_DIR, "worker");
+
+interface DeployStatus {
+  wranglerInstalled: boolean;
+  wranglerAuthenticated: boolean;
+  dockerInstalled: boolean;
+  dockerAuthenticated: boolean;
+  workerDeployed: boolean;
+  workerUrl?: string;
+  imagePushed: boolean;
+  secretsSet: boolean;
+}
+
+export async function checkDeployStatus(): Promise<DeployStatus> {
+  const status: DeployStatus = {
+    wranglerInstalled: false,
+    wranglerAuthenticated: false,
+    dockerInstalled: false,
+    dockerAuthenticated: false,
+    workerDeployed: false,
+    imagePushed: false,
+    secretsSet: false,
+  };
+
+  // Check wrangler
+  try {
+    execSync("wrangler --version", { stdio: "ignore" });
+    status.wranglerInstalled = true;
+  } catch {
+    // not installed
+  }
+
+  if (status.wranglerInstalled) {
+    try {
+      execSync("wrangler whoami", { stdio: "ignore" });
+      status.wranglerAuthenticated = true;
+    } catch {
+      // not authenticated
+    }
+  }
+
+  // Check docker
+  try {
+    execSync("docker --version", { stdio: "ignore" });
+    status.dockerInstalled = true;
+  } catch {
+    // not installed
+  }
+
+  if (status.dockerInstalled) {
+    try {
+      // Check if logged into ghcr.io
+      const info = execSync("docker info --format '{{.IndexServerAddress}}'", { encoding: "utf8" });
+      status.dockerAuthenticated = info.includes("ghcr.io") || info.includes("docker.io");
+    } catch {
+      // not authenticated
+    }
+  }
+
+  // Check if worker is already deployed
+  const cfg = await loadConfig();
+  if (cfg?.remoteWorkerUrl) {
+    try {
+      const res = await fetch(`${cfg.remoteWorkerUrl}/health`, { signal: AbortSignal.timeout(5000) });
+      if (res.ok) {
+        status.workerDeployed = true;
+        status.workerUrl = cfg.remoteWorkerUrl;
+      }
+    } catch {
+      // not reachable
+    }
+  }
+
+  return status;
+}
+
+export async function runDeployWizard(): Promise<void> {
+  console.log("🚀 kimiflare remote deployment wizard\n");
+
+  const status = await checkDeployStatus();
+
+  // Step 1: Prerequisites
+  console.log("Checking prerequisites...\n");
+
+  if (!status.wranglerInstalled) {
+    console.log("❌ wrangler CLI not found. Install it:");
+    console.log("   npm install -g wrangler");
+    console.log("   Then run: wrangler login\n");
+    return;
+  }
+  console.log("✅ wrangler installed");
+
+  if (!status.wranglerAuthenticated) {
+    console.log("❌ wrangler not authenticated. Run:");
+    console.log("   wrangler login\n");
+    return;
+  }
+  console.log("✅ wrangler authenticated");
+
+  if (!status.dockerInstalled) {
+    console.log("❌ Docker not found. Install Docker Desktop:");
+    console.log("   https://docs.docker.com/get-docker/\n");
+    return;
+  }
+  console.log("✅ Docker installed");
+
+  // Step 2: Build agent bundle
+  console.log("\n📦 Building remote agent bundle...");
+  try {
+    execSync("npm run build:remote-agent", {
+      cwd: join(REMOTE_DIR, ".."),
+      stdio: "inherit",
+    });
+    console.log("✅ Agent bundle built\n");
+  } catch (err) {
+    console.error("❌ Failed to build agent bundle:", err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  // Step 3: Deploy Worker
+  console.log("🌐 Deploying Worker...");
+  try {
+    execSync("wrangler deploy", {
+      cwd: WORKER_DIR,
+      stdio: "inherit",
+    });
+    console.log("✅ Worker deployed\n");
+  } catch (err) {
+    console.error("❌ Failed to deploy Worker:", err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  // Get Worker URL from wrangler
+  let workerUrl: string | undefined;
+  try {
+    const output = execSync("wrangler info", { cwd: WORKER_DIR, encoding: "utf8" });
+    // Try to extract URL from wrangler output
+    const match = output.match(/https:\/\/[^\s]+\.workers\.dev/);
+    if (match) workerUrl = match[0];
+  } catch {
+    // ignore
+  }
+
+  if (!workerUrl) {
+    console.log("⚠️  Could not auto-detect Worker URL.");
+    console.log("   Check your Cloudflare dashboard or wrangler output.\n");
+  } else {
+    console.log(`✅ Worker URL: ${workerUrl}\n`);
+  }
+
+  // Step 4: Set secrets
+  console.log("🔐 Setting Worker secrets...");
+  console.log("   You'll need to enter these interactively.\n");
+
+  console.log("   Setting REMOTE_AUTH_SECRET...");
+  console.log("   (Enter a strong random string, or press Enter to generate one)");
+  // We can't easily do interactive input here, so we document it
+  console.log("   Run: cd remote/worker && wrangler secret put REMOTE_AUTH_SECRET\n");
+
+  console.log("   Setting CF_API_TOKEN...");
+  console.log("   (Create at https://dash.cloudflare.com/profile/api-tokens with Workers AI + Account read)");
+  console.log("   Run: cd remote/worker && wrangler secret put CF_API_TOKEN\n");
+
+  // Step 5: Build and push container
+  console.log("🐳 Building container image...");
+  const imageTag = "ghcr.io/sinameraji/kimiflare-remote-agent:latest";
+  try {
+    execSync(`docker build -t ${imageTag} .`, {
+      cwd: REMOTE_DIR,
+      stdio: "inherit",
+    });
+    console.log("✅ Image built\n");
+  } catch (err) {
+    console.error("❌ Failed to build image:", err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  console.log(`📤 Pushing image to ${imageTag}...`);
+  console.log("   (Make sure you're logged into ghcr.io: docker login ghcr.io -u USERNAME)");
+  try {
+    execSync(`docker push ${imageTag}`, {
+      cwd: REMOTE_DIR,
+      stdio: "inherit",
+    });
+    console.log("✅ Image pushed\n");
+  } catch (err) {
+    console.error("❌ Failed to push image:", err instanceof Error ? err.message : String(err));
+    console.log("   You may need to authenticate with GitHub Container Registry first.\n");
+    return;
+  }
+
+  // Step 6: Save config
+  if (workerUrl) {
+    const cfg = (await loadConfig()) ?? {
+      accountId: "",
+      apiToken: "",
+      model: "@cf/moonshotai/kimi-k2.6",
+    };
+    await saveConfig({
+      ...cfg,
+      remoteWorkerUrl: workerUrl,
+    });
+    console.log(`💾 Saved remoteWorkerUrl to config\n`);
+  }
+
+  console.log("🎉 Deployment complete!");
+  console.log("\nNext steps:");
+  console.log("  1. Set the Worker secrets (see above)");
+  console.log("  2. Authenticate with GitHub: kimiflare auth github");
+  console.log("  3. Set the auth secret in config: kimiflare config remoteAuthSecret YOUR_SECRET");
+  console.log("  4. Start a session: kimiflare → /remote <prompt>\n");
+}

--- a/src/remote/session-store.ts
+++ b/src/remote/session-store.ts
@@ -1,0 +1,63 @@
+import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface RemoteSession {
+  sessionId: string;
+  prompt: string;
+  repo: string;
+  workerUrl: string;
+  status: "pending" | "running" | "done" | "error" | "cancelled";
+  branch?: string;
+  prUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt?: string;
+}
+
+function remoteDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "remote");
+}
+
+export async function saveRemoteSession(session: RemoteSession): Promise<void> {
+  const dir = remoteDir();
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, `${session.sessionId}.json`);
+  await writeFile(path, JSON.stringify(session, null, 2) + "\n", "utf8");
+}
+
+export async function loadRemoteSession(sessionId: string): Promise<RemoteSession | null> {
+  try {
+    const path = join(remoteDir(), `${sessionId}.json`);
+    const raw = await readFile(path, "utf8");
+    return JSON.parse(raw) as RemoteSession;
+  } catch {
+    return null;
+  }
+}
+
+export async function listRemoteSessions(): Promise<RemoteSession[]> {
+  const dir = remoteDir();
+  try {
+    const files = await readdir(dir);
+    const sessions: RemoteSession[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const raw = await readFile(join(dir, file), "utf8");
+        sessions.push(JSON.parse(raw) as RemoteSession);
+      } catch {
+        // ignore corrupt files
+      }
+    }
+    return sessions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  } catch {
+    return [];
+  }
+}
+
+export async function getMostRecentRemoteSession(): Promise<RemoteSession | null> {
+  const sessions = await listRemoteSessions();
+  return sessions[0] ?? null;
+}

--- a/src/remote/tui-auth.ts
+++ b/src/remote/tui-auth.ts
@@ -1,0 +1,112 @@
+import { loadConfig, saveConfig } from "../config.js";
+
+const GITHUB_DEVICE_AUTH_URL = "https://github.com/login/device/code";
+const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const CLIENT_ID = process.env.KIMIFLARE_GITHUB_CLIENT_ID ?? "Ov23liM7lJX1xE2V1sVK";
+
+export interface AuthStep {
+  message: string;
+  url?: string;
+  code?: string;
+  done?: boolean;
+  error?: boolean;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function* authGitHubForTui(): AsyncGenerator<AuthStep, void, void> {
+  yield { message: "Starting GitHub OAuth device flow..." };
+
+  const deviceRes = await fetch(GITHUB_DEVICE_AUTH_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ client_id: CLIENT_ID, scope: "repo" }),
+  });
+
+  if (!deviceRes.ok) {
+    yield { message: `Failed to request device code: ${deviceRes.status}`, error: true };
+    throw new Error("Device code request failed");
+  }
+
+  const deviceData = await deviceRes.json() as {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    expires_in: number;
+    interval: number;
+  };
+
+  yield {
+    message: `Open ${deviceData.verification_uri} and enter code: ${deviceData.user_code}`,
+    url: deviceData.verification_uri,
+    code: deviceData.user_code,
+  };
+
+  const startTime = Date.now();
+  const expiresIn = deviceData.expires_in * 1000;
+  const interval = deviceData.interval * 1000;
+
+  while (Date.now() - startTime < expiresIn) {
+    await sleep(interval);
+
+    const tokenRes = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        device_code: deviceData.device_code,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+    });
+
+    if (!tokenRes.ok) continue;
+
+    const tokenData = await tokenRes.json() as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      error?: string;
+    };
+
+    if (tokenData.error === "authorization_pending") {
+      continue;
+    }
+    if (tokenData.error === "slow_down") {
+      await sleep(interval * 2);
+      continue;
+    }
+    if (tokenData.error) {
+      yield { message: `OAuth error: ${tokenData.error}`, error: true };
+      throw new Error(tokenData.error);
+    }
+
+    if (tokenData.access_token) {
+      const cfg = (await loadConfig()) ?? {
+        accountId: "",
+        apiToken: "",
+        model: "@cf/moonshotai/kimi-k2.6",
+      };
+
+      await saveConfig({
+        ...cfg,
+        githubOAuthToken: tokenData.access_token,
+        githubRefreshToken: tokenData.refresh_token,
+        githubTokenExpiry: tokenData.expires_in ? Date.now() + tokenData.expires_in * 1000 : undefined,
+      });
+
+      yield { message: "GitHub authentication successful!", done: true };
+      return;
+    }
+  }
+
+  yield { message: "Device flow expired. Please try again.", error: true };
+  throw new Error("Device flow expired");
+}

--- a/src/remote/tui-deploy.ts
+++ b/src/remote/tui-deploy.ts
@@ -1,0 +1,149 @@
+import { execSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
+import { loadConfig, saveConfig } from "../config.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REMOTE_DIR = join(__dirname, "..", "..", "..", "remote");
+const WORKER_DIR = join(REMOTE_DIR, "worker");
+
+function generateSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function runCapture(cmd: string, cwd?: string): string {
+  return execSync(cmd, { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+}
+
+export interface DeployStep {
+  message: string;
+  done?: boolean;
+  error?: boolean;
+}
+
+export async function* deployForTui(): AsyncGenerator<DeployStep, { workerUrl: string; authSecret: string }, void> {
+  // -- 1. Prerequisites --
+  yield { message: "Checking prerequisites..." };
+
+  try {
+    runCapture("wrangler --version");
+  } catch {
+    yield { message: "wrangler not found. Install: npm install -g wrangler", error: true };
+    yield { message: "Then run: wrangler login", error: true };
+    throw new Error("wrangler not installed");
+  }
+  yield { message: "wrangler OK" };
+
+  try {
+    runCapture("wrangler whoami");
+  } catch {
+    yield { message: "wrangler not authenticated. Run: wrangler login", error: true };
+    throw new Error("wrangler not authenticated");
+  }
+  yield { message: "wrangler authenticated" };
+
+  try {
+    runCapture("docker --version");
+  } catch {
+    yield { message: "Docker not found. Install: https://docs.docker.com/get-docker/", error: true };
+    throw new Error("docker not installed");
+  }
+  yield { message: "Docker OK" };
+
+  // -- 2. Build agent bundle --
+  yield { message: "Building remote agent bundle..." };
+  try {
+    runCapture("npm run build:remote-agent", join(REMOTE_DIR, ".."));
+    yield { message: "Agent bundle built" };
+  } catch (err) {
+    yield { message: `Build failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  // -- 3. Deploy Worker --
+  yield { message: "Deploying Worker to Cloudflare..." };
+  try {
+    runCapture("wrangler deploy", WORKER_DIR);
+    yield { message: "Worker deployed" };
+  } catch (err) {
+    yield { message: `Deploy failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  // Extract Worker URL
+  let workerUrl: string | undefined;
+  try {
+    const info = runCapture("wrangler info", WORKER_DIR);
+    const match = info.match(/https:\/\/[^\s]+\.workers\.dev/);
+    if (match) workerUrl = match[0];
+  } catch { /* ignore */ }
+
+  if (!workerUrl) {
+    yield { message: "Could not auto-detect Worker URL", error: true };
+    throw new Error("Worker URL not found");
+  }
+  yield { message: `Worker URL: ${workerUrl}` };
+
+  // -- 4. Auto-generate and set secrets --
+  const authSecret = generateSecret();
+  const cfg = await loadConfig();
+  const cfToken = process.env.CF_API_TOKEN ?? cfg?.apiToken;
+
+  if (!cfToken) {
+    yield { message: "CF_API_TOKEN not found. Set CF_API_TOKEN env var or apiToken in config", error: true };
+    throw new Error("CF_API_TOKEN missing");
+  }
+
+  yield { message: "Setting Worker secrets..." };
+  try {
+    execSync(`wrangler secret put REMOTE_AUTH_SECRET`, {
+      cwd: WORKER_DIR,
+      input: authSecret,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    execSync(`wrangler secret put CF_API_TOKEN`, {
+      cwd: WORKER_DIR,
+      input: cfToken,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    yield { message: "Secrets set" };
+  } catch (err) {
+    yield { message: `Secret setup failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  // -- 5. Build and push container --
+  const imageTag = "ghcr.io/sinameraji/kimiflare-remote-agent:latest";
+
+  yield { message: "Building container image..." };
+  try {
+    runCapture(`docker build -t ${imageTag} .`, REMOTE_DIR);
+    yield { message: "Image built" };
+  } catch (err) {
+    yield { message: `Image build failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  yield { message: `Pushing ${imageTag}...` };
+  try {
+    runCapture(`docker push ${imageTag}`, REMOTE_DIR);
+    yield { message: "Image pushed" };
+  } catch (err) {
+    yield { message: `Push failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    yield { message: "Make sure you're logged into ghcr.io: docker login ghcr.io -u USERNAME -p GITHUB_TOKEN", error: true };
+    throw err;
+  }
+
+  // -- 6. Save config --
+  const nextCfg = {
+    ...(cfg ?? { accountId: "", apiToken: "", model: "@cf/moonshotai/kimi-k2.6" }),
+    remoteWorkerUrl: workerUrl,
+    remoteAuthSecret: authSecret,
+  };
+  await saveConfig(nextCfg);
+  yield { message: "Config saved" };
+
+  yield { message: "Remote infrastructure ready!", done: true };
+  return { workerUrl, authSecret };
+}

--- a/src/remote/worker-client.ts
+++ b/src/remote/worker-client.ts
@@ -1,5 +1,6 @@
 import type { KimiConfig } from "../config.js";
 import { saveRemoteSession, type RemoteSession } from "./session-store.js";
+import { readSSE } from "../util/sse.js";
 
 export interface StartRemoteSessionOpts {
   prompt: string;
@@ -62,38 +63,22 @@ export async function startRemoteSession(opts: StartRemoteSessionOpts): Promise<
 export async function* streamRemoteProgress(
   workerUrl: string,
   sessionId: string,
+  signal?: AbortSignal,
 ): AsyncGenerator<unknown, void, void> {
-  const res = await fetch(`${workerUrl}/remote/stream/${sessionId}`);
+  const res = await fetch(`${workerUrl}/remote/stream/${sessionId}`, { signal });
   if (!res.ok) {
     throw new Error(`Failed to connect to stream: ${res.status}`);
   }
 
-  const reader = res.body?.getReader();
-  if (!reader) {
+  if (!res.body) {
     throw new Error("No response body");
   }
 
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith("data: ")) {
-        try {
-          const data = JSON.parse(trimmed.slice(6));
-          yield data;
-        } catch {
-          // ignore malformed lines
-        }
-      }
+  for await (const line of readSSE(res.body, signal)) {
+    try {
+      yield JSON.parse(line);
+    } catch {
+      // ignore malformed lines
     }
   }
 }

--- a/src/remote/worker-client.ts
+++ b/src/remote/worker-client.ts
@@ -1,0 +1,99 @@
+import type { KimiConfig } from "../config.js";
+import { saveRemoteSession, type RemoteSession } from "./session-store.js";
+
+export interface StartRemoteSessionOpts {
+  prompt: string;
+  repo: { owner: string; name: string };
+  cfg: KimiConfig;
+}
+
+export async function startRemoteSession(opts: StartRemoteSessionOpts): Promise<{
+  sessionId: string;
+  streamUrl: string;
+}> {
+  const workerUrl = opts.cfg.remoteWorkerUrl;
+  if (!workerUrl) {
+    throw new Error("Remote worker URL not configured. Set remoteWorkerUrl in config.");
+  }
+
+  const githubToken = opts.cfg.githubOAuthToken;
+  if (!githubToken) {
+    throw new Error("GitHub token not found. Run `kimiflare auth github` first.");
+  }
+
+  const res = await fetch(`${workerUrl}/remote/start`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.cfg.remoteAuthSecret ?? ""}`,
+    },
+    body: JSON.stringify({
+      prompt: opts.prompt,
+      repo: opts.repo,
+      githubToken,
+      accountId: opts.cfg.accountId,
+      apiToken: opts.cfg.apiToken,
+      model: opts.cfg.model,
+      reasoningEffort: opts.cfg.reasoningEffort,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to start remote session: ${res.status} ${text}`);
+  }
+
+  const data = await res.json() as { sessionId: string; streamUrl: string };
+
+  await saveRemoteSession({
+    sessionId: data.sessionId,
+    prompt: opts.prompt,
+    repo: `${opts.repo.owner}/${opts.repo.name}`,
+    workerUrl,
+    status: "running",
+    branch: `kimiflare/remote/${data.sessionId}`,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+
+  return data;
+}
+
+export async function* streamRemoteProgress(
+  workerUrl: string,
+  sessionId: string,
+): AsyncGenerator<unknown, void, void> {
+  const res = await fetch(`${workerUrl}/remote/stream/${sessionId}`);
+  if (!res.ok) {
+    throw new Error(`Failed to connect to stream: ${res.status}`);
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new Error("No response body");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("data: ")) {
+        try {
+          const data = JSON.parse(trimmed.slice(6));
+          yield data;
+        } catch {
+          // ignore malformed lines
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements the `/remote` feature for running autonomous coding tasks on Cloudflare infrastructure.

## What it does
Type `/remote <prompt>` in the kimiflare TUI and it handles everything automatically:
1. **Auto-deploys** the Cloudflare Worker + container if not already deployed (live progress in chat)
2. **Auto-authenticates** with GitHub via OAuth device flow if needed (shows URL + code in chat)
3. **Starts a remote session** — the agent runs in a Cloudflare Sandbox while your laptop is off
4. **Streams progress** back to your TUI in real-time
5. **Opens a PR** on GitHub when done

## Architecture
- **Orchestrator Worker** (`remote/worker/`) — Durable Objects, SSE streaming, LLM relay, GitHub PR creation
- **Headless Agent** (`remote/agent/`) — Runs in Sandbox, auto-approves tools, commits to Artifacts
- **Local CLI/TUI integration** — `/remote` slash command, `kimiflare remote list|status|cancel`, `kimiflare auth github`
- **Deploy wizard** — `kimiflare remote deploy` for shell-based deployment
- **TUI deploy/auth** — generator-based flows that yield chat-friendly progress messages

## Quick start

```bash
# One-time prerequisites
wrangler login
docker login ghcr.io -u USERNAME -p GITHUB_TOKEN
export CF_API_TOKEN=your_cloudflare_token

# Then just use it
kimiflare
/remote "Refactor the auth module"
```

That's it. Deploy, auth, session start, and progress streaming all happen automatically.

## Files added
- `remote/worker/` — Cloudflare Worker (Durable Objects, SSE, LLM relay, GitHub API)
- `remote/agent/` — Headless agent bundle (auto-approve, progress reporter, git ops)
- `src/remote/` — Local integration (CLI commands, session store, worker client, TUI deploy/auth)
- `src/auth/github.ts` — GitHub OAuth device flow
- `docs/remote-architecture.md` — Full architecture doc
- `docs/remote-local-testing.md` — Local testing guide

See `docs/remote-architecture.md` for full details.

Co-authored-by: kimiflare <kimiflare@proton.me>
