### PR TITLE
feat: add theme picker with 4-color palette

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -78,6 +78,10 @@ import { CommandWizard } from "./ui/command-wizard.js";
 import { CommandPicker } from "./ui/command-picker.js";
 import { CommandList } from "./ui/command-list.js";
 import { LspWizard } from "./ui/lsp-wizard.js";
+import { ThemeProvider } from "./ui/theme-context.js";
+import { ThemePicker } from "./ui/theme-picker.js";
+import { resolveTheme, themeList, themeNames, DEFAULT_THEME_NAME } from "./ui/theme.js";
+import type { Theme } from "./ui/theme.js";
 import { saveProjectLspConfig, type ResolvedLspConfig } from "./util/lsp-config.js";
 import { maybeLspNudge } from "./util/lsp-nudge.js";
 import fg from "fast-glob";
@@ -298,6 +302,7 @@ interface Cfg {
   lspServers?: Record<string, { command: string[]; env?: Record<string, string>; enabled?: boolean; rootPatterns?: string[] }>;
   costAttribution?: boolean;
   filePicker?: boolean;
+  theme?: string;
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
@@ -488,6 +493,9 @@ function App({
   const [verbose, setVerbose] = useState(false);
   const [hasUpdate, setHasUpdate] = useState(initialUpdateResult?.hasUpdate ?? false);
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
+  const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
+  const [showThemePicker, setShowThemePicker] = useState(false);
+  const [originalTheme, setOriginalTheme] = useState<Theme | null>(null);
 
   // Picker state — single popup at a time (file mention or slash command).
   const [cursorOffset, setCursorOffset] = useState(0);
@@ -1598,6 +1606,25 @@ function App({
     }
   }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
 
+  const handleThemePick = useCallback(
+    (picked: Theme | null) => {
+      setShowThemePicker(false);
+      setOriginalTheme(null);
+      if (!picked) {
+        if (originalTheme) setTheme(originalTheme);
+        return;
+      }
+      setTheme(picked);
+      setCfg((c) => (c ? { ...c, theme: picked.name } : c));
+      if (cfg) void saveConfig({ ...cfg, theme: picked.name }).catch(() => {});
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: `theme: ${picked.label}` },
+      ]);
+    },
+    [cfg, originalTheme],
+  );
+
   const handleResumePick = useCallback(
     async (picked: SessionSummary | null) => {
       setResumeSessions(null);
@@ -1911,6 +1938,29 @@ function App({
         ]);
         return true;
       }
+      if (c === "/theme") {
+        if (!arg) {
+          setOriginalTheme(theme);
+          setShowThemePicker(true);
+          return true;
+        }
+        const next = resolveTheme(arg);
+        if (next.name === DEFAULT_THEME_NAME && arg !== DEFAULT_THEME_NAME) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `unknown theme "${arg}" — available: ${themeNames().join(", ")}` },
+          ]);
+          return true;
+        }
+        setTheme(next);
+        setCfg((c) => (c ? { ...c, theme: next.name } : c));
+        if (cfg) void saveConfig({ ...cfg, theme: next.name }).catch(() => {});
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `theme: ${next.label}` },
+        ]);
+        return true;
+      }
       if (c === "/agent") {
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "Multi-agent has been replaced with specialist delegation. The generalist automatically delegates to research or coding specialists when needed." }]);
         return true;
@@ -2172,7 +2222,7 @@ function App({
       }
       return false;
     },
