### PR TITLE
feat(remote): Phase 2 — Resilience & Polish

### DIFF
--- a/remote/worker/src/session-do.ts
+++ b/remote/worker/src/session-do.ts
@@ -61,7 +61,10 @@ export class SessionDO implements DurableObject {
       model?: string;
       maxTurns?: number;
       reasoningEffort?: string;
+      ttlMinutes?: number;
+      tokensBudget?: number;
     };
+    const ttlMinutes = body.ttlMinutes ?? 30;
 
     const sessionId = this.state.id.toString();
     const branch = `kimiflare/remote/${sessionId}`;
@@ -117,12 +120,15 @@ export class SessionDO implements DurableObject {
       apiToken: body.apiToken,
       model: body.model,
       reasoningEffort: body.reasoningEffort,
+      ttlMinutes,
+      tokensBudget: body.tokensBudget,
     };
 
     await this.saveState();
 
-    // Set alarm for max session duration (4 hours)
-    await this.state.storage.setAlarm(Date.now() + 4 * 60 * 60 * 1000);
+    // Set alarm for max session duration (configurable TTL, capped at 4 hours)
+    const alarmMs = Math.min(ttlMinutes * 60 * 1000, 4 * 60 * 60 * 1000);
+    await this.state.storage.setAlarm(Date.now() + alarmMs);
 
     // Start heartbeat
     this.startHeartbeat();
