### PR TITLE
feat: add Zed Agent Panel (ACP) integration

### DIFF
--- a/acp/bin/kimiflare-acp.mjs
+++ b/acp/bin/kimiflare-acp.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/index.js";

--- a/acp/package-lock.json
+++ b/acp/package-lock.json
@@ -1,36 +1,29 @@
 {
-  "name": "kimiflare",
-  "version": "0.33.0",
+  "name": "kimiflare-acp",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kimiflare",
-      "version": "0.33.0",
+      "name": "kimiflare-acp",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.21.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.1.0",
         "diff": "^7.0.0",
         "fast-glob": "^3.3.2",
-        "ink": "^7.0.1",
-        "ink-select-input": "^6.2.0",
-        "ink-spinner": "^5.0.0",
-        "ink-text-input": "^6.0.0",
-        "isolated-vm": "^6.1.2",
-        "react": "^19.2.0",
-        "turndown": "^7.2.0",
-        "vscode-languageserver-protocol": "^3.17.5"
+        "turndown": "^7.2.0"
       },
       "bin": {
-        "kimiflare": "bin/kimiflare.mjs"
+        "kimiflare-acp": "bin/kimiflare-acp.mjs"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/diff": "^7.0.0",
         "@types/node": "^22.9.0",
-        "@types/react": "^19.2.0",
         "@types/turndown": "^5.0.5",
         "tsup": "^8.3.5",
         "tsx": "^4.19.2",
@@ -40,17 +33,13 @@
         "node": ">=20"
       }
     },
-    "node_modules/@alcalzone/ansi-tokenize": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
-      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
+      "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -628,9 +617,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -642,9 +631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -656,9 +645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -670,9 +659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -684,9 +673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -698,9 +687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -712,9 +701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -726,9 +715,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -740,9 +729,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -754,9 +743,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -768,9 +757,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
@@ -782,9 +771,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
@@ -796,9 +785,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
@@ -810,9 +799,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -824,9 +813,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -838,9 +827,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -852,9 +841,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -866,9 +855,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -880,9 +869,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -894,9 +883,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
       "cpu": [
         "x64"
       ],
@@ -908,9 +897,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -922,9 +911,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -936,9 +925,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -950,9 +939,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -964,9 +953,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -1011,16 +1000,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/turndown": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
@@ -1055,9 +1034,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1087,63 +1066,12 @@
         }
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1323,18 +1251,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1356,73 +1272,6 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
-    },
-    "node_modules/cli-boxes": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
-      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20 <19 || >=20.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz",
-      "integrity": "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==",
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^9.0.0",
-        "string-width": "^8.2.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/code-excerpt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
-      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
-      "license": "MIT",
-      "dependencies": {
-        "convert-to-spaces": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -1470,15 +1319,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/convert-to-spaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
-      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/cookie": {
@@ -1529,13 +1369,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1643,18 +1476,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1684,16 +1505,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1742,15 +1553,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1835,9 +1637,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
-      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -1875,9 +1677,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
+      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
       "funding": [
         {
           "type": "github",
@@ -1897,21 +1699,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -2011,18 +1798,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2130,9 +1905,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2194,18 +1969,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2217,117 +1980,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
-    },
-    "node_modules/ink": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-7.0.1.tgz",
-      "integrity": "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.3.0",
-        "ansi-escapes": "^7.3.0",
-        "ansi-styles": "^6.2.3",
-        "auto-bind": "^5.0.1",
-        "chalk": "^5.6.2",
-        "cli-boxes": "^4.0.1",
-        "cli-cursor": "^4.0.0",
-        "cli-truncate": "^6.0.0",
-        "code-excerpt": "^4.0.0",
-        "es-toolkit": "^1.45.1",
-        "indent-string": "^5.0.0",
-        "is-in-ci": "^2.0.0",
-        "patch-console": "^2.0.0",
-        "react-reconciler": "^0.33.0",
-        "scheduler": "^0.27.0",
-        "signal-exit": "^3.0.7",
-        "slice-ansi": "^9.0.0",
-        "stack-utils": "^2.0.6",
-        "string-width": "^8.2.0",
-        "terminal-size": "^4.0.1",
-        "type-fest": "^5.5.0",
-        "widest-line": "^6.0.0",
-        "wrap-ansi": "^10.0.0",
-        "ws": "^8.20.0",
-        "yoga-layout": "~3.2.1"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "@types/react": ">=19.2.0",
-        "react": ">=19.2.0",
-        "react-devtools-core": ">=6.1.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-devtools-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ink-select-input": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
-      "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "figures": "^6.1.0",
-        "to-rotated": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "ink": ">=5.0.0",
-        "react": ">=18.0.0"
-      }
-    },
-    "node_modules/ink-spinner": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
-      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
-      "license": "MIT",
-      "dependencies": {
-        "cli-spinners": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "peerDependencies": {
-        "ink": ">=4.0.0",
-        "react": ">=18.0.0"
-      }
-    },
-    "node_modules/ink-text-input": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
-      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "type-fest": "^4.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "ink": ">=5",
-        "react": ">=18"
-      }
-    },
-    "node_modules/ink-text-input/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -2356,21 +2008,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2381,21 +2018,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-in-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
-      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
-      "license": "MIT",
-      "bin": {
-        "is-in-ci": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -2413,41 +2035,16 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/isolated-vm": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
-      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2592,15 +2189,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -2675,26 +2263,15 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -2739,21 +2316,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2761,15 +2323,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/patch-console": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
-      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-key": {
@@ -3015,30 +2568,6 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-reconciler": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
-      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3096,22 +2625,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3123,9 +2636,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3139,31 +2652,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -3230,12 +2743,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3394,12 +2901,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -3445,22 +2946,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
-      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "is-fullwidth-code-point": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3469,18 +2954,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/statuses": {
@@ -3499,37 +2972,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3574,18 +3016,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -3612,18 +3042,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/terminal-size": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
-      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thenify": {
@@ -3714,18 +3132,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/to-rotated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
-      "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/toidentifier": {
@@ -3852,21 +3258,6 @@
         "npm": ">=9"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -3896,9 +3287,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3933,31 +3324,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3973,75 +3339,16 @@
         "node": ">= 8"
       }
     },
