### PR TITLE
feat: Phase 3 — intent classification + telemetry

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -55,6 +55,8 @@ export interface AgentTurnOpts {
   continueOnLimit?: boolean;
   /** Cumulative prompt token budget. When exceeded, a final synthesis turn is run and then BudgetExhaustedError is thrown. */
   maxInputTokens?: number;
+  /** Intent classification result for this turn, for telemetry. */
+  intentClassification?: { intent: string; tier: "light" | "medium" | "heavy"; rawScore: number; confidence: number };
 }
 
 export class BudgetExhaustedError extends Error {
@@ -67,6 +69,7 @@ export class BudgetExhaustedError extends Error {
 const codeModeApiCache = new Map<string, string>();
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
+  const turnStart = performance.now();
   const max = opts.maxToolIterations ?? 50;
   const codeMode = opts.codeMode ?? false;
 
@@ -508,6 +511,9 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         toolResults,
         usage: lastUsage,
         shadowStrip: shadowStripMetrics,
+        durationMs: Math.round(performance.now() - turnStart),
+        intentClassification: opts.intentClassification,
+        codeMode: opts.codeMode,
       });
     }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,6 +50,7 @@ import {
   type ReasoningEffort,
 } from "./config.js";
 import { nextMode, type Mode, isBlockedInPlanMode, isReadOnlyBash } from "./mode.js";
