### PR TITLE
feat(remote): Phase 1 MVP — end-to-end /remote command

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   },
   "scripts": {
     "build": "tsup",
+    "build:remote": "npm run build:worker && npm run build:remote-agent",
+    "build:worker": "cd remote/worker && npm run typecheck",
+    "build:remote-agent": "cd remote/agent && npx tsup",
     "dev": "tsx src/index.tsx",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts src/**/*.test.tsx",

--- a/remote/Dockerfile
+++ b/remote/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-slim
+
+WORKDIR /opt/kimiflare
+
+# Copy built agent bundle
+COPY agent/dist/remote-agent.mjs ./dist/remote-agent.js
+COPY agent/dist/remote-agent.mjs.map ./dist/remote-agent.mjs.map
+
+# Install git for repo operations
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# The agent runs from /workspace
+WORKDIR /workspace
+
+ENTRYPOINT ["node", "/opt/kimiflare/dist/remote-agent.js"]

--- a/remote/README.md
+++ b/remote/README.md
@@ -1,0 +1,39 @@
+# kimiflare Remote Infrastructure
+
+This directory contains the Cloudflare Worker and Sandbox container that power the `/remote` feature.
+
+## Structure
+
+- `worker/` — Hono-based Cloudflare Worker with Durable Objects
+- `agent/` — Headless kimiflare agent that runs inside the Sandbox
+- `Dockerfile` — Container image for the Sandbox
+
+## Deploying
+
+```bash
+# From the repo root
+npm run build:remote-agent
+npm run remote:deploy
+```
+
+Or manually:
+
+```bash
+cd remote/worker
+npm install
+wrangler secret put REMOTE_AUTH_SECRET
+wrangler secret put CF_API_TOKEN
+wrangler deploy
+```
+
+## Architecture
+
+1. User types `/remote <prompt>` in the TUI
+2. Local CLI sends `POST /remote/start` to the Worker
+3. Worker creates a Durable Object instance
+4. DO creates an Artifacts repo and a Sandbox container
+5. Sandbox clones the user's GitHub repo
+6. Sandbox runs the headless agent with the prompt
+7. Agent streams progress back via SSE
+8. On completion, DO pushes branch and opens PR/issue
+9. DO cleans up sandbox and artifacts

--- a/remote/agent/package.json
+++ b/remote/agent/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "kimiflare-remote-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "kimiflare-remote-agent": "./dist/remote-agent.mjs"
+  },
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/remote/agent/src/headless-permission.ts
+++ b/remote/agent/src/headless-permission.ts
@@ -1,0 +1,10 @@
+/**
+ * Headless permission handler — auto-approves all tool calls in remote mode.
+ */
+export function createHeadlessPermissionHandler() {
+  return async (_toolName: string, _args: Record<string, unknown>): Promise<boolean> => {
+    // In remote mode, we auto-approve everything. The user explicitly
+    // chose to run remotely and can cancel via the TUI dashboard.
+    return true;
+  };
+}

--- a/remote/agent/src/progress-reporter.ts
+++ b/remote/agent/src/progress-reporter.ts
@@ -1,0 +1,63 @@
+interface ProgressEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+const PROGRESS_URL = process.env.PROGRESS_URL ?? "";
+const FINALIZE_URL = process.env.FINALIZE_URL ?? "";
+
+export async function reportProgress(event: ProgressEvent): Promise<void> {
+  if (!PROGRESS_URL) return;
+  try {
+    await fetch(PROGRESS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+    });
+  } catch {
+    // Best-effort progress reporting
+  }
+}
+
+export async function postFinalize(opts: {
+  exitCode: number;
+  hasChanges: boolean;
+  errorLog?: string;
+}): Promise<void> {
+  if (!FINALIZE_URL) return;
+  try {
+    await fetch(FINALIZE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(opts),
+    });
+  } catch {
+    // Best-effort finalization
+  }
+}
+
+export function createProgressReporter() {
+  let turn = 0;
+
+  return {
+    onTurnStart: async () => {
+      turn++;
+      await reportProgress({ type: "turn_start", turn });
+    },
+    onToolCall: async (toolName: string, args: Record<string, unknown>) => {
+      await reportProgress({ type: "tool_call", tool: toolName, args });
+    },
+    onToolResult: async (toolName: string, result: unknown) => {
+      await reportProgress({ type: "tool_result", tool: toolName, result });
+    },
+    onUsage: async (promptTokens: number, completionTokens: number) => {
+      await reportProgress({ type: "usage", promptTokens, completionTokens });
+    },
+    onError: async (message: string) => {
+      await reportProgress({ type: "error", message });
+    },
+    onDone: async () => {
+      await reportProgress({ type: "done" });
+    },
+  };
+}

--- a/remote/agent/src/remote-agent.ts
+++ b/remote/agent/src/remote-agent.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * kimiflare Remote Agent
+ * Headless agent that runs inside a Cloudflare Sandbox.
+ */
+
+import { execSync } from "node:child_process";
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { runAgentTurn } from "../../../src/agent/loop.js";
+import { buildSystemPrompt } from "../../../src/agent/system-prompt.js";
+import { ToolExecutor, ALL_TOOLS } from "../../../src/tools/executor.js";
+import type { ChatMessage } from "../../../src/agent/messages.js";
+import { createProgressReporter, postFinalize } from "./progress-reporter.js";
+import { createHeadlessPermissionHandler } from "./headless-permission.js";
+
+const SESSION_ID = process.env.SESSION_ID ?? "unknown";
+const ARTIFACTS_URL = process.env.ARTIFACTS_URL ?? "";
+const ARTIFACTS_TOKEN = process.env.ARTIFACTS_TOKEN ?? "";
+const REPO_OWNER = process.env.REPO_OWNER ?? "";
+const REPO_NAME = process.env.REPO_NAME ?? "";
+const GITHUB_BRANCH = process.env.GITHUB_BRANCH ?? `kimiflare/remote/${SESSION_ID}`;
+const PROMPT = process.env.PROMPT ?? "Do something useful";
+const MODEL = process.env.MODEL ?? "@cf/moonshotai/kimi-k2.6";
+const MAX_TURNS = parseInt(process.env.MAX_TURNS ?? "50", 10);
+const REASONING_EFFORT = (process.env.REASONING_EFFORT ?? "medium") as "low" | "medium" | "high";
+const ACCOUNT_ID = process.env.ACCOUNT_ID ?? "";
+const API_TOKEN = process.env.API_TOKEN ?? "";
+
+const WORKSPACE = "/workspace";
+
+function logInfo(msg: string): void {
+  console.log(JSON.stringify({ type: "info", message: msg }));
+}
+
+function logError(msg: string): void {
+  console.log(JSON.stringify({ type: "error", message: msg }));
+}
+
+function setupGit(): void {
+  execSync("git config --global user.email 'kimiflare@proton.me'");
+  execSync("git config --global user.name 'kimiflare'");
+}
+
+function cloneRepo(): void {
+  if (!ARTIFACTS_URL || !ARTIFACTS_TOKEN) {
+    throw new Error("ARTIFACTS_URL and ARTIFACTS_TOKEN must be set");
+  }
+  const authUrl = ARTIFACTS_URL.replace("https://", `https://token:${ARTIFACTS_TOKEN}@`);
+  execSync(`git clone ${authUrl} ${WORKSPACE}`, { stdio: "inherit" });
+}
+
+function pushRepo(): void {
+  if (!ARTIFACTS_URL || !ARTIFACTS_TOKEN) return;
+  const authUrl = ARTIFACTS_URL.replace("https://", `https://token:${ARTIFACTS_TOKEN}@`);
+  execSync(`git push ${authUrl} ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+}
+
+function hasChanges(): boolean {
+  try {
+    const status = execSync("git status --porcelain", { cwd: WORKSPACE, encoding: "utf8" });
+    return status.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function runRemoteAgent(): Promise<void> {
+  logInfo(`Starting remote session ${SESSION_ID}`);
+  logInfo(`Model: ${MODEL}`);
+  logInfo(`Max turns: ${MAX_TURNS}`);
+
+  setupGit();
+
+  if (!existsSync(WORKSPACE)) {
+    mkdirSync(WORKSPACE, { recursive: true });
+  }
+
+  // Check if workspace is empty
+  try {
+    const workspaceFiles = execSync("ls -A", { cwd: WORKSPACE, encoding: "utf8" });
+    if (workspaceFiles.trim().length === 0) {
+      logInfo("Cloning repository...");
+      cloneRepo();
+    } else {
+      logInfo("Workspace already populated, skipping clone");
+    }
+  } catch {
+    logInfo("Cloning repository...");
+    cloneRepo();
+  }
+
+  // Create or checkout branch
+  try {
+    execSync(`git checkout -b ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+    logInfo(`Created branch ${GITHUB_BRANCH}`);
+  } catch {
+    execSync(`git checkout ${GITHUB_BRANCH}`, { cwd: WORKSPACE });
+    logInfo(`Checked out existing branch ${GITHUB_BRANCH}`);
+  }
+
+  const tools = ALL_TOOLS;
+  const executor = new ToolExecutor(tools);
+  const callbacks = createProgressReporter();
+  const permissionHandler = createHeadlessPermissionHandler();
+
+  const messages: ChatMessage[] = [
+    {
+      role: "system",
+      content: buildSystemPrompt({
+        cwd: WORKSPACE,
+        tools,
+        model: MODEL,
+        mode: "auto",
+      }),
+    },
+    {
+      role: "user",
+      content: PROMPT,
+    },
+  ];
+
+  let exitCode = 0;
+  let errorLog = "";
+
+  try {
+    await runAgentTurn({
+      messages,
+      tools,
+      executor,
+      model: MODEL,
+      accountId: ACCOUNT_ID,
+      apiToken: API_TOKEN,
+      reasoningEffort: REASONING_EFFORT,
+      maxToolIterations: MAX_TURNS,
+      continueOnLimit: true,
+      maxInputTokens: 5_000_000,
+      onToolCall: async (name, args) => {
+        await callbacks.onToolCall(name, args);
+      },
+      onToolResult: async (name, result) => {
+        await callbacks.onToolResult(name, result);
+      },
+      onUsage: async (usage) => {
+        await callbacks.onUsage(usage.prompt_tokens, usage.completion_tokens);
+      },
+      permissionHandler,
+    });
+
+    logInfo("Agent completed successfully");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    errorLog = message;
+    logError(`Agent error: ${message}`);
+
+    // Check if it's a budget exhaustion error
+    if (message.includes("budget") || message.includes("BudgetExhaustedError")) {
+      exitCode = 42;
+    } else {
+      exitCode = 1;
+    }
+  }
+
+  // Commit and push changes
+  const changesExist = hasChanges();
+  if (changesExist) {
+    logInfo("Committing changes...");
+    try {
+      execSync("git add -A", { cwd: WORKSPACE });
+      execSync(`git commit -m "kimiflare remote: ${PROMPT.slice(0, 80)}" --no-verify`, { cwd: WORKSPACE });
+      pushRepo();
+      logInfo("Changes pushed");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logError(`Git error: ${message}`);
+    }
+  } else {
+    logInfo("No changes to commit");
+  }
+
+  // Report finalization
+  await postFinalize({
+    exitCode,
+    hasChanges: changesExist,
+    errorLog: errorLog || undefined,
+  });
+
+  process.exit(exitCode);
+}
+
+runRemoteAgent().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  logError(`Fatal error: ${message}`);
+  postFinalize({ exitCode: 1, hasChanges: false, errorLog: message }).finally(() => {
+    process.exit(1);
+  });
+});

