### PR TITLE
feat(remote): Phase 0 — core loop changes for headless remote execution

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -50,6 +50,17 @@ export interface AgentTurnOpts {
   codeMode?: boolean;
   /** Called after write/edit tools succeed so LSP document sync can fire. */
   onFileChange?: (path: string, content: string) => void;
+  /** When true, hitting the tool-call limit resets the counter and appends a continue message instead of throwing. */
+  continueOnLimit?: boolean;
+  /** Cumulative prompt token budget. When exceeded, a final synthesis turn is run and then BudgetExhaustedError is thrown. */
+  maxInputTokens?: number;
+}
+
+export class BudgetExhaustedError extends Error {
+  constructor(message = "Cumulative input token budget exhausted") {
+    super(message);
+    this.name = "BudgetExhaustedError";
+  }
 }
 
 const codeModeApiCache = new Map<string, string>();
@@ -114,7 +125,37 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const MAX_WEB_FETCH_PER_TURN = 5;
   const WEB_FETCH_DOMAIN_THRESHOLD = 2; // 3rd fetch to same domain triggers warning
 
-  for (let iter = 0; iter < max; iter++) {
+  let cumulativePromptTokens = 0;
+  let iter = 0;
+  let budgetExhausted = false;
+
+  while (true) {
+    // Budget enforcement: before starting a new turn, if we've already hit the
+    // limit, run one final synthesis turn and then signal budget exhaustion.
+    if (budgetExhausted) {
+      opts.messages.push({
+        role: "system",
+        content:
+          "You have reached the cumulative input token budget for this session. " +
+          "Please synthesize your findings and provide a final summary of what was accomplished.",
+      });
+    }
+
+    if (iter >= max) {
+      if (opts.continueOnLimit) {
+        opts.messages.push({
+          role: "system",
+          content:
+            "You have reached the tool-call limit for this session. " +
+            "The counter has been reset so you can continue working. Please proceed with your task.",
+        });
+        iter = 0;
+      } else {
+        throw new Error(`kimiflare: tool iteration limit reached (${max})`);
+      }
+    }
+
+    iter++;
     turn++;
     const previousMessages = opts.messages.slice();
     const toolCalls: ToolCall[] = [];
@@ -225,7 +266,19 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
     if (opts.signal.aborted) throw new DOMException("aborted", "AbortError");
 
-    if (lastUsage) opts.callbacks.onUsageFinal?.(lastUsage, gatewayMeta);
+    if (lastUsage) {
+      opts.callbacks.onUsageFinal?.(lastUsage, gatewayMeta);
+      cumulativePromptTokens += lastUsage.prompt_tokens;
+      if (
+        !budgetExhausted &&
+        opts.maxInputTokens !== undefined &&
+        opts.maxInputTokens > 0 &&
+        cumulativePromptTokens >= opts.maxInputTokens &&
+        toolCalls.length > 0
+      ) {
+        budgetExhausted = true;
+      }
+    }
 
     const assistantMsg: ChatMessage = {
       role: "assistant",
@@ -257,6 +310,9 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           usage: lastUsage,
           shadowStrip: shadowStripMetrics,
         });
+      }
+      if (budgetExhausted) {
+        throw new BudgetExhaustedError();
       }
       return;
     }
@@ -422,9 +478,11 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         shadowStrip: shadowStripMetrics,
       });
     }
-  }
 