+import { classifyIntent } from "./intent/classify.js";
 import {
   listSessions,
   loadSession,
@@ -1404,6 +1405,14 @@ function App({
     const controller = new AbortController();
     activeControllerRef.current = controller;
 
+    const initClassification = classifyIntent(prompt);
+    const initEffortForTier: Record<string, ReasoningEffort> = {
+      light: "low",
+      medium: "medium",
+      heavy: "high",
+    };
+    const initReasoningEffort = initEffortForTier[initClassification.tier] ?? effortRef.current;
+
     try {
       await runAgentTurn({
         accountId: cfg.accountId,
@@ -1415,7 +1424,8 @@ function App({
         executor: executorRef.current,
         cwd,
         signal: controller.signal,
-        reasoningEffort: effortRef.current,
+        reasoningEffort: initReasoningEffort,
+        intentClassification: initClassification,
         coauthor:
           cfg.coauthor !== false
             ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "kimiflare@proton.me" }
@@ -2361,6 +2371,14 @@ function App({
       setGatewayMeta(null);
       setTurnStartedAt(Date.now());
 
+      const classification = classifyIntent(trimmed);
+      const effortForTier: Record<string, ReasoningEffort> = {
+        light: "low",
+        medium: "medium",
+        heavy: "high",
+      };
+      const turnReasoningEffort = overrideEffort ?? effortForTier[classification.tier] ?? effortRef.current;
+
       const controller = new AbortController();
       activeControllerRef.current = controller;
 
@@ -2480,7 +2498,7 @@ function App({
             executor: executorRef.current,
             cwd: process.cwd(),
             signal: controller.signal,
-            reasoningEffort: overrideEffort ?? effortRef.current,
+            reasoningEffort: turnReasoningEffort,
             coauthor:
               cfg.coauthor !== false
                 ? { name: cfg.coauthorName || "kimiflare", email: cfg.coauthorEmail || "kimiflare@proton.me" }
@@ -2489,6 +2507,7 @@ function App({
             memoryManager: memoryManagerRef.current,
             keepLastImageTurns: cfg.imageHistoryTurns ?? 2,
             codeMode,
+            intentClassification: classification,
             onFileChange: (path, content) => {
               if (content) {
                 lspManagerRef.current.notifyChange(path, content);

--- a/src/cost-debug.ts
+++ b/src/cost-debug.ts
@@ -41,6 +41,13 @@ export interface CompactionMetrics {
   memoriesStored?: number;
 }
 
+export interface IntentClassification {
+  intent: string;
+  tier: "light" | "medium" | "heavy";
+  rawScore: number;
+  confidence: number;
+}
+
 export interface CostDebugEntry {
   v: number;
   ts: string;
@@ -58,6 +65,9 @@ export interface CostDebugEntry {
   compaction?: CompactionMetrics;
   shadowStrip?: ShadowStripMetrics;
   signals?: string[]; // Literal categories detected this turn (cost attribution)
+  durationMs?: number; // NEW: wall-clock time for this turn
+  intentClassification?: IntentClassification; // NEW: what we predicted
+  codeMode?: boolean; // NEW: was Code Mode enabled this turn
 }
 
 function debugDir(): string {
@@ -149,6 +159,9 @@ export interface TurnDebugContext {
   previousMessages?: ChatMessage[];
   compaction?: CompactionMetrics;
   shadowStrip?: ShadowStripMetrics;
+  durationMs?: number;
+  intentClassification?: IntentClassification;
+  codeMode?: boolean;
 }
 
 /** Serialize the prompt prefix (all leading system messages) for comparison. */
@@ -254,5 +267,8 @@ export async function logTurnDebug(ctx: TurnDebugContext): Promise<void> {
     cacheDiagnostics,
     compaction: ctx.compaction,
     shadowStrip: ctx.shadowStrip,
+    durationMs: ctx.durationMs,
+    intentClassification: ctx.intentClassification,
+    codeMode: ctx.codeMode,
   });
 }

--- a/src/intent/classify.ts
+++ b/src/intent/classify.ts
@@ -1,0 +1,52 @@
+export interface IntentResult {
+  intent: string;
+  rawScore: number; // 0.0 - 1.0
+  tier: "light" | "medium" | "heavy";
+  confidence: number; // 0.0 - 1.0
+}
+
+const INTENT_PATTERNS: Record<string, RegExp> = {
+  qa: /\b(what|how|why|explain|describe|what's|what is)\b/i,
+  diagnose: /\b(broken|failing|error|bug|crash|why.*fail|not working)\b/i,
+  verify: /\b(correct|right|verify|review|check|is this|does this)\b/i,
+  polish: /\b(rename|refactor|extract|move|clean|lint|format)\b/i,
+  small_edit: /\b(add|change|update|fix|remove|delete)\b.+\b(line|here|this|variable|function)\b/i,
+  feature_bounded: /\b(add|implement|create|support)\b.+\b(flag|option|param|arg|field)\b/i,
+  feature_exploratory: /\b(add|implement|migrate|integrate|build)\b.+\b(module|system|auth|oauth|framework|service)\b/i,
+  explore: /\b(how.*work|architecture|structure|where.*used|find.*all|understand)\b/i,
+  meta: /\b(plan|design|strategy|ontology|roadmap|approach)\b/i,
+};
+
+export function classifyIntent(prompt: string): IntentResult {
+  let intentScore = 0;
+  let matchedIntent = "other";
+
+  for (const [intent, pattern] of Object.entries(INTENT_PATTERNS)) {
+    const matches = (prompt.match(pattern) || []).length;
+    if (matches > intentScore) {
+      intentScore = matches;
+      matchedIntent = intent;
+    }
+  }
+
+  const hasFileMentions = (prompt.match(/@\w+|\b[\w/-]+\.(ts|tsx|js|jsx|py|go|rs)\b/g) || []).length;
+  const hasMutatingVerb = /\b(add|create|write|edit|delete|remove|rename|migrate|implement)\b/i.test(prompt);
+  const isQuestion = prompt.trim().endsWith("?") || /\b(what|how|why|is|does|can)\b/i.test(prompt.split(" ")[0] || "");
+
+  const rawScore = Math.min(
+    1.0,
+    intentScore * 0.25 +
+      (hasFileMentions > 2 ? 0.3 : hasFileMentions * 0.1) +
+      (hasMutatingVerb ? 0.25 : 0) +
+      (isQuestion ? 0 : 0.1),
+  );
+
+  const tier = rawScore < 0.3 ? "light" : rawScore < 0.65 ? "medium" : "heavy";
+
+  return {
+    intent: matchedIntent,
+    rawScore,
+    tier,
+    confidence: 0.5 + (intentScore > 0 ? 0.3 : 0) + (hasFileMentions > 0 ? 0.1 : 0),
+  };
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the adaptive agent routing plan: classify every user prompt by complexity and adapt `reasoningEffort` accordingly, with telemetry to measure effectiveness.

## Changes

- **New:** `src/intent/classify.ts` — deterministic regex/keyword heuristic (no LLM call) that classifies prompts into `light` / `medium` / `heavy` tiers.
- **Adaptive reasoning:** `light` → `low`, `medium` → `medium`, `heavy` → `high`.
- **Telemetry:** adds `durationMs`, `intentClassification`, and `codeMode` to `CostDebugEntry`.
- **Duration measurement:** measured inside `runAgentTurn` and logged via `logTurnDebug`.
- **Override respect:** custom slash-command `effort` overrides still take precedence.

## Validation

After a few sessions, run:

```bash
python3 -c "
import json
from collections import defaultdict
by_tier = defaultdict(lambda: {'turns': [], 'tokens': [], 'durations': []})
with open('~/.local/share/kimiflare/cost-debug.jsonl') as f:
    for line in f:
        d = json.loads(line)
        if 'intentClassification' in d:
            tier = d['intentClassification']['tier']
            by_tier[tier]['turns'].append(d['turn'])
            by_tier[tier]['tokens'].append(d['usage']['total_tokens'])
            by_tier[tier]['durations'].append(d.get('durationMs', 0))
for tier in ['light', 'medium', 'heavy']:
    t = by_tier[tier]
    if t['turns']:
        print(f'{tier}: avg {sum(t[\"turns\"])/len(t[\"turns\"]):.1f} turns, '
              f'avg {sum(t[\"tokens\"])/len(t[\"tokens\"]):.0f} tokens, '
              f'avg {sum(t[\"durations\"])/len(t[\"durations\"]):.0f}ms')
"
```

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes (279 tests)
- [x] Follows existing code style and conventions

---

**Note on README:** I verified the README situation — `npm pack --dry-run` shows `README.md` is included in the tarball, and `npm view kimiflare@0.33.0 readme` returns the full content. The README appears to be present in the registry; if npmjs.com isn't rendering it, that may be a transient npmjs.com UI issue rather than a packaging problem.