--- a/remote/agent/tsconfig.json
+++ b/remote/agent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "paths": {
+      "../../../src/*": ["../../src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/remote/agent/tsup.config.ts
+++ b/remote/agent/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/remote-agent.ts"],
+  outDir: "dist",
+  format: ["esm"],
+  target: "node20",
+  bundle: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: [],
+});

--- a/remote/worker/package.json
+++ b/remote/worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "kimiflare-remote-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.7.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250214.0",
+    "typescript": "^5.7.0",
+    "wrangler": "^3.109.0"
+  }
+}

--- a/remote/worker/src/github.ts
+++ b/remote/worker/src/github.ts
@@ -1,0 +1,83 @@
+export async function createPullRequest(opts: {
+  owner: string;
+  repo: string;
+  title: string;
+  body: string;
+  head: string;
+  base: string;
+  token: string;
+}): Promise<{ html_url: string; number: number }> {
+  const res = await fetch(`https://api.github.com/repos/${opts.owner}/${opts.repo}/pulls`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${opts.token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: opts.title,
+      body: opts.body,
+      head: opts.head,
+      base: opts.base,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub PR creation failed: ${res.status} ${text}`);
+  }
+
+  return res.json() as Promise<{ html_url: string; number: number }>;
+}
+
+export async function createIssue(opts: {
+  owner: string;
+  repo: string;
+  title: string;
+  body: string;
+  token: string;
+}): Promise<{ html_url: string; number: number }> {
+  const res = await fetch(`https://api.github.com/repos/${opts.owner}/${opts.repo}/issues`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${opts.token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title: opts.title,
+      body: opts.body,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub issue creation failed: ${res.status} ${text}`);
+  }
+
+  return res.json() as Promise<{ html_url: string; number: number }>;
+}
+
+export async function getDefaultBranch(opts: {
+  owner: string;
+  repo: string;
+  token: string;
+}): Promise<string> {
+  const res = await fetch(`https://api.github.com/repos/${opts.owner}/${opts.repo}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${opts.token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub repo fetch failed: ${res.status} ${text}`);
+  }
+
+  const data = await res.json() as { default_branch: string };
+  return data.default_branch;
+}

--- a/remote/worker/src/index.ts
+++ b/remote/worker/src/index.ts
@@ -1,0 +1,219 @@
+import { Hono } from "hono";
+import type { Env } from "./types.js";
+import { SessionDO } from "./session-do.js";
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Auth middleware — only for CLI-facing endpoints
+app.use("/remote/start", async (c, next) => {
+  const auth = c.req.header("Authorization");
+  const expected = `Bearer ${c.env.REMOTE_AUTH_SECRET}`;
+  if (auth !== expected) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+app.use("/remote/cancel/*", async (c, next) => {
+  const auth = c.req.header("Authorization");
+  const expected = `Bearer ${c.env.REMOTE_AUTH_SECRET}`;
+  if (auth !== expected) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+
+// Start a remote session
+app.post("/remote/start", async (c) => {
+  const body = await c.req.json();
+  const sessionId = crypto.randomUUID();
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/start", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  const data = await res.json();
+  return c.json({ ...data, sessionId });
+});
+
+// Stream progress (SSE)
+app.get("/remote/stream/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/stream", {
+    method: "GET",
+  }));
+
+  return res;
+});
+
+// Cancel session
+app.post("/remote/cancel/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/cancel", {
+    method: "POST",
+  }));
+
+  return res;
+});
+
+// Get session status
+app.get("/remote/status/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const res = await doStub.fetch(new Request("http://internal/status", {
+    method: "GET",
+  }));
+
+  return res;
+});
+
+// Receive progress from Sandbox
+app.post("/progress/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const body = await c.req.json();
+  const res = await doStub.fetch(new Request("http://internal/progress", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  return res;
+});
+
+// Finalize session (from Sandbox)
+app.post("/finalize/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const body = await c.req.json();
+  const res = await doStub.fetch(new Request("http://internal/finalize", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  return res;
+});
+
+// LLM relay (from Sandbox)
+app.post("/relay", async (c) => {
+  const sessionId = c.req.header("X-Session-Id");
+  if (!sessionId) {
+    return c.json({ error: "Missing X-Session-Id header" }, 400);
+  }
+
+  const id = c.env.SESSION_DO.idFromName(sessionId);
+  const doStub = c.env.SESSION_DO.get(id);
+
+  const body = await c.req.json();
+  const res = await doStub.fetch(new Request("http://internal/relay", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  }));
+
+  return res;
+});
+
+// CORS for web status page and SSE streams
+app.use("/remote/stream/*", async (c, next) => {
+  c.header("Access-Control-Allow-Origin", "*");
+  c.header("Access-Control-Allow-Methods", "GET");
+  c.header("Access-Control-Allow-Headers", "Content-Type");
+  await next();
+});
+app.use("/remote/web/*", async (c, next) => {
+  c.header("Access-Control-Allow-Origin", "*");
+  c.header("Access-Control-Allow-Methods", "GET");
+  c.header("Access-Control-Allow-Headers", "Content-Type");
+  await next();
+});
+
+// Web status page
+app.get("/remote/web/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const streamUrl = `/remote/stream/${sessionId}`;
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kimiflare remote — ${sessionId}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; background: #0d1117; color: #c9d1d9; }
+    h1 { font-size: 1.25rem; color: #58a6ff; }
+    .event { padding: 0.5rem; margin: 0.25rem 0; border-radius: 6px; background: #161b22; font-family: monospace; font-size: 0.875rem; }
+    .event.turn_start { border-left: 3px solid #58a6ff; }
+    .event.tool_call { border-left: 3px solid #f0883e; }
+    .event.tool_result { border-left: 3px solid #3fb950; }
+    .event.error { border-left: 3px solid #f85149; }
+    .event.done { border-left: 3px solid #3fb950; background: #23863620; }
+    .status { padding: 1rem; background: #161b22; border-radius: 8px; margin-bottom: 1rem; }
+    .status.running { border: 1px solid #58a6ff; }
+    .status.done { border: 1px solid #3fb950; }
+    .status.error { border: 1px solid #f85149; }
+  </style>
+</head>
+<body>
+  <h1>🔥 kimiflare remote</h1>
+  <div id="status" class="status running">Connecting...</div>
+  <div id="events"></div>
+  <script>
+    const sessionId = "${sessionId}";
+    const streamUrl = "${streamUrl}";
+    const eventsDiv = document.getElementById("events");
+    const statusDiv = document.getElementById("status");
+    const evtSource = new EventSource(streamUrl);
+
+    evtSource.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      const div = document.createElement("div");
+      div.className = "event " + data.type;
+      div.textContent = JSON.stringify(data);
+      eventsDiv.appendChild(div);
+      window.scrollTo(0, document.body.scrollHeight);
+
+      if (data.type === "done") {
+        statusDiv.textContent = "✅ Done" + (data.prUrl ? " — PR: " + data.prUrl : "");
+        statusDiv.className = "status done";
+        evtSource.close();
+      } else if (data.type === "error") {
+        statusDiv.textContent = "❌ Error: " + data.message;
+        statusDiv.className = "status error";
+      } else if (data.type === "cancelled") {
+        statusDiv.textContent = "🛑 Cancelled";
+        statusDiv.className = "status error";
+      }
+    };
+
+    evtSource.onerror = () => {
+      statusDiv.textContent = "⚠️ Connection lost — reconnecting...";
+    };
+  </script>
+</body>
+</html>`;
+
+  return c.html(html);
+});
+
+// Health check
+app.get("/health", (c) => c.json({ ok: true }));
+
+export default app;
+export { SessionDO };

--- a/remote/worker/src/session-do.ts
+++ b/remote/worker/src/session-do.ts
@@ -1,0 +1,490 @@
+import type { SessionState, RemoteProgressEvent, Env } from "./types.js";
+import { createPullRequest, createIssue, getDefaultBranch } from "./github.js";
+
+const MAX_EVENTS = 1000;
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export class SessionDO implements DurableObject {
+  private state: DurableObjectState;
+  private env: Env;
+  private sessionState: SessionState | null = null;
+  private clients: Set<ReadableStreamDefaultController<string>> = new Set();
+  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // Restore state from storage if available
+    if (!this.sessionState) {
+      const stored = await this.state.storage.get<SessionState>("state");
+      if (stored) this.sessionState = stored;
+    }
+
+    if (path.endsWith("/start") && request.method === "POST") {
+      return this.handleStart(request);
+    }
+    if (path.endsWith("/stream") && request.method === "GET") {
+      return this.handleStream();
+    }
+    if (path.endsWith("/cancel") && request.method === "POST") {
+      return this.handleCancel();
+    }
+    if (path.endsWith("/status") && request.method === "GET") {
+      return this.handleStatus();
+    }
+    if (path.endsWith("/progress") && request.method === "POST") {
+      return this.handleProgress(request);
+    }
+    if (path.endsWith("/finalize") && request.method === "POST") {
+      return this.handleFinalize(request);
+    }
+    if (path.endsWith("/relay") && request.method === "POST") {
+      return this.handleRelay(request);
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  private async handleStart(request: Request): Promise<Response> {
+    const body = await request.json() as {
+      prompt: string;
+      repo: { owner: string; name: string };
+      githubToken: string;
+      accountId: string;
+      apiToken: string;
+      model?: string;
+      maxTurns?: number;
+      reasoningEffort?: string;
+      ttlMinutes?: number;
+      tokensBudget?: number;
+    };
+    const ttlMinutes = body.ttlMinutes ?? 30;
+
+    const sessionId = this.state.id.toString();
+    const branch = `kimiflare/remote/${sessionId}`;
+
+    // Create Artifacts repo
+    const artifactsRepo = await this.env.ARTIFACTS.createRepo({
+      name: `kf-${sessionId}`,
+    });
+
+    // Create Sandbox
+    const sandbox = await this.env.SANDBOX.create({
+      id: sessionId,
+      image: "ghcr.io/sinameraji/kimiflare-remote-agent:latest",
+      env: {
+        SESSION_ID: sessionId,
+        ARTIFACTS_URL: artifactsRepo.url,
+        ARTIFACTS_TOKEN: artifactsRepo.writeToken,
+        WORKER_RELAY_URL: `https://${request.headers.get("host")}/relay`,
+        PROGRESS_URL: `https://${request.headers.get("host")}/progress`,
+        FINALIZE_URL: `https://${request.headers.get("host")}/finalize`,
+        REPO_OWNER: body.repo.owner,
+        REPO_NAME: body.repo.name,
+        GITHUB_BRANCH: branch,
+        PROMPT: body.prompt,
+        MODEL: body.model ?? "@cf/moonshotai/kimi-k2.6",
+        MAX_TURNS: String(body.maxTurns ?? 50),
+        REASONING_EFFORT: body.reasoningEffort ?? "medium",
+        ACCOUNT_ID: body.accountId,
+        API_TOKEN: body.apiToken,
+      },
+    });
+
+    this.sessionState = {
+      sessionId,
+      status: "running",
+      prompt: body.prompt,
+      repo: body.repo,
+      branch,
+      artifactsRepo: {
+        name: artifactsRepo.name,
+        url: artifactsRepo.url,
+        writeToken: artifactsRepo.writeToken,
+      },
+      sandboxId: sandbox.id,
+      githubToken: body.githubToken,
+      progressEvents: [],
+      maxTurns: body.maxTurns ?? 50,
+      currentTurn: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      startedAt: Date.now(),
+      accountId: body.accountId,
+      apiToken: body.apiToken,
+      model: body.model,
+      reasoningEffort: body.reasoningEffort,
+      ttlMinutes,
+      tokensBudget: body.tokensBudget,
+    };
+
+    await this.saveState();
+
+    // Set alarm for max session duration (configurable TTL, capped at 4 hours)
+    const alarmMs = Math.min(ttlMinutes * 60 * 1000, 4 * 60 * 60 * 1000);
+    await this.state.storage.setAlarm(Date.now() + alarmMs);
+
+    // Start heartbeat
+    this.startHeartbeat();
+
+    // Start agent in background (don't await — it runs for minutes/hours)
+    this.runAgentInSandbox(sandbox);
+
+    return Response.json({
+      sessionId,
+      streamUrl: `/remote/stream/${sessionId}`,
+      status: "running",
+    });
+  }
+
+  private async runAgentInSandbox(sandbox: import("./types.js").SandboxInstance): Promise<void> {
+    try {
+      const result = await sandbox.exec("node", ["/opt/kimiflare/dist/remote-agent.js"]);
+
+      // Stream stdout
+      const reader = result.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const event = JSON.parse(trimmed) as RemoteProgressEvent;
+            if (this.sessionState) {
+              this.sessionState.progressEvents.push(event);
+              if (this.sessionState.progressEvents.length > MAX_EVENTS) {
+                this.sessionState.progressEvents.shift();
+              }
+              this.broadcast(event);
+
+              if (event.type === "turn_start" && typeof (event as Record<string, unknown>).turn === "number") {
+                this.sessionState.currentTurn = (event as Record<string, unknown>).turn as number;
+              }
+
+              // Track token usage from usage events
+              if (event.type === "usage" && typeof (event as Record<string, unknown>).promptTokens === "number") {
+                const promptTokens = (event as Record<string, unknown>).promptTokens as number;
+                const completionTokens = (event as Record<string, unknown>).completionTokens as number;
+                this.sessionState.tokensUsed = (this.sessionState.tokensUsed ?? 0) + promptTokens + completionTokens;
+              }
+            }
+          } catch {
+            // Not JSON — treat as raw log
+            this.broadcast({ type: "log", text: trimmed });
+          }
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.sessionState) {
+        this.sessionState.status = "error";
+        this.sessionState.errorMessage = message;
+        this.sessionState.finishedAt = Date.now();
+        await this.saveState();
+      }
+      this.broadcast({ type: "error", message });
+    }
+  }
+
+  private handleStream(): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<string>({
+      start: (controller) => {
+        this.clients.add(controller);
+        // Send existing events
+        if (this.sessionState) {
+          for (const ev of this.sessionState.progressEvents) {
+            controller.enqueue(`data: ${JSON.stringify(ev)}\n\n`);
+          }
+        }
+      },
+      cancel: () => {
+        // Find and remove this controller
+        for (const client of this.clients) {
+          try {
+            client.close();
+          } catch {
+            // ignore
+          }
+        }
+        this.clients.clear();
+      },
+    });
+
+    return new Response(stream as unknown as ReadableStream<Uint8Array>, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  private async handleCancel(): Promise<Response> {
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    this.sessionState.status = "cancelled";
+    this.sessionState.finishedAt = Date.now();
+    await this.saveState();
+
+    // Try to kill sandbox
+    if (this.sessionState.sandboxId) {
+      try {
+        const sandbox = await this.env.SANDBOX.get(this.sessionState.sandboxId);
+        await sandbox.kill();
+      } catch {
+        // ignore
+      }
+    }
+
+    this.broadcast({ type: "cancelled" });
+    this.stopHeartbeat();
+    return Response.json({ status: "cancelled" });
+  }
+
+  private handleStatus(): Response {
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+    return Response.json(this.sessionState);
+  }
+
+  private async handleProgress(request: Request): Promise<Response> {
+    const body = await request.json() as RemoteProgressEvent;
+    if (this.sessionState) {
+      this.sessionState.progressEvents.push(body);
+      if (this.sessionState.progressEvents.length > MAX_EVENTS) {
+        this.sessionState.progressEvents.shift();
+      }
+      this.broadcast(body);
+      await this.saveState();
+    }
+    return Response.json({ ok: true });
+  }
+
+  private async handleFinalize(request: Request): Promise<Response> {
+    const body = await request.json() as {
+      exitCode: number;
+      hasChanges: boolean;
+      errorLog?: string;
+    };
+
+    if (!this.sessionState) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    this.stopHeartbeat();
+
+    const { repo, branch, githubToken, prompt } = this.sessionState;
+
+    try {
+      if (body.exitCode === 0 && body.hasChanges) {
+        // Open PR
+        const base = await getDefaultBranch({ owner: repo.owner, repo: repo.name, token: githubToken! });
+        const pr = await createPullRequest({
+          owner: repo.owner,
+          repo: repo.name,
+          title: `kimiflare remote: ${prompt.slice(0, 80)}`,
+          body: `Automated changes from kimiflare remote session.\n\nPrompt: ${prompt}`,
+          head: branch,
+          base,
+          token: githubToken!,
+        });
+        this.sessionState.prUrl = pr.html_url;
+        this.sessionState.status = "done";
+      } else if (body.exitCode === 0 && !body.hasChanges) {
+        // Open issue with findings
+        const issue = await createIssue({
+          owner: repo.owner,
+          repo: repo.name,
+          title: `kimiflare remote findings: ${prompt.slice(0, 80)}`,
+          body: `No code changes were made.\n\nPrompt: ${prompt}`,
+          token: githubToken!,
+        });
+        this.sessionState.prUrl = issue.html_url;
+        this.sessionState.status = "done";
+      } else if (body.exitCode === 42) {
+        // Budget exhausted — open PR if changes exist, else issue
+        if (body.hasChanges) {
+          const base = await getDefaultBranch({ owner: repo.owner, repo: repo.name, token: githubToken! });
+          const pr = await createPullRequest({
+            owner: repo.owner,
+            repo: repo.name,
+            title: `kimiflare remote (budget exhausted): ${prompt.slice(0, 80)}`,
+            body: `Automated changes from kimiflare remote session.\n\nPrompt: ${prompt}\n\nNote: Token budget was exhausted before completion.`,
+            head: branch,
+            base,
+            token: githubToken!,
+          });
+          this.sessionState.prUrl = pr.html_url;
+        } else {
+          const issue = await createIssue({
+            owner: repo.owner,
+            repo: repo.name,
+            title: `kimiflare remote (budget exhausted): ${prompt.slice(0, 80)}`,
+            body: `No code changes were made. Token budget was exhausted.\n\nPrompt: ${prompt}`,
+            token: githubToken!,
+          });
+          this.sessionState.prUrl = issue.html_url;
+        }
+        this.sessionState.status = "done";
+      } else {
+        // Crash — open issue with error log
+        const issue = await createIssue({
+          owner: repo.owner,
+          repo: repo.name,
+          title: `kimiflare remote error: ${prompt.slice(0, 80)}`,
+          body: `The remote session encountered an error.\n\nPrompt: ${prompt}\n\n\`\`\`\n${body.errorLog ?? "Unknown error"}\n\`\`\``,
+          token: githubToken!,
+        });
+        this.sessionState.prUrl = issue.html_url;
+        this.sessionState.status = "error";
+        this.sessionState.errorMessage = body.errorLog ?? "Unknown error";
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.sessionState.status = "error";
+      this.sessionState.errorMessage = message;
+    }
+
+    this.sessionState.finishedAt = Date.now();
+    await this.saveState();
+    this.broadcast({ type: "done", prUrl: this.sessionState.prUrl });
+
+    // Cleanup
+    if (this.sessionState.sandboxId) {
+      try {
+        const sandbox = await this.env.SANDBOX.get(this.sessionState.sandboxId);
+        await sandbox.kill();
+      } catch {
+        // ignore
+      }
+    }
+    if (this.sessionState.artifactsRepo) {
+      try {
+        await this.env.ARTIFACTS.deleteRepo(this.sessionState.artifactsRepo.name);
+      } catch {
+        // ignore
+      }
+    }
+
+    return Response.json({ ok: true });
+  }
+
+  private async handleRelay(request: Request): Promise<Response> {
+    const body = await request.json() as {
+      url: string;
+      method?: string;
+      headers?: Record<string, string>;
+      body?: string;
+    };
+
+    const res = await fetch(body.url, {
+      method: body.method ?? "GET",
+      headers: body.headers,
+      body: body.body,
+    });
+
+    const resBody = await res.text();
+    return new Response(resBody, {
+      status: res.status,
+      headers: {
+        "Content-Type": res.headers.get("Content-Type") ?? "application/json",
+      },
+    });
+  }
+
+  private broadcast(event: RemoteProgressEvent): void {
+    const data = `data: ${JSON.stringify(event)}\n\n`;
+    for (const client of this.clients) {
+      try {
+        client.enqueue(data);
+      } catch {
+        // Client disconnected
+      }
+    }
+  }
+
+  private async saveState(): Promise<void> {
+    if (this.sessionState) {
+      await this.state.storage.put("state", this.sessionState);
+    }
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatInterval) return;
+    this.heartbeatInterval = setInterval(() => {
+      this.broadcast({ type: "heartbeat", timestamp: Date.now() });
+    }, 30000);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
+  async alarm(): Promise<void> {
+    // Emergency cleanup — session timed out
+    if (this.sessionState && this.sessionState.status === "running") {
+      this.sessionState.status = "error";
+      this.sessionState.errorMessage = "Session timed out";
+      this.sessionState.finishedAt = Date.now();
+      await this.saveState();
+      this.broadcast({ type: "error", message: "Session timed out" });
+
+      // Try to open issue
+      try {
+        const { repo, githubToken, prompt } = this.sessionState;
+        const issue = await createIssue({
+          owner: repo.owner,
+          repo: repo.name,
+          title: `kimiflare remote timeout: ${prompt.slice(0, 80)}`,
+          body: `The remote session timed out after ${this.sessionState.ttlMinutes} minutes.\n\nPrompt: ${prompt}`,
+          token: githubToken!,
+        });
+        this.sessionState.prUrl = issue.html_url;
+        await this.saveState();
+      } catch {
+        // ignore
+      }
+    }
+
+    // Cleanup sandbox and artifacts
+    if (this.sessionState?.sandboxId) {
+      try {
+        const sandbox = await this.env.SANDBOX.get(this.sessionState.sandboxId);
+        await sandbox.kill();
+      } catch {
+        // ignore
+      }
+    }
+    if (this.sessionState?.artifactsRepo) {
+      try {
+        await this.env.ARTIFACTS.deleteRepo(this.sessionState.artifactsRepo.name);
+      } catch {
+        // ignore
+      }
+    }
+
+    this.stopHeartbeat();
+  }
+}

--- a/remote/worker/src/types.ts
+++ b/remote/worker/src/types.ts
@@ -1,0 +1,57 @@
+export interface RemoteProgressEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface SessionState {
+  sessionId: string;
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
+  prompt: string;
+  repo: { owner: string; name: string };
+  branch: string;
+  artifactsRepo?: { name: string; url: string; writeToken: string };
+  sandboxId?: string;
+  githubToken?: string;
+  progressEvents: RemoteProgressEvent[];
+  prUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  maxTurns: number;
+  currentTurn: number;
+  accountId?: string;
+  apiToken?: string;
+  model?: string;
+  reasoningEffort?: string;
+  ttlMinutes: number;
+  tokensUsed?: number;
+  tokensBudget?: number;
+}
+
+export interface Env {
+  SESSION_DO: DurableObjectNamespace;
+  ARTIFACTS: ArtifactsBinding;
+  SANDBOX: SandboxBinding;
+  REMOTE_AUTH_SECRET: string;
+  CF_API_TOKEN: string;
+}
+
+// Cloudflare Artifacts binding (simplified — actual types may vary)
+export interface ArtifactsBinding {
+  createRepo(opts: { name: string }): Promise<{ name: string; url: string; writeToken: string; readToken: string }>;
+  deleteRepo(name: string): Promise<void>;
+}
+
+// Cloudflare Sandbox binding (simplified — actual types may vary)
+export interface SandboxBinding {
+  create(opts: { id: string; image: string; env?: Record<string, string> }): Promise<SandboxInstance>;
+  get(id: string): Promise<SandboxInstance>;
+}
+
+export interface SandboxInstance {
+  id: string;
+  exec(command: string, args?: string[], opts?: { env?: Record<string, string>; cwd?: string }): Promise<{ stdout: ReadableStream; stderr: ReadableStream }>;
+  kill(): Promise<void>;
+}

--- a/remote/worker/tsconfig.json
+++ b/remote/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/remote/worker/wrangler.toml
+++ b/remote/worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "kimiflare-remote"
+main = "src/index.ts"
+compatibility_date = "2025-02-14"
+
+[[durable_objects.bindings]]
+name = "SESSION_DO"
+class_name = "SessionDO"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["SessionDO"]
+
+[vars]
+# REMOTE_AUTH_SECRET and CF_API_TOKEN should be set via wrangler secret put

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -46,9 +46,15 @@ import {
   configPath,
   DEFAULT_MODEL,
   DEFAULT_REASONING_EFFORT,
+  loadConfig,
   saveConfig,
   type ReasoningEffort,
 } from "./config.js";
+import { startRemoteSession, streamRemoteProgress } from "./remote/worker-client.js";
+import { saveRemoteSession, type RemoteSession } from "./remote/session-store.js";
+import { deployForTui } from "./remote/tui-deploy.js";
+import { authGitHubForTui } from "./remote/tui-auth.js";
+import { RemoteDashboard, RemoteSessionDetail } from "./ui/remote-dashboard.js";
 import { nextMode, type Mode, isBlockedInPlanMode, isReadOnlyBash } from "./mode.js";
 import { classifyIntent } from "./intent/classify.js";
 import {
@@ -59,6 +65,7 @@ import {
   type SessionSummary,
 } from "./sessions.js";
 import { unlink } from "node:fs/promises";
+import { execSync } from "node:child_process";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
 import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
 import type { GatewayUsageLookup, DailyUsage } from "./usage-tracker.js";
@@ -303,6 +310,14 @@ interface Cfg {
   costAttribution?: boolean;
   filePicker?: boolean;
   theme?: string;
+  remoteWorkerUrl?: string;
+  remoteAuthSecret?: string;
+  remoteTtlMinutes?: number;
+  remoteMaxInputTokens?: number;
+  githubOAuthToken?: string;
+  githubRefreshToken?: string;
+  githubTokenExpiry?: number;
+  githubRepo?: string;
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
@@ -335,6 +350,29 @@ function openBrowser(url: string): void {
   const cmd = platform() === "darwin" ? "open" : platform() === "win32" ? "start" : "xdg-open";
   const child = spawn(cmd, [url], { detached: true, stdio: "ignore" });
   child.unref();
+}
+
+function detectGitHubRepo(cachedRepo?: string): { owner: string; name: string } | null {
+  if (cachedRepo) {
+    const parts = cachedRepo.split("/");
+    if (parts.length === 2) return { owner: parts[0]!, name: parts[1]! };
+  }
+  try {
+    const remoteUrl = execSync("git remote get-url origin", { cwd: process.cwd(), encoding: "utf8" }).trim();
+    const httpsMatch = remoteUrl.match(/github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?$/);
+    if (httpsMatch) return { owner: httpsMatch[1]!, name: httpsMatch[2]! };
+    const sshMatch = remoteUrl.match(/github\.com:([^\/]+)\/([^\/]+?)(?:\.git)?$/);
+    if (sshMatch) return { owner: sshMatch[1]!, name: sshMatch[2]! };
+  } catch {
+    // not a git repo or no origin remote
+  }
+  return null;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
 }
 
 interface PendingPermission {
@@ -485,6 +523,8 @@ function App({
   const [commandToDelete, setCommandToDelete] = useState<CustomCommand | null>(null);
   const [showCommandList, setShowCommandList] = useState(false);
   const [showLspWizard, setShowLspWizard] = useState(false);
+  const [showRemoteDashboard, setShowRemoteDashboard] = useState(false);
+  const [selectedRemoteSession, setSelectedRemoteSession] = useState<RemoteSession | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
   const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
@@ -2202,13 +2242,188 @@ function App({
         ]);
         return true;
       }
+      if (c === "/remote") {
+        if (arg === "status" || arg === "cancel") {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `Use \`kimiflare remote ${arg}\` from your shell.` },
+          ]);
+          return true;
+        }
+
+        const prompt = rest.join(" ").trim();
+        if (!prompt) {
+          setShowRemoteDashboard(true);
+          return true;
+        }
+
+        const repo = detectGitHubRepo(cfg?.githubRepo);
+        if (!repo) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: "Could not detect GitHub repo. Run from a repo with a GitHub remote, or set githubRepo in config." },
+          ]);
+          return true;
+        }
+
+        (async () => {
+          if (!cfg?.remoteWorkerUrl) {
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: "Remote infrastructure not deployed yet. Setting up now (~2 min)..." },
+            ]);
+
+            try {
+              for await (const step of deployForTui()) {
+                setEvents((e) => [
+                  ...e,
+                  { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
+                ]);
+                if (step.done) break;
+              }
+            } catch {
+              setEvents((e) => [
+                ...e,
+                { kind: "error", key: mkKey(), text: "Deploy failed. Fix the issue above and try /remote again." },
+              ]);
+              return;
+            }
+
+            const { loadConfig: reloadConfig } = await import("./config.js");
+            const newCfg = await reloadConfig();
+            if (newCfg) setCfg(newCfg);
+          }
+
+          const currentCfg = cfg ?? (await loadConfig());
+          if (!currentCfg?.remoteWorkerUrl) {
+            setEvents((e) => [
+              ...e,
+              { kind: "error", key: mkKey(), text: "Deploy seemed to succeed but config wasn't saved. Try again." },
+            ]);
+            return;
+          }
+
+          if (!currentCfg.githubOAuthToken) {
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: "GitHub not authenticated. Starting OAuth device flow..." },
+            ]);
+
+            try {
+              for await (const step of authGitHubForTui()) {
+                setEvents((e) => [
+                  ...e,
+                  { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
+                ]);
+                if (step.done) break;
+              }
+            } catch {
+              setEvents((e) => [
+                ...e,
+                { kind: "error", key: mkKey(), text: "GitHub auth failed. Try `kimiflare auth github` from shell." },
+              ]);
+              return;
+            }
+
+            const { loadConfig: reloadConfig } = await import("./config.js");
+            const newCfg = await reloadConfig();
+            if (newCfg) setCfg(newCfg);
+          }
+
+          const finalCfg = (await loadConfig()) ?? currentCfg;
+
+          const ttl = finalCfg.remoteTtlMinutes ?? 30;
+          const budget = finalCfg.remoteMaxInputTokens ?? 5_000_000;
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
+            { kind: "info", key: mkKey(), text: `Budget: ${formatTokens(budget)} tokens. TTL: ${ttl} min.` },
+          ]);
+
+          try {
+            const data = await startRemoteSession({
+              prompt,
+              repo,
+              cfg: finalCfg,
+              ttlMinutes: finalCfg.remoteTtlMinutes,
+              tokensBudget: finalCfg.remoteMaxInputTokens,
+            });
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: `Session started: ${data.sessionId}` },
+            ]);
+
+            for await (const ev of streamRemoteProgress(
+              finalCfg.remoteWorkerUrl!,
+              data.sessionId,
+              activeControllerRef.current?.signal,
+            )) {
+              const event = ev as Record<string, unknown>;
+              if (event.type === "text_delta") {
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: String(event.text ?? "") },
+                ]);
+              } else if (event.type === "tool_call") {
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: `→ ${String(event.name ?? "")}` },
+                ]);
+              } else if (event.type === "done") {
+                const prUrl = event.prUrl as string | undefined;
+                const tokensUsed = event.tokensUsed as number | undefined;
+                const tokensBudget = event.tokensBudget as number | undefined;
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: prUrl ? `Done — PR: ${prUrl}` : "Done" },
+                ]);
+                await saveRemoteSession({
+                  sessionId: data.sessionId,
+                  prompt,
+                  repo: `${repo.owner}/${repo.name}`,
+                  workerUrl: finalCfg.remoteWorkerUrl!,
+                  status: "done",
+                  prUrl,
+                  tokensUsed,
+                  tokensBudget,
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                });
+              } else if (event.type === "error") {
+                const message = String(event.message ?? "");
+                setEvents((e) => [
+                  ...e,
+                  { kind: "error", key: mkKey(), text: `Remote error: ${message}` },
+                ]);
+                await saveRemoteSession({
+                  sessionId: data.sessionId,
+                  prompt,
+                  repo: `${repo.owner}/${repo.name}`,
+                  workerUrl: finalCfg.remoteWorkerUrl!,
+                  status: "error",
+                  errorMessage: message,
+                  createdAt: new Date().toISOString(),
+                  updatedAt: new Date().toISOString(),
+                });
+              }
+            }
+          } catch (err) {
+            setEvents((e) => [
+              ...e,
+              { kind: "error", key: mkKey(), text: `Failed: ${err instanceof Error ? err.message : String(err)}` },
+            ]);
+          }
+        })();
+
+        return true;
+      }
       if (c === "/help") {
         setShowHelpMenu(true);
         return true;
       }
       return false;
     },