-    "node_modules/widest-line": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
-      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/yoga-layout": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
-      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
-      "license": "MIT"
-    },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/acp/package.json
+++ b/acp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "kimiflare-acp",
+  "version": "0.1.0",
+  "description": "ACP (Agent Client Protocol) wrapper for kimiflare — use kimiflare from Zed and other ACP-compatible editors",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "kimiflare-acp": "bin/kimiflare-acp.mjs"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/**/*.test.ts",
+    "dev": "tsx src/index.ts",
+    "start": "node bin/kimiflare-acp.mjs"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^0.21.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "better-sqlite3": "^12.9.0",
+    "commander": "^12.1.0",
+    "diff": "^7.0.0",
+    "fast-glob": "^3.3.2",
+    "turndown": "^7.2.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/diff": "^7.0.0",
+    "@types/node": "^22.9.0",
+    "@types/turndown": "^5.0.5",
+    "tsup": "^8.3.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/acp/src/agent.ts
+++ b/acp/src/agent.ts
@@ -1,0 +1,659 @@
+import type {
+  Agent,
+  AgentSideConnection,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  CancelNotification,
+  SetSessionModeRequest,
+  SetSessionModeResponse,
+  ListSessionsRequest,
+  ListSessionsResponse,
+  CloseSessionRequest,
+  CloseSessionResponse,
+  SessionModeState,
+  ContentBlock,
+} from "@agentclientprotocol/sdk";
+import { RequestError } from "@agentclientprotocol/sdk";
+import { randomUUID } from "node:crypto";
+
+import { loadConfig, DEFAULT_MODEL } from "#kimiflare/config.js";
+import { ToolExecutor, ALL_TOOLS } from "#kimiflare/tools/executor.js";
+import type {
+  PermissionRequest,
+  PermissionDecision,
+} from "#kimiflare/tools/executor.js";
+import { McpManager } from "#kimiflare/mcp/manager.js";
+import { runAgentTurn, BudgetExhaustedError } from "#kimiflare/agent/loop.js";
+import type { AgentCallbacks } from "#kimiflare/agent/loop.js";
+import { buildSystemPrompt } from "#kimiflare/agent/system-prompt.js";
+import type { ChatMessage, Usage } from "#kimiflare/agent/messages.js";
+import {
+  makeSessionId,
+  saveSession,
+  listSessions as kimiListSessions,
+} from "#kimiflare/sessions.js";
+import type { Mode } from "#kimiflare/mode.js";
+import { isBlockedInPlanMode, isReadOnlyBash } from "#kimiflare/mode.js";
+import type { Task } from "#kimiflare/tasks-state.js";
+
+import {
+  getSession,
+  setSession,
+  deleteSession,
+  type AcpSession,
+} from "./sessions.js";
+import {
+  toAcpToolCall,
+  toAcpToolUpdate,
+  permissionOptions,
+  fromAcpPermissionOutcome,
+} from "./tools.js";
+
+// ---------------------------------------------------------------------------
+// Permission mode resolution
+// ---------------------------------------------------------------------------
+
+const VALID_MODES = ["edit", "plan", "auto"] as const;
+type AcpMode = (typeof VALID_MODES)[number];
+
+const MODE_ALIASES: Record<string, AcpMode> = {
+  edit: "edit",
+  plan: "plan",
+  auto: "auto",
+  bypass: "auto",
+  bypasspermissions: "auto",
+  acceptedits: "auto",
+};
+
+function resolveDefaultMode(): AcpMode {
+  const raw = process.env.ACP_PERMISSION_MODE;
+  if (!raw) return "edit";
+  const normalized = raw.trim().toLowerCase();
+  const resolved = MODE_ALIASES[normalized];
+  if (!resolved) {
+    console.error(
+      `Unknown ACP_PERMISSION_MODE "${raw}", falling back to "edit"`,
+    );
+    return "edit";
+  }
+  return resolved;
+}
+
+const DEFAULT_ACP_MODE = resolveDefaultMode();
+
+const AVAILABLE_MODES: SessionModeState = {
+  currentModeId: DEFAULT_ACP_MODE,
+  availableModes: [
+    {
+      id: "edit",
+      name: "Edit",
+      description:
+        "Default mode — prompts for permission before mutating tools",
+    },
+    {
+      id: "plan",
+      name: "Plan",
+      description: "Read-only research — blocks writes/edits/mutating bash",
+    },
+    {
+      id: "auto",
+      name: "Auto",
+      description: "Autonomous — auto-approves every tool call (use with care)",
+    },
+  ],
+};
+
+export class KimiflareAcpAgent implements Agent {
+  private client: AgentSideConnection;
+
+  constructor(client: AgentSideConnection) {
+    this.client = client;
+  }
+
+  async initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return {
+      protocolVersion: 1,
+      agentInfo: { name: "kimiflare", version: "0.1.0" },
+      agentCapabilities: {
+        promptCapabilities: { image: true },
+        sessionCapabilities: {
+          close: {},
+          list: {},
+        },
+      },
+    };
+  }
+
+  async authenticate(): Promise<void> {
+    // kimiflare uses env vars / config file — no interactive auth needed
+  }
+
+  async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
+    const config = await loadConfig();
+    if (!config) {
+      throw RequestError.authRequired(
+        undefined,
+        "Cloudflare credentials not configured. Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN, or create ~/.config/kimiflare/config.json.",
+      );
+    }
+
+    const cwd = params.cwd;
+    const sessionId = makeSessionId("acp-session");
+    const executor = new ToolExecutor(ALL_TOOLS);
+    const mcpManager = new McpManager();
+
+    // Connect MCP servers from config
+    if (config.mcpServers) {
+      for (const [name, srv] of Object.entries(config.mcpServers)) {
+        if (srv.enabled === false) continue;
+        try {
+          if (srv.type === "remote" && srv.url) {
+            await mcpManager.addRemoteServer(name, srv.url, srv.headers);
+          } else if (srv.command) {
+            await mcpManager.addLocalServer(name, srv.command, srv.env);
+          } else {
+            // Fix #3: warn on malformed MCP server config
+            console.error(
+              `MCP server "${name}" has no command or url — skipping.`,
+            );
+          }
+        } catch (err) {
+          console.error(`Failed to connect MCP server "${name}":`, err);
+        }
+      }
+    }
+
+    // Connect MCP servers from ACP client
+    for (const srv of params.mcpServers ?? []) {
+      try {
+        if ("url" in srv) {
+          // HTTP or SSE transport
+          const headers: Record<string, string> = {};
+          if ("headers" in srv && Array.isArray(srv.headers)) {
+            for (const h of srv.headers) {
+              headers[h.name] = h.value;
+            }
+          }
+          await mcpManager.addRemoteServer(
+            srv.name,
+            srv.url,
+            Object.keys(headers).length > 0 ? headers : undefined,
+          );
+        } else {
+          // Stdio transport
+          const env: Record<string, string> = {};
+          if (Array.isArray(srv.env)) {
+            for (const e of srv.env) {
+              env[e.name] = e.value;
+            }
+          }
+          await mcpManager.addLocalServer(
+            srv.name,
+            [srv.command, ...srv.args],
+            Object.keys(env).length > 0 ? env : undefined,
+          );
+        }
+      } catch (err) {
+        console.error(`Failed to connect client MCP server:`, err);
+      }
+    }
+
+    // Register MCP tools with the executor
+    for (const tool of mcpManager.getAllTools()) {
+      executor.register(tool);
+    }
+
+    const allTools = executor.list();
+    const initialMode: AcpMode = VALID_MODES.includes(DEFAULT_ACP_MODE)
+      ? DEFAULT_ACP_MODE
+      : "edit";
+    const systemPrompt = buildSystemPrompt({
+      cwd,
+      tools: allTools,
+      model: config.model,
+      mode: initialMode,
+    });
+    const messages: ChatMessage[] = [{ role: "system", content: systemPrompt }];
+
+    const now = new Date().toISOString();
+    const session: AcpSession = {
+      id: sessionId,
+      cwd,
+      config,
+      executor,
+      mcpManager,
+      messages,
+      mode: initialMode,
+      abortController: new AbortController(),
+      promptRunning: false,
+      memoryManager: null,
+      createdAt: now,
+    };
+    setSession(sessionId, session);
+
+    return {
+      sessionId,
+      modes: { ...AVAILABLE_MODES },
+    };
+  }
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    const session = getSession(params.sessionId);
+    if (!session) {
+      throw RequestError.invalidParams(
+        undefined,
+        `Unknown session: ${params.sessionId}`,
+      );
+    }
+    // Note: promptRunning is not mutex-guarded. This is acceptable for
+    // stdio-based single-client usage but would need a lock for concurrent
+    // multi-session scenarios.
+    if (session.promptRunning) {
+      throw RequestError.invalidRequest(
+        undefined,
+        "A prompt is already running in this session",
+      );
+    }
+
+    session.promptRunning = true;
+    session.abortController = new AbortController();
+    const { signal } = session.abortController;
+
+    // Build user message from ACP ContentBlocks
+    const userContent = acpContentToKimi(params.prompt);
+    session.messages.push(userContent);
+
+    // Track cumulative usage for the response
+    let totalUsage: Usage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    };
+    let messageId = randomUUID();
+
+    // Track the current tool call ID so the permission callback can reference it
+    let currentToolCallId: string | undefined;
+
+    const callbacks: AgentCallbacks = {
+      onTextDelta: (text) => {
+        this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text },
+              messageId,
+            },
+          })
+          .catch(() => {});
+      },
+
+      onReasoningDelta: (text) => {
+        this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "agent_thought_chunk",
+              content: { type: "text", text },
+              messageId,
+            },
+          })
+          .catch(() => {});
+      },
+
+      onAssistantStart: () => {
+        messageId = randomUUID();
+      },
+
+      onToolCallFinalized: (tc) => {
+        // Stash the current tool call ID for the permission callback
+        currentToolCallId = tc.id;
+        this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "tool_call",
+              ...toAcpToolCall(tc),
+            },
+          })
+          .catch(() => {});
+      },
+
+      onToolResult: (result) => {
+        this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "tool_call_update",
+              ...toAcpToolUpdate(result),
+            },
+          })
+          .catch(() => {});
+      },
+
+      onTasks: (tasks: Task[]) => {
+        this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "plan",
+              entries: tasks.map((t) => ({
+                id: t.id,
+                content: t.title,
+                status: t.status as "pending" | "in_progress" | "completed",
+                priority: "medium" as const,
+              })),
+            },
+          })
+          .catch(() => {});
+      },
+
+      onUsage: (usage) => {
+        totalUsage = usage;
+      },
+
+      onUsageFinal: (usage) => {
+        totalUsage = usage;
+        this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "usage_update",
+              size: 262144,
+              used: usage.prompt_tokens + usage.completion_tokens,
+            },
+          })
+          .catch(() => {});
+      },
+
+      askPermission: async (
+        req: PermissionRequest,
+      ): Promise<PermissionDecision> => {
+        // Auto mode: allow everything
+        if (session.mode === "auto") return "allow";
+
+        // Plan mode: block mutating tools (except read-only bash)
+        if (session.mode === "plan" && isBlockedInPlanMode(req.tool.name)) {
+          if (req.tool.name === "bash") {
+            const cmd =
+              typeof req.args.command === "string" ? req.args.command : "";
+            if (isReadOnlyBash(cmd)) return "allow";
+          }
+          return "deny";
+        }
+
+        // Edit mode: ask the client for permission
+        if (!req.tool.needsPermission) return "allow";
+
+        try {
+          const toolCallForPerm = {
+            // Fix #9: use the actual tool call ID so Zed can match it to
+            // the previously-emitted tool_call notification
+            toolCallId: currentToolCallId ?? req.sessionKey,
+            title: req.tool.name,
+            status: "in_progress" as const,
+            rawInput: req.args,
+          };
+
+          const response = await this.client.requestPermission({
+            sessionId: session.id,
+            toolCall: toolCallForPerm,
+            options: permissionOptions(),
+          });
+
+          return fromAcpPermissionOutcome(response.outcome);
+        } catch {
+          return "deny";
+        }
+      },
+    };
+
+    const coauthor = session.config.coauthor
+      ? {
+          name: session.config.coauthorName ?? "kimiflare",
+          email: session.config.coauthorEmail ?? "kimiflare@proton.me",
+        }
+      : undefined;
+
+    let stopReason: "end_turn" | "cancelled" = "end_turn";
+
+    try {
+      await runAgentTurn({
+        accountId: session.config.accountId,
+        apiToken: session.config.apiToken,
+        model: session.config.model || DEFAULT_MODEL,
+        messages: session.messages,
+        tools: session.executor.list(),
+        executor: session.executor,
+        cwd: session.cwd,
+        signal,
+        callbacks,
+        reasoningEffort: session.config.reasoningEffort,
+        coauthor,
+        sessionId: session.id,
+        gateway: session.config.aiGatewayId
+          ? {
+              id: session.config.aiGatewayId,
+              cacheTtl: session.config.aiGatewayCacheTtl,
+              skipCache: session.config.aiGatewaySkipCache,
+              collectLogPayload: session.config.aiGatewayCollectLogPayload,
+              metadata: session.config.aiGatewayMetadata,
+            }
+          : undefined,
+        keepLastImageTurns: session.config.imageHistoryTurns,
+        memoryManager: session.memoryManager,
+        codeMode: session.config.codeMode,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        stopReason = "cancelled";
+      } else if (err instanceof BudgetExhaustedError) {
+        // Fix #2: notify the client that the budget was exhausted
+        await this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                type: "text",
+                text: "\n\n[Token budget exhausted. The session has reached its cumulative input token limit.]",
+              },
+              messageId,
+            },
+          })
+          .catch(() => {});
+        stopReason = "end_turn";
+      } else {
+        // Fix #4: send a user-visible error message before returning
+        const errMsg = err instanceof Error ? err.message : String(err);
+        await this.client
+          .sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: {
+                type: "text",
+                text: `\n\n[Error: ${errMsg}]`,
+              },
+              messageId,
+            },
+          })
+          .catch(() => {});
+        stopReason = "end_turn";
+      }
+    } finally {
+      session.promptRunning = false;
+      // Save session in the background
+      this.saveSessionState(session).catch(() => {});
+    }
+
+    return {
+      stopReason,
+      usage: {
+        inputTokens: totalUsage.prompt_tokens,
+        outputTokens: totalUsage.completion_tokens,
+        totalTokens: totalUsage.total_tokens,
+        cachedReadTokens: totalUsage.prompt_tokens_details?.cached_tokens ?? 0,
+        cachedWriteTokens: 0,
+      },
+    };
+  }
+
+  async cancel(params: CancelNotification): Promise<void> {
+    const session = getSession(params.sessionId);
+    if (session) {
+      session.abortController.abort();
+    }
+  }
+
+  async setSessionMode(
+    params: SetSessionModeRequest,
+  ): Promise<SetSessionModeResponse> {
+    const session = getSession(params.sessionId);
+    if (!session) {
+      throw RequestError.invalidParams(
+        undefined,
+        `Unknown session: ${params.sessionId}`,
+      );
+    }
+
+    const newMode = params.modeId as AcpMode;
+    if (!(VALID_MODES as readonly string[]).includes(newMode)) {
+      throw RequestError.invalidParams(
+        undefined,
+        `Unknown mode: ${params.modeId}`,
+      );
+    }
+
+    session.mode = newMode;
+    session.executor.clearSessionPermissions();
+
+    // Rebuild system prompt with the new mode
+    const allTools = session.executor.list();
+    const systemPrompt = buildSystemPrompt({
+      cwd: session.cwd,
+      tools: allTools,
+      model: session.config.model,
+      mode: newMode,
+    });
+
+    // Replace the system message(s) at the start
+    const firstNonSystem = session.messages.findIndex(
+      (m) => m.role !== "system",
+    );
+    const insertAt =
+      firstNonSystem === -1 ? session.messages.length : firstNonSystem;
+    session.messages.splice(0, insertAt, {
+      role: "system",
+      content: systemPrompt,
+    });
+
+    // Notify the client of the mode change
+    this.client
+      .sessionUpdate({
+        sessionId: session.id,
+        update: {
+          sessionUpdate: "current_mode_update",
+          currentModeId: newMode,
+        },
+      })
+      .catch(() => {});
+
+    return {};
+  }
+
+  async listSessions(
+    params: ListSessionsRequest,
+  ): Promise<ListSessionsResponse> {
+    const summaries = await kimiListSessions(30);
+    const cwd = params.cwd;
+    const filtered = cwd ? summaries.filter((s) => s.cwd === cwd) : summaries;
+    return {
+      sessions: filtered.map((s) => ({
+        sessionId: s.id,
+        cwd: s.cwd,
+        title: s.firstPrompt,
+        lastUpdateTime: s.updatedAt,
+      })),
+    };
+  }
+
+  async closeSession(
+    params: CloseSessionRequest,
+  ): Promise<CloseSessionResponse> {
+    const session = getSession(params.sessionId);
+    if (!session) return {};
+
+    // Cancel any in-progress work
+    session.abortController.abort();
+
+    // Save session with the original createdAt
+    await this.saveSessionState(session).catch(() => {});
+
+    // Disconnect MCP servers
+    await session.mcpManager.disconnectAll().catch(() => {});
+
+    deleteSession(params.sessionId);
+    return {};
+  }
+
+  // Fix #6 & #13: centralized save that preserves the original createdAt
+  private async saveSessionState(session: AcpSession): Promise<void> {
+    await saveSession({
+      id: session.id,
+      cwd: session.cwd,
+      model: session.config.model || DEFAULT_MODEL,
+      createdAt: session.createdAt,
+      updatedAt: new Date().toISOString(),
+      messages: session.messages,
+    });
+  }
+}
+
+/**
+ * Convert ACP ContentBlock[] prompt to a kimiflare ChatMessage.
+ */
+function acpContentToKimi(prompt: ContentBlock[]): ChatMessage {
+  if (prompt.length === 1 && prompt[0]!.type === "text") {
+    return { role: "user", content: prompt[0]!.text };
+  }
+
+  const parts = prompt
+    .map((block) => {
+      switch (block.type) {
+        case "text":
+          return { type: "text" as const, text: block.text };
+        case "image":
+          return {
+            type: "image_url" as const,
+            image_url: { url: block.data },
+          };
+        case "resource": {
+          // Embedded resources — extract text content
+          const res = block.resource;
+          if (res && "text" in res) {
+            const label = res.uri ? `[${res.uri}]\n` : "";
+            return { type: "text" as const, text: label + res.text };
+          }
+          return null;
+        }
+        case "resource_link":
+          return { type: "text" as const, text: `[resource: ${block.uri}]` };
+        default:
+          return null;
+      }
+    })
+    .filter((p): p is NonNullable<typeof p> => p !== null);
+
+  if (parts.length === 0) {
+    return { role: "user", content: "" };
+  }
+  if (parts.length === 1 && parts[0]!.type === "text") {
+    return { role: "user", content: parts[0]!.text };
+  }
+  return { role: "user", content: parts };
+}

