### PR TITLE
fix: remove hardcoded 200k input token budget from code mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1558,8 +1558,6 @@ function App({
         sessionId: ensureSessionId(),
         memoryManager: memoryManagerRef.current,
         codeMode: effectiveCodeMode,
-        maxInputTokens: effectiveCodeMode ? 200_000 : undefined,
-        continueOnLimit: effectiveCodeMode ? true : undefined,
         onIterationEnd,
         onFileChange: (path, content) => {
           if (content) {
@@ -2816,8 +2814,6 @@ function App({
           memoryManager: memoryManagerRef.current,
           keepLastImageTurns: cfg.imageHistoryTurns ?? 2,
           codeMode: effectiveCodeMode,
-          maxInputTokens: effectiveCodeMode ? 200_000 : undefined,
-          continueOnLimit: effectiveCodeMode ? true : undefined,
           onIterationEnd,
           intentClassification: classification,
           onFileChange: (path, content) => {


### PR DESCRIPTION
Removes the surprise 200k `maxInputTokens` limit that only applied in code mode (heavy intent classification), causing mid-turn `BudgetExhaustedError` interruptions with no user visibility.

The guardrail was more harmful than helpful — users could simply start a new turn anyway. If we want budget enforcement in the future, it should be a user-configurable setting applied consistently across all modes.

Co-authored-by: kimiflare <kimiflare@proton.me>