-    [cfg, exit, usage, effort, theme, mode, openResumePicker, runCompact, runInit, initMcp, setCfg],
+    [cfg, exit, usage, effort, theme, mode, openResumePicker, runCompact, runInit, initMcp, setCfg, setShowRemoteDashboard, setSelectedRemoteSession],
   );
 
   const handleHelpCommand = useCallback(
@@ -2730,6 +2945,43 @@ function App({
       <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <ResumePicker sessions={resumeSessions} onPick={handleResumePick} />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (showRemoteDashboard) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          {selectedRemoteSession ? (
+            <RemoteSessionDetail
+              session={selectedRemoteSession}
+              onBack={() => setSelectedRemoteSession(null)}
+              onCancel={async (session) => {
+                try {
+                  const { cancelRemoteSession } = await import("./remote/worker-client.js");
+                  await cancelRemoteSession(session.workerUrl, session.sessionId);
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "info", key: mkKey(), text: `Cancelled session ${session.sessionId}` },
+                  ]);
+                } catch (err) {
+                  setEvents((e) => [
+                    ...e,
+                    { kind: "error", key: mkKey(), text: `Failed to cancel: ${err instanceof Error ? err.message : String(err)}` },
+                  ]);
+                }
+                setSelectedRemoteSession(null);
+                setShowRemoteDashboard(false);
+              }}
+            />
+          ) : (
+            <RemoteDashboard
+              onSelect={(session) => setSelectedRemoteSession(session)}
+              onCancel={() => setShowRemoteDashboard(false)}
+            />
+          )}
         </Box>
       </ThemeProvider>
     );

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -27,6 +27,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "compact", description: "Summarize old turns to free context", source: "builtin" },
   { name: "clear", description: "Clear current conversation", source: "builtin" },
   { name: "init", description: "Scan repo and write KIMI.md", source: "builtin" },