--- a/acp/src/index.ts
+++ b/acp/src/index.ts
@@ -1,0 +1,79 @@
+import { Writable, Readable } from "node:stream";
+import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
+import { KimiflareAcpAgent } from "./agent.js";
+
+// stdout is used for ACP JSON-RPC messages — redirect console to stderr
+console.log = console.error;
+console.info = console.error;
+console.warn = console.error;
+console.debug = console.error;
+
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("Unhandled Rejection at:", promise, "reason:", reason);
+});
+
+function nodeToWebWritable(nodeStream: Writable): WritableStream<Uint8Array> {
+  return new WritableStream<Uint8Array>({
+    write(chunk) {
+      return new Promise<void>((resolve, reject) => {
+        nodeStream.write(Buffer.from(chunk), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  });
+}
+
+// Note: this eagerly enqueues without backpressure. Acceptable for a
+// stdio-based ACP connection where the client writes at human speed.
+function nodeToWebReadable(nodeStream: Readable): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      nodeStream.on("data", (chunk: Buffer) => {
+        controller.enqueue(new Uint8Array(chunk));
+      });
+      nodeStream.on("end", () => controller.close());
+      nodeStream.on("error", (err) => controller.error(err));
+    },
+  });
+}
+
+// Ensure stdin is flowing before creating the ReadableStream so that the
+// "data" listener attached inside start() receives events immediately.
+process.stdin.resume();
+
+const stream = ndJsonStream(
+  nodeToWebWritable(process.stdout),
+  nodeToWebReadable(process.stdin),
+);
+
+const connection = new AgentSideConnection(
+  (conn) => new KimiflareAcpAgent(conn),
+  stream,
+);
+
+let shuttingDown = false;
+
+async function shutdown() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  // Drain stdout before exiting so in-flight sessionUpdate notifications
+  // are not lost.
+  if (!process.stdout.writableEnded) {
+    await new Promise<void>((resolve) => {
+      if ((process.stdout as NodeJS.WriteStream).writableNeedDrain) {
+        process.stdout.once("drain", resolve);
+      } else {
+        resolve();
+      }
+    });
+  }
+  process.exit(0);
+}
+
+connection.closed.then(shutdown);
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/acp/src/integration.test.ts
+++ b/acp/src/integration.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+
+const BIN = join(import.meta.dirname, "..", "bin", "kimiflare-acp.mjs");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface AcpClient {
+  child: ChildProcess;
+  send: (msg: Record<string, unknown>) => void;
+  readResponse: (timeoutMs?: number) => Promise<Record<string, unknown>>;
+  readAll: (timeoutMs?: number) => Promise<Record<string, unknown>[]>;
+  kill: () => void;
+}
+
+function spawnAcpAgent(): AcpClient {
+  const child = spawn("node", [BIN], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      // Ensure no real credentials leak into tests unless the env already has them
+    },
+  });
+
+  let buffer = "";
+  const messageQueue: Record<string, unknown>[] = [];
+  let waitResolve: ((msg: Record<string, unknown>) => void) | null = null;
+
+  child.stdout!.setEncoding("utf8");
+  child.stdout!.on("data", (data: string) => {
+    buffer += data;
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const msg = JSON.parse(trimmed) as Record<string, unknown>;
+        if (waitResolve) {
+          const resolve = waitResolve;
+          waitResolve = null;
+          resolve(msg);
+        } else {
+          messageQueue.push(msg);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  });
+
+  return {
+    child,
+    send(msg) {
+      child.stdin!.write(JSON.stringify(msg) + "\n");
+    },
+    readResponse(timeoutMs = 5000): Promise<Record<string, unknown>> {
+      if (messageQueue.length > 0) {
+        return Promise.resolve(messageQueue.shift()!);
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          waitResolve = null;
+          reject(new Error("Timed out waiting for ACP response"));
+        }, timeoutMs);
+        waitResolve = (msg) => {
+          clearTimeout(timer);
+          resolve(msg);
+        };
+      });
+    },
+    async readAll(timeoutMs = 1000): Promise<Record<string, unknown>[]> {
+      // Read messages until timeout (for collecting notifications)
+      const messages: Record<string, unknown>[] = [];
+      while (true) {
+        try {
+          const msg = await this.readResponse(timeoutMs);
+          messages.push(msg);
+        } catch {
+          break;
+        }
+      }
+      return messages;
+    },
+    kill() {
+      child.kill("SIGTERM");
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ACP protocol integration", () => {
+  let client: AcpClient;
+
+  beforeEach(() => {
+    client = spawnAcpAgent();
+  });
+
+  afterEach(() => {
+    client.kill();
+  });
+
+  describe("initialize", () => {
+    it("returns a valid InitializeResponse", async () => {
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+
+      const resp = await client.readResponse();
+      assert.strictEqual(resp.jsonrpc, "2.0");
+      assert.strictEqual(resp.id, 1);
+
+      const result = resp.result as Record<string, unknown>;
+      assert.strictEqual(result.protocolVersion, 1);
+
+      const agentInfo = result.agentInfo as Record<string, unknown>;
+      assert.strictEqual(agentInfo.name, "kimiflare");
+
+      const caps = result.agentCapabilities as Record<string, unknown>;
+      const sessionCaps = caps.sessionCapabilities as Record<string, unknown>;
+      assert.deepStrictEqual(sessionCaps.close, {});
+      assert.deepStrictEqual(sessionCaps.list, {});
+
+      const promptCaps = caps.promptCapabilities as Record<string, unknown>;
+      assert.strictEqual(promptCaps.image, true);
+    });
+  });
+
+  describe("session/new without credentials", () => {
+    it("returns auth_required error when no credentials are configured", async () => {
+      // First initialize
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+      await client.readResponse();
+
+      // Override env to ensure no credentials
+      client.kill();
+      const noAuthClient = spawnAcpAgentNoAuth();
+      try {
+        noAuthClient.send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: 1,
+            clientCapabilities: {},
+            clientInfo: { name: "test", version: "0.1" },
+          },
+        });
+        await noAuthClient.readResponse();
+
+        noAuthClient.send({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "session/new",
+          params: {
+            cwd: "/tmp",
+            mcpServers: [],
+          },
+        });
+
+        const resp = await noAuthClient.readResponse();
+        assert.strictEqual(resp.jsonrpc, "2.0");
+        assert.strictEqual(resp.id, 2);
+
+        const error = resp.error as { code: number; message: string } | undefined;
+        if (error) {
+          // Auth required error — credentials are not configured
+          assert.ok(error.message.includes("credentials") || error.message.includes("Cloudflare"),
+            `Expected auth error, got: ${error.message}`);
+        } else {
+          // Credentials were present in env — session was created successfully
+          const result = resp.result as Record<string, unknown>;
+          assert.ok(typeof result.sessionId === "string");
+        }
+      } finally {
+        noAuthClient.kill();
+      }
+    });
+  });
+
+  describe("session lifecycle with credentials", () => {
+    it("creates a session, gets modes, and closes it", async () => {
+      // Initialize
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+      await client.readResponse();
+
+      // Create session
+      client.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/new",
+        params: {
+          cwd: "/tmp",
+          mcpServers: [],
+        },
+      });
+
+      const newResp = await client.readResponse();
+      if (newResp.error) {
+        // No credentials — skip the rest of this test
+        const error = newResp.error as { message: string };
+        assert.ok(
+          error.message.includes("credentials") || error.message.includes("Cloudflare"),
+          "Expected auth error when no credentials",
+        );
+        return;
+      }
+
+      const newResult = newResp.result as Record<string, unknown>;
+      const sessionId = newResult.sessionId as string;
+      assert.ok(typeof sessionId === "string" && sessionId.length > 0);
+
+      // Verify modes are returned
+      const modes = newResult.modes as Record<string, unknown>;
+      assert.strictEqual(modes.currentModeId, "edit");
+      const availableModes = modes.availableModes as Array<{ id: string }>;
+      const modeIds = availableModes.map((m) => m.id);
+      assert.deepStrictEqual(modeIds, ["edit", "plan", "auto"]);
+
+      // Set mode to plan
+      client.send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "session/setMode",
+        params: {
+          sessionId,
+          modeId: "plan",
+        },
+      });
+
+      // Read the response + any notifications
+      const modeMessages = await client.readAll(2000);
+      // Should have the setMode response and a current_mode_update notification
+      const modeResp = modeMessages.find((m) => m.id === 3);
+      assert.ok(modeResp, "Should receive setSessionMode response");
+      assert.ok(!modeResp!.error, "setSessionMode should not error");
+
+      // Check for current_mode_update notification
+      const modeNotification = modeMessages.find(
+        (m) => !m.id && (m.params as Record<string, unknown>)?.update,
+      );
+      if (modeNotification) {
+        const params = modeNotification.params as Record<string, unknown>;
+        const update = params.update as Record<string, unknown>;
+        assert.strictEqual(update.sessionUpdate, "current_mode_update");
+        assert.strictEqual(update.currentModeId, "plan");
+      }
+
+      // Close session
+      client.send({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "session/close",
+        params: { sessionId },
+      });
+
+      const closeResp = await client.readResponse();
+      assert.strictEqual(closeResp.id, 4);
+      assert.ok(!closeResp.error, "closeSession should not error");
+
+      // Trying to close again should not error (idempotent)
+      client.send({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "session/close",
+        params: { sessionId },
+      });
+
+      const closeResp2 = await client.readResponse();
+      assert.strictEqual(closeResp2.id, 5);
+      assert.ok(!closeResp2.error);
+    });
+  });
+
+  describe("cancel on unknown session", () => {
+    it("does not error on cancel for nonexistent session", async () => {
+      // Initialize
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+      await client.readResponse();
+
+      // Cancel is a notification (no id in JSON-RPC spec), but the SDK
+      // may handle it. Send and ensure no crash.
+      client.send({
+        jsonrpc: "2.0",
+        method: "session/cancel",
+        params: { sessionId: "nonexistent-session" },
+      });
+
+      // Give it a moment to process — if the agent crashes, the next
+      // request will fail
+      await new Promise((r) => setTimeout(r, 500));
+
+      // Verify agent is still alive by sending another request
+      client.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+
+      const resp = await client.readResponse();
+      assert.strictEqual(resp.id, 2);
+      assert.ok(resp.result);
+    });
+  });
+
+  describe("prompt on unknown session", () => {
+    it("returns an error for unknown session", async () => {
+      // Initialize
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+      await client.readResponse();
+
+      // Prompt with unknown session
+      client.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/prompt",
+        params: {
+          sessionId: "nonexistent",
+          prompt: [{ type: "text", text: "hello" }],
+        },
+      });
+
+      const resp = await client.readResponse();
+      assert.strictEqual(resp.id, 2);
+      assert.ok(resp.error, "Should return error for unknown session");
+      const error = resp.error as { message: string };
+      assert.ok(error.message.includes("Unknown session"));
+    });
+  });
+
+  describe("setMode on unknown session", () => {
+    it("returns an error", async () => {
+      // Initialize
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+      await client.readResponse();
+
+      client.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/setMode",
+        params: { sessionId: "nonexistent", modeId: "plan" },
+      });
+
+      const resp = await client.readResponse();
+      assert.strictEqual(resp.id, 2);
+      assert.ok(resp.error);
+    });
+  });
+
+  describe("setMode with invalid mode", () => {
+    it("returns an error for unknown mode ID", async () => {
+      // Initialize
+      client.send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: {},
+          clientInfo: { name: "test", version: "0.1" },
+        },
+      });
+      await client.readResponse();
+
+      // Create session
+      client.send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/new",
+        params: { cwd: "/tmp", mcpServers: [] },
+      });
+
+      const newResp = await client.readResponse();
+      if (newResp.error) return; // no credentials
+
+      const sessionId = (newResp.result as Record<string, unknown>).sessionId as string;
+
+      // Set invalid mode
+      client.send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "session/setMode",
+        params: { sessionId, modeId: "invalid_mode" },
+      });
+
+      const resp = await client.readResponse();
+      assert.strictEqual(resp.id, 3);
+      assert.ok(resp.error);
+      const error = resp.error as { message: string };
+      assert.ok(error.message.includes("Unknown mode"));
+    });
+  });
+
+  describe("multiple requests on same connection", () => {
+    it("handles sequential requests without crashing", async () => {
+      // Send multiple initialize requests (legal per JSON-RPC)
+      for (let i = 1; i <= 3; i++) {
+        client.send({
+          jsonrpc: "2.0",
+          id: i,
+          method: "initialize",
+          params: {
+            protocolVersion: 1,
+            clientCapabilities: {},
+            clientInfo: { name: "test", version: "0.1" },
+          },
+        });
+        const resp = await client.readResponse();
+        assert.strictEqual(resp.id, i);
+        assert.ok(resp.result);
+      }
+    });
+  });
+});
+
+// Helper to spawn without credentials
+function spawnAcpAgentNoAuth(): AcpClient {
+  const child = spawn("node", [BIN], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      // Strip Cloudflare credentials from env
+      ...Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([k]) =>
+            !k.startsWith("CLOUDFLARE_") &&
+            !k.startsWith("CF_") &&
+            k !== "KIMI_MODEL",
+        ),
+      ),
+      // Point config to a nonexistent path so loadConfig returns null
+      XDG_CONFIG_HOME: "/tmp/kimiflare-acp-test-no-config",
+    },
+  });
+
+  let buffer = "";
+  const messageQueue: Record<string, unknown>[] = [];
+  let waitResolve: ((msg: Record<string, unknown>) => void) | null = null;
+
+  child.stdout!.setEncoding("utf8");
+  child.stdout!.on("data", (data: string) => {
+    buffer += data;
+    const lines = buffer.split("\n");
+    buffer = lines.pop()!;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const msg = JSON.parse(trimmed) as Record<string, unknown>;
+        if (waitResolve) {
+          const resolve = waitResolve;
+          waitResolve = null;
+          resolve(msg);
+        } else {
+          messageQueue.push(msg);
+        }
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  return {
+    child,
+    send(msg) {
+      child.stdin!.write(JSON.stringify(msg) + "\n");
+    },
+    readResponse(timeoutMs = 5000): Promise<Record<string, unknown>> {
+      if (messageQueue.length > 0) {
+        return Promise.resolve(messageQueue.shift()!);
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          waitResolve = null;
+          reject(new Error("Timed out waiting for ACP response"));
+        }, timeoutMs);
+        waitResolve = (msg) => {
+          clearTimeout(timer);
+          resolve(msg);
+        };
+      });
+    },
+    async readAll(timeoutMs = 1000): Promise<Record<string, unknown>[]> {
+      const messages: Record<string, unknown>[] = [];
+      while (true) {
+        try {
+          const msg = await this.readResponse(timeoutMs);
+          messages.push(msg);
+        } catch {
+          break;
+        }
+      }
+      return messages;
+    },
+    kill() {
+      child.kill("SIGTERM");
+    },
+  };
+}