-    [cfg, exit, usage, effort, mode, openResumePicker, runCompact, runInit, initMcp, setCfg],
+    [cfg, exit, usage, effort, theme, mode, openResumePicker, runCompact, runInit, initMcp, setCfg],
   );
 
   const handleHelpCommand = useCallback(
@@ -2689,7 +2739,8 @@ function App({
 
   if (!cfg) {
     return (
-      <Onboarding
+      <ThemeProvider theme={theme}>
+        <Onboarding
         onDone={(newCfg) => {
           setCfg(newCfg);
           setEvents((e) => [
@@ -2698,22 +2749,23 @@ function App({
           ]);
         }}
       />
+      </ThemeProvider>
     );
   }
 
   if (resumeSessions !== null) {
     return (
-      <>
+      <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <ResumePicker sessions={resumeSessions} onPick={handleResumePick} />
         </Box>
-      </>
+      </ThemeProvider>
     );
   }
 
   if (showHelpMenu) {
     return (
-      <>
+      <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <HelpMenu
             customCommands={customCommandsRef.current
@@ -2724,13 +2776,13 @@ function App({
             onCommand={handleHelpCommand}
           />
         </Box>
-      </>
+      </ThemeProvider>
     );
   }
 
   if (showLspWizard) {
     return (
-      <>
+      <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <LspWizard
             servers={cfg?.lspServers ?? {}}
@@ -2766,13 +2818,13 @@ function App({
             }}
           />
         </Box>
-      </>
+      </ThemeProvider>
     );
   }
 
   if (commandWizard) {
     return (
-      <>
+      <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <CommandWizard
             mode={commandWizard.mode}
@@ -2783,13 +2835,13 @@ function App({
             onSave={handleCommandSave}
           />
         </Box>
-      </>
+      </ThemeProvider>
     );
   }
 
   if (commandPicker) {
     return (
-      <>
+      <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <CommandPicker
             commands={customCommandsRef.current}
@@ -2805,17 +2857,18 @@ function App({
             }}
           />
         </Box>
-      </>
+      </ThemeProvider>
     );
   }
 
   if (commandToDelete) {
     return (
-      <Box flexDirection="column" borderStyle="round" borderColor="#d699b6" paddingX={1}>
-        <Text color="#d699b6" bold>
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+        <Text color={theme.accent} bold>
           Delete /{commandToDelete.name}?
         </Text>
-        <Text color="#7a8478" dimColor>
+        <Text color={theme.info.color}>
           {commandToDelete.filepath}
         </Text>
         <Box marginTop={1}>
@@ -2834,26 +2887,37 @@ function App({
           />
         </Box>
       </Box>
+      </ThemeProvider>
     );
   }
 
   if (showCommandList) {
     return (
-      <>
+      <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <CommandList
             commands={customCommandsRef.current}
             onDone={() => setShowCommandList(false)}
           />
         </Box>
-      </>
+      </ThemeProvider>
+    );
+  }
+
+  if (showThemePicker) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <ThemePicker themes={themeList()} onPick={handleThemePick} onPreview={(t) => setTheme(t)} />
+        </Box>
+      </ThemeProvider>
     );
   }
 
   const hasConversation = events.some((e) => e.kind === "user" || e.kind === "assistant");
 
   return (
-    <>
+    <ThemeProvider theme={theme}>
       <Box flexDirection="column">
         {!hasConversation && events.length === 0 ? (
           <Welcome accountId={cfg.accountId} />
@@ -2882,7 +2946,7 @@ function App({
             {queue.length > 0 && (
               <Box flexDirection="column" marginBottom={1}>
                 {queue.map((q, i) => (
-                  <Text key={`queue_${i}`} color="#7a8478" dimColor={true}>
+                  <Text key={`queue_${i}`} color={theme.info.color}>
                     ⏳ {q.display}
                   </Text>
                 ))}
@@ -2970,7 +3034,7 @@ function App({
         </Box>
       )}
     </Box>
-    </>
+    </ThemeProvider>
   );
 }
 

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -9,6 +9,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "help", description: "Show keybindings and command list", source: "builtin" },
   { name: "model", description: "Show current model", source: "builtin" },
   { name: "mode", argHint: "edit|plan|auto", description: "Switch agent mode", source: "builtin" },
+  { name: "theme", argHint: "[<name>]", description: "Switch color theme", source: "builtin" },
   { name: "plan", description: "Switch to plan mode", source: "builtin" },
   { name: "auto", description: "Switch to auto mode", source: "builtin" },
   { name: "edit", description: "Switch to edit mode", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,8 @@ export interface KimiConfig {
   costAttribution?: boolean;
   /** Enable @ file mention picker in chat input. Default: false. */
   filePicker?: boolean;
+  /** UI theme name. Default: everforest-dark. */
+  theme?: string;
 }
 
 export interface CustomAgentConfig {

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -3,7 +3,8 @@ import { Box, Text, Static } from "ink";
 import Spinner from "ink-spinner";
 import { ToolView, type ToolEventState } from "./tool-view.js";
 import { MD } from "./markdown.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 export type ChatEvent =
   | { kind: "user"; key: string; text: string; images?: string[] }
@@ -35,6 +36,7 @@ interface StaticItem {
 }
 
 export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose }: Props) {
+  const theme = useTheme();
   const finalized: StaticItem[] = [];
   const active: ChatEvent[] = [];
 
@@ -59,7 +61,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
           <Box key={item.id} flexDirection="column">
             {item.showSeparator && (
               <Box marginY={1}>
-                <Text color={theme.info.color} dimColor={theme.info.dim}>
+                <Text color={theme.info.color} >
                   {"─".repeat(40)}
                 </Text>
               </Box>
@@ -76,7 +78,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
           <Box key={e.key} flexDirection="column">
             {showSeparator && (
               <Box marginY={1}>
-                <Text color={theme.info.color} dimColor={theme.info.dim}>
+                <Text color={theme.info.color} >
                   {"─".repeat(40)}
                 </Text>
               </Box>
@@ -98,6 +100,7 @@ const EventView = React.memo(function EventView({
   showReasoning: boolean;
   verbose?: boolean;
 }) {
+  const theme = useTheme();
   if (evt.kind === "user") {
     return (
       <Box flexDirection="column">
@@ -109,7 +112,7 @@ const EventView = React.memo(function EventView({
         </Box>
         {evt.images && evt.images.length > 0 && (
           <Box paddingLeft={2}>
-            <Text color={theme.info.color} dimColor={theme.info.dim}>
+            <Text color={theme.info.color} >
               🖼️ {evt.images.join(", ")}
             </Text>
           </Box>
@@ -122,14 +125,14 @@ const EventView = React.memo(function EventView({
       <Box flexDirection="column" paddingLeft={2}>
         {evt.agentRole && (
           <Box marginBottom={1}>
-            <Text color={theme.info.color} dimColor={theme.info.dim}>
+            <Text color={theme.info.color} >
               ◆ {evt.agentRole} agent
             </Text>
           </Box>
         )}
         {showReasoning && evt.reasoning ? (
           <Box flexDirection="column" marginBottom={1}>
-            <Text color={theme.reasoning.color} dimColor={theme.reasoning.dim}>
+            <Text color={theme.reasoning.color}>
               thinking…{" "}
               {evt.reasoning.length > 400 ? evt.reasoning.slice(0, 400) + "…" : evt.reasoning}
             </Text>
@@ -149,14 +152,14 @@ const EventView = React.memo(function EventView({
   }
   if (evt.kind === "info") {
     return (
-      <Text color={theme.info.color} dimColor={theme.info.dim}>
+      <Text color={theme.info.color} >
         · {evt.text}
       </Text>
     );
   }
   if (evt.kind === "memory") {
     return (
-      <Text color={theme.info.color} dimColor={theme.info.dim}>
+      <Text color={theme.info.color} >
         ◈ {evt.text}
       </Text>
     );

--- a/src/ui/command-list.tsx
+++ b/src/ui/command-list.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Box, Text, useInput } from "ink";
 import type { CustomCommand } from "../commands/types.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   commands: CustomCommand[];
@@ -9,6 +10,7 @@ interface Props {
 }
 
 export function CommandList({ commands, onDone }: Props) {
+  const theme = useTheme();
   useInput((_input, key) => {
     if (key.escape) {
       onDone();
@@ -25,7 +27,7 @@ export function CommandList({ commands, onDone }: Props) {
       </Text>
       <Box marginTop={1} flexDirection="column">
         {commands.length === 0 && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             No custom commands found.
           </Text>
         )}
@@ -34,42 +36,42 @@ export function CommandList({ commands, onDone }: Props) {
             <Text color={theme.accent} bold>
               /{cmd.name}
             </Text>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               {"  "}source:  {cmd.source}
             </Text>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               {"  "}path:    {cmd.filepath}
             </Text>
             {cmd.description && (
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}desc:    {cmd.description}
               </Text>
             )}
             {cmd.mode && (
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}mode:    {cmd.mode}
               </Text>
             )}
             {cmd.effort && (
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}effort:  {cmd.effort}
               </Text>
             )}
             {cmd.model && (
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}model:   {cmd.model}
               </Text>
             )}
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               {"  "}template:
             </Text>
             {cmd.template.split("\n").slice(0, 5).map((line, i) => (
-              <Text key={i} color={theme.info.color} dimColor>
+              <Text key={i} color={theme.info.color}>
                 {"    "}{line || " "}
               </Text>
             ))}
             {cmd.template.split("\n").length > 5 && (
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"    "}...
               </Text>
             )}

--- a/src/ui/command-picker.tsx
+++ b/src/ui/command-picker.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import type { CustomCommand } from "../commands/types.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   commands: CustomCommand[];
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export function CommandPicker({ commands, title, onPick }: Props) {
+  const theme = useTheme();
   const items = commands.map((cmd) => ({
     label: `/${cmd.name.padEnd(20)} ${cmd.description ?? ""}`,
     value: cmd,

--- a/src/ui/command-wizard.tsx
+++ b/src/ui/command-wizard.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import { Box, Text, useInput, useWindowSize } from "ink";
 import SelectInput from "ink-select-input";
 import { CustomTextInput } from "./text-input.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 import type { Mode } from "../mode.js";
 import type { ReasoningEffort } from "../config.js";
 import type { CommandSource, CustomCommand } from "../commands/types.js";
@@ -31,6 +32,7 @@ type Step =
 const NAME_RE = /^[a-zA-Z][a-zA-Z0-9_\-/]*$/;
 
 export function CommandWizard({ mode, initial, existingNames, builtinNames, onDone, onSave }: Props) {
+  const theme = useTheme();
   const [step, setStep] = useState<Step>("name");
   const [name, setName] = useState(initial?.name ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
@@ -188,7 +190,7 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
                 focus
               />
             </Box>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               letters, numbers, _ - / only; must start with a letter
             </Text>
           </>
@@ -208,7 +210,7 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
                 focus
               />
             </Box>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               Press Enter to skip
             </Text>
           </>
@@ -220,20 +222,20 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
             <Text color={theme.accent} bold>
               What is this?
             </Text>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               A prompt template — instructions to the AI.
             </Text>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               When you type /{name || "yourcommand"} later, this gets sent to the model.
             </Text>
             <Box marginTop={1} flexDirection="column">
               <Text color={theme.accent} bold>
                 Variables
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}$1, $2 ...     → arguments you type
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}$ARGUMENTS     → everything after the command
               </Text>
             </Box>
@@ -241,10 +243,10 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
               <Text color={theme.accent} bold>
                 Dynamic inlines
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}!`git diff`    → shell output inlined
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {"  "}@README.md     → file contents inlined
               </Text>
             </Box>
@@ -252,13 +254,13 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
               <Text color={theme.accent} bold>
                 Example
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 Review this PR diff:
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 !`git diff main...HEAD`
               </Text>
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 Focus on: $1
               </Text>
             </Box>
@@ -279,10 +281,10 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
             </Box>
             {columns < 100 && (
               <>
-                <Text color={theme.info.color} dimColor>
+                <Text color={theme.info.color}>
                   Paste multi-line templates with Ctrl+V.
                 </Text>
-                <Text color={theme.info.color} dimColor>
+                <Text color={theme.info.color}>
                   Variables: $1 $2 ... $ARGUMENTS  Shell: !`cmd`  File: @path
                 </Text>
               </>
@@ -350,7 +352,7 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
             <Text color={theme.accent} bold>
               Mode override ({stepIndex}/{totalSteps})
             </Text>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               Saved to file but not yet enforced at runtime
             </Text>
             <Box marginTop={1}>
@@ -406,7 +408,7 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
                 focus
               />
             </Box>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               Press Enter to skip
             </Text>
           </>
@@ -432,7 +434,7 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
                 }}
               />
             </Box>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               Project: .kimiflare/commands/    Global: ~/.config/kimiflare/commands/
             </Text>
           </>
@@ -449,13 +451,13 @@ export function CommandWizard({ mode, initial, existingNames, builtinNames, onDo
             <Text color={theme.accent} bold>
               {mode === "create" ? "Create" : "Edit"} custom command — Confirm ({stepIndex}/{totalSteps})
             </Text>
-            <Text color={theme.info.color} dimColor>
+            <Text color={theme.info.color}>
               {source === "project" ? ".kimiflare/commands/" : "~/.config/kimiflare/commands/"}
               {name}.md
             </Text>
             <Box marginTop={1} flexDirection="column">
               {previewContent().split("\n").map((line, i) => (
-                <Text key={i} color={theme.info.color} dimColor>
+                <Text key={i} color={theme.info.color}>
                   {line || " "}
                 </Text>
               ))}

--- a/src/ui/diff-view.tsx
+++ b/src/ui/diff-view.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { createTwoFilesPatch } from "diff";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   path: string;
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export function DiffView({ path, before, after, maxLines = 40 }: Props) {
+  const theme = useTheme();
   const patch = createTwoFilesPatch(path, path, before, after, "", "", { context: 2 });
   const raw = patch.split("\n").slice(4);
   const lines = raw.filter((l) => {
@@ -32,7 +34,7 @@ export function DiffView({ path, before, after, maxLines = 40 }: Props) {
     <Box flexDirection="column">
       {truncated.map((line, i) => <DiffLine key={i} line={line} />)}
       {filtered.length > maxLines && (
-        <Text color={theme.palette.muted}>... ({filtered.length - maxLines} more lines)</Text>
+        <Text color={theme.info.color} >... ({filtered.length - maxLines} more lines)</Text>
       )}
     </Box>
   );
@@ -51,8 +53,9 @@ function countChanges(lines: string[]): { changed: number; context: number; hunk
 }
 
 function DiffLine({ line }: { line: string }) {
+  const theme = useTheme();
   if (line.startsWith("+")) return <Text color={theme.palette.success}>{line}</Text>;
   if (line.startsWith("-")) return <Text color={theme.palette.error}>{line}</Text>;
   if (line.startsWith("@@")) return <Text color={theme.palette.secondary}>{line}</Text>;
-  return <Text color={theme.palette.muted}>{line}</Text>;
+  return <Text color={theme.info.color} >{line}</Text>;
 }

--- a/src/ui/file-picker.test.tsx
+++ b/src/ui/file-picker.test.tsx
@@ -3,10 +3,16 @@ import assert from "node:assert";
 import React from "react";
 import { renderToString } from "ink";
 import { FilePicker, type FilePickerItem } from "./file-picker.js";
+import { ThemeProvider } from "./theme-context.js";
+import { resolveTheme } from "./theme.js";
+
+const testTheme = resolveTheme();
 
 function renderPicker(items: FilePickerItem[], selectedIndex: number, query = ""): string {
   return renderToString(
-    <FilePicker items={items} selectedIndex={selectedIndex} query={query} />,
+    <ThemeProvider theme={testTheme}>
+      <FilePicker items={items} selectedIndex={selectedIndex} query={query} />
+    </ThemeProvider>,
   );
 }
 

--- a/src/ui/file-picker.tsx
+++ b/src/ui/file-picker.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 export interface FilePickerItem {
   name: string;
@@ -16,6 +17,7 @@ interface Props {
 const VISIBLE_LIMIT = 12;
 
 export function FilePicker({ items, selectedIndex, query }: Props) {
+  const theme = useTheme();
   // Scroll the visible window so the selected item is always in view.
   // Keep the selected item at the bottom edge when scrolling down.
   let startIndex = 0;
@@ -36,12 +38,12 @@ export function FilePicker({ items, selectedIndex, query }: Props) {
       </Text>
       <Box marginTop={1} flexDirection="column">
         {visible.length === 0 && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             No matches
           </Text>
         )}
         {hasMoreAbove && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             … {startIndex} more above
           </Text>
         )}
@@ -57,7 +59,7 @@ export function FilePicker({ items, selectedIndex, query }: Props) {
           );
         })}
         {hasMoreBelow && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             … {items.length - (startIndex + VISIBLE_LIMIT)} more below
           </Text>
         )}

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface CustomCommandSummary {
   name: string;
@@ -173,6 +174,7 @@ const SINGLE_COMMANDS: CommandItem[] = [
 ];
 
 export function HelpMenu({ customCommands, costAttributionEnabled, onDone, onCommand }: Props) {
+  const theme = useTheme();
   const [page, setPage] = useState<Page>("main");
   const customs = customCommands ?? [];
 
@@ -306,7 +308,7 @@ export function HelpMenu({ customCommands, costAttributionEnabled, onDone, onCom
       {staticCmds.length > 0 && (
         <Box marginTop={1} flexDirection="column">
           {staticCmds.map((cmd) => (
-            <Text key={cmd.command} color={theme.info.color} dimColor>
+            <Text key={cmd.command} color={theme.info.color}>
               {`  ${cmd.command.padEnd(28)} ${cmd.description}`}
             </Text>
           ))}

--- a/src/ui/lsp-wizard.tsx
+++ b/src/ui/lsp-wizard.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { spawn } from "node:child_process";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 import type { LspServerConfig } from "../config.js";
 import { CustomTextInput } from "./text-input.js";
 
@@ -138,6 +139,7 @@ interface InstallState {
 }
 
 export function LspWizard({ servers, currentScope, hasProjectDir, onDone, onSave }: Props) {
+  const theme = useTheme();
   const [page, setPage] = useState<Page>("main");
   const [selectedPreset, setSelectedPreset] = useState<Preset | null>(null);
   const [customName, setCustomName] = useState("");

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { Box, Text } from "ink";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
 
 interface Props {
@@ -13,6 +13,7 @@ interface InlineSegment {
 }
 
 export function MD({ text }: Props) {
+  const theme = useTheme();
   const blocks = useMemo(() => parseBlocks(text), [text]);
   return (
     <Box flexDirection="column">
@@ -95,6 +96,7 @@ function parseBlocks(src: string): Block[] {
 }
 
 const Block = React.memo(function Block({ block }: { block: Block }) {
+  const theme = useTheme();
   if (block.kind === "blank") return <Text> </Text>;
   if (block.kind === "heading") {
     return (
@@ -120,7 +122,7 @@ const Block = React.memo(function Block({ block }: { block: Block }) {
   if (block.kind === "quote") {
     return (
       <Box marginLeft={2}>
-        <Text color={theme.info.color} dimColor={theme.info.dim} italic>
+        <Text color={theme.info.color} italic>
           {renderInline(block.text, theme)}
         </Text>
       </Box>

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import { Box, Text } from "ink";
 import { CustomTextInput } from "./text-input.js";
 import { saveConfig, DEFAULT_MODEL } from "../config.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   onDone: (cfg: { accountId: string; apiToken: string; model: string }) => void;
@@ -13,6 +14,7 @@ type Step = "accountId" | "apiToken" | "model" | "confirm";
 const STEPS: Step[] = ["accountId", "apiToken", "model", "confirm"];
 
 export function Onboarding({ onDone }: Props) {
+  const theme = useTheme();
   const [step, setStep] = useState<Step>("accountId");
   const [accountId, setAccountId] = useState("");
   const [apiToken, setApiToken] = useState("");
@@ -58,12 +60,12 @@ export function Onboarding({ onDone }: Props) {
         <Text bold color={theme.palette.primary}>
           kimiflare
         </Text>
-        <Text color={theme.palette.muted} dimColor>
+        <Text color={theme.info.color} >
           {"  "}Terminal coding agent
         </Text>
       </Box>
 
-      <Text color={theme.palette.muted} dimColor>
+      <Text color={theme.info.color} >
         Step {stepIndex} of {STEPS.length}
       </Text>
 
@@ -85,7 +87,7 @@ export function Onboarding({ onDone }: Props) {
         {step === "apiToken" && (
           <>
             <Text>Enter your Cloudflare API Token</Text>
-            <Text color={theme.palette.muted} dimColor>
+            <Text color={theme.info.color} >
               Create one at https://dash.cloudflare.com/profile/api-tokens
             </Text>
             <Box marginTop={1}>
@@ -103,7 +105,7 @@ export function Onboarding({ onDone }: Props) {
         {step === "model" && (
           <>
             <Text>Model ID (press Enter for default)</Text>
-            <Text color={theme.palette.muted} dimColor>
+            <Text color={theme.info.color} >
               default: {DEFAULT_MODEL}
             </Text>
             <Box marginTop={1}>
@@ -125,12 +127,12 @@ export function Onboarding({ onDone }: Props) {
               marginTop={1}
               marginBottom={1}
               borderStyle="single"
-              borderColor={theme.palette.muted}
+              borderColor={theme.info.color}
               paddingX={1}
             >
-              <Text color={theme.palette.muted}>Account ID: {accountId}</Text>
-              <Text color={theme.palette.muted}>API Token: {"•".repeat(apiToken.length)}</Text>
-              <Text color={theme.palette.muted}>Model: {model}</Text>
+              <Text color={theme.info.color} >Account ID: {accountId}</Text>
+              <Text color={theme.info.color} >API Token: {"•".repeat(apiToken.length)}</Text>
+              <Text color={theme.info.color} >Model: {model}</Text>
             </Box>
             <Text>Press Enter to confirm, or Ctrl+C to cancel</Text>
             <Box marginTop={1}>

--- a/src/ui/permission.tsx
+++ b/src/ui/permission.tsx
@@ -4,7 +4,8 @@ import SelectInput from "ink-select-input";
 import type { ToolSpec } from "../tools/registry.js";
 import type { PermissionDecision } from "../tools/executor.js";
 import { DiffView } from "./diff-view.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   tool: ToolSpec;
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export function PermissionModal({ tool, args, onDecide }: Props) {
+  const theme = useTheme();
   const render = tool.render?.(args);
   const items = [
     { label: "Allow once", value: "allow" as const },
@@ -34,7 +36,7 @@ export function PermissionModal({ tool, args, onDecide }: Props) {
           <DiffView {...render.diff} />
         </Box>
       ) : (
-        <Text color={theme.info.color} dimColor={theme.info.dim}>args: {JSON.stringify(args)}</Text>
+        <Text color={theme.info.color} >args: {JSON.stringify(args)}</Text>
       )}
       <Box marginTop={1}>
         <SelectInput items={items} onSelect={(item) => onDecide(item.value)} />

--- a/src/ui/resume-picker.tsx
+++ b/src/ui/resume-picker.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import { Box, Text, useWindowSize } from "ink";
 import SelectInput from "ink-select-input";
 import type { SessionSummary } from "../sessions.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   sessions: SessionSummary[];
@@ -14,6 +15,7 @@ const FOOTER_ROWS = 2; // cancel + bottom padding
 const MIN_PAGE_SIZE = 5;
 
 export function ResumePicker({ sessions, onPick }: Props) {
+  const theme = useTheme();
   const { rows } = useWindowSize();
   const [page, setPage] = useState(0);
 
@@ -27,7 +29,7 @@ export function ResumePicker({ sessions, onPick }: Props) {
         <Text color={theme.accent} bold>
           Resume a session
         </Text>
-        <Text color={theme.info.color} dimColor={theme.info.dim}>
+        <Text color={theme.info.color} >
           No saved sessions yet. Press Enter to dismiss.
         </Text>
         <Box marginTop={1}>
@@ -62,7 +64,7 @@ export function ResumePicker({ sessions, onPick }: Props) {
       <Text color={theme.accent} bold>
         Resume a session
       </Text>
-      <Text color={theme.info.color} dimColor={theme.info.dim}>
+      <Text color={theme.info.color} >
         Arrow keys to select, Enter to confirm. Page {safePage + 1} of {totalPages} ({sessions.length} total)
       </Text>
       <Box marginTop={1}>

--- a/src/ui/slash-picker.test.tsx
+++ b/src/ui/slash-picker.test.tsx
@@ -4,10 +4,16 @@ import React from "react";
 import { renderToString } from "ink";
 import { SlashPicker } from "./slash-picker.js";
 import type { SlashItem } from "../commands/types.js";
+import { ThemeProvider } from "./theme-context.js";
+import { resolveTheme } from "./theme.js";
+
+const testTheme = resolveTheme();
 
 function render(items: SlashItem[], selectedIndex: number, query = ""): string {
   return renderToString(
-    <SlashPicker items={items} selectedIndex={selectedIndex} query={query} />,
+    <ThemeProvider theme={testTheme}>
+      <SlashPicker items={items} selectedIndex={selectedIndex} query={query} />
+    </ThemeProvider>,
   );
 }
 

--- a/src/ui/slash-picker.tsx
+++ b/src/ui/slash-picker.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { SlashItem } from "../commands/types.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   items: SlashItem[];
@@ -24,6 +25,7 @@ function commandLabel(item: SlashItem): string {
 }
 
 export function SlashPicker({ items, selectedIndex, query }: Props) {
+  const theme = useTheme();
   let startIndex = 0;
   if (selectedIndex >= VISIBLE_LIMIT) {
     startIndex = selectedIndex - VISIBLE_LIMIT + 1;
@@ -45,12 +47,12 @@ export function SlashPicker({ items, selectedIndex, query }: Props) {
       </Text>
       <Box marginTop={1} flexDirection="column">
         {visible.length === 0 && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             No matches
           </Text>
         )}
         {hasMoreAbove && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             … {startIndex} more above
           </Text>
         )}
@@ -63,7 +65,7 @@ export function SlashPicker({ items, selectedIndex, query }: Props) {
             <Text key={item.name} color={isSelected ? theme.accent : undefined} bold={isSelected}>
               {isSelected ? "› " : "  "}
               {nameCol}
-              <Text color={theme.info.color} dimColor>
+              <Text color={theme.info.color}>
                 {item.description}
                 {badge && `  [${badge}]`}
               </Text>
@@ -71,7 +73,7 @@ export function SlashPicker({ items, selectedIndex, query }: Props) {
           );
         })}
         {hasMoreBelow && (
-          <Text color={theme.info.color} dimColor>
+          <Text color={theme.info.color}>
             … {items.length - (startIndex + VISIBLE_LIMIT)} more below
           </Text>
         )}

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -3,7 +3,8 @@ import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import type { Usage } from "../agent/messages.js";
 import type { GatewayMeta } from "../agent/client.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 import type { ReasoningEffort } from "../config.js";
 import type { Mode } from "../mode.js";
 import { calculateCost } from "../pricing.js";
@@ -25,6 +26,7 @@ interface Props {
 }
 
 export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode }: Props) {
+  const theme = useTheme();
   const [now, setNow] = useState(Date.now());
   const modeColor =
     mode === "plan" ? theme.modeBadge.plan : mode === "auto" ? theme.modeBadge.auto : theme.modeBadge.edit;
@@ -54,14 +56,14 @@ export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt,
             thinking{elapsed ? ` · ${elapsed}` : ""}
           </Text>
         ) : (
-          <Text color={theme.info.color} dimColor={theme.info.dim}>
+          <Text color={theme.info.color} >
             {leftParts.join("  ·  ")}  ·  ready
           </Text>
         )}
       </Box>
       {usage && (
         <Box>
-          <Text color={theme.info.color} dimColor={theme.info.dim}>
+          <Text color={theme.info.color} >
             {buildRightParts(usage, contextLimit, sessionUsage, gatewayMeta).join("  ·  ")}
           </Text>
           {warn ? (

--- a/src/ui/task-list.tsx
+++ b/src/ui/task-list.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useRef, useState } from "react";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import type { Task } from "../tasks-state.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   tasks: Task[];
@@ -13,6 +14,7 @@ interface Props {
 const MAX_VISIBLE = 6;
 
 export function TaskList({ tasks, startedAt, tokensDelta }: Props) {
+  const theme = useTheme();
   const [now, setNow] = useState(Date.now());
   const tasksRef = useRef(tasks);
   tasksRef.current = tasks;
@@ -53,7 +55,7 @@ export function TaskList({ tasks, startedAt, tokensDelta }: Props) {
           {header}
         </Text>
         {headerStats && (
-          <Text color={theme.info.color} dimColor={theme.info.dim}>
+          <Text color={theme.info.color} >
             {"  "}({headerStats})
           </Text>
         )}
@@ -62,7 +64,7 @@ export function TaskList({ tasks, startedAt, tokensDelta }: Props) {
         <TaskRow key={t.id} task={t} />
       ))}
       {hiddenPending > 0 && (
-        <Text color={theme.info.color} dimColor={theme.info.dim}>
+        <Text color={theme.info.color} >
           {"  "}… +{hiddenPending} more
         </Text>
       )}
@@ -71,9 +73,10 @@ export function TaskList({ tasks, startedAt, tokensDelta }: Props) {
 }
 
 function TaskRow({ task }: { task: Task }) {
+  const theme = useTheme();
   if (task.status === "completed") {
     return (
-      <Text color={theme.info.color} dimColor={theme.info.dim}>
+      <Text color={theme.info.color} >
         {"  "}✓ <Text strikethrough>{task.title}</Text>
       </Text>
     );
@@ -86,7 +89,7 @@ function TaskRow({ task }: { task: Task }) {
     );
   }
   return (
-    <Text color={theme.info.color} dimColor={theme.info.dim}>
+    <Text color={theme.info.color} >
       {"  "}☐ {task.title}
     </Text>
   );

--- a/src/ui/theme-context.tsx
+++ b/src/ui/theme-context.tsx
@@ -1,0 +1,22 @@
+import React, { createContext, useContext } from "react";
+import type { Theme } from "./theme.js";
+
+const ThemeContext = createContext<Theme | null>(null);
+
+export function ThemeProvider({
+  theme,
+  children,
+}: {
+  theme: Theme;
+  children: React.ReactNode;
+}) {
+  return (
+    <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): Theme {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used inside ThemeProvider");
+  return ctx;
+}

--- a/src/ui/theme-picker.tsx
+++ b/src/ui/theme-picker.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import type { Theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+
+interface Props {
+  themes: Theme[];
+  onPick: (theme: Theme | null) => void;
+  onPreview?: (theme: Theme) => void;
+}
+
+function PaletteSwatches({ palette }: { palette: Theme["palette"] }) {
+  const colors = [
+    palette.primary,
+    palette.secondary,
+    palette.success,
+    palette.error,
+  ];
+  return (
+    <Box>
+      {colors.map((c, i) => (
+        <Text key={i} color={c}>
+          █
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+export function ThemePicker({ themes, onPick, onPreview }: Props) {
+  const current = useTheme();
+  const items = [
+    ...themes.map((t) => ({ label: t.label, value: t.name })),
+    { label: "< Back", value: "__back__" },
+  ];
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={current.accent} paddingX={1}>
+      <Text color={current.accent} bold>
+        Pick a theme
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onHighlight={(item) => {
+            if (item.value === "__back__") return;
+            const t = themes.find((x) => x.name === item.value);
+            if (t) onPreview?.(t);
+          }}
+          onSelect={(item) => {
+            if (item.value === "__back__") {
+              onPick(null);
+              return;
+            }
+            const t = themes.find((x) => x.name === item.value);
+            onPick(t ?? null);
+          }}
+          itemComponent={({ label, isSelected }) => {
+            const t = themes.find((x) => x.label === label);
+            const color = t?.accent ?? current.accent;
+            return (
+              <Box>
+                <Text color={color} bold={isSelected} dimColor={!isSelected}>
+                  {label}
+                </Text>
+                {t && (
+                  <Box marginLeft={1}>
+                    <PaletteSwatches palette={t.palette} />
+                  </Box>
+                )}
+              </Box>
+            );
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -5,15 +5,12 @@ export interface DimColor {
   dim: boolean;
 }
 
-/** The raw palette an author provides — only 6-7 colors. */
+/** Raw palette — only 4 colors. Everything else derives from these. */
 export interface ColorPalette {
   primary: string;
   secondary: string;
   success: string;
   error: string;
-  warning: string;
-  info: string;
-  muted: string;
 }
 
 /** Full theme shape consumed by components. */
@@ -35,28 +32,96 @@ export interface Theme {
   modeBadge: { plan: ColorName; auto: ColorName; edit: ColorName };
 }
 
-export const DEFAULT_THEME: Theme = {
-  name: "everforest-dark",
-  label: "everforest-dark (nature — moss & bark)",
-  palette: {
-    primary: "#a7c080",
-    secondary: "#d699b6",
-    success: "#a7c080",
-    error: "#e67e80",
-    warning: "#dbbc7f",
-    info: "#7a8478",
-    muted: "#7a8478",
-  },
-  user: "#a7c080",
-  assistant: "#d3c6aa",
-  tool: "#7fbbb3",
-  spinner: "#a7c080",
-  accent: "#d699b6",
+/** Optional overrides for any semantic slot beyond the palette defaults. */
+export type ThemeOverrides = Partial<
+  Omit<Theme, "name" | "label" | "palette">
+>;
+
+/** Build a full Theme from a 4-color palette. */
+export function buildTheme(
+  name: string,
+  label: string,
+  palette: ColorPalette,
+  overrides?: ThemeOverrides,
+): Theme {
+  const base: Theme = {
+    name,
+    label,
+    palette,
+    user: palette.primary,
+    tool: palette.secondary,
+    spinner: palette.primary,
+    accent: palette.primary,
+    error: palette.error,
+    warn: palette.error,
+    info: { color: palette.secondary, dim: false },
+    reasoning: { color: palette.secondary, dim: false },
+    permission: palette.error,
+    queue: { color: palette.secondary, dim: false },
+    assistant: undefined,
+    modeBadge: {
+      plan: palette.primary,
+      auto: palette.success,
+      edit: palette.error,
+    },
+  };
+  if (!overrides) return base;
+  return {
+    ...base,
+    ...overrides,
+    modeBadge: overrides.modeBadge ?? base.modeBadge,
+    info: overrides.info ?? base.info,
+    reasoning: overrides.reasoning ?? base.reasoning,
+    queue: overrides.queue ?? base.queue,
+  };
+}
+
+const everforestDark = buildTheme("everforest-dark", "everforest-dark", {
+  primary: "#a7c080",
+  secondary: "#d3c6aa",
+  success: "#a7c080",
   error: "#e67e80",
-  warn: "#dbbc7f",
-  info: { color: "#7a8478", dim: false },
-  reasoning: { color: "#7a8478", dim: true },
-  permission: "#dbbc7f",
-  queue: { color: "#7a8478", dim: true },
-  modeBadge: { plan: "#7fbbb3", auto: "#a7c080", edit: "#e67e80" },
+});
+
+const everforestLight = buildTheme("everforest-light", "everforest-light", {
+  primary: "#c5e49a",
+  secondary: "#f0e6c8",
+  success: "#c5e49a",
+  error: "#e07070",
+});
+
+const kanagawaDark = buildTheme("kanagawa-dark", "kanagawa-dark", {
+  primary: "#8aadf4",
+  secondary: "#f0e6c8",
+  success: "#a6e3a1",
+  error: "#f38ba8",
+});
+
+const draculaDark = buildTheme("dracula-dark", "dracula-dark", {
+  primary: "#ff79c6",
+  secondary: "#f8f8f2",
+  success: "#50fa7b",
+  error: "#ff5555",
+});
+
+export const THEMES: Record<string, Theme> = {
+  "everforest-dark": everforestDark,
+  "everforest-light": everforestLight,
+  "kanagawa-dark": kanagawaDark,
+  "dracula-dark": draculaDark,
 };
+
+export const DEFAULT_THEME_NAME = "everforest-dark";
+
+export function resolveTheme(name?: string): Theme {
+  if (!name) return THEMES[DEFAULT_THEME_NAME]!;
+  return THEMES[name] ?? THEMES[DEFAULT_THEME_NAME]!;
+}
+
+export function themeNames(): string[] {
+  return Object.keys(THEMES);
+}
+
+export function themeList(): Theme[] {
+  return Object.values(THEMES);
+}

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -3,7 +3,8 @@ import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import { DiffView } from "./diff-view.js";
 import { collapsePathsInText } from "../util/paths.js";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 export interface ToolEventState {
   id: string;
@@ -21,9 +22,10 @@ interface Props {
 }
 
 export const ToolView = React.memo(function ToolView({ evt, verbose }: Props) {
+  const theme = useTheme();
   const statusIcon =
     evt.status === "running" ? (
-      <Text color={theme.palette.muted}>
+      <Text color={theme.info.color} >
         <Spinner type="dots" />
       </Text>
     ) : evt.status === "error" ? (
@@ -40,7 +42,7 @@ export const ToolView = React.memo(function ToolView({ evt, verbose }: Props) {
     <Box flexDirection="column" marginLeft={2}>
       <Text>
         {statusIcon}{" "}
-        <Text color="gray">{title}</Text>
+        <Text color={theme.info.color}>{title}</Text>
       </Text>
       {evt.render?.diff ? (
         <Box marginLeft={2}>
@@ -53,23 +55,23 @@ export const ToolView = React.memo(function ToolView({ evt, verbose }: Props) {
           marginTop={1}
           flexDirection="column"
           borderStyle="single"
-          borderColor="gray"
+          borderColor={theme.info.color}
           paddingX={1}
         >
           {lines.slice(0, showLimit).map((l, i) => (
-            <Text key={i} color="gray" dimColor>
+            <Text key={i} color={theme.info.color}>
               {l}
             </Text>
           ))}
           {lines.length > showLimit && (
-            <Text color="gray" dimColor>
+            <Text color={theme.info.color}>
               … ({lines.length - showLimit} more lines)
             </Text>
           )}
         </Box>
       ) : null}
       {evt.result && !expand && evt.status !== "running" ? (
-        <Text color="gray" dimColor>
+        <Text color={theme.info.color}>
           {"  "}{firstLine(evt.result)}
         </Text>
       ) : null}

--- a/src/ui/welcome.tsx
+++ b/src/ui/welcome.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { DEFAULT_THEME as theme } from "./theme.js";
+import { useTheme } from "./theme-context.js";
+import type { Theme } from "./theme.js";
 
 interface Props {
   accountId?: string;
@@ -13,19 +14,20 @@ const SUGGESTIONS = [
 ];
 
 export function Welcome({ accountId }: Props) {
+  const theme = useTheme();
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box marginBottom={1}>
         <Text bold color={theme.accent}>
           kimiflare
         </Text>
-        <Text color={theme.info.color} dimColor={theme.info.dim}>
+        <Text color={theme.info.color} >
           {"  "}Ready when you are.
         </Text>
       </Box>
       {accountId && (
         <Box marginBottom={1}>
-          <Text color={theme.info.color} dimColor={theme.info.dim}>
+          <Text color={theme.info.color} >
             {"  "}Check your Cloudflare billing: https://dash.cloudflare.com/{accountId}/billing/billable-usage
           </Text>
         </Box>
@@ -33,7 +35,7 @@ export function Welcome({ accountId }: Props) {
       <Box flexDirection="column">
         {SUGGESTIONS.map((s, i) => (
           <Box key={i}>
-            <Text color={theme.info.color} dimColor={theme.info.dim}>
+            <Text color={theme.info.color} >
               {"  "}›{" "}
             </Text>
             <Text color={theme.user}>{s}</Text>
@@ -41,12 +43,12 @@ export function Welcome({ accountId }: Props) {
         ))}
       </Box>
       <Box marginTop={1}>
-        <Text color={theme.info.color} dimColor={theme.info.dim}>
+        <Text color={theme.info.color} >
           Type a message or /help for commands · ctrl-c to exit · shift+tab to cycle modes
         </Text>
       </Box>
       <Box>
-        <Text color={theme.info.color} dimColor={theme.info.dim}>
+        <Text color={theme.info.color} >
           Tip: type /hello to send feedback to the creator
         </Text>
       </Box>


### PR DESCRIPTION
- Add /theme slash command and interactive picker with live preview
- 4 themes: everforest-dark, everforest-light, kanagawa-dark, dracula-dark
- 4-color palette per theme (primary, secondary, success, error)
- ThemeProvider + useTheme hook for dynamic theme switching
- Persist theme choice to config
- All UI components read theme dynamically