### PR TITLE
fix: stream formatted markdown instead of raw text

### DIFF
--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -137,7 +137,7 @@ const EventView = React.memo(function EventView({
             </Text>
           </Box>
         ) : null}
-        {evt.text ? <MD text={evt.text} streaming={evt.streaming} /> : null}
+        {evt.text ? <MD text={evt.text} /> : null}
         {evt.streaming && (
           <Text color={theme.spinner}>
             <Spinner type="dots" />

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -5,7 +5,6 @@ import type { Theme } from "./theme.js";
 
 interface Props {
   text: string;
-  streaming?: boolean;
 }
 
 interface InlineSegment {
@@ -13,11 +12,8 @@ interface InlineSegment {
   text: string;
 }
 
-export function MD({ text, streaming }: Props) {
+export function MD({ text }: Props) {
   const theme = useTheme();
-  if (streaming) {
-    return <Text>{text}</Text>;
-  }
   const blocks = useMemo(() => parseBlocks(text), [text]);
   return (
     <Box flexDirection="column">


### PR DESCRIPTION
Removes the streaming fast-path in `MD` that skipped markdown parsing while deltas were arriving. The parser already handles incomplete constructs gracefully (unmatched backticks/asterisks stay plain), so we can format incrementally without a jarring re-render at the end.