--- a/acp/src/sessions.test.ts
+++ b/acp/src/sessions.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+import { getSession, setSession, deleteSession, type AcpSession } from "./sessions.js";
+
+function makeStubSession(id: string, overrides?: Partial<AcpSession>): AcpSession {
+  return {
+    id,
+    cwd: "/tmp",
+    config: { accountId: "test", apiToken: "test", model: "test-model" } as AcpSession["config"],
+    executor: { list: () => [], clearSessionPermissions: () => {} } as unknown as AcpSession["executor"],
+    mcpManager: { disconnectAll: () => Promise.resolve() } as unknown as AcpSession["mcpManager"],
+    messages: [],
+    mode: "edit",
+    abortController: new AbortController(),
+    promptRunning: false,
+    memoryManager: null,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// The sessions module uses a module-level Map, so we need to clean up
+// between tests. Since we can't reset the module, we delete keys manually.
+function clearAllSessions() {
+  // Delete sessions by trying known IDs until none remain
+  for (let i = 0; i < 200; i++) {
+    deleteSession(`s-${i}`);
+  }
+  deleteSession("a");
+  deleteSession("b");
+  deleteSession("c");
+  deleteSession("test-session");
+}
+
+describe("sessions", () => {
+  beforeEach(() => {
+    clearAllSessions();
+  });
+
+  describe("getSession / setSession / deleteSession", () => {
+    it("stores and retrieves a session", () => {
+      const session = makeStubSession("test-session");
+      setSession("test-session", session);
+      const retrieved = getSession("test-session");
+      assert.strictEqual(retrieved, session);
+      assert.strictEqual(retrieved!.id, "test-session");
+    });
+
+    it("returns undefined for unknown session", () => {
+      assert.strictEqual(getSession("nonexistent"), undefined);
+    });
+
+    it("deletes a session", () => {
+      const session = makeStubSession("test-session");
+      setSession("test-session", session);
+      assert.strictEqual(deleteSession("test-session"), true);
+      assert.strictEqual(getSession("test-session"), undefined);
+    });
+
+    it("returns false when deleting nonexistent session", () => {
+      assert.strictEqual(deleteSession("nonexistent"), false);
+    });
+
+    it("overwrites an existing session with same ID", () => {
+      const s1 = makeStubSession("test-session", { cwd: "/a" });
+      const s2 = makeStubSession("test-session", { cwd: "/b" });
+      setSession("test-session", s1);
+      setSession("test-session", s2);
+      assert.strictEqual(getSession("test-session")!.cwd, "/b");
+    });
+  });
+
+  describe("MAX_SESSIONS eviction", () => {
+    it("evicts the oldest session when limit is reached", () => {
+      // Fill up to 64 sessions
+      for (let i = 0; i < 64; i++) {
+        setSession(`s-${i}`, makeStubSession(`s-${i}`));
+      }
+      // Verify all 64 exist
+      assert.notStrictEqual(getSession("s-0"), undefined);
+      assert.notStrictEqual(getSession("s-63"), undefined);
+
+      // Adding a 65th should evict s-0
+      setSession("s-64", makeStubSession("s-64"));
+      assert.strictEqual(getSession("s-0"), undefined);
+      assert.notStrictEqual(getSession("s-1"), undefined);
+      assert.notStrictEqual(getSession("s-64"), undefined);
+    });
+
+    it("does not evict when updating an existing session", () => {
+      for (let i = 0; i < 64; i++) {
+        setSession(`s-${i}`, makeStubSession(`s-${i}`));
+      }
+      // Update s-63 (existing key) — should not evict anything
+      setSession("s-63", makeStubSession("s-63", { cwd: "/updated" }));
+      assert.notStrictEqual(getSession("s-0"), undefined);
+      assert.strictEqual(getSession("s-63")!.cwd, "/updated");
+    });
+
+    it("aborts the evicted session's abort controller", () => {
+      for (let i = 0; i < 64; i++) {
+        setSession(`s-${i}`, makeStubSession(`s-${i}`));
+      }
+      const evicted = getSession("s-0")!;
+      assert.strictEqual(evicted.abortController.signal.aborted, false);
+
+      // Trigger eviction
+      setSession("s-64", makeStubSession("s-64"));
+      assert.strictEqual(evicted.abortController.signal.aborted, true);
+    });
+  });
+});

--- a/acp/src/sessions.ts
+++ b/acp/src/sessions.ts
@@ -1,0 +1,49 @@
+import type { KimiConfig } from "#kimiflare/config.js";
+import type { ToolExecutor } from "#kimiflare/tools/executor.js";
+import type { McpManager } from "#kimiflare/mcp/manager.js";
+import type { ChatMessage } from "#kimiflare/agent/messages.js";
+import type { Mode } from "#kimiflare/mode.js";
+import type { MemoryManager } from "#kimiflare/memory/manager.js";
+
+export interface AcpSession {
+  id: string;
+  cwd: string;
+  config: KimiConfig;
+  executor: ToolExecutor;
+  mcpManager: McpManager;
+  messages: ChatMessage[];
+  mode: Mode;
+  abortController: AbortController;
+  promptRunning: boolean;
+  memoryManager: MemoryManager | null;
+  createdAt: string;
+}
+
+const MAX_SESSIONS = 64;
+const sessions = new Map<string, AcpSession>();
+
+export function getSession(id: string): AcpSession | undefined {
+  return sessions.get(id);
+}
+
+export function setSession(id: string, session: AcpSession): void {
+  // Evict the oldest session if we've hit the limit
+  if (sessions.size >= MAX_SESSIONS && !sessions.has(id)) {
+    const oldest = sessions.keys().next().value;
+    if (oldest !== undefined) {
+      const stale = sessions.get(oldest);
+      sessions.delete(oldest);
+      if (stale) {
+        // Abort any in-progress work on the evicted session
+        stale.abortController.abort();
+        // Best-effort cleanup of MCP connections
+        stale.mcpManager.disconnectAll().catch(() => {});
+      }
+    }
+  }
+  sessions.set(id, session);
+}
+
+export function deleteSession(id: string): boolean {
+  return sessions.delete(id);
+}

--- a/acp/src/tools.test.ts
+++ b/acp/src/tools.test.ts
@@ -1,0 +1,352 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  toAcpToolCall,
+  toAcpToolUpdate,
+  permissionOptions,
+  fromAcpPermissionOutcome,
+} from "./tools.js";
+import type { ToolCall } from "#kimiflare/agent/messages.js";
+import type { ToolResult } from "#kimiflare/tools/executor.js";
+
+// ---------------------------------------------------------------------------
+// toAcpToolCall
+// ---------------------------------------------------------------------------
+
+describe("toAcpToolCall", () => {
+  it("maps a read tool call", () => {
+    const tc: ToolCall = {
+      id: "tc-1",
+      type: "function",
+      function: {
+        name: "read",
+        arguments: JSON.stringify({ path: "/tmp/foo.ts", offset: 10, limit: 20 }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.toolCallId, "tc-1");
+    assert.strictEqual(result.kind, "read");
+    assert.strictEqual(result.status, "in_progress");
+    assert.strictEqual(result.title, "Read /tmp/foo.ts (10-29)");
+    assert.deepStrictEqual(result.locations, [{ path: "/tmp/foo.ts", line: 10 }]);
+    assert.deepStrictEqual(result.content, []);
+  });
+
+  it("maps a read tool call with no offset/limit", () => {
+    const tc: ToolCall = {
+      id: "tc-2",
+      type: "function",
+      function: {
+        name: "read",
+        arguments: JSON.stringify({ path: "/tmp/bar.ts" }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.title, "Read /tmp/bar.ts");
+    assert.deepStrictEqual(result.locations, [{ path: "/tmp/bar.ts", line: 1 }]);
+  });
+
+  it("maps a write tool call with diff content", () => {
+    const tc: ToolCall = {
+      id: "tc-3",
+      type: "function",
+      function: {
+        name: "write",
+        arguments: JSON.stringify({ path: "/tmp/new.ts", content: "hello world" }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.kind, "edit");
+    assert.strictEqual(result.title, "Write /tmp/new.ts");
+    assert.strictEqual(result.content!.length, 1);
+    assert.strictEqual(result.content![0]!.type, "diff");
+    const diff = result.content![0] as { type: "diff"; path: string; oldText: null; newText: string };
+    assert.strictEqual(diff.oldText, null);
+    assert.strictEqual(diff.newText, "hello world");
+  });
+
+  it("maps an edit tool call with diff content", () => {
+    const tc: ToolCall = {
+      id: "tc-4",
+      type: "function",
+      function: {
+        name: "edit",
+        arguments: JSON.stringify({
+          path: "/tmp/file.ts",
+          old_string: "foo",
+          new_string: "bar",
+        }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.kind, "edit");
+    assert.strictEqual(result.title, "Edit /tmp/file.ts");
+    const diff = result.content![0] as { type: "diff"; oldText: string; newText: string };
+    assert.strictEqual(diff.oldText, "foo");
+    assert.strictEqual(diff.newText, "bar");
+  });
+
+  it("maps a bash tool call", () => {
+    const tc: ToolCall = {
+      id: "tc-5",
+      type: "function",
+      function: {
+        name: "bash",
+        arguments: JSON.stringify({ command: "cd /tmp && ls -la" }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.kind, "execute");
+    assert.strictEqual(result.title, "$ ls -la");
+  });
+
+  it("truncates bash title to 120 chars", () => {
+    const longCmd = "echo " + "x".repeat(200);
+    const tc: ToolCall = {
+      id: "tc-6",
+      type: "function",
+      function: { name: "bash", arguments: JSON.stringify({ command: longCmd }) },
+    };
+    const result = toAcpToolCall(tc);
+    assert.ok(result.title.length <= 120);
+  });
+
+  it("maps glob and grep to search kind", () => {
+    const glob: ToolCall = {
+      id: "tc-7",
+      type: "function",
+      function: { name: "glob", arguments: JSON.stringify({ pattern: "**/*.ts" }) },
+    };
+    assert.strictEqual(toAcpToolCall(glob).kind, "search");
+    assert.strictEqual(toAcpToolCall(glob).title, "Find **/*.ts");
+
+    const grep: ToolCall = {
+      id: "tc-8",
+      type: "function",
+      function: {
+        name: "grep",
+        arguments: JSON.stringify({ pattern: "TODO", path: "/src", case_insensitive: true }),
+      },
+    };
+    const grepResult = toAcpToolCall(grep);
+    assert.strictEqual(grepResult.kind, "search");
+    assert.ok(grepResult.title.includes("grep -i"));
+    assert.ok(grepResult.title.includes('"TODO"'));
+  });
+
+  it("truncates grep title to 120 chars", () => {
+    const longPattern = "x".repeat(200);
+    const tc: ToolCall = {
+      id: "tc-9",
+      type: "function",
+      function: { name: "grep", arguments: JSON.stringify({ pattern: longPattern }) },
+    };
+    const result = toAcpToolCall(tc);
+    assert.ok(result.title.length <= 120);
+  });
+
+  it("maps web_fetch to fetch kind", () => {
+    const tc: ToolCall = {
+      id: "tc-10",
+      type: "function",
+      function: {
+        name: "web_fetch",
+        arguments: JSON.stringify({ url: "https://example.com" }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.kind, "fetch");
+    assert.strictEqual(result.title, "GET https://example.com");
+  });
+
+  it("truncates web_fetch title to 120 chars", () => {
+    const longUrl = "https://example.com/" + "a".repeat(200);
+    const tc: ToolCall = {
+      id: "tc-11",
+      type: "function",
+      function: { name: "web_fetch", arguments: JSON.stringify({ url: longUrl }) },
+    };
+    const result = toAcpToolCall(tc);
+    assert.ok(result.title.length <= 120);
+  });
+
+  it("maps tasks_set to think kind", () => {
+    const tc: ToolCall = {
+      id: "tc-12",
+      type: "function",
+      function: {
+        name: "tasks_set",
+        arguments: JSON.stringify({ tasks: [{ id: "1", title: "a" }] }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.kind, "think");
+    assert.strictEqual(result.title, "Update tasks (1 items)");
+  });
+
+  it("maps unknown tools to other kind", () => {
+    const tc: ToolCall = {
+      id: "tc-13",
+      type: "function",
+      function: { name: "mcp_custom_tool", arguments: "{}" },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.kind, "other");
+    assert.strictEqual(result.title, "mcp_custom_tool");
+  });
+
+  it("handles malformed JSON arguments gracefully", () => {
+    const tc: ToolCall = {
+      id: "tc-14",
+      type: "function",
+      function: { name: "read", arguments: "not valid json{" },
+    };
+    // Should not throw
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.toolCallId, "tc-14");
+    assert.strictEqual(result.kind, "read");
+    // Falls back to generic title with no path
+    assert.strictEqual(result.title, "Read file");
+  });
+
+  it("handles empty arguments string", () => {
+    const tc: ToolCall = {
+      id: "tc-15",
+      type: "function",
+      function: { name: "bash", arguments: "" },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.title, "$ ");
+  });
+
+  it("includes rawInput in the result", () => {
+    const tc: ToolCall = {
+      id: "tc-16",
+      type: "function",
+      function: { name: "read", arguments: JSON.stringify({ path: "/x" }) },
+    };
+    const result = toAcpToolCall(tc);
+    assert.deepStrictEqual(result.rawInput, { path: "/x" });
+  });
+
+  it("maps edit with replace_all flag", () => {
+    const tc: ToolCall = {
+      id: "tc-17",
+      type: "function",
+      function: {
+        name: "edit",
+        arguments: JSON.stringify({
+          path: "/tmp/f.ts",
+          old_string: "a",
+          new_string: "b",
+          replace_all: true,
+        }),
+      },
+    };
+    const result = toAcpToolCall(tc);
+    assert.strictEqual(result.title, "Edit /tmp/f.ts (replace_all)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toAcpToolUpdate
+// ---------------------------------------------------------------------------
+
+describe("toAcpToolUpdate", () => {
+  it("maps a successful tool result", () => {
+    const result: ToolResult = {
+      tool_call_id: "tc-1",
+      name: "read",
+      content: "file contents here",
+      ok: true,
+    };
+    const update = toAcpToolUpdate(result);
+    assert.strictEqual(update.toolCallId, "tc-1");
+    assert.strictEqual(update.status, "completed");
+    assert.strictEqual(update.content!.length, 1);
+    assert.strictEqual(update.content![0]!.type, "content");
+    assert.strictEqual(update.rawOutput, "file contents here");
+  });
+
+  it("maps a failed tool result", () => {
+    const result: ToolResult = {
+      tool_call_id: "tc-2",
+      name: "bash",
+      content: "Error: command not found",
+      ok: false,
+    };
+    const update = toAcpToolUpdate(result);
+    assert.strictEqual(update.status, "failed");
+    assert.strictEqual(update.rawOutput, "Error: command not found");
+  });
+
+  it("handles empty content", () => {
+    const result: ToolResult = {
+      tool_call_id: "tc-3",
+      name: "write",
+      content: "",
+      ok: true,
+    };
+    const update = toAcpToolUpdate(result);
+    assert.strictEqual(update.status, "completed");
+    assert.strictEqual(update.content, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// permissionOptions
+// ---------------------------------------------------------------------------
+
+describe("permissionOptions", () => {
+  it("returns three options with correct kinds", () => {
+    const opts = permissionOptions();
+    assert.strictEqual(opts.length, 3);
+    assert.strictEqual(opts[0]!.kind, "allow_once");
+    assert.strictEqual(opts[1]!.kind, "allow_always");
+    assert.strictEqual(opts[2]!.kind, "reject_once");
+  });
+
+  it("has unique option IDs", () => {
+    const opts = permissionOptions();
+    const ids = opts.map((o) => o.optionId);
+    assert.strictEqual(new Set(ids).size, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fromAcpPermissionOutcome
+// ---------------------------------------------------------------------------
+
+describe("fromAcpPermissionOutcome", () => {
+  it("maps cancelled to deny", () => {
+    assert.strictEqual(fromAcpPermissionOutcome({ outcome: "cancelled" }), "deny");
+  });
+
+  it("maps allow_once to allow", () => {
+    assert.strictEqual(
+      fromAcpPermissionOutcome({ outcome: "selected", optionId: "allow_once" }),
+      "allow",
+    );
+  });
+
+  it("maps allow_session to allow_session", () => {
+    assert.strictEqual(
+      fromAcpPermissionOutcome({ outcome: "selected", optionId: "allow_session" }),
+      "allow_session",
+    );
+  });
+
+  it("maps deny to deny", () => {
+    assert.strictEqual(
+      fromAcpPermissionOutcome({ outcome: "selected", optionId: "deny" }),
+      "deny",
+    );
+  });
+
+  it("maps unknown optionId to deny", () => {
+    assert.strictEqual(
+      fromAcpPermissionOutcome({ outcome: "selected", optionId: "unknown_thing" }),
+      "deny",
+    );
+  });
+});

--- a/acp/src/tools.ts
+++ b/acp/src/tools.ts
@@ -1,0 +1,240 @@
+import type {
+  ToolCall as AcpToolCall,
+  ToolCallContent,
+  ToolCallUpdate,
+  ToolKind,
+  ToolCallLocation,
+} from "@agentclientprotocol/sdk";
+import type { ToolCall } from "#kimiflare/agent/messages.js";
+import type { ToolResult } from "#kimiflare/tools/executor.js";
+import type { ToolSpec } from "#kimiflare/tools/registry.js";
+
+/**
+ * Map a kimiflare tool name to an ACP ToolKind.
+ */
+function toolKind(name: string): ToolKind {
+  switch (name) {
+    case "read":
+      return "read";
+    case "write":
+    case "edit":
+      return "edit";
+    case "bash":
+      return "execute";
+    case "glob":
+    case "grep":
+      return "search";
+    case "web_fetch":
+      return "fetch";
+    case "tasks_set":
+    case "expand_artifact":
+      return "think";
+    default:
+      return "other";
+  }
+}
+
+/**
+ * Build a human-readable title for an ACP tool call from kimiflare's tool call.
+ */
+function toolTitle(name: string, args: Record<string, unknown>): string {
+  switch (name) {
+    case "read": {
+      const path = typeof args.path === "string" ? args.path : "file";
+      let label = `Read ${path}`;
+      if (typeof args.offset === "number" || typeof args.limit === "number") {
+        const from = typeof args.offset === "number" ? args.offset : 1;
+        const to =
+          typeof args.limit === "number" ? from + args.limit - 1 : undefined;
+        label += to !== undefined ? ` (${from}-${to})` : ` (from ${from})`;
+      }
+      return label;
+    }
+    case "write": {
+      const path = typeof args.path === "string" ? args.path : "file";
+      return `Write ${path}`;
+    }
+    case "edit": {
+      const path = typeof args.path === "string" ? args.path : "file";
+      return `Edit ${path}${args.replace_all ? " (replace_all)" : ""}`;
+    }
+    case "bash": {
+      let cmd = typeof args.command === "string" ? args.command.trim() : "";
+      // Strip leading cd + && to show the actual command
+      const m = cmd.match(/^cd\s+[^\s&;]+\s*(?:&&|;)\s*(.*)$/);
+      if (m) cmd = m[1]!.trim();
+      return `$ ${cmd}`.slice(0, 120);
+    }
+    case "glob": {
+      const pattern = typeof args.pattern === "string" ? args.pattern : "";
+      return `Find ${pattern}`;
+    }
+    case "grep": {
+      const pattern = typeof args.pattern === "string" ? args.pattern : "";
+      let label = "grep";
+      if (args.case_insensitive) label += " -i";
+      if (typeof args.glob === "string") label += ` --include="${args.glob}"`;
+      label += ` "${pattern}"`;
+      if (typeof args.path === "string") label += ` ${args.path}`;
+      return label.slice(0, 120);
+    }
+    case "web_fetch": {
+      const url = typeof args.url === "string" ? args.url : "";
+      return `GET ${url}`.slice(0, 120);
+    }
+    case "tasks_set":
+      return `Update tasks (${Array.isArray(args.tasks) ? args.tasks.length : 0} items)`;
+    case "expand_artifact":
+      return `Expand ${typeof args.artifact_id === "string" ? args.artifact_id : "artifact"}`;
+    default:
+      return name;
+  }
+}
+
+/**
+ * Extract file locations from a tool call's arguments for ACP "follow-along".
+ */
+function toolLocations(
+  name: string,
+  args: Record<string, unknown>,
+): ToolCallLocation[] {
+  const path = typeof args.path === "string" ? args.path : null;
+  if (!path) return [];
+  switch (name) {
+    case "read":
+      return [
+        { path, line: typeof args.offset === "number" ? args.offset : 1 },
+      ];
+    case "write":
+    case "edit":
+      return [{ path }];
+    case "glob":
+    case "grep":
+      return [{ path }];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Build the initial ACP ToolCallContent from a kimiflare tool call.
+ * For write/edit, we send diff content blocks. For everything else, empty.
+ */
+function toolContent(
+  name: string,
+  args: Record<string, unknown>,
+): ToolCallContent[] {
+  switch (name) {
+    case "write": {
+      const path = typeof args.path === "string" ? args.path : "";
+      const content = typeof args.content === "string" ? args.content : "";
+      return [
+        {
+          type: "diff",
+          path,
+          oldText: null,
+          newText: content,
+        },
+      ];
+    }
+    case "edit": {
+      const path = typeof args.path === "string" ? args.path : "";
+      const oldText =
+        typeof args.old_string === "string" ? args.old_string : "";
+      const newText =
+        typeof args.new_string === "string" ? args.new_string : "";
+      return [
+        {
+          type: "diff",
+          path,
+          oldText: oldText || null,
+          newText,
+        },
+      ];
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * Convert a finalized kimiflare ToolCall into an ACP tool_call SessionUpdate.
+ */
+export function toAcpToolCall(tc: ToolCall): AcpToolCall {
+  let args: Record<string, unknown> = {};
+  try {
+    args = JSON.parse(tc.function.arguments || "{}");
+  } catch {
+    console.error(
+      `Warning: malformed JSON arguments for tool "${tc.function.name}" (id: ${tc.id}), using empty args`,
+    );
+  }
+
+  return {
+    toolCallId: tc.id,
+    title: toolTitle(tc.function.name, args),
+    kind: toolKind(tc.function.name),
+    status: "in_progress",
+    content: toolContent(tc.function.name, args),
+    locations: toolLocations(tc.function.name, args),
+    rawInput: args,
+  };
+}
+
+/**
+ * Convert a kimiflare ToolResult into an ACP tool_call_update SessionUpdate.
+ */
+export function toAcpToolUpdate(result: ToolResult): ToolCallUpdate {
+  const content: ToolCallContent[] = [];
+
+  if (result.content) {
+    content.push({
+      type: "content",
+      content: { type: "text", text: result.content },
+    });
+  }
+
+  return {
+    toolCallId: result.tool_call_id,
+    status: result.ok ? "completed" : "failed",
+    content: content.length > 0 ? content : undefined,
+    rawOutput: result.content,
+  };
+}
+
+/**
+ * Map a kimiflare ToolSpec to an ACP PermissionOption set for requestPermission.
+ */
+export function permissionOptions(): Array<{
+  optionId: string;
+  name: string;
+  kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+}> {
+  return [
+    { optionId: "allow_once", name: "Allow once", kind: "allow_once" },
+    {
+      optionId: "allow_session",
+      name: "Allow for this session",
+      kind: "allow_always",
+    },
+    { optionId: "deny", name: "Deny", kind: "reject_once" },
+  ];
+}
+
+/**
+ * Convert an ACP permission outcome to a kimiflare PermissionDecision.
+ */
+export function fromAcpPermissionOutcome(
+  outcome: { outcome: "cancelled" } | { outcome: "selected"; optionId: string },
+): "allow" | "allow_session" | "deny" {
+  if (outcome.outcome === "cancelled") return "deny";
+  switch (outcome.optionId) {
+    case "allow_once":
+      return "allow";
+    case "allow_session":
+      return "allow_session";
+    case "deny":
+    default:
+      return "deny";
+  }
+}

--- a/acp/tsconfig.json
+++ b/acp/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "outDir": "dist",
+    "rootDir": "..",
+    "paths": {
+      "#kimiflare/*": ["../src/*"],
+    },
+    "skipLibCheck": true,
+  },
+  "include": ["src/**/*", "../src/**/*"],
+  "exclude": [
+    "../**/*.test.*",
+    "../src/index.tsx",
+    "../src/app.tsx",
+    "../src/ui/**",
+  ],
+}

--- a/acp/tsup.config.ts
+++ b/acp/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node20",
+  platform: "node",
+  clean: true,
+  sourcemap: true,
+  dts: false,
+  splitting: false,
+  shims: false,
+  minify: false,
+  banner: { js: "" },
+  external: [
+    "@agentclientprotocol/sdk",
+    "@modelcontextprotocol/sdk",
+    "better-sqlite3",
+    "fast-glob",
+    "diff",
+    "turndown",
+    "isolated-vm",
+    "vscode-languageserver-protocol",
+  ],
+});


### PR DESCRIPTION
Introduces the `acp/` sub-package for running Kimiflare inside Zed's Agent Control Protocol panels.

Includes:
- MCP-style tool routing
- Session management
- Bundled entrypoint (`bin/kimiflare-acp.mjs`)
- Tests for agent, sessions, tools, and integration