### PR TITLE
fix: enable filePicker by default in app.tsx

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -473,7 +473,7 @@ function App({
 
   const [mode, setMode] = useState<Mode>("edit");
   const [codeMode, setCodeMode] = useState<boolean>(initialCfg?.codeMode ?? false);
-  const filePickerEnabled = initialCfg?.filePicker ?? false;
+  const filePickerEnabled = initialCfg?.filePicker ?? true;
   const [effort, setEffort] = useState<ReasoningEffort>(
     initialCfg?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
   );

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -151,7 +151,7 @@ const CATEGORIES: Category[] = [
     commands: [
       { command: "/init", description: "scan this repo and write a KIMI.md" },
       { command: "/logout", description: "clear credentials" },
-      { command: "filePicker", description: "enable with KIMIFLARE_FILE_PICKER=1 or filePicker: true in config", selectable: false },
+      { command: "filePicker", description: "enabled by default; disable with KIMIFLARE_FILE_PICKER=0 or filePicker: false in config", selectable: false },
     ],
   },
 ];


### PR DESCRIPTION
The config already defaulted `filePicker` to `true`, but the App component still fell back to `false` when `initialCfg` was null or `filePicker` was undefined. This ensures the @ mention file picker is enabled by default for all users.

Also updates the help menu description to reflect the new default.

Co-authored-by: kimiflare <kimiflare@proton.me>