### PR TITLE
fix(code-mode): use typescript compiler when available for transpilation

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -434,9 +434,12 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           opts.callbacks.onToolResult?.(toolResult);
         }
 
+        const warningPrefix = sandboxResult.warnings?.length
+          ? `Warning: ${sandboxResult.warnings.join(" ")}\n\n`
+          : "";
         const resultContent = sandboxResult.error
-          ? `Error: ${sandboxResult.error}\n\nOutput:\n${sandboxResult.output}`
-          : sandboxResult.output;
+          ? `${warningPrefix}Error: ${sandboxResult.error}\n\nOutput:\n${sandboxResult.output}`
+          : `${warningPrefix}${sandboxResult.output}`;
 
         const result: ToolResult = {
           tool_call_id: tc.id,

--- a/src/code-mode/sandbox.test.ts
+++ b/src/code-mode/sandbox.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { stripTypescript, runInSandbox } from "./sandbox.js";
+import type { ToolSpec } from "../tools/registry.js";
+
+const mockTools: ToolSpec[] = [];
+
+const mockExecutor = {
+  run: async () => ({ content: "ok", ok: true }),
+};
+
+const mockAskPermission = async () => true;
+
+const mockCtx = {
+  cwd: process.cwd(),
+  signal: undefined as AbortSignal | undefined,
+  onTasks: undefined as ((tasks: { id: string; title: string; status: string }[]) => void) | undefined,
+  coauthor: false,
+  memoryManager: undefined,
+  sessionId: "test",
+};
+
+describe("stripTypescript", () => {
+  it("strips basic type annotations", () => {
+    const ts = `const x: string = "hello";`;
+    const js = stripTypescript(ts);
+    assert.ok(!js.includes(": string"));
+    assert.ok(js.includes('const x'));
+    assert.ok(js.includes('"hello"'));
+  });
+
+  it("strips function parameter types", () => {
+    const ts = `function greet(name: string): void { console.log(name); }`;
+    const js = stripTypescript(ts);
+    assert.ok(!js.includes(": string"));
+    assert.ok(!js.includes(": void"));
+    assert.ok(js.includes("function greet(name)"));
+  });
+
+  it("fails on nested parenthesis types (documented limitation)", () => {
+    const ts = `function foo(x: (string | number)) { return x; }`;
+    const js = stripTypescript(ts);
+    // The regex-based stripper produces invalid JS for nested parens
+    assert.ok(js.includes("function foo(x))"));
+  });
+});
+
+describe("runInSandbox", () => {
+  it("executes plain JS without types", async () => {
+    const result = await runInSandbox({
+      code: `console.log("hello");`,
+      tools: mockTools,
+      executor: mockExecutor,
+      askPermission: mockAskPermission,
+      ctx: mockCtx,
+    });
+    assert.strictEqual(result.output, "hello");
+    assert.strictEqual(result.error, undefined);
+  });
+
+  it("executes TS with nested types when typescript is available", async () => {
+    const ts = `
+      function foo(x: (string | number)): (string | number) {
+        return x;
+      }
+      console.log(foo(42));
+    `;
+    const result = await runInSandbox({
+      code: ts,
+      tools: mockTools,
+      executor: mockExecutor,
+      askPermission: mockAskPermission,
+      ctx: mockCtx,
+    });
+
+    // If typescript is installed in the project, this should work
+    // If not, it falls back to stripTypescript and may emit a warning
+    if (result.warnings && result.warnings.length > 0) {
+      assert.ok(result.warnings[0].includes("fallback parser"));
+    } else {
+      assert.strictEqual(result.output, "42");
+      assert.strictEqual(result.error, undefined);
+    }
+  });
+
+  it("emits a warning when typescript is not found", async () => {
+    // Use a non-existent cwd to force typescript resolution to fail
+    const result = await runInSandbox({
+      code: `console.log(1);`,
+      tools: mockTools,
+      executor: mockExecutor,
+      askPermission: mockAskPermission,
+      ctx: { ...mockCtx, cwd: "/nonexistent/path" },
+    });
+
+    assert.ok(result.warnings && result.warnings.length > 0);
+    assert.ok(result.warnings![0].includes("fallback parser"));
+  });
+});

--- a/src/code-mode/sandbox.ts
+++ b/src/code-mode/sandbox.ts
@@ -1,3 +1,5 @@
+import { join, dirname } from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ToolSpec, ToolContext } from "../tools/registry.js";
 import type { ToolExecutor, PermissionAsker, ToolResult } from "../tools/executor.js";
 
