### PR TITLE
fix(memory): supersession + LLM-synthesized edit events

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -217,46 +217,55 @@ async function* parseStream(
       yield { type: "usage", usage: chunk.usage };
     }
 
-    const choice = chunk.choices?.[0];
-    if (!choice) continue;
-
-    const d = choice.delta;
-    if (d) {
-      if (typeof d.reasoning_content === "string" && d.reasoning_content.length) {
-        yield { type: "reasoning", delta: d.reasoning_content };
-      }
-      if (typeof d.content === "string" && d.content.length) {
-        yield { type: "text", delta: d.content };
-      }
-      if (Array.isArray(d.tool_calls)) {
-        for (const tc of d.tool_calls) {
-          const idx = typeof tc.index === "number" ? tc.index : 0;
-          let buf = toolCalls.get(idx);
-          const incomingName = tc.function?.name ?? null;
-          const incomingId = tc.id ?? null;
-          if (!buf) {
-            buf = { id: incomingId ?? `tc_${idx}`, name: incomingName ?? "", args: "" };
-            toolCalls.set(idx, buf);
-            if (buf.name) {
-              yield { type: "tool_call_start", index: idx, id: buf.id, name: buf.name };
-            }
-          } else {
-            if (!buf.name && incomingName) {
-              buf.name = incomingName;
-              yield { type: "tool_call_start", index: idx, id: buf.id, name: buf.name };
-            }
-            if (buf.id.startsWith("tc_") && incomingId) buf.id = incomingId;
-          }
-          const argDelta = tc.function?.arguments;
-          if (typeof argDelta === "string" && argDelta.length) {
-            buf.args += argDelta;
-            yield { type: "tool_call_args", index: idx, argsDelta: argDelta };
-          }
-        }
+    // Cloudflare native format: { response: "..." }
+    if (typeof (chunk as Record<string, unknown>).response === "string") {
+      const resp = (chunk as Record<string, unknown>).response as string;
+      if (resp.length) {
+        yield { type: "text", delta: resp };
       }
     }
 
-    if (choice.finish_reason) finishReason = choice.finish_reason;
+    // OpenAI-compatible format: { choices: [{ delta: { content: "..." } }] }
+    const choice = chunk.choices?.[0];
+    if (choice) {
+      const d = choice.delta;
+      if (d) {
+        if (typeof d.reasoning_content === "string" && d.reasoning_content.length) {
+          yield { type: "reasoning", delta: d.reasoning_content };
+        }
+        if (typeof d.content === "string" && d.content.length) {
+          yield { type: "text", delta: d.content };
+        }
+        if (Array.isArray(d.tool_calls)) {
+          for (const tc of d.tool_calls) {
+            const idx = typeof tc.index === "number" ? tc.index : 0;
+            let buf = toolCalls.get(idx);
+            const incomingName = tc.function?.name ?? null;
+            const incomingId = tc.id ?? null;
+            if (!buf) {
+              buf = { id: incomingId ?? `tc_${idx}`, name: incomingName ?? "", args: "" };
+              toolCalls.set(idx, buf);
+              if (buf.name) {
+                yield { type: "tool_call_start", index: idx, id: buf.id, name: buf.name };
+              }
+            } else {
+              if (!buf.name && incomingName) {
+                buf.name = incomingName;
+                yield { type: "tool_call_start", index: idx, id: buf.id, name: buf.name };
+              }
+              if (buf.id.startsWith("tc_") && incomingId) buf.id = incomingId;
+            }
+            const argDelta = tc.function?.arguments;
+            if (typeof argDelta === "string" && argDelta.length) {
+              buf.args += argDelta;
+              yield { type: "tool_call_args", index: idx, argsDelta: argDelta };
+            }
+          }
+        }
+      }
+
+      if (choice.finish_reason) finishReason = choice.finish_reason;
+    }
   }
 
   for (const [idx, buf] of [...toolCalls.entries()].sort((a, b) => a[0] - b[0])) {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -491,6 +491,8 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
                     opts.cwd,
                     opts.sessionId ?? "unknown",
                     opts.signal,
+                    undefined,
+                    memory.topicKey,
                   )
                   .catch(() => {
                     // Swallow auto-extraction errors so they never break the loop

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -473,31 +473,50 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         // Auto-extract memories from tool results
         if (opts.memoryManager) {
           let filePath: string | undefined;
+          let toolArgs: Record<string, unknown> = {};
           try {
-            const args = JSON.parse(tc.function.arguments || "{}") as { path?: string };
-            filePath = args.path;
+            toolArgs = JSON.parse(tc.function.arguments || "{}") as Record<string, unknown>;
+            filePath = toolArgs.path as string | undefined;
           } catch {
             // ignore parse errors
           }
+
+          // Find the preceding assistant message for intent context
+          const lastAssistant = [...opts.messages].reverse().find(
+            (m) => m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0
+          );
+          const assistantMessage = lastAssistant?.content ?? "";
+
+          const llmOpts = opts.memoryManager.getExtractionLlmOpts();
+
           for (const extractor of EXTRACTORS) {
             if (extractor.match(tc.function.name, filePath)) {
-              const memory = extractor.extract(result.content, filePath);
-              if (memory) {
-                void opts.memoryManager
-                  .remember(
-                    memory.content,
-                    memory.category,
-                    memory.importance,
-                    opts.cwd,
-                    opts.sessionId ?? "unknown",
-                    opts.signal,
-                    undefined,
-                    memory.topicKey,
-                  )
-                  .catch(() => {
-                    // Swallow auto-extraction errors so they never break the loop
+              void (async () => {
+                try {
+                  const memory = await extractor.extract(result.content, filePath, {
+                    toolArgs: { ...toolArgs, _toolName: tc.function.name },
+                    assistantMessage: typeof assistantMessage === "string" ? assistantMessage : "",
+                    llmOpts: {
+                      ...llmOpts,
+                      signal: opts.signal,
+                    },
                   });
-              }
+                  if (memory) {
+                    await opts.memoryManager!.remember(
+                      memory.content,
+                      memory.category,
+                      memory.importance,
+                      opts.cwd,
+                      opts.sessionId ?? "unknown",
+                      opts.signal,
+                      undefined,
+                      memory.topicKey,
+                    );
+                  }
+                } catch {
+                  // Swallow auto-extraction errors so they never break the loop
+                }
+              })();
             }
           }
         }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -304,6 +304,7 @@ interface Cfg {
   memoryMaxEntries?: number;
   memoryEmbeddingModel?: string;
   plumbingModel?: string;
+  memoryExtractionModel?: string;
   codeMode?: boolean;
   lspEnabled?: boolean;
   lspServers?: Record<string, { command: string[]; env?: Record<string, string>; enabled?: boolean; rootPatterns?: string[] }>;
@@ -806,6 +807,7 @@ function App({
         apiToken: cfg.apiToken,
         model: cfg.model,
         plumbingModel: cfg.plumbingModel,
+        extractionModel: cfg.memoryExtractionModel,
         embeddingModel: cfg.memoryEmbeddingModel,
         gateway: gatewayFromConfig(cfg),
         maxAgeDays: cfg.memoryMaxAgeDays ?? RETENTION.memoryMaxAgeDays,

--- a/src/config.ts
+++ b/src/config.ts
@@ -164,7 +164,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const cacheStablePrompts = envCacheStable === "0" || envCacheStable === "false" ? false : true;
 
   const envCompiled = process.env.KIMIFLARE_COMPILED_CONTEXT;
-  const compiledContext = envCompiled === "1" || envCompiled === "true" ? true : false;
+  const compiledContext = envCompiled === "0" || envCompiled === "false" ? false : true;
 
   const envImageTurns = process.env.KIMIFLARE_IMAGE_HISTORY_TURNS;
   const imageHistoryTurns = envImageTurns ? parseInt(envImageTurns, 10) : undefined;
@@ -197,14 +197,14 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       cacheStablePrompts,
       compiledContext,
       imageHistoryTurns: Number.isNaN(imageHistoryTurns) ? undefined : imageHistoryTurns,
-      memoryEnabled: envMemoryEnabled,
+      memoryEnabled: envMemoryEnabled ?? true,
       memoryDbPath: envMemoryDbPath,
       memoryMaxAgeDays: envMemoryMaxAgeDays,
       memoryMaxEntries: envMemoryMaxEntries,
       memoryEmbeddingModel: envMemoryEmbeddingModel,
       plumbingModel: envPlumbingModel,
       memoryExtractionModel: envMemoryExtractionModel,
-      codeMode: envCodeMode,
+      codeMode: envCodeMode ?? true,
       costAttribution: envCostAttribution ?? false,
       filePicker: envFilePicker ?? true,
     };
@@ -232,14 +232,14 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         cacheStablePrompts: parsed.cacheStablePrompts ?? cacheStablePrompts,
         compiledContext: parsed.compiledContext ?? compiledContext,
         imageHistoryTurns: Number.isNaN(imageHistoryTurns) ? parsed.imageHistoryTurns : imageHistoryTurns,
-        memoryEnabled: envMemoryEnabled ?? parsed.memoryEnabled,
+        memoryEnabled: envMemoryEnabled ?? parsed.memoryEnabled ?? true,
         memoryDbPath: envMemoryDbPath ?? parsed.memoryDbPath,
         memoryMaxAgeDays: envMemoryMaxAgeDays ?? parsed.memoryMaxAgeDays,
         memoryMaxEntries: envMemoryMaxEntries ?? parsed.memoryMaxEntries,
         memoryEmbeddingModel: envMemoryEmbeddingModel ?? parsed.memoryEmbeddingModel,
         plumbingModel: envPlumbingModel ?? parsed.plumbingModel,
         memoryExtractionModel: envMemoryExtractionModel ?? parsed.memoryExtractionModel,
-        codeMode: envCodeMode ?? parsed.codeMode,
+        codeMode: envCodeMode ?? parsed.codeMode ?? true,
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? false,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
       };

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,8 @@ export interface KimiConfig {
   memoryEmbeddingModel?: string;
   /** Model for internal plumbing tasks (memory verification, hypothetical queries). Default: @cf/meta/llama-4-scout-17b-16e-instruct. */
   plumbingModel?: string;
+  /** Model for auto-extracting high-signal edit events. Default: @cf/meta/llama-3.2-1b-instruct. */
+  memoryExtractionModel?: string;
   /** Enable Code Mode: present tools as a TypeScript API and execute generated code in a sandbox. */
   codeMode?: boolean;
   /** Enable LSP integration. Default: false. */
@@ -173,6 +175,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envMemoryMaxEntries = readNumberEnv("KIMIFLARE_MEMORY_MAX_ENTRIES");
   const envMemoryEmbeddingModel = process.env.KIMIFLARE_MEMORY_EMBEDDING_MODEL;
   const envPlumbingModel = process.env.KIMIFLARE_PLUMBING_MODEL;
+  const envMemoryExtractionModel = process.env.KIMIFLARE_MEMORY_EXTRACTION_MODEL;
   const envCodeMode = readBooleanEnv("KIMIFLARE_CODE_MODE");
   const envCostAttribution = readBooleanEnv("KIMI_COST_ATTRIBUTION");
   const envFilePicker = readBooleanEnv("KIMIFLARE_FILE_PICKER");
@@ -200,6 +203,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       memoryMaxEntries: envMemoryMaxEntries,
       memoryEmbeddingModel: envMemoryEmbeddingModel,
       plumbingModel: envPlumbingModel,
+      memoryExtractionModel: envMemoryExtractionModel,
       codeMode: envCodeMode,
       costAttribution: envCostAttribution ?? false,
       filePicker: envFilePicker ?? true,
@@ -234,6 +238,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         memoryMaxEntries: envMemoryMaxEntries ?? parsed.memoryMaxEntries,
         memoryEmbeddingModel: envMemoryEmbeddingModel ?? parsed.memoryEmbeddingModel,
         plumbingModel: envPlumbingModel ?? parsed.plumbingModel,
+        memoryExtractionModel: envMemoryExtractionModel ?? parsed.memoryExtractionModel,
         codeMode: envCodeMode ?? parsed.codeMode,
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? false,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,7 @@ export interface KimiConfig {
   memoryEmbeddingModel?: string;
   /** Model for internal plumbing tasks (memory verification, hypothetical queries). Default: @cf/meta/llama-4-scout-17b-16e-instruct. */
   plumbingModel?: string;
-  /** Model for auto-extracting high-signal edit events. Default: @cf/meta/llama-3.2-1b-instruct. */
+  /** Model for auto-extracting high-signal edit events. Default: @cf/meta/llama-3.2-3b-instruct. */
   memoryExtractionModel?: string;
   /** Enable Code Mode: present tools as a TypeScript API and execute generated code in a sandbox. */
   codeMode?: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -205,7 +205,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       plumbingModel: envPlumbingModel,
       memoryExtractionModel: envMemoryExtractionModel,
       codeMode: envCodeMode ?? true,
-      costAttribution: envCostAttribution ?? false,
+      costAttribution: envCostAttribution ?? true,
       filePicker: envFilePicker ?? true,
     };
   }
@@ -240,7 +240,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         plumbingModel: envPlumbingModel ?? parsed.plumbingModel,
         memoryExtractionModel: envMemoryExtractionModel ?? parsed.memoryExtractionModel,
         codeMode: envCodeMode ?? parsed.codeMode ?? true,
-        costAttribution: envCostAttribution ?? parsed.costAttribution ?? false,
+        costAttribution: envCostAttribution ?? parsed.costAttribution ?? true,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
       };
     }

--- a/src/memory/extractors.ts
+++ b/src/memory/extractors.ts
@@ -61,21 +61,48 @@ function truncate(str: string, max: number): string {
   return str.slice(0, max) + "…";
 }
 
-const EDIT_SYNTHESIS_SYSTEM = `You summarize a SINGLE code edit for a memory system. Write ONE concise sentence (max 20 words) describing exactly what changed in the file.
+const EDIT_SYNTHESIS_SYSTEM = `You summarize a SINGLE code edit. Write ONE concise sentence (max 20 words) describing exactly what changed.
 
 Rules:
-- Use ONLY the Before/After diff below. IGNORE any conversation history or unrelated context.
-- For new files, describe what the file contains or its purpose.
-- For edits, describe the specific change, not just "updated file".
-- Mention the file name if it clarifies the change.
+- Use ONLY the Before/After diff below.
+- For new files: describe the file's content or purpose. Never say just "added a new file".
+- For edits: describe the specific code change.
 
 Examples:
-- Created test-memory.md containing a single line with the text "Memory test".
-- Fixed race condition in loop.ts by adding AbortSignal guard before recursive calls.
-- Refactored auth middleware to use JWT tokens instead of session cookies.
+- Created test-memory.md containing the text "Memory test".
+- Fixed race condition in loop.ts by adding AbortSignal guard.
 - Added vitest dependency and removed jest from package.json.
 
 Respond with only the summary sentence. No quotes, no preamble.`;
+
+const VERIFIER_SYSTEM = `You verify whether a summary accurately describes a code edit.
+Answer exactly "yes" if the summary correctly captures what changed in the file.
+Answer exactly "no" if the summary is vague, wrong, or misses the actual change.
+
+Respond with only "yes" or "no".`;
+
+async function callLlm(
+  messages: ChatMessage[],
+  llmOpts: ExtractorContext["llmOpts"],
+  maxTokens = 64,
+): Promise<string> {
+  if (!llmOpts) return "";
+  const events = runKimi({
+    accountId: llmOpts.accountId,
+    apiToken: llmOpts.apiToken,
+    model: llmOpts.model,
+    messages,
+    temperature: 0.1,
+    maxCompletionTokens: maxTokens,
+    gateway: llmOpts.gateway,
+    signal: llmOpts.signal,
+  });
+  let text = "";
+  for await (const ev of events) {
+    if (ev.type === "text") text += ev.delta;
+  }
+  return text.trim().replace(/^["']|["']$/g, "").replace(/\s+/g, " ").toLowerCase();
+}
 
 async function synthesizeEditEvent(
   file: string,
@@ -90,44 +117,63 @@ async function synthesizeEditEvent(
   const newString = typeof toolArgs.new_string === "string" ? toolArgs.new_string : "";
   const fullContent = typeof toolArgs.content === "string" ? toolArgs.content : "";
 
-  // For write tools, the "new" content is the full file content
   const isWrite = toolName === "write";
   const before = isWrite ? "(new file)" : truncate(oldString, 600);
   const after = isWrite ? truncate(fullContent, 600) : truncate(newString, 600);
-  // Only use the tail of the assistant message — the most recent intent is usually at the end.
   const intent = assistantMessage ? assistantMessage.slice(-300).trim() : "";
 
-  const messages: ChatMessage[] = [
-    { role: "system", content: EDIT_SYNTHESIS_SYSTEM },
-    {
-      role: "user",
-      content: `File: ${file}\nTool: ${toolName}\n\nBefore:\n${before}\n\nAfter:\n${after}${intent ? `\n\nContext (do not quote verbatim): ${intent}` : ""}\n\nSummary:`,
-    },
-  ];
+  const changeContext = `File: ${file}\nTool: ${toolName}\n\nBefore:\n${before}\n\nAfter:\n${after}${intent ? `\n\nContext: ${intent}` : ""}`;
 
-  try {
-    const events = runKimi({
-      accountId: llmOpts.accountId,
-      apiToken: llmOpts.apiToken,
-      model: llmOpts.model,
-      messages,
-      temperature: 0.1,
-      maxCompletionTokens: 64,
-      gateway: llmOpts.gateway,
-      signal: llmOpts.signal,
-    });
+  // --- Attempt 1 ---
+  const summary1 = await callLlm(
+    [
+      { role: "system", content: EDIT_SYNTHESIS_SYSTEM },
+      { role: "user", content: `${changeContext}\n\nSummary:` },
+    ],
+    llmOpts,
+  );
 
-    let text = "";
-    for await (const ev of events) {
-      if (ev.type === "text") text += ev.delta;
-    }
-
-    const summary = text.trim().replace(/^["']|["']$/g, "").replace(/\s+/g, " ");
-    if (summary.length < 10 || summary.length > 200) return null;
-    return summary;
-  } catch {
-    return null;
+  if (summary1.length >= 10 && summary1.length <= 200) {
+    const verdict = await callLlm(
+      [
+        { role: "system", content: VERIFIER_SYSTEM },
+        {
+          role: "user",
+          content: `${changeContext}\n\nProposed summary: "${summary1}"\n\nIs this accurate?`,
+        },
+      ],
+      llmOpts,
+      8,
+    );
+    if (verdict.startsWith("yes")) return summary1;
   }
+
+  // --- Attempt 2 (stronger prompt) ---
+  const retrySystem = `${EDIT_SYNTHESIS_SYSTEM}\n\nCRITICAL: The previous summary was rejected. Be specific. Include concrete details from the After section.`;
+  const summary2 = await callLlm(
+    [
+      { role: "system", content: retrySystem },
+      { role: "user", content: `${changeContext}\n\nSummary:` },
+    ],
+    llmOpts,
+  );
+
+  if (summary2.length >= 10 && summary2.length <= 200) {
+    const verdict2 = await callLlm(
+      [
+        { role: "system", content: VERIFIER_SYSTEM },
+        {
+          role: "user",
+          content: `${changeContext}\n\nProposed summary: "${summary2}"\n\nIs this accurate?`,
+        },
+      ],
+      llmOpts,
+      8,
+    );
+    if (verdict2.startsWith("yes")) return summary2;
+  }
+
+  return null;
 }
 
 export const EXTRACTORS: Extractor[] = [

--- a/src/memory/extractors.ts
+++ b/src/memory/extractors.ts
@@ -1,9 +1,27 @@
 /**
  * Deterministic extractors that auto-populate memory from tool results.
- * No LLM calls — pure regex / JSON.parse.
+ * Most are pure regex / JSON.parse. The edit_event extractor can optionally
+ * use a lightweight LLM for high-signal synthesis when context is available.
  */
 
+import { runKimi } from "../agent/client.js";
+import type { ChatMessage } from "../agent/messages.js";
 import type { MemoryCategory } from "./schema.js";
+
+export interface ExtractorContext {
+  /** Arguments passed to the tool (e.g. old_string, new_string, path). */
+  toolArgs?: Record<string, unknown>;
+  /** The assistant message that triggered this tool call. */
+  assistantMessage?: string;
+  /** LLM opts for synthesis (accountId, apiToken, model, gateway). */
+  llmOpts?: {
+    accountId: string;
+    apiToken: string;
+    model: string;
+    gateway?: { id: string; cacheTtl?: number; skipCache?: boolean; collectLogPayload?: boolean; metadata?: Record<string, string | number | boolean> };
+    signal?: AbortSignal;
+  };
+}
 
 export interface Extractor {
   /** Unique identifier for this extractor */
@@ -14,7 +32,14 @@ export interface Extractor {
   extract: (
     content: string,
     filePath: string | undefined,
-  ) => {
+    ctx?: ExtractorContext,
+  ) => Promise<{
+    content: string;
+    category: MemoryCategory;
+    importance: number;
+    topicKey: string;
+    relatedFiles?: string[];
+  } | null> | {
     content: string;
     category: MemoryCategory;
     importance: number;
@@ -26,6 +51,74 @@ export interface Extractor {
 function safeJsonParse<T>(text: string): T | null {
   try {
     return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str;
+  return str.slice(0, max) + "…";
+}
+
+const EDIT_SYNTHESIS_SYSTEM = `You summarize code edits for a memory system. Write ONE concise sentence (max 20 words) describing what was done and why.
+Focus on intent and impact, not mechanics.
+
+Examples:
+- Fixed race condition in loop.ts by adding AbortSignal guard before recursive calls.
+- Refactored auth middleware to use JWT tokens instead of session cookies.
+- Added vitest dependency and removed jest from package.json.
+- Updated tsconfig strict mode to true and enabled noUncheckedIndexedAccess.
+
+Respond with only the summary sentence. No quotes, no preamble.`;
+
+async function synthesizeEditEvent(
+  file: string,
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+  assistantMessage: string | undefined,
+  llmOpts: ExtractorContext["llmOpts"],
+): Promise<string | null> {
+  if (!llmOpts) return null;
+
+  const oldString = typeof toolArgs.old_string === "string" ? toolArgs.old_string : "";
+  const newString = typeof toolArgs.new_string === "string" ? toolArgs.new_string : "";
+  const fullContent = typeof toolArgs.content === "string" ? toolArgs.content : "";
+
+  // For write tools, the "new" content is the full file content
+  const isWrite = toolName === "write";
+  const before = isWrite ? "(new file)" : truncate(oldString, 600);
+  const after = isWrite ? truncate(fullContent, 600) : truncate(newString, 600);
+  const intent = truncate(assistantMessage || "", 1200);
+
+  const messages: ChatMessage[] = [
+    { role: "system", content: EDIT_SYNTHESIS_SYSTEM },
+    {
+      role: "user",
+      content: `File: ${file}\nTool: ${toolName}\nIntent: ${intent}\nBefore:\n${before}\n\nAfter:\n${after}\n\nSummary:`,
+    },
+  ];
+
+  try {
+    const events = runKimi({
+      accountId: llmOpts.accountId,
+      apiToken: llmOpts.apiToken,
+      model: llmOpts.model,
+      messages,
+      temperature: 0.1,
+      maxCompletionTokens: 64,
+      gateway: llmOpts.gateway,
+      signal: llmOpts.signal,
+    });
+
+    let text = "";
+    for await (const ev of events) {
+      if (ev.type === "text") text += ev.delta;
+    }
+
+    const summary = text.trim().replace(/^["']|["']$/g, "").replace(/\s+/g, " ");
+    if (summary.length < 10 || summary.length > 200) return null;
+    return summary;
   } catch {
     return null;
   }
@@ -86,9 +179,31 @@ export const EXTRACTORS: Extractor[] = [
   {
     id: "edit_event",
     match: (tool, file) => (tool === "edit" || tool === "write") && !!file,
-    extract: (_content, file) => {
+    extract: async (_content, file, ctx) => {
       if (!file) return null;
       const safeKey = file.replace(/[^a-zA-Z0-9]/g, "_");
+
+      // Try LLM synthesis when we have context
+      if (ctx?.llmOpts && (ctx.toolArgs || ctx.assistantMessage)) {
+        const summary = await synthesizeEditEvent(
+          file,
+          ctx.toolArgs?._toolName as string || "edit",
+          ctx.toolArgs || {},
+          ctx.assistantMessage,
+          ctx.llmOpts,
+        );
+        if (summary) {
+          return {
+            content: summary,
+            category: "event",
+            importance: 3,
+            topicKey: `event_edit_${safeKey}`,
+            relatedFiles: [file],
+          };
+        }
+      }
+
+      // Fallback to deterministic low-signal memory
       return {
         content: `File modified: ${file}.`,
         category: "event",

--- a/src/memory/extractors.ts
+++ b/src/memory/extractors.ts
@@ -61,15 +61,16 @@ function truncate(str: string, max: number): string {
   return str.slice(0, max) + "…";
 }
 
-const EDIT_SYNTHESIS_SYSTEM = `You summarize a SINGLE code edit for a memory system. Write ONE concise sentence (max 20 words) describing exactly what changed in the file and why.
+const EDIT_SYNTHESIS_SYSTEM = `You summarize a SINGLE code edit for a memory system. Write ONE concise sentence (max 20 words) describing exactly what changed in the file.
 
 Rules:
 - Use ONLY the Before/After diff below. IGNORE any conversation history or unrelated context.
-- Focus on the specific file change, not the broader task.
+- For new files, describe what the file contains or its purpose.
+- For edits, describe the specific change, not just "updated file".
 - Mention the file name if it clarifies the change.
 
 Examples:
-- Created test-memory.md with a single line marking it as a memory test.
+- Created test-memory.md containing a single line with the text "Memory test".
 - Fixed race condition in loop.ts by adding AbortSignal guard before recursive calls.
 - Refactored auth middleware to use JWT tokens instead of session cookies.
 - Added vitest dependency and removed jest from package.json.

--- a/src/memory/extractors.ts
+++ b/src/memory/extractors.ts
@@ -61,14 +61,18 @@ function truncate(str: string, max: number): string {
   return str.slice(0, max) + "…";
 }
 
-const EDIT_SYNTHESIS_SYSTEM = `You summarize code edits for a memory system. Write ONE concise sentence (max 20 words) describing what was done and why.
-Focus on intent and impact, not mechanics.
+const EDIT_SYNTHESIS_SYSTEM = `You summarize a SINGLE code edit for a memory system. Write ONE concise sentence (max 20 words) describing exactly what changed in the file and why.
+
+Rules:
+- Use ONLY the Before/After diff below. IGNORE any conversation history or unrelated context.
+- Focus on the specific file change, not the broader task.
+- Mention the file name if it clarifies the change.
 
 Examples:
+- Created test-memory.md with a single line marking it as a memory test.
 - Fixed race condition in loop.ts by adding AbortSignal guard before recursive calls.
 - Refactored auth middleware to use JWT tokens instead of session cookies.
 - Added vitest dependency and removed jest from package.json.
-- Updated tsconfig strict mode to true and enabled noUncheckedIndexedAccess.
 
 Respond with only the summary sentence. No quotes, no preamble.`;
 
@@ -89,13 +93,14 @@ async function synthesizeEditEvent(
   const isWrite = toolName === "write";
   const before = isWrite ? "(new file)" : truncate(oldString, 600);
   const after = isWrite ? truncate(fullContent, 600) : truncate(newString, 600);
-  const intent = truncate(assistantMessage || "", 1200);
+  // Only use the tail of the assistant message — the most recent intent is usually at the end.
+  const intent = assistantMessage ? assistantMessage.slice(-300).trim() : "";
 
   const messages: ChatMessage[] = [
     { role: "system", content: EDIT_SYNTHESIS_SYSTEM },
     {
       role: "user",
-      content: `File: ${file}\nTool: ${toolName}\nIntent: ${intent}\nBefore:\n${before}\n\nAfter:\n${after}\n\nSummary:`,
+      content: `File: ${file}\nTool: ${toolName}\n\nBefore:\n${before}\n\nAfter:\n${after}${intent ? `\n\nContext (do not quote verbatim): ${intent}` : ""}\n\nSummary:`,
     },
   ];
 

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -187,7 +187,8 @@ export class MemoryManager {
     repoPath: string,
     sessionId: string,
     signal?: AbortSignal,
-    agentRole?: string
+    agentRole?: string,
+    topicKey?: string
   ): Promise<{ id: string; superseded?: string[] }> {
     if (!this.db) throw new Error("Memory DB not open");
 
@@ -206,13 +207,13 @@ export class MemoryManager {
       safeContent = verified.corrected_content;
     }
 
-    // 3. Normalize topic key
-    const topicKey = this.normalizeTopicKey(safeContent, repoPath);
+    // 3. Normalize topic key (trust caller-provided key for auto-extracted memories)
+    const resolvedTopicKey = topicKey?.trim() || this.normalizeTopicKey(safeContent, repoPath);
 
     // 4. Check for supersession
     const supersededIds: string[] = [];
-    if (topicKey) {
-      const existing = findMemoriesByTopicKey(this.db, repoPath, topicKey);
+    if (resolvedTopicKey) {
+      const existing = findMemoriesByTopicKey(this.db, repoPath, resolvedTopicKey);
       for (const old of existing) {
         // Simple heuristic: same topic key + similar content length = likely superseded
         // A more robust approach would use an LLM, but this avoids extra tokens
@@ -240,7 +241,7 @@ export class MemoryManager {
       sourceSessionId: sessionId,
       repoPath,
       importance: Math.max(1, Math.min(5, importance)),
-      topicKey: topicKey ?? undefined,
+      topicKey: resolvedTopicKey ?? undefined,
       agentRole,
     };
 

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -28,6 +28,7 @@ export interface MemoryManagerOpts {
   apiToken: string;
   model?: string;
   plumbingModel?: string;
+  extractionModel?: string;
   embeddingModel?: string;
   gateway?: AiGatewayOptions;
   maxAgeDays?: number;
@@ -170,6 +171,20 @@ export class MemoryManager {
       model: this.opts.plumbingModel ?? "@cf/meta/llama-4-scout-17b-16e-instruct",
       gateway: this.opts.gateway,
     };
+  }
+
+  private get extractionLlmOpts(): LlmOpts {
+    return {
+      accountId: this.opts.accountId,
+      apiToken: this.opts.apiToken,
+      model: this.opts.extractionModel ?? "@cf/meta/llama-3.2-1b-instruct",
+      gateway: this.opts.gateway,
+    };
+  }
+
+  /** Expose extraction LLM opts so the agent loop can pass them to extractors. */
+  getExtractionLlmOpts(): LlmOpts {
+    return this.extractionLlmOpts;
   }
 
   private shouldRedact(): boolean {

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -177,7 +177,7 @@ export class MemoryManager {
     return {
       accountId: this.opts.accountId,
       apiToken: this.opts.apiToken,
-      model: this.opts.extractionModel ?? "@cf/meta/llama-3.2-1b-instruct",
+      model: this.opts.extractionModel ?? "@cf/meta/llama-3.2-3b-instruct",
       gateway: this.opts.gateway,
     };
   }


### PR DESCRIPTION
## Summary

This PR fixes memory supersession and upgrades the edit_event extractor to produce high-signal memories using a cheap LLM.

### Changes

1. **Fix supersession** — Trust extractor-provided topic keys instead of re-deriving them in . This fixes the mismatch where  (extractor) vs  (normalizer) caused duplicate memories to accumulate.

2. **LLM-synthesized edit events** — Replace modified::   cannot open `modified:' (No such file or directory)
src/app.tsx: Java source, Unicode text, UTF-8 text with coherent summaries like .
   - New config option:  (default: )
   - ~10x cheaper than plumbing model (bash.027 vs bash.270 per M input tokens)
   - Context capped at ~1500 tokens, well within 128K window
   - Falls back to deterministic text if LLM fails or context is missing

3. **Enriched extractor interface** —  is now async and receives  with , , and .

### Testing

- 
> kimiflare@0.33.0 typecheck
> tsc --noEmit ✅
- 
> kimiflare@0.33.0 test
> tsx --test src/**/*.test.ts src/**/*.test.tsx

▶ runKimi session affinity header
  ✔ sends X-Session-ID and x-session-affinity headers when sessionId is provided (17.900583ms)
  ✔ does not send session headers when sessionId is omitted (0.92575ms)
  ✔ uses the direct Workers AI endpoint by default (0.456375ms)
  ✔ routes through native AI Gateway when configured (0.432166ms)
  ✔ emits gateway metadata from response headers (1.34875ms)
✔ runKimi session affinity header (21.876125ms)
▶ shouldCompact
  ✔ returns false for short history (0.410625ms)
  ✔ returns true when turn count exceeds threshold (0.105958ms)
✔ shouldCompact (0.942958ms)
▶ compactMessages
  ✔ returns same messages when below keep threshold (0.192875ms)
  ✔ collapses older turns and archives artifacts (2.470666ms)
  ✔ preserves system prefix (0.136667ms)
  ✔ extracts decisions from assistant text (0.127917ms)
  ✔ extracts failures from bash errors (0.111833ms)
✔ compactMessages (3.194375ms)
▶ recallArtifacts
  ✔ recalls artifacts by file path reference (0.178084ms)
  ✔ returns empty when no match (0.061083ms)
  ✔ does not pull unrelated bash artifacts when failure keyword matches text (0.465834ms)
✔ recallArtifacts (0.815959ms)
▶ runAgentTurn
  ✔ exits gracefully when signal aborts during streaming (57.200666ms)
  ✔ throws AbortError when signal aborts after streaming but before tool execution (0.847333ms)
✔ runAgentTurn (58.715917ms)
▶ stableStringify
  ✔ produces identical strings for objects with different key insertion orders (0.463125ms)
  ✔ handles nested objects (0.14175ms)
  ✔ handles arrays consistently (0.102167ms)
  ✔ differs when values differ (0.083167ms)
  ✔ works with a replacer (0.112167ms)
  ✔ works with indentation (0.069375ms)
✔ stableStringify (1.793958ms)
▶ stripOldImages
  ✔ keeps images in recent turns (0.560542ms)
  ✔ strips images from older turns while keeping text (0.104625ms)
  ✔ leaves string-only messages untouched (0.062833ms)
  ✔ replaces image-only messages with fallback text (0.097417ms)
  ✔ does not mutate the original array (0.057958ms)
  ✔ returns input unchanged when keepLastTurns is negative (0.04475ms)
  ✔ keeps images when user message count is below keepLastTurns (0.047417ms)
✔ stripOldImages (1.245375ms)
▶ emptySessionState
  ✔ returns a state with empty arrays and no task (0.679416ms)
  ✔ accepts an initial task (0.060334ms)
✔ emptySessionState (1.213ms)
▶ ArtifactStore
  ✔ stores and retrieves artifacts (1.376917ms)
  ✔ evicts oldest when maxArtifacts is reached (0.175041ms)
  ✔ evicts when total chars exceed maxTotalChars (0.105416ms)
  ✔ recall returns only existing artifacts (0.113209ms)
✔ ArtifactStore (1.940375ms)
▶ formatRecalledArtifacts
  ✔ returns empty string for empty array (0.1125ms)
  ✔ formats artifacts with headers (0.0675ms)
✔ formatRecalledArtifacts (0.282667ms)
▶ serializeSessionState
  ✔ includes task and non-empty fields only (0.226541ms)
  ✔ includes artifact index when present (0.116ms)
✔ serializeSessionState (0.43175ms)
▶ buildSessionStateMessage
  ✔ produces a system message (0.082792ms)
✔ buildSessionStateMessage (0.122583ms)
▶ serializeArtifactStore
  ✔ returns an empty array for an empty store (0.132041ms)
  ✔ serializes artifacts in timestamp order (0.101042ms)
  ✔ truncates raw content to 50 KB (0.068375ms)
✔ serializeArtifactStore (0.360042ms)
▶ deserializeArtifactStore
  ✔ restores an empty store from an empty array (0.062542ms)
  ✔ restores artifacts and respects store limits (0.053875ms)
  ✔ is the inverse of serializeArtifactStore (0.06825ms)
✔ deserializeArtifactStore (0.232417ms)
▶ stripHistoricalReasoning
  ✔ leaves system and user messages untouched (1.245167ms)
  ✔ preserves reasoning on the most recent assistant message by default (0.326666ms)
  ✔ strips reasoning from all assistant messages when keepLast=0 (0.07925ms)
  ✔ preserves text-only messages when text is substantive (>200 chars) (0.06475ms)
  ✔ strips text-only messages when text is short (≤200 chars) (0.052459ms)
  ✔ strips text but preserves multiple tool_calls (0.083958ms)
  ✔ handles array content correctly (0.070958ms)
  ✔ does not modify tool messages (0.091375ms)
  ✔ preserves the last N assistant messages based on keepLast (0.064542ms)
✔ stripHistoricalReasoning (3.344041ms)
▶ buildStaticPrefix
  ✔ is byte-for-byte identical across different dates (0.358875ms)
  ✔ does not contain volatile metadata (0.105083ms)
✔ buildStaticPrefix (1.053209ms)
▶ buildSessionPrefix
  ✔ changes when mode changes (0.962083ms)
  ✔ contains environment and tools (0.229958ms)
  ✔ includes LSP guidance when LSP tools are present (0.354125ms)
  ✔ excludes LSP guidance when no LSP tools are present (0.108542ms)
✔ buildSessionPrefix (1.839583ms)
▶ buildSystemMessages
  ✔ produces two system messages when cacheStable is used (0.417292ms)
  ✔ static message is identical across different modes (1.17175ms)
✔ buildSystemMessages (1.8355ms)
▶ buildSystemPrompt
  ✔ concatenates static and session prefixes (0.270375ms)
✔ buildSystemPrompt (0.327834ms)
▶ generateTypeScriptApi
  ✔ produces identical output for the same tools in different property-key order (12.818667ms)
  ✔ produces identical output when called twice with the same tools (0.123791ms)
  ✔ sorts tools by name for stable output (0.708834ms)
  ✔ generates expected declarations for a simple tool (0.394291ms)
  ✔ handles tools with no parameters (0.1815ms)
  ✔ handles nested object properties in sorted order (1.336541ms)
✔ generateTypeScriptApi (17.498791ms)
▶ parseFrontmatter
  ✔ returns whole input as body when no frontmatter fence (0.790625ms)
  ✔ parses simple flat keys (0.220916ms)
  ✔ strips matched double-quote pairs (0.057333ms)
  ✔ strips matched single-quote pairs (0.057875ms)
  ✔ does not strip mismatched quotes (0.051292ms)
  ✔ ignores comment lines and blank lines (0.063458ms)
  ✔ flags unparseable lines with errors (0.087041ms)
  ✔ flags unclosed frontmatter (0.050166ms)
  ✔ supports CRLF line endings (0.060416ms)
  ✔ trims trailing whitespace from values (0.079834ms)
  ✔ accepts keys with hyphens, digits, and underscores (0.058583ms)
✔ parseFrontmatter (2.221709ms)
▶ filenameToCommandName
  ✔ strips extension (0.435583ms)
  ✔ uses subdir as namespace (0.129125ms)
  ✔ rejects path traversal (0.054958ms)
  ✔ rejects empty stem (0.056958ms)
✔ filenameToCommandName (1.177875ms)
▶ loadCustomCommands
  ✔ returns empty when no dirs exist (6.833667ms)
  ✔ parses frontmatter and body (18.517083ms)
  ✔ treats agent as alias for mode and maps build->edit (6.765542ms)
  ✔ namespaces commands by subdir (6.903667ms)
  ✔ warns on unknown mode and ignores it (3.8925ms)
  ✔ skips files with unclosed frontmatter and warns (8.1405ms)
  ✔ project commands override global on name collision (77.752625ms)
  ✔ skips files with unparseable frontmatter lines (19.380875ms)
  ✔ rejects project commands dir when it is a symlink escaping cwd (3.61725ms)
  ✔ returns commands sorted by name (15.984583ms)
  ✔ parses shell and files frontmatter flags (5.411834ms)
  ✔ warns when template contains ungated shell substitution (8.266708ms)
  ✔ warns when template contains ungated file inclusion (6.976167ms)
  ✔ warns when project command shadows global command (12.494375ms)
✔ loadCustomCommands (209.059042ms)
▶ renderer
  ✔ tokenizes bare words (0.951833ms)
  ✔ keeps double-quoted words together (0.086792ms)
  ✔ keeps mixed quoted words together (0.060958ms)
  ✔ $ARGUMENTS raw substitution preserves quotes/whitespace (0.32825ms)
  ✔ $1 $2 substitutes first/second token (0.149ms)
  ✔ highest $N absorbs trailing tokens (0.119ms)
  ✔ implicitly appends args when template has no placeholders (0.069791ms)
  ✔ does not append when template has $ARGUMENTS even if rendered args are empty (0.164667ms)
  ✔ does not append when args are empty (0.1195ms)
  ✔ substitutes shell output when shell: true (26.774375ms)
  ✔ warns and substitutes empty string on shell timeout when shell: true (108.02325ms)
  ✔ substitutes existing temp file contents when files: true (4.400291ms)
  ✔ warns and substitutes empty string for missing file when files: true (23.85775ms)
  ✔ warns and substitutes empty string for oversize file when files: true (15.422042ms)
  ✔ does not treat email addresses as file inclusions (0.357ms)
  ✔ does not include backtick-wrapped @ paths (0.086333ms)
  ✔ warns when rendered prompt is empty (0.055416ms)
  ✔ strips leading slash command name before substitution (0.068666ms)
  ✔ treats args-only input as args (0.03775ms)
  ✔ single $N absorbs all remaining tokens (0.047083ms)
  ✔ rejects @file paths outside cwd (parent traversal) when files: true (3.925917ms)
  ✔ rejects @file paths with absolute prefix when files: true (0.91875ms)
  ✔ rejects @file paths with ~ prefix when files: true (0.253459ms)
  ✔ preserves trailing sentence punctuation outside @file path when files: true (7.1215ms)
  ✔ allows filenames that begin with two dots inside cwd when files: true (4.411625ms)
  ✔ rejects symlinks inside cwd that point outside when files: true (3.633875ms)
  ✔ uses a default shell timeout to bound renders when shell: true (5007.773125ms)
  ✔ blocks shell substitution when shell: false (0.840334ms)
  ✔ blocks file inclusion when files: false (8.102166ms)
  ✔ does not execute shell command injected via $ARGUMENTS (0.305042ms)
  ✔ does not resolve @file injected via $ARGUMENTS (3.293209ms)
  ✔ blocks secret file patterns even with files: true (3.054667ms)
  ✔ blocks id_rsa secret file pattern even with files: true (3.26925ms)
✔ renderer (5231.292958ms)
▶ classifyTurn
  ✔ classifies read_file on .ts as reading-source-code (0.524834ms)
  ✔ classifies write_file on .md as writing-documentation (0.12875ms)
  ✔ classifies str_replace on .ts as editing-source-code (0.073ms)
  ✔ classifies bash npm test as running-tests (0.159208ms)
  ✔ classifies web_fetch as reading-web-content (0.070458ms)
  ✔ classifies grep as searching-code (0.049375ms)
  ✔ returns empty for unknown tools (0.044125ms)
✔ classifyTurn (1.567166ms)
▶ classifySession
  ✔ picks dominant category by weighted score (0.273375ms)
  ✔ falls back to other for short sessions (0.06225ms)
  ✔ classifies mixed writing signals (0.098166ms)
✔ classifySession (0.537584ms)
▶ needsLlmFallback
  ✔ returns true for low confidence (0.0735ms)
  ✔ returns true for other category (0.044167ms)
  ✔ returns false for high confidence non-other (0.040416ms)
✔ needsLlmFallback (0.218208ms)
▶ renderTerminal
  ✔ renders category rows (19.050917ms)
  ✔ renders total row (0.237875ms)
  ✔ renders top sessions (0.161959ms)
  ✔ renders reconciliation verified (0.129083ms)
  ✔ renders reconciliation drift (0.128083ms)
  ✔ renders reconciliation error (0.134667ms)
  ✔ renders local-only (0.128208ms)
✔ renderTerminal (20.859125ms)
▶ renderJson
  ✔ produces valid JSON (0.109167ms)
✔ renderJson (0.177083ms)
▶ buildReport
  ✔ aggregates sessions by category (1.352667ms)
  ✔ computes week-over-week change (0.140333ms)
  ✔ filters by category (0.079333ms)
  ✔ includes top sessions (0.394709ms)
  ✔ omits empty categories (0.096791ms)
✔ buildReport (4.81625ms)
▶ formatLocation
  ✔ formats a location with relative path (0.380375ms)
  ✔ falls back to absolute path when outside cwd (0.108292ms)
✔ formatLocation (0.931458ms)
▶ formatLocations
  ✔ returns fallback for null (0.087666ms)
  ✔ returns fallback for empty array (0.052708ms)
  ✔ formats multiple locations (0.073083ms)
  ✔ formats single location (0.055458ms)
✔ formatLocations (0.369917ms)
▶ formatHover
  ✔ returns fallback for null (0.09ms)
  ✔ formats string contents (0.526375ms)
  ✔ formats array of strings (0.077417ms)
  ✔ formats MarkupContent (0.088958ms)
  ✔ formats mixed array (0.048333ms)
✔ formatHover (1.274042ms)
▶ formatDocumentSymbols
  ✔ returns fallback for null (0.104875ms)
  ✔ returns fallback for empty array (0.040083ms)
  ✔ formats flat symbols (0.081792ms)
  ✔ formats nested symbols (0.051041ms)
✔ formatDocumentSymbols (0.340625ms)
▶ formatWorkspaceSymbols
  ✔ returns fallback for null (0.049709ms)
  ✔ formats symbols with container (0.067167ms)
✔ formatWorkspaceSymbols (0.158125ms)
▶ formatDiagnostics
  ✔ returns fallback for empty array (0.052958ms)
  ✔ formats error diagnostic (0.057416ms)
  ✔ formats warning without code or source (0.037583ms)
✔ formatDiagnostics (0.193416ms)
▶ formatWorkspaceEdit
  ✔ returns fallback for null (0.069125ms)
  ✔ formats changes (0.06625ms)
  ✔ returns fallback when no changes (0.029958ms)
✔ formatWorkspaceEdit (0.212542ms)
▶ formatCodeActions
  ✔ returns fallback for null (0.047417ms)
  ✔ returns fallback for empty array (0.025041ms)
  ✔ formats actions with kind (0.048875ms)
✔ formatCodeActions (0.1585ms)
▶ deterministicTopicKey
  ✔ lowercases and snake_cases a simple phrase (0.452834ms)
  ✔ strips non-alphanumeric characters (0.060584ms)
  ✔ collapses multiple spaces into a single underscore (0.053917ms)
  ✔ truncates to 60 characters (0.051584ms)
  ✔ returns empty string for empty input (0.051542ms)
  ✔ returns empty string for input with only special chars (0.054792ms)
✔ deterministicTopicKey (1.2325ms)
▶ pickTopicKey
  ✔ returns a new key when no existing keys match (0.32175ms)
  ✔ reuses an existing key when it is a substring of the new key (0.156167ms)
  ✔ reuses an existing key when the new key is a substring of it (0.141083ms)
  ✔ returns null for empty content (0.09ms)
  ✔ picks the first matching existing key (0.066042ms)
✔ pickTopicKey (1.872542ms)
▶ isDiffCommand
  ✔ matches `git show` and its argument forms (0.52475ms)
  ✔ does not match `git show-ref` or `git show-branch` (0.876375ms)
  ✔ matches `git diff` with various flags (0.080041ms)
  ✔ does not match commands that merely start with `git diff` as a substring (0.056417ms)
  ✔ matches `git log` only when -p / --patch is present (0.064791ms)
  ✔ matches `git format-patch` (0.050833ms)
  ✔ matches `git stash show` only when -p / --patch is present (0.072459ms)
  ✔ rejects unrelated commands (0.047917ms)
✔ isDiffCommand (2.459084ms)
▶ ToolArtifactStore
  ✔ stores and retrieves artifacts (0.43ms)
  ✔ evicts oldest when maxArtifacts reached (0.088875ms)
  ✔ evicts when total chars exceed maxTotalChars (0.059042ms)
  ✔ clears all artifacts (0.138459ms)
  ✔ produces unique IDs (0.228083ms)
✔ ToolArtifactStore (1.654708ms)
▶ reduceToolOutput — grep
  ✔ returns file paths and hit counts in discovery mode (0.386583ms)
  ✔ shows sample matches per file (0.106ms)
  ✔ passes through files-only mode compactly (0.086292ms)
  ✔ expansion restores full raw content (0.08375ms)
✔ reduceToolOutput — grep (0.797833ms)
▶ reduceToolOutput — read
  ✔ returns structure outline for full file reads (0.363042ms)
  ✔ returns slice directly when offset/limit provided (0.056625ms)
  ✔ caps large slices (0.107084ms)
✔ reduceToolOutput — read (0.605042ms)
▶ reduceToolOutput — bash
  ✔ passes through short outputs unchanged (0.171709ms)
  ✔ returns compact failure summary for errors (0.494375ms)
  ✔ deduplicates repeated lines (0.09625ms)
  ✔ preserves stack trace frames in error block (0.116917ms)
✔ reduceToolOutput — bash (0.958916ms)
▶ reduceToolOutput — web_fetch
  ✔ returns title, URL, headings, and excerpt (0.169917ms)
✔ reduceToolOutput — web_fetch (0.208166ms)
▶ reduceToolOutput — lsp
  ✔ passes through short LSP outputs unchanged (0.072958ms)
  ✔ truncates long LSP outputs by line count (0.067416ms)
  ✔ truncates long LSP outputs by char count (0.05075ms)
  ✔ stores artifact for truncated LSP output (0.044333ms)
✔ reduceToolOutput — lsp (0.289167ms)
▶ reduceToolOutput — disabled
  ✔ returns raw content when enabled is false (0.047375ms)
✔ reduceToolOutput — disabled (0.08875ms)
▶ reduceToolOutput — unknown tool
  ✔ passes through unknown tools unchanged (0.036042ms)
✔ reduceToolOutput — unknown tool (0.058459ms)
▶ FilePicker
  ✔ renders empty state (25.058041ms)
  ✔ renders items with selection indicator (2.642458ms)
  ✔ renders query header when filtering (1.308291ms)
  ✔ shows 'and N more' when items exceed visible limit (2.949708ms)
  ✔ uses stable keys by item name (1.275667ms)
✔ FilePicker (33.796125ms)
▶ SlashPicker
  ✔ renders empty state (24.82525ms)
  ✔ renders items with selection indicator and arg hint (3.346208ms)
  ✔ renders query header when filtering (1.412458ms)
  ✔ shows project/global source badge for custom commands (1.316708ms)
  ✔ does not render a badge for built-ins (1.623167ms)
  ✔ keeps a separator between long labels and the description (1.18525ms)
  ✔ shows 'more above' / 'more below' on overflow (2.0425ms)
✔ SlashPicker (36.346834ms)
▶ status gateway cache formatting
  ✔ shows gateway cache status separately from token cache (0.712542ms)
  ✔ omits gateway cache status when Cloudflare does not return it (0.074541ms)
✔ status gateway cache formatting (1.226958ms)
▶ loadConfig AI Gateway fields
  ✔ loads AI Gateway settings from env credentials (0.92525ms)
  ✔ loads AI Gateway settings from config file (7.872083ms)
✔ loadConfig AI Gateway fields (9.452333ms)
▶ fuzzyMatch
  ✔ matches empty query with score 0 (0.834291ms)
  ✔ rejects when query longer than text (0.0775ms)
  ✔ matches when chars appear in order (0.111625ms)
  ✔ rejects when chars are out of order (0.049833ms)
  ✔ scores exact prefix better than gappy match (0.1025ms)
  ✔ rewards word-boundary matches (0.059292ms)
  ✔ is case-insensitive (0.048667ms)
  ✔ does NOT swap letters/digits to match (0.045833ms)
✔ fuzzyMatch (2.355333ms)
▶ fuzzyFilter
  ✔ returns all items unchanged for empty query (0.125875ms)
  ✔ filters out non-matching items (0.148625ms)
  ✔ ranks tighter matches above gappier ones (0.09275ms)
  ✔ requires all space-separated tokens to match (0.058417ms)
✔ fuzzyFilter (0.539667ms)
▶ findProjectLspConfigPath
  ✔ finds config in cwd (8.836375ms)
  ✔ finds config in parent when missing in cwd (4.614084ms)
  ✔ stops at git root (9.695417ms)
  ✔ returns null when no config exists (0.781833ms)
✔ findProjectLspConfigPath (24.565375ms)
▶ loadProjectLspConfig
  ✔ loads lspEnabled and lspServers (6.242916ms)
  ✔ returns null when file is missing (1.20075ms)
✔ loadProjectLspConfig (7.607375ms)
▶ saveProjectLspConfig
  ✔ writes config and appends to .gitignore (6.181375ms)
  ✔ does not duplicate gitignore entry (4.830292ms)
✔ saveProjectLspConfig (11.192292ms)
▶ resolveLspConfig
  ✔ falls back to global when no project config (1.391333ms)
  ✔ uses project config when present (2.931167ms)
  ✔ falls back to global lspEnabled when project omits it (2.664292ms)
  ✔ falls back to global lspServers when project omits it (1.9595ms)
✔ resolveLspConfig (9.192042ms)
▶ maybeLspNudge
  ✔ returns null when LSP is already configured (0.643666ms)
  ✔ returns null for non-code messages (0.984709ms)
  ✔ nudges for TypeScript files (0.97825ms)
  ✔ nudges for Python files (0.178166ms)
  ✔ nudges for Rust files (0.077875ms)
  ✔ nudges for Go files (0.077209ms)
  ✔ combines multiple detected languages (0.084125ms)
  ✔ nudges when LSP is enabled but no servers are configured (0.070083ms)
✔ maybeLspNudge (3.726542ms)
▶ readSSE
  ✔ exits gracefully when signal aborts during pending read (15.520416ms)
  ✔ yields events when stream completes normally (0.866042ms)
✔ readSSE (17.188667ms)
▶ AI Gateway usage enrichment
  ✔ fetches a gateway log by cf-aig-log-id (12.421208ms)
  ✔ records local usage with gateway metadata as best-effort enrichment (6.972333ms)
✔ AI Gateway usage enrichment (20.15425ms)
ℹ tests 279
ℹ suites 62
ℹ pass 279
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5826.827833 (279 tests) ✅

Co-authored-by: kimiflare <kimiflare@proton.me>