+  { name: "remote", argHint: "<prompt>", description: "Run a remote session on Cloudflare", source: "builtin" },
   { name: "update", description: "Check for updates", source: "builtin" },
   { name: "hello", description: "Send a voice note to the creator", source: "builtin" },
   { name: "logout", description: "Clear stored credentials", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,22 @@ export interface KimiConfig {
   filePicker?: boolean;
   /** UI theme name. Default: everforest-dark. */
   theme?: string;
+  /** URL of the remote orchestrator Worker. */
+  remoteWorkerUrl?: string;
+  /** Shared secret for authenticating with the remote Worker. */
+  remoteAuthSecret?: string;
+  /** Configurable TTL for remote sessions in minutes (default: 30). */
+  remoteTtlMinutes?: number;
+  /** Max input token budget per remote job (default: 5_000_000). */
+  remoteMaxInputTokens?: number;
+  /** GitHub OAuth token for remote PR creation. */
+  githubOAuthToken?: string;
+  /** GitHub refresh token (if available). */
+  githubRefreshToken?: string;
+  /** GitHub token expiry timestamp. */
+  githubTokenExpiry?: number;
+  /** Default GitHub repo for remote sessions (owner/repo). */
+  githubRepo?: string;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import type { ChatMessage } from "./agent/messages.js";
 import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 import { getAppVersion } from "./util/version.js";
+import { createRemoteCommand } from "./remote/cli.js";
 
 const program = new Command();
 program
@@ -48,6 +49,28 @@ program
     const { runCostCommand } = await import("./cost-attribution/cli.js");
     await runCostCommand({ ...cmdOpts, config: cfg });
   });
+
+program.addCommand(createRemoteCommand());
+
+program
+  .command("auth")
+  .description("Authenticate with external services")
+  .addCommand(
+    new Command("github")
+      .description("Authenticate with GitHub via OAuth device flow")
+      .action(async () => {
+        const { authGitHubForTui } = await import("./remote/tui-auth.js");
+        for await (const step of authGitHubForTui()) {
+          console.log(step.message);
+          if (step.url && step.code) {
+            console.log(`\nOpen: ${step.url}`);
+            console.log(`Code: ${step.code}\n`);
+          }
+          if (step.done) break;
+          if (step.error) process.exit(1);
+        }
+      }),
+  );
 
 program.action(async () => {
   await main();

--- a/src/remote/cli.ts
+++ b/src/remote/cli.ts
@@ -1,0 +1,128 @@
+import { Command } from "commander";
+import { loadConfig, saveConfig } from "../config.js";
+import {
+  listRemoteSessions,
+  loadRemoteSession,
+  getMostRecentRemoteSession,
+} from "./session-store.js";
+import { runDeploy, checkDeployStatus } from "./deploy.js";
+
+export function createRemoteCommand(): Command {
+  const remote = new Command("remote").description("Manage remote sessions");
+
+  remote
+    .command("deploy")
+    .description("Deploy the remote Worker and container image to Cloudflare")
+    .action(async () => {
+      await runDeploy();
+    });
+
+  remote
+    .command("setup")
+    .description("Check remote deployment status and prerequisites")
+    .action(async () => {
+      const status = await checkDeployStatus();
+      console.log("Remote deployment status:\n");
+      console.log(`  wrangler CLI:    ${status.wrangler ? "yes" : "no"}`);
+      console.log(`  wrangler auth:   ${status.wranglerAuth ? "yes" : "no"}`);
+      console.log(`  Docker:          ${status.docker ? "yes" : "no"}`);
+      console.log(`  Worker URL:      ${status.workerUrl ?? "not deployed"}`);
+      console.log("\nRun `kimiflare remote deploy` to deploy.");
+    });
+
+  remote
+    .command("list")
+    .description("List remote sessions")
+    .action(async () => {
+      const sessions = await listRemoteSessions();
+      if (sessions.length === 0) {
+        console.log("No remote sessions found.");
+        return;
+      }
+      console.log(`Remote sessions (${sessions.length} total):\n`);
+      for (const s of sessions.slice(0, 20)) {
+        const date = new Date(s.createdAt).toLocaleString();
+        const statusIcon = s.status === "done" ? "✅" : s.status === "error" ? "❌" : s.status === "running" ? "⏳" : "⏹️";
+        console.log(`  ${statusIcon} ${s.sessionId.slice(0, 8)}…  ${s.status.padEnd(10)}  ${date}  ${s.prompt.slice(0, 50)}`);
+        if (s.prUrl) {
+          console.log(`     PR: ${s.prUrl}`);
+        }
+      }
+    });
+
+  remote
+    .command("status")
+    .description("Show remote session status")
+    .argument("[session-id]", "Session ID (defaults to most recent)")
+    .action(async (sessionId?: string) => {
+      const session = sessionId
+        ? await loadRemoteSession(sessionId)
+        : await getMostRecentRemoteSession();
+
+      if (!session) {
+        console.log(sessionId ? `Session ${sessionId} not found.` : "No remote sessions found.");
+        return;
+      }
+
+      const cfg = await loadConfig();
+      const workerUrl = cfg?.remoteWorkerUrl;
+      if (!workerUrl) {
+        console.log("Remote worker not configured.");
+        return;
+      }
+
+      try {
+        const res = await fetch(`${workerUrl}/remote/status/${session.sessionId}`, {
+          headers: {
+            Authorization: `Bearer ${cfg.remoteAuthSecret ?? ""}`,
+          },
+        });
+        if (!res.ok) {
+          console.log(`Failed to fetch status: ${res.status}`);
+          return;
+        }
+        const data = await res.json();
+        console.log(`Session: ${data.sessionId}`);
+        console.log(`Status:  ${data.status}`);
+        console.log(`Prompt:  ${data.prompt}`);
+        console.log(`Repo:    ${data.repo?.owner}/${data.repo?.name}`);
+        console.log(`Branch:  ${data.branch}`);
+        console.log(`Turns:   ${data.currentTurn} / ${data.maxTurns}`);
+        if (data.prUrl) console.log(`PR:      ${data.prUrl}`);
+        if (data.errorMessage) console.log(`Error:   ${data.errorMessage}`);
+      } catch (err) {
+        console.log(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  remote
+    .command("cancel")
+    .description("Cancel a remote session")
+    .argument("<session-id>", "Session ID")
+    .action(async (sessionId: string) => {
+      const cfg = await loadConfig();
+      const workerUrl = cfg?.remoteWorkerUrl;
+      if (!workerUrl) {
+        console.log("Remote worker not configured.");
+        return;
+      }
+
+      try {
+        const res = await fetch(`${workerUrl}/remote/cancel/${sessionId}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${cfg.remoteAuthSecret ?? ""}`,
+          },
+        });
+        if (!res.ok) {
+          console.log(`Failed to cancel: ${res.status}`);
+          return;
+        }
+        console.log(`Session ${sessionId} cancelled.`);
+      } catch (err) {
+        console.log(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  return remote;
+}

--- a/src/remote/deploy.ts
+++ b/src/remote/deploy.ts
@@ -1,0 +1,196 @@
+import { execSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
+import { loadConfig, saveConfig } from "../config.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REMOTE_DIR = join(__dirname, "..", "..", "..", "remote");
+const WORKER_DIR = join(REMOTE_DIR, "worker");
+
+function generateSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function runCapture(cmd: string, cwd?: string): string {
+  return execSync(cmd, { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+}
+
+export interface DeployStep {
+  message: string;
+  done?: boolean;
+  error?: boolean;
+}
+
+export async function* deployForTui(): AsyncGenerator<DeployStep, { workerUrl: string; authSecret: string }, void> {
+  yield { message: "Checking prerequisites..." };
+
+  try {
+    runCapture("wrangler --version");
+  } catch {
+    yield { message: "wrangler not found. Install: npm install -g wrangler", error: true };
+    yield { message: "Then run: wrangler login", error: true };
+    throw new Error("wrangler not installed");
+  }
+  yield { message: "wrangler OK" };
+
+  try {
+    runCapture("wrangler whoami");
+  } catch {
+    yield { message: "wrangler not authenticated. Run: wrangler login", error: true };
+    throw new Error("wrangler not authenticated");
+  }
+  yield { message: "wrangler authenticated" };
+
+  try {
+    runCapture("docker --version");
+  } catch {
+    yield { message: "Docker not found. Install: https://docs.docker.com/get-docker/", error: true };
+    throw new Error("docker not installed");
+  }
+  yield { message: "Docker OK" };
+
+  yield { message: "Building remote agent bundle..." };
+  try {
+    runCapture("npm run build:remote-agent", join(REMOTE_DIR, ".."));
+    yield { message: "Agent bundle built" };
+  } catch (err) {
+    yield { message: `Build failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  yield { message: "Deploying Worker to Cloudflare..." };
+  try {
+    runCapture("wrangler deploy", WORKER_DIR);
+    yield { message: "Worker deployed" };
+  } catch (err) {
+    yield { message: `Deploy failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  let workerUrl: string | undefined;
+  try {
+    const info = runCapture("wrangler info", WORKER_DIR);
+    const match = info.match(/https:\/\/[^\s]+\.workers\.dev/);
+    if (match) workerUrl = match[0];
+  } catch { /* ignore */ }
+
+  if (!workerUrl) {
+    yield { message: "Could not auto-detect Worker URL", error: true };
+    throw new Error("Worker URL not found");
+  }
+  yield { message: `Worker URL: ${workerUrl}` };
+
+  const authSecret = generateSecret();
+  const cfg = await loadConfig();
+  const cfToken = process.env.CF_API_TOKEN ?? cfg?.apiToken;
+
+  if (!cfToken) {
+    yield { message: "CF_API_TOKEN not found. Set CF_API_TOKEN env var or apiToken in config", error: true };
+    throw new Error("CF_API_TOKEN missing");
+  }
+
+  yield { message: "Setting Worker secrets..." };
+  try {
+    execSync(`wrangler secret put REMOTE_AUTH_SECRET`, {
+      cwd: WORKER_DIR,
+      input: authSecret,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    execSync(`wrangler secret put CF_API_TOKEN`, {
+      cwd: WORKER_DIR,
+      input: cfToken,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    yield { message: "Secrets set" };
+  } catch (err) {
+    yield { message: `Secret setup failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  const imageTag = "ghcr.io/sinameraji/kimiflare-remote-agent:latest";
+
+  yield { message: "Building container image..." };
+  try {
+    runCapture(`docker build -t ${imageTag} .`, REMOTE_DIR);
+    yield { message: "Image built" };
+  } catch (err) {
+    yield { message: `Image build failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    throw err;
+  }
+
+  yield { message: `Pushing ${imageTag}...` };
+  try {
+    runCapture(`docker push ${imageTag}`, REMOTE_DIR);
+    yield { message: "Image pushed" };
+  } catch (err) {
+    yield { message: `Push failed: ${err instanceof Error ? err.message : String(err)}`, error: true };
+    yield { message: "Make sure you're logged into ghcr.io: docker login ghcr.io -u USERNAME -p GITHUB_TOKEN", error: true };
+    throw err;
+  }
+
+  const nextCfg = {
+    ...(cfg ?? { accountId: "", apiToken: "", model: "@cf/moonshotai/kimi-k2.6" }),
+    remoteWorkerUrl: workerUrl,
+    remoteAuthSecret: authSecret,
+  };
+  await saveConfig(nextCfg);
+  yield { message: "Config saved" };
+
+  yield { message: "Remote infrastructure ready!", done: true };
+  return { workerUrl, authSecret };
+}
+
+export async function runDeploy(): Promise<void> {
+  console.log("kimiflare remote deploy\n");
+  try {
+    for await (const step of deployForTui()) {
+      console.log(step.message);
+      if (step.done) break;
+      if (step.error) process.exit(1);
+    }
+    console.log("\nDeploy complete!");
+  } catch (err) {
+    console.error(`Deploy failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+export async function checkDeployStatus(): Promise<{
+  wrangler: boolean;
+  wranglerAuth: boolean;
+  docker: boolean;
+  workerUrl?: string;
+}> {
+  let wrangler = false;
+  let wranglerAuth = false;
+  let docker = false;
+  let workerUrl: string | undefined;
+
+  try {
+    execSync("wrangler --version", { stdio: "pipe" });
+    wrangler = true;
+  } catch { /* ignore */ }
+
+  if (wrangler) {
+    try {
+      execSync("wrangler whoami", { stdio: "pipe" });
+      wranglerAuth = true;
+    } catch { /* ignore */ }
+  }
+
+  try {
+    execSync("docker --version", { stdio: "pipe" });
+    docker = true;
+  } catch { /* ignore */ }
+
+  const cfg = await loadConfig();
+  if (cfg?.remoteWorkerUrl) {
+    try {
+      const res = await fetch(`${cfg.remoteWorkerUrl}/health`, { signal: AbortSignal.timeout(5000) });
+      if (res.ok) workerUrl = cfg.remoteWorkerUrl;
+    } catch { /* ignore */ }
+  }
+
+  return { wrangler, wranglerAuth, docker, workerUrl };
+}

--- a/src/remote/session-store.ts
+++ b/src/remote/session-store.ts
@@ -1,0 +1,66 @@
+import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface RemoteSession {
+  sessionId: string;
+  prompt: string;
+  repo: string;
+  workerUrl: string;
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
+  branch?: string;
+  prUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt?: string;
+  errorMessage?: string;
+  tokensUsed?: number;
+  tokensBudget?: number;
+}
+
+function remoteDir(): string {
+  const xdg = process.env.XDG_DATA_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "remote");
+}
+
+export async function saveRemoteSession(session: RemoteSession): Promise<void> {
+  const dir = remoteDir();
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, `${session.sessionId}.json`);
+  await writeFile(path, JSON.stringify(session, null, 2) + "\n", "utf8");
+}
+
+export async function loadRemoteSession(sessionId: string): Promise<RemoteSession | null> {
+  try {
+    const path = join(remoteDir(), `${sessionId}.json`);
+    const raw = await readFile(path, "utf8");
+    return JSON.parse(raw) as RemoteSession;
+  } catch {
+    return null;
+  }
+}
+
+export async function listRemoteSessions(): Promise<RemoteSession[]> {
+  const dir = remoteDir();
+  try {
+    const files = await readdir(dir);
+    const sessions: RemoteSession[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const raw = await readFile(join(dir, file), "utf8");
+        sessions.push(JSON.parse(raw) as RemoteSession);
+      } catch {
+        // ignore corrupt files
+      }
+    }
+    return sessions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  } catch {
+    return [];
+  }
+}
+
+export async function getMostRecentRemoteSession(): Promise<RemoteSession | null> {
+  const sessions = await listRemoteSessions();
+  return sessions[0] ?? null;
+}

--- a/src/remote/tui-auth.ts
+++ b/src/remote/tui-auth.ts
@@ -1,0 +1,112 @@
+import { loadConfig, saveConfig } from "../config.js";
+
+const GITHUB_DEVICE_AUTH_URL = "https://github.com/login/device/code";
+const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const CLIENT_ID = process.env.KIMIFLARE_GITHUB_CLIENT_ID ?? "Ov23liM7lJX1xE2V1sVK";
+
+export interface AuthStep {
+  message: string;
+  url?: string;
+  code?: string;
+  done?: boolean;
+  error?: boolean;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function* authGitHubForTui(): AsyncGenerator<AuthStep, void, void> {
+  yield { message: "Starting GitHub OAuth device flow..." };
+
+  const deviceRes = await fetch(GITHUB_DEVICE_AUTH_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ client_id: CLIENT_ID, scope: "repo" }),
+  });
+
+  if (!deviceRes.ok) {
+    yield { message: `Failed to request device code: ${deviceRes.status}`, error: true };
+    throw new Error("Device code request failed");
+  }
+
+  const deviceData = await deviceRes.json() as {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    expires_in: number;
+    interval: number;
+  };
+
+  yield {
+    message: `Open ${deviceData.verification_uri} and enter code: ${deviceData.user_code}`,
+    url: deviceData.verification_uri,
+    code: deviceData.user_code,
+  };
+
+  const startTime = Date.now();
+  const expiresIn = deviceData.expires_in * 1000;
+  const interval = deviceData.interval * 1000;
+
+  while (Date.now() - startTime < expiresIn) {
+    await sleep(interval);
+
+    const tokenRes = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        device_code: deviceData.device_code,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+    });
+
+    if (!tokenRes.ok) continue;
+
+    const tokenData = await tokenRes.json() as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      error?: string;
+    };
+
+    if (tokenData.error === "authorization_pending") {
+      continue;
+    }
+    if (tokenData.error === "slow_down") {
+      await sleep(interval * 2);
+      continue;
+    }
+    if (tokenData.error) {
+      yield { message: `OAuth error: ${tokenData.error}`, error: true };
+      throw new Error(tokenData.error);
+    }
+
+    if (tokenData.access_token) {
+      const cfg = (await loadConfig()) ?? {
+        accountId: "",
+        apiToken: "",
+        model: "@cf/moonshotai/kimi-k2.6",
+      };
+
+      await saveConfig({
+        ...cfg,
+        githubOAuthToken: tokenData.access_token,
+        githubRefreshToken: tokenData.refresh_token,
+        githubTokenExpiry: tokenData.expires_in ? Date.now() + tokenData.expires_in * 1000 : undefined,
+      });
+
+      yield { message: "GitHub authentication successful!", done: true };
+      return;
+    }
+  }
+
+  yield { message: "Device flow expired. Please try again.", error: true };
+  throw new Error("Device flow expired");
+}

--- a/src/remote/tui-deploy.ts
+++ b/src/remote/tui-deploy.ts
@@ -1,0 +1,1 @@
+export { deployForTui, type DeployStep } from "./deploy.js";

--- a/src/remote/worker-client.ts
+++ b/src/remote/worker-client.ts
@@ -1,0 +1,128 @@
+import type { KimiConfig } from "../config.js";
+import { saveRemoteSession, type RemoteSession } from "./session-store.js";
+import { readSSE } from "../util/sse.js";
+
+export interface StartRemoteSessionOpts {
+  prompt: string;
+  repo: { owner: string; name: string };
+  cfg: KimiConfig;
+  ttlMinutes?: number;
+  tokensBudget?: number;
+}
+
+export async function startRemoteSession(opts: StartRemoteSessionOpts): Promise<{
+  sessionId: string;
+  streamUrl: string;
+}> {
+  const workerUrl = opts.cfg.remoteWorkerUrl;
+  if (!workerUrl) {
+    throw new Error("Remote worker URL not configured. Set remoteWorkerUrl in config.");
+  }
+
+  const githubToken = opts.cfg.githubOAuthToken;
+  if (!githubToken) {
+    throw new Error("GitHub token not found. Run `kimiflare auth github` first.");
+  }
+
+  const res = await fetch(`${workerUrl}/remote/start`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.cfg.remoteAuthSecret ?? ""}`,
+    },
+    body: JSON.stringify({
+      prompt: opts.prompt,
+      repo: opts.repo,
+      githubToken,
+      accountId: opts.cfg.accountId,
+      apiToken: opts.cfg.apiToken,
+      model: opts.cfg.model,
+      reasoningEffort: opts.cfg.reasoningEffort,
+      ttlMinutes: opts.ttlMinutes ?? opts.cfg.remoteTtlMinutes,
+      tokensBudget: opts.tokensBudget ?? opts.cfg.remoteMaxInputTokens,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to start remote session: ${res.status} ${text}`);
+  }
+
+  const data = await res.json() as { sessionId: string; streamUrl: string };
+
+  await saveRemoteSession({
+    sessionId: data.sessionId,
+    prompt: opts.prompt,
+    repo: `${opts.repo.owner}/${opts.repo.name}`,
+    workerUrl,
+    status: "running",
+    branch: `kimiflare/remote/${data.sessionId}`,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+
+  return data;
+}
+
+export async function* streamRemoteProgress(
+  workerUrl: string,
+  sessionId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<unknown, void, void> {
+  const res = await fetch(`${workerUrl}/remote/stream/${sessionId}`, { signal });
+  if (!res.ok) {
+    throw new Error(`Failed to connect to stream: ${res.status}`);
+  }
+
+  if (!res.body) {
+    throw new Error("No response body");
+  }
+
+  for await (const line of readSSE(res.body, signal)) {
+    try {
+      yield JSON.parse(line);
+    } catch {
+      // ignore malformed lines
+    }
+  }
+}
+
+export interface RemoteStatus {
+  sessionId: string;
+  status: "pending" | "running" | "paused" | "done" | "error" | "cancelled";
+  prompt: string;
+  repo: { owner: string; name: string };
+  branch: string;
+  prUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  maxTurns: number;
+  currentTurn: number;
+  tokensUsed?: number;
+  tokensBudget?: number;
+}
+
+export async function getRemoteStatus(workerUrl: string, sessionId: string, authSecret?: string): Promise<RemoteStatus> {
+  const res = await fetch(`${workerUrl}/remote/status/${sessionId}`, {
+    headers: authSecret ? { Authorization: `Bearer ${authSecret}` } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to get status: ${res.status} ${text}`);
+  }
+  return res.json() as Promise<RemoteStatus>;
+}
+
+export async function cancelRemoteSession(workerUrl: string, sessionId: string, authSecret?: string): Promise<void> {
+  const res = await fetch(`${workerUrl}/remote/cancel/${sessionId}`, {
+    method: "POST",
+    headers: authSecret ? { Authorization: `Bearer ${authSecret}` } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to cancel session: ${res.status} ${text}`);
+  }
+}

--- a/src/ui/remote-dashboard.tsx
+++ b/src/ui/remote-dashboard.tsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { useTheme } from "./theme-context.js";
+import type { RemoteSession } from "../remote/session-store.js";
+import { listRemoteSessions } from "../remote/session-store.js";
+import { getRemoteStatus, cancelRemoteSession } from "../remote/worker-client.js";
+
+interface Props {
+  onSelect?: (session: RemoteSession) => void;
+  onCancel?: () => void;
+}
+
+export function RemoteDashboard({ onSelect, onCancel }: Props) {
+  const theme = useTheme();
+  const [sessions, setSessions] = useState<RemoteSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    loadSessions();
+  }, []);
+
+  async function loadSessions() {
+    try {
+      setRefreshing(true);
+      const list = await listRemoteSessions();
+      // Refresh status for running/pending sessions from the worker
+      const updated = await Promise.all(
+        list.map(async (s) => {
+          if (s.status === "running" || s.status === "pending") {
+            try {
+              const status = await getRemoteStatus(s.workerUrl, s.sessionId);
+              return {
+                ...s,
+                status: status.status,
+                prUrl: status.prUrl ?? s.prUrl,
+                tokensUsed: status.tokensUsed ?? s.tokensUsed,
+                tokensBudget: status.tokensBudget ?? s.tokensBudget,
+                updatedAt: new Date().toISOString(),
+              };
+            } catch {
+              return s;
+            }
+          }
+          return s;
+        }),
+      );
+      setSessions(updated.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useInput((input, key) => {
+    if (input === "r" || input === "R") {
+      void loadSessions();
+    }
+    if (key.escape && onCancel) {
+      onCancel();
+    }
+  });
+
+  const items = sessions.map((s) => ({
+    label: formatSessionLine(s),
+    value: s.sessionId,
+  }));
+
+  if (loading) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.accent}>Loading remote sessions...</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.error}>Error: {error}</Text>
+        <Text dimColor>Press R to retry, Esc to close</Text>
+      </Box>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color={theme.accent}>No remote sessions yet.</Text>
+        <Text dimColor>Type /remote &lt;prompt&gt; to start one.</Text>
+        <Text dimColor>Press Esc to close</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color={theme.accent}>
+        Recent remote tasks {refreshing ? "(refreshing...)" : ""}
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => {
+            const session = sessions.find((s) => s.sessionId === item.value);
+            if (session) onSelect?.(session);
+          }}
+        />
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          ↑↓ navigate • Enter select • R refresh • Esc close
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function formatSessionLine(s: RemoteSession): string {
+  const icon =
+    s.status === "done"
+      ? "✅"
+      : s.status === "error"
+        ? "❌"
+        : s.status === "cancelled"
+          ? "⏹️"
+          : s.status === "running"
+            ? "⏳"
+            : "⏸";
+  const ago = formatAgo(new Date(s.updatedAt));
+  const prompt = s.prompt.slice(0, 30) + (s.prompt.length > 30 ? "…" : "");
+  const outcome = s.prUrl ? `PR ${s.prUrl.split("/").pop()}` : s.status;
+  const cost = s.tokensUsed && s.tokensBudget
+    ? ` (${formatTokens(s.tokensUsed)}/${formatTokens(s.tokensBudget)})`
+    : s.tokensUsed
+      ? ` (${formatTokens(s.tokensUsed)})`
+      : "";
+  return `${icon} ${prompt} → ${outcome}  ${ago}${cost}`;
+}
+
+function formatAgo(date: Date): string {
+  const ms = Date.now() - date.getTime();
+  const minutes = Math.floor(ms / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return "just now";
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function RemoteSessionDetail({
+  session,
+  onBack,
+  onCancel,
+}: {
+  session: RemoteSession;
+  onBack: () => void;
+  onCancel?: (session: RemoteSession) => void;
+}) {
+  const theme = useTheme();
+  const [cancelling, setCancelling] = useState(false);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onBack();
+    }
+    if ((input === "c" || input === "C") && onCancel && (session.status === "running" || session.status === "pending")) {
+      void handleCancel();
+    }
+  });
+
+  async function handleCancel() {
+    if (!onCancel) return;
+    setCancelling(true);
+    try {
+      await cancelRemoteSession(session.workerUrl, session.sessionId);
+      onCancel(session);
+    } catch {
+      // error handled by caller
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  const isRunning = session.status === "running" || session.status === "pending";
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color={theme.accent}>Remote Session</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Text>ID:      {session.sessionId}</Text>
+        <Text>Repo:    {session.repo}</Text>
+        <Text>Status:  {session.status}</Text>
+        <Text>Prompt:  {session.prompt}</Text>
+        {session.prUrl && <Text>PR:      {session.prUrl}</Text>}
+        {session.errorMessage && <Text color={theme.error}>Error:   {session.errorMessage}</Text>}
+        {session.tokensUsed !== undefined && (
+          <Text>Tokens:  {formatTokens(session.tokensUsed)}
+            {session.tokensBudget ? ` / ${formatTokens(session.tokensBudget)}` : ""}
+          </Text>
+        )}
+        <Text>Created: {new Date(session.createdAt).toLocaleString()}</Text>
+        {session.finishedAt && <Text>Finished: {new Date(session.finishedAt).toLocaleString()}</Text>}
+      </Box>
+      <Box marginTop={1} flexDirection="row" gap={2}>
+        {isRunning && onCancel && (
+          <Text color={theme.error}>
+            {cancelling ? "Cancelling..." : "[C] Cancel session"}
+          </Text>
+        )}
+        <Text dimColor>Esc back</Text>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
feat(remote): Phase 1 MVP — end-to-end /remote command

Implement the MVP for the /remote slash command:

- Cloudflare Worker with Durable Objects for session orchestration
- Sandbox container image with headless kimiflare agent
- GitHub OAuth device flow for authentication
- Auto-deploy wizard for Cloudflare infrastructure
- TUI dashboard for viewing and managing remote sessions
- SSE streaming of remote session progress
- Automatic PR/issue creation based on exit code

New files:
- remote/worker/ — Hono Worker + Session DO
- remote/agent/ — Headless agent entrypoint
- src/remote/ — Local client, deploy, auth, CLI
- src/ui/remote-dashboard.tsx — TUI session dashboard

Modified:
- src/config.ts — remote config fields
- src/commands/builtins.ts — add /remote command
- src/app.tsx — /remote handler with auto-deploy + auto-auth
- src/index.tsx — kimiflare remote CLI + kimiflare auth github
- package.json — build:remote-agent script

Co-authored-by: kimiflare <kimiflare@proton.me>