### PR TITLE
fix: scope /resume to current project directory

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1402,7 +1402,7 @@ function App({
   }, [cfg, busy, saveSessionSafe]);
 
   const openResumePicker = useCallback(async () => {
-    const sessions = await listSessions(200);
+    const sessions = await listSessions(200, process.cwd());
     setResumeSessions(sessions);
   }, []);
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -61,7 +61,7 @@ export async function pruneSessions(): Promise<number> {
   return pruneFiles(files, RETENTION.sessionMaxAgeDays, RETENTION.sessionMaxCount);
 }
 
-export async function listSessions(limit = 30): Promise<SessionSummary[]> {
+export async function listSessions(limit = 30, cwd?: string): Promise<SessionSummary[]> {
   const dir = sessionsDir();
   let entries: string[];
   try {
@@ -77,6 +77,7 @@ export async function listSessions(limit = 30): Promise<SessionSummary[]> {
     try {
       const [s, raw] = await Promise.all([stat(path), readFile(path, "utf8")]);
       const parsed = JSON.parse(raw) as SessionFile;
+      if (cwd && parsed.cwd !== cwd) continue;
       const firstUser = parsed.messages.find((m) => m.role === "user");
       const firstPrompt =
         typeof firstUser?.content === "string"


### PR DESCRIPTION
The `/resume` command was showing all past sessions across every project because `listSessions()` had no cwd filter.

**Changes:**
- Add an optional `cwd` parameter to `listSessions()` in `src/sessions.ts`
- Pass `process.cwd()` from `openResumePicker` in `src/app.tsx`

This ensures users only see sessions started in the current working directory when using `/resume`.

Co-authored-by: kimiflare <kimiflare@proton.me>