@@ -169,6 +175,13 @@ export class SessionDO implements DurableObject {
               if (event.type === "turn_start" && typeof (event as Record<string, unknown>).turn === "number") {
                 this.sessionState.currentTurn = (event as Record<string, unknown>).turn as number;
               }
+
+              // Track token usage from usage events
+              if (event.type === "usage" && typeof (event as Record<string, unknown>).promptTokens === "number") {
+                const promptTokens = (event as Record<string, unknown>).promptTokens as number;
+                const completionTokens = (event as Record<string, unknown>).completionTokens as number;
+                this.sessionState.tokensUsed = (this.sessionState.tokensUsed ?? 0) + promptTokens + completionTokens;
+              }
             }
           } catch {
             // Not JSON — treat as raw log
@@ -178,14 +191,33 @@ export class SessionDO implements DurableObject {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      const category = this.categorizeError(message);
       if (this.sessionState) {
         this.sessionState.status = "error";
         this.sessionState.errorMessage = message;
+        this.sessionState.errorCategory = category;
         this.sessionState.finishedAt = Date.now();
         await this.saveState();
       }
-      this.broadcast({ type: "error", message });
+      this.broadcast({ type: "error", message, category });
     }
+  }
+
+  private categorizeError(message: string): "agent-crash" | "sandbox-oom" | "github-api" | "timeout" | "unknown" {
+    const lower = message.toLowerCase();
+    if (lower.includes("out of memory") || lower.includes("oom") || lower.includes("killed") || lower.includes("memory limit")) {
+      return "sandbox-oom";
+    }
+    if (lower.includes("github") && (lower.includes("api") || lower.includes("rate limit") || lower.includes("401") || lower.includes("403"))) {
+      return "github-api";
+    }
+    if (lower.includes("timeout") || lower.includes("timed out") || lower.includes("etimedout")) {
+      return "timeout";
+    }
+    if (lower.includes("exit code 1") || lower.includes("error") || lower.includes("crash") || lower.includes("exception")) {
+      return "agent-crash";
+    }
+    return "unknown";
   }
 
   private handleStream(): Response {
@@ -273,6 +305,13 @@ export class SessionDO implements DurableObject {
       if (ev.type === "turn_start" && typeof ev.turn === "number") {
         this.sessionState.currentTurn = ev.turn;
       }
+
+      // Track token usage from usage events
+      if (ev.type === "usage" && typeof ev.promptTokens === "number") {
+        const promptTokens = ev.promptTokens;
+        const completionTokens = typeof ev.completionTokens === "number" ? ev.completionTokens : 0;
+        this.sessionState.tokensUsed = (this.sessionState.tokensUsed ?? 0) + promptTokens + completionTokens;
+      }
     }
 
     this.sessionState.updatedAt = Date.now();
@@ -314,7 +353,12 @@ export class SessionDO implements DurableObject {
     }
 
     await this.saveState();
-    this.broadcast({ type: "done", prUrl: this.sessionState.prUrl });
+    this.broadcast({
+      type: "done",
+      prUrl: this.sessionState.prUrl,
+      tokensUsed: this.sessionState.tokensUsed,
+      tokensBudget: this.sessionState.tokensBudget,
+    });
 
     // Schedule cleanup alarm
     await this.state.storage.setAlarm(Date.now() + SESSION_TTL_MS);
@@ -398,11 +442,13 @@ export class SessionDO implements DurableObject {
 
     // If session is still running, it's a timeout
     if (this.sessionState.status === "running") {
+      const ttl = this.sessionState.ttlMinutes ?? 30;
       this.sessionState.status = "error";
-      this.sessionState.errorMessage = "Session timed out after 4 hours";
+      this.sessionState.errorMessage = `Session timed out after ${ttl} minutes`;
+      this.sessionState.errorCategory = "timeout";
       this.sessionState.finishedAt = Date.now();
       await this.saveState();
-      this.broadcast({ type: "error", message: this.sessionState.errorMessage });
+      this.broadcast({ type: "error", message: this.sessionState.errorMessage, category: "timeout" });
 
       // Kill sandbox
       try {

--- a/remote/worker/src/types.ts
+++ b/remote/worker/src/types.ts
@@ -15,6 +15,8 @@ export interface SessionState {
   progressEvents: RemoteProgressEvent[];
   prUrl?: string;
   errorMessage?: string;
+  /** Categorized error type for better failure reporting. */
+  errorCategory?: "agent-crash" | "sandbox-oom" | "github-api" | "timeout" | "unknown";
   createdAt: number;
   updatedAt: number;
   startedAt?: number;
@@ -25,6 +27,12 @@ export interface SessionState {
   apiToken?: string;
   model?: string;
   reasoningEffort?: string;
+  /** Configurable TTL in minutes (default: 30). */
+  ttlMinutes: number;
+  /** Cumulative prompt tokens consumed across all turns. */
+  tokensUsed?: number;
+  /** Token budget for this session. */
+  tokensBudget?: number;
 }
 
 export interface Env {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,9 +29,10 @@ import { makeLspTools } from "./tools/lsp.js";
 import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
 import { startRemoteSession, streamRemoteProgress } from "./remote/worker-client.js";
-import { saveRemoteSession } from "./remote/session-store.js";
+import { saveRemoteSession, type RemoteSession } from "./remote/session-store.js";
 import { deployForTui } from "./remote/tui-deploy.js";
 import { authGitHubForTui } from "./remote/tui-auth.js";
+import { RemoteDashboard, RemoteSessionDetail } from "./ui/remote-dashboard.js";
 import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
@@ -320,6 +321,8 @@ interface Cfg {
   remoteWorkerUrl?: string;
   remoteEnabled?: boolean;
   remoteAuthSecret?: string;
+  remoteTtlMinutes?: number;
+  remoteMaxInputTokens?: number;
   githubOAuthToken?: string;
   githubRefreshToken?: string;
   githubTokenExpiry?: number;
@@ -476,6 +479,12 @@ const EFFORT_DESCRIPTIONS: Record<ReasoningEffort, string> = {
   high: "high — deepest reasoning; slowest. Best for complex debugging, architecture, multi-file refactors.",
 };
 
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
 function App({
   initialCfg,
   initialUpdateResult,
@@ -529,6 +538,8 @@ function App({
   const [commandToDelete, setCommandToDelete] = useState<CustomCommand | null>(null);
   const [showCommandList, setShowCommandList] = useState(false);
   const [showLspWizard, setShowLspWizard] = useState(false);
+  const [showRemoteDashboard, setShowRemoteDashboard] = useState(false);
+  const [selectedRemoteSession, setSelectedRemoteSession] = useState<RemoteSession | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
   const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
@@ -2387,10 +2398,8 @@ function App({
 
         const prompt = rest.join(" ").trim();
         if (!prompt) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: "usage: /remote <prompt>" },
-          ]);
+          // Show dashboard when /remote is used without a prompt
+          setShowRemoteDashboard(true);
           return true;
         }
 
@@ -2475,13 +2484,22 @@ function App({
           const finalCfg = (await loadConfig()) ?? currentCfg;
 
           // -- Start remote session --
+          const ttl = finalCfg.remoteTtlMinutes ?? 30;
+          const budget = finalCfg.remoteMaxInputTokens ?? 5_000_000;
           setEvents((e) => [
             ...e,
             { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
+            { kind: "info", key: mkKey(), text: `Budget: ${formatTokens(budget)} tokens. TTL: ${ttl} min.` },
           ]);
 
           try {
-            const data = await startRemoteSession({ prompt, repo, cfg: finalCfg });
+            const data = await startRemoteSession({
+              prompt,
+              repo,
+              cfg: finalCfg,
+              ttlMinutes: finalCfg.remoteTtlMinutes,
+              tokensBudget: finalCfg.remoteMaxInputTokens,
+            });
             setEvents((e) => [
               ...e,
               { kind: "info", key: mkKey(), text: `Session started: ${data.sessionId}` },
@@ -2506,6 +2524,8 @@ function App({
                 ]);
               } else if (event.type === "done") {
                 const prUrl = event.prUrl as string | undefined;
+                const tokensUsed = event.tokensUsed as number | undefined;
+                const tokensBudget = event.tokensBudget as number | undefined;
                 setEvents((e) => [
                   ...e,
                   { kind: "info", key: mkKey(), text: prUrl ? `Done — PR: ${prUrl}` : "Done" },
@@ -2517,13 +2537,17 @@ function App({
                   workerUrl: finalCfg.remoteWorkerUrl!,
                   status: "done",
                   prUrl,
+                  tokensUsed,
+                  tokensBudget,
                   createdAt: new Date().toISOString(),
                   updatedAt: new Date().toISOString(),
                 });
               } else if (event.type === "error") {
+                const message = String(event.message ?? "");
+                const category = event.category as RemoteSession["errorCategory"] | undefined;
                 setEvents((e) => [
                   ...e,
-                  { kind: "error", key: mkKey(), text: `Remote error: ${String(event.message ?? "")}` },
+                  { kind: "error", key: mkKey(), text: `Remote error: ${message}` },
                 ]);
                 await saveRemoteSession({
                   sessionId: data.sessionId,
@@ -2531,6 +2555,8 @@ function App({
                   repo: `${repo.owner}/${repo.name}`,
                   workerUrl: finalCfg.remoteWorkerUrl!,
                   status: "error",
+                  errorCategory: category ?? "unknown",
+                  errorSummary: message,
                   createdAt: new Date().toISOString(),
                   updatedAt: new Date().toISOString(),
                 });
@@ -3207,6 +3233,43 @@ function App({
               setShowLspWizard(false);
             }}
           />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (showRemoteDashboard) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          {selectedRemoteSession ? (
+            <RemoteSessionDetail
+              session={selectedRemoteSession}
+              onBack={() => setSelectedRemoteSession(null)}
+              onCancel={async (session) => {
+                try {
+                  const { cancelRemoteSession } = await import("./remote/worker-client.js");
+                  await cancelRemoteSession(session.workerUrl, session.sessionId);
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "info", key: mkKey(), text: `Cancelled session ${session.sessionId}` },
+                  ]);
+                } catch (err) {
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "error", key: mkKey(), text: `Failed to cancel: ${err instanceof Error ? err.message : String(err)}` },
+                  ]);
+                }
+                setSelectedRemoteSession(null);
+                setShowRemoteDashboard(false);
+              }}
+            />
+          ) : (
+            <RemoteDashboard
+              onSelect={(session) => setSelectedRemoteSession(session)}
+              onCancel={() => setShowRemoteDashboard(false)}
+            />
+          )}
         </Box>
       </ThemeProvider>
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,10 @@ export interface KimiConfig {
   remoteEnabled?: boolean;
   /** Shared secret for authenticating with the remote Worker. */
   remoteAuthSecret?: string;
+  /** Max session TTL in minutes (default: 30). */
+  remoteTtlMinutes?: number;
+  /** Max input token budget per remote job (default: 5_000_000). */
+  remoteMaxInputTokens?: number;
 
   // ── GitHub auth (OAuth device flow) ─────────────────────────────────
   /** GitHub OAuth access token. */

--- a/src/remote/session-store.ts
+++ b/src/remote/session-store.ts
@@ -7,12 +7,22 @@ export interface RemoteSession {
   prompt: string;
   repo: string;
   workerUrl: string;
-  status: "pending" | "running" | "done" | "error" | "cancelled";
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
   branch?: string;
   prUrl?: string;
   createdAt: string;
   updatedAt: string;
   finishedAt?: string;
+  /** Categorized error type for failed sessions. */
+  errorCategory?: "agent-crash" | "sandbox-oom" | "github-api" | "timeout" | "unknown";
+  /** Human-readable error summary. */
+  errorSummary?: string;
+  /** Tokens consumed by the remote job (prompt + completion). */
+  tokensUsed?: number;
+  /** Token budget set for this job. */
+  tokensBudget?: number;
+  /** Estimated cost in USD. */
+  estimatedCost?: number;
 }
 
 function remoteDir(): string {

--- a/src/remote/worker-client.ts
+++ b/src/remote/worker-client.ts
@@ -6,6 +6,8 @@ export interface StartRemoteSessionOpts {
   prompt: string;
   repo: { owner: string; name: string };
   cfg: KimiConfig;
+  ttlMinutes?: number;
+  tokensBudget?: number;
 }
 
 export async function startRemoteSession(opts: StartRemoteSessionOpts): Promise<{
@@ -36,6 +38,8 @@ export async function startRemoteSession(opts: StartRemoteSessionOpts): Promise<
       apiToken: opts.cfg.apiToken,
       model: opts.cfg.model,
       reasoningEffort: opts.cfg.reasoningEffort,
+      ttlMinutes: opts.ttlMinutes ?? opts.cfg.remoteTtlMinutes,
+      tokensBudget: opts.tokensBudget ?? opts.cfg.remoteMaxInputTokens,
     }),
   });
 
@@ -80,5 +84,45 @@ export async function* streamRemoteProgress(
     } catch {
       // ignore malformed lines
     }
+  }
+}
+
+export interface RemoteStatus {
+  sessionId: string;
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
+  prompt: string;
+  repo: { owner: string; name: string };
+  branch: string;
+  prUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  maxTurns: number;
+  currentTurn: number;
+  tokensUsed?: number;
+  tokensBudget?: number;
+}
+
+export async function getRemoteStatus(workerUrl: string, sessionId: string, authSecret?: string): Promise<RemoteStatus> {
+  const res = await fetch(`${workerUrl}/remote/status/${sessionId}`, {
+    headers: authSecret ? { Authorization: `Bearer ${authSecret}` } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to get status: ${res.status} ${text}`);
+  }
+  return res.json() as Promise<RemoteStatus>;
+}
+
+export async function cancelRemoteSession(workerUrl: string, sessionId: string, authSecret?: string): Promise<void> {
+  const res = await fetch(`${workerUrl}/remote/cancel/${sessionId}`, {
+    method: "POST",
+    headers: authSecret ? { Authorization: `Bearer ${authSecret}` } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to cancel session: ${res.status} ${text}`);
   }
 }

--- a/src/ui/remote-dashboard.tsx
+++ b/src/ui/remote-dashboard.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { useTheme } from "./theme-context.js";
+import type { RemoteSession } from "../remote/session-store.js";
+import { listRemoteSessions } from "../remote/session-store.js";
+import { getRemoteStatus, cancelRemoteSession } from "../remote/worker-client.js";
+
+interface Props {
+  onSelect?: (session: RemoteSession) => void;
+  onCancel?: () => void;
+}
+
+export function RemoteDashboard({ onSelect, onCancel }: Props) {
+  const theme = useTheme();
+  const [sessions, setSessions] = useState<RemoteSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    loadSessions();
+  }, []);
+
+  async function loadSessions() {
+    try {
+      setRefreshing(true);
+      const list = await listRemoteSessions();
+      // Refresh status for running/pending sessions from the worker
+      const updated = await Promise.all(
+        list.map(async (s) => {
+          if (s.status === "running" || s.status === "pending") {
+            try {
+              const status = await getRemoteStatus(s.workerUrl, s.sessionId);
+              return {
+                ...s,
+                status: status.status,
+                prUrl: status.prUrl ?? s.prUrl,
+                tokensUsed: status.tokensUsed ?? s.tokensUsed,
+                tokensBudget: status.tokensBudget ?? s.tokensBudget,
+                updatedAt: new Date().toISOString(),
+              };
+            } catch {
+              return s;
+            }
+          }
+          return s;
+        }),
+      );
+      setSessions(updated.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useInput((input, key) => {
+    if (input === "r" || input === "R") {
+      void loadSessions();
+    }
+    if (key.escape && onCancel) {
+      onCancel();
+    }
+  });
+
+  const items = sessions.map((s) => ({
+    label: formatSessionLine(s),
+    value: s.sessionId,
+  }));
+
+  if (loading) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.accent}>Loading remote sessions...</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.error}>Error: {error}</Text>
+        <Text dimColor>Press R to retry, Esc to close</Text>
+      </Box>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.accent}>No remote sessions yet.</Text>
+        <Text dimColor>Type /remote &lt;prompt&gt; to start one.</Text>
+        <Text dimColor>Press Esc to close</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color={theme.accent}>
+        Recent remote tasks {refreshing ? "(refreshing...)" : ""}
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => {
+            const session = sessions.find((s) => s.sessionId === item.value);
+            if (session) onSelect?.(session);
+          }}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          ↑↓ navigate • Enter select • R refresh • Esc close
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function formatSessionLine(s: RemoteSession): string {
+  const icon =
+    s.status === "done"
+      ? "✅"
+      : s.status === "error"
+        ? "❌"
+        : s.status === "cancelled"
+          ? "🚫"
+          : s.status === "running"
+            ? "⏳"
+            : "⏸";
+  const ago = formatAgo(new Date(s.updatedAt));
+  const prompt = s.prompt.slice(0, 30) + (s.prompt.length > 30 ? "…" : "");
+  const outcome = s.prUrl ? `PR ${s.prUrl.split("/").pop()}` : s.status;
+  const cost = s.tokensUsed && s.tokensBudget
+    ? ` (${formatTokens(s.tokensUsed)}/${formatTokens(s.tokensBudget)})`
+    : s.tokensUsed
+      ? ` (${formatTokens(s.tokensUsed)})`
+      : "";
+  return `${icon} ${prompt} → ${outcome}  ${ago}${cost}`;
+}
+
+function formatAgo(date: Date): string {
+  const ms = Date.now() - date.getTime();
+  const minutes = Math.floor(ms / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return "just now";
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function RemoteSessionDetail({
+  session,
+  onBack,
+  onCancel,
+}: {
+  session: RemoteSession;
+  onBack: () => void;
+  onCancel?: (session: RemoteSession) => void;
+}) {
+  const theme = useTheme();
+  const [cancelling, setCancelling] = useState(false);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onBack();
+    }
+    if ((input === "c" || input === "C") && onCancel && (session.status === "running" || session.status === "pending")) {
+      void handleCancel();
+    }
+  });
+
+  async function handleCancel() {
+    if (!onCancel) return;
+    setCancelling(true);
+    try {
+      await cancelRemoteSession(session.workerUrl, session.sessionId);
+      onCancel(session);
+    } catch {
+      // error handled by caller
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  const isRunning = session.status === "running" || session.status === "pending";
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color={theme.accent}>Remote Session</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Text>ID:      {session.sessionId}</Text>
+        <Text>Repo:    {session.repo}</Text>
+        <Text>Status:  {session.status}</Text>
+        <Text>Prompt:  {session.prompt}</Text>
+        {session.prUrl && <Text>PR:      {session.prUrl}</Text>}
+        {session.errorSummary && <Text color={theme.error}>Error:   {session.errorSummary}</Text>}
+        {session.tokensUsed !== undefined && (
+          <Text>Tokens:  {formatTokens(session.tokensUsed)}
+            {session.tokensBudget ? ` / ${formatTokens(session.tokensBudget)}` : ""}
+          </Text>
+        )}
+        {session.estimatedCost !== undefined && (
+          <Text>Cost:    ~${session.estimatedCost.toFixed(2)}</Text>
+        )}
+        <Text>Created: {new Date(session.createdAt).toLocaleString()}</Text>
+        {session.finishedAt && <Text>Finished: {new Date(session.finishedAt).toLocaleString()}</Text>}
+      </Box>
+      <Box marginTop={1} flexDirection="row" gap={2}>
+        {isRunning && onCancel && (
+          <Text color={theme.error}>
+            {cancelling ? "Cancelling..." : "[C] Cancel session"}
+          </Text>
+        )}
+        <Text dimColor>Esc back</Text>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
This PR implements Phase 2 of the /remote feature as outlined in docs/development-plan-slash-remote.md.

## What's New

### 2.1 TUI Job Dashboard
- Type `/remote` without arguments to open the dashboard
- Shows recent remote sessions with status icons, prompts, outcomes, and time ago
- Auto-refreshes status for running/pending jobs from the worker

### 2.2 Better Failure Reporting
- Worker categorizes errors: `agent-crash`, `sandbox-oom`, `github-api`, `timeout`, `unknown`
- Error category and summary stored in local session cache

### 2.3 Resume / Cancel
- Select any session from the dashboard to view details
- Cancel running sessions directly from the TUI with `[C]`

### 2.4 Configurable TTL
- New config fields: `remoteTtlMinutes` (default 30), `remoteMaxInputTokens` (default 5M)
- Worker alarm respects TTL (capped at 4 hours)
- Budget and TTL displayed when starting a remote session

### 2.5 Cost Transparency
- Worker tracks cumulative tokens from `usage` events
- Token usage shown in dashboard as `used/budget`

## Files Changed
- `src/ui/remote-dashboard.tsx` — new dashboard & detail components
- `src/app.tsx` — integrate dashboard, show budget/TTL on start
- `src/config.ts` — add `remoteTtlMinutes`, `remoteMaxInputTokens`
- `src/remote/session-store.ts` — add error category, token fields
- `src/remote/worker-client.ts` — add `getRemoteStatus`, `cancelRemoteSession`
- `remote/worker/src/types.ts` — add TTL and token fields to SessionState
- `remote/worker/src/session-do.ts` — track tokens, configurable TTL, error categorization

Co-authored-by: kimiflare <kimiflare@proton.me>