-  throw new Error(`kimiflare: tool iteration limit reached (${opts.maxToolIterations ?? 50})`);
+    if (budgetExhausted) {
+      throw new BudgetExhaustedError();
+    }
+  }
 }
 
 function validateToolArguments(raw: string): string {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { loadConfig, DEFAULT_MODEL } from "./config.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
-import { runAgentTurn } from "./agent/loop.js";
+import { runAgentTurn, BudgetExhaustedError } from "./agent/loop.js";
 import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
@@ -18,7 +18,9 @@ program
   .option("-p, --print <prompt>", "one-shot mode: send prompt, stream reply to stdout, exit")
   .option("-m, --model <id>", "model id (defaults to @cf/moonshotai/kimi-k2.6)")
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")
-  .option("--reasoning", "include reasoning in stdout (print mode only)");
+  .option("--reasoning", "include reasoning in stdout (print mode only)")
+  .option("--continue-on-limit", "reset tool-call counter and continue when the 50-call limit is hit (print mode only)")
+  .option("--max-input-tokens <n>", "cumulative prompt token budget; exits 42 when exhausted (print mode only)", (v) => parseInt(v, 10));
 
 program
   .command("cost")
@@ -57,6 +59,8 @@ const opts = program.opts<{
   model?: string;
   dangerouslyAllowAll?: boolean;
   reasoning?: boolean;
+  continueOnLimit?: boolean;
+  maxInputTokens?: number;
 }>();
 
 async function main() {
@@ -96,6 +100,8 @@ async function main() {
       allowAll: !!opts.dangerouslyAllowAll,
       showReasoning: !!opts.reasoning,
       codeMode: cfg.codeMode,
+      continueOnLimit: !!opts.continueOnLimit,
+      maxInputTokens: opts.maxInputTokens,
       updateResult,
     });
     return;
@@ -134,6 +140,8 @@ interface PrintOpts {
   aiGatewayMetadata?: Record<string, string | number | boolean>;
   updateResult: UpdateCheckResult;
   codeMode?: boolean;
+  continueOnLimit?: boolean;
+  maxInputTokens?: number;
 }
 
 function gatewayFromPrintOpts(opts: PrintOpts): AiGatewayOptions | undefined {
@@ -168,55 +176,66 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
   let printedReasoningHeader = false;
   let printedAnswerHeader = false;
 
-  await runAgentTurn({
-    accountId: opts.accountId,
-    apiToken: opts.apiToken,
-    model: opts.model,
-    gateway: gatewayFromPrintOpts(opts),
-    messages,
-    tools: ALL_TOOLS,
-    executor,
-    cwd,
-    signal: controller.signal,
-    codeMode: opts.codeMode,
-    coauthor:
-      opts.coauthor !== false
-        ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "kimiflare@proton.me" }
-        : undefined,
-    callbacks: {
-      onReasoningDelta: opts.showReasoning
-        ? (delta) => {
-            if (!printedReasoningHeader) {
-              process.stderr.write("\x1b[2m--- reasoning ---\n");
-              printedReasoningHeader = true;
+  try {
+    await runAgentTurn({
+      accountId: opts.accountId,
+      apiToken: opts.apiToken,
+      model: opts.model,
+      gateway: gatewayFromPrintOpts(opts),
+      messages,
+      tools: ALL_TOOLS,
+      executor,
+      cwd,
+      signal: controller.signal,
+      codeMode: opts.codeMode,
+      continueOnLimit: opts.continueOnLimit,
+      maxInputTokens: opts.maxInputTokens,
+      coauthor:
+        opts.coauthor !== false
+          ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "kimiflare@proton.me" }
+          : undefined,
+      callbacks: {
+        onReasoningDelta: opts.showReasoning
+          ? (delta) => {
+              if (!printedReasoningHeader) {
+                process.stderr.write("\x1b[2m--- reasoning ---\n");
+                printedReasoningHeader = true;
+              }
+              process.stderr.write(delta);
             }
-            process.stderr.write(delta);
+          : undefined,
+        onTextDelta: (delta) => {
+          if (opts.showReasoning && printedReasoningHeader && !printedAnswerHeader) {
+            process.stderr.write("\n--- answer ---\x1b[0m\n");
+            printedAnswerHeader = true;
           }
-        : undefined,
-      onTextDelta: (delta) => {
-        if (opts.showReasoning && printedReasoningHeader && !printedAnswerHeader) {
-          process.stderr.write("\n--- answer ---\x1b[0m\n");
-          printedAnswerHeader = true;
-        }
-        process.stdout.write(delta);
+          process.stdout.write(delta);
+        },
+        onToolCallFinalized: (call) => {
+          process.stderr.write(`\x1b[2m[tool ${call.function.name}(${call.function.arguments})]\x1b[0m\n`);
+        },
+        onToolResult: (result) => {
+          const snippet =
+            result.content.length > 400 ? result.content.slice(0, 400) + "..." : result.content;
+          process.stderr.write(`\x1b[2m[result: ${snippet.replace(/\n/g, " ⏎ ")}]\x1b[0m\n`);
+        },
+        askPermission: async ({ tool, args }) => {
+          if (opts.allowAll) return "allow";
+          process.stderr.write(
+            `\x1b[31m[permission denied: ${tool.name}(${JSON.stringify(args)}) — pass --dangerously-allow-all to approve in print mode]\x1b[0m\n`,
+          );
+          return "deny";
+        },
       },
-      onToolCallFinalized: (call) => {
-        process.stderr.write(`\x1b[2m[tool ${call.function.name}(${call.function.arguments})]\x1b[0m\n`);
-      },
-      onToolResult: (result) => {
-        const snippet =
-          result.content.length > 400 ? result.content.slice(0, 400) + "..." : result.content;
-        process.stderr.write(`\x1b[2m[result: ${snippet.replace(/\n/g, " ⏎ ")}]\x1b[0m\n`);
-      },
-      askPermission: async ({ tool, args }) => {
-        if (opts.allowAll) return "allow";
-        process.stderr.write(
-          `\x1b[31m[permission denied: ${tool.name}(${JSON.stringify(args)}) — pass --dangerously-allow-all to approve in print mode]\x1b[0m\n`,
-        );
-        return "deny";
-      },
-    },
-  });
+    });
+  } catch (err) {
+    if (err instanceof BudgetExhaustedError) {
+      process.stderr.write("\n\x1b[33m[Budget exhausted — exiting with code 42]\x1b[0m\n");
+      process.exitCode = 42;
+      return;
+    }
+    throw err;
+  }
 
   process.stdout.write("\n");
 }


### PR DESCRIPTION
## Summary

Implements Phase 0 of the `/slash remote` development plan: make KimiFlare capable of running headlessly with auto-continue and token budgeting.

## Changes

### src/agent/loop.ts
- Added `continueOnLimit?` and `maxInputTokens?` to `AgentTurnOpts`
- Added `BudgetExhaustedError` exported class
- Restructured inner loop from `for` to `while` to support counter reset
- When `continueOnLimit` is true and the 50-call limit is hit, appends a system continue-message and resets the counter instead of throwing
- Tracks cumulative `prompt_tokens` across turns
- When cumulative tokens hit `maxInputTokens`, runs one final synthesis turn then throws `BudgetExhaustedError`

### src/index.tsx
- Added CLI flags:
  - `--continue-on-limit` — reset tool-call counter and continue when limit is hit (print mode only)
  - `--max-input-tokens <n>` — cumulative prompt token budget; exits 42 when exhausted (print mode only)
- Wires flags through to `runAgentTurn`
- Catches `BudgetExhaustedError` and exits with code **42**
- Normal completion exits **0**; crashes re-throw and exit **1**

## Deliverable

`kimiflare --print "..." --dangerously-allow-all --continue-on-limit --max-input-tokens 5000000` works locally.

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | Normal completion |
| 1 | Crash / unhandled error |
| 42 | Token budget exhausted |

---

Part of the `/slash remote` feature. Phase 1 (MVP worker + TUI integration) will build on top of these core loop primitives.

Co-authored-by: kimiflare <kimiflare@proton.me>