@@ -10,6 +12,8 @@ export interface SandboxResult {
   error?: string;
   /** Tool calls made during execution */
   toolCalls: SandboxToolCall[];
+  /** Warnings emitted during transpilation or execution */
+  warnings?: string[];
 }
 
 export interface SandboxToolCall {
@@ -71,6 +75,39 @@ export function stripTypescript(code: string): string {
   return js.trim();
 }
 
+async function loadTypescript(cwd: string): Promise<typeof import("typescript") | null> {
+  let dir = cwd;
+  while (dir !== dirname(dir)) {
+    try {
+      const tsPath = join(dir, "node_modules", "typescript", "lib", "typescript.js");
+      return await import(pathToFileURL(tsPath).href);
+    } catch {
+      // continue walking up
+    }
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+async function transpileOrStrip(code: string, cwd: string): Promise<{ js: string; warnings: string[] }> {
+  const ts = await loadTypescript(cwd);
+  if (ts) {
+    const result = ts.transpileModule(code, {
+      compilerOptions: {
+        module: ts.ModuleKind.ES2022,
+        target: ts.ScriptTarget.ES2022,
+        esModuleInterop: true,
+        isolatedModules: true,
+      },
+    });
+    return { js: result.outputText, warnings: [] };
+  }
+  return {
+    js: stripTypescript(code),
+    warnings: ["TypeScript not found in node_modules. Using fallback parser; install typescript for reliable transpilation."],
+  };
+}
+
 async function runWithIsolatedVm(opts: SandboxOptions): Promise<SandboxResult> {
   const { Isolate } = await import("isolated-vm");
   const isolate = new Isolate({ memoryLimit: opts.memoryLimitMB ?? 128 });
@@ -130,7 +167,7 @@ async function runWithIsolatedVm(opts: SandboxOptions): Promise<SandboxResult> {
   await context.eval(`var api = {\n${apiMethods}\n};`);
 
   // Compile TS to JS
-  const jsCode = stripTypescript(opts.code);
+  const { js: jsCode, warnings } = await transpileOrStrip(opts.code, opts.ctx.cwd);
 
   // Wrap in async IIFE to support top-level await
   const wrapped = `(async function() {\n${jsCode}\n})();`;
@@ -143,12 +180,12 @@ async function runWithIsolatedVm(opts: SandboxOptions): Promise<SandboxResult> {
     await new Promise((r) => setTimeout(r, 10));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { output: "", logs, error: message, toolCalls };
+    return { output: "", logs, error: message, toolCalls, warnings };
   } finally {
     isolate.dispose();
   }
 
-  return { output: logs.join("\n"), logs, toolCalls };
+  return { output: logs.join("\n"), logs, toolCalls, warnings };
 }
 
 async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
@@ -225,7 +262,7 @@ async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
     };
   }
 
-  const jsCode = stripTypescript(opts.code);
+  const { js: jsCode, warnings } = await transpileOrStrip(opts.code, opts.ctx.cwd);
   const wrapped = `"use strict";\n(async function() {\n${jsCode}\n})();`;
 
   try {
@@ -235,10 +272,10 @@ async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
     await new Promise((r) => setTimeout(r, 10));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { output: "", logs, error: message, toolCalls };
+    return { output: "", logs, error: message, toolCalls, warnings };
   }
 
-  return { output: logs.join("\n"), logs, toolCalls };
+  return { output: logs.join("\n"), logs, toolCalls, warnings };
 }
 
 export async function runInSandbox(opts: SandboxOptions): Promise<SandboxResult> {


### PR DESCRIPTION
The regex-based `stripTypescript()` function fails on nested parentheses in type annotations (e.g. `function foo(x: (string | number))`), producing `SyntaxError: Unexpected token ')'`.

This change:
- Detects if `typescript` is installed in the project's node_modules
- Uses `ts.transpileModule()` for correct transpilation when available
- Falls back to `stripTypescript()` with a user-visible warning when not
- Adds `warnings` field to `SandboxResult` and surfaces them in `loop.ts`
- Adds tests for both the regex limitation and the transpile fallback

Fixes syntax errors in code mode for TS with complex types.