### PR TITLE
feat: interactive modal when tool-call limit is reached

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -25,6 +25,10 @@ export interface AgentCallbacks {
   onToolResult?: (result: ToolResult) => void;
   onTasks?: (tasks: Task[]) => void;
   askPermission: PermissionAsker;
+  /** Called when the tool-call iteration limit is reached. Return "continue" to
+   *  reset the counter and keep going, or "summarize" to ask the model to present
+   *  findings and end the turn. */
+  onToolLimitReached?: () => Promise<"continue" | "summarize">;
 }
 
 export interface AgentTurnOpts {
@@ -151,7 +155,26 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     }
 
     if (iter >= max) {
-      if (opts.continueOnLimit) {
+      if (opts.callbacks.onToolLimitReached) {
+        const decision = await opts.callbacks.onToolLimitReached();
+        if (decision === "continue") {
+          opts.messages.push({
+            role: "system",
+            content:
+              "You have reached the tool-call limit for this session. " +
+              "The counter has been reset so you can continue working. Please proceed with your task.",
+          });
+          iter = 0;
+        } else {
+          opts.messages.push({
+            role: "system",
+            content:
+              "You have reached the tool-call limit for this session. " +
+              "Please synthesize your findings and present a summary of what was accomplished so far.",
+          });
+          budgetExhausted = true;
+        }
+      } else if (opts.continueOnLimit) {
         opts.messages.push({
           role: "system",
           content:

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -26,9 +26,8 @@ export interface AgentCallbacks {
   onTasks?: (tasks: Task[]) => void;
   askPermission: PermissionAsker;
   /** Called when the tool-call iteration limit is reached. Return "continue" to
-   *  reset the counter and keep going, or "summarize" to ask the model to present
-   *  findings and end the turn. */
-  onToolLimitReached?: () => Promise<"continue" | "summarize">;
+   *  reset the counter and keep going, or "stop" to end the turn immediately. */
+  onToolLimitReached?: () => Promise<"continue" | "stop">;
 }
 
 export interface AgentTurnOpts {
@@ -166,13 +165,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           });
           iter = 0;
         } else {
-          opts.messages.push({
-            role: "system",
-            content:
-              "You have reached the tool-call limit for this session. " +
-              "Please synthesize your findings and present a summary of what was accomplished so far.",
-          });
-          budgetExhausted = true;
+          return;
         }
       } else if (opts.continueOnLimit) {
         opts.messages.push({

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1316,7 +1316,7 @@ function App({
         setPerm(null);
       }
       if (hadLimit) {
-        limitResolveRef.current!("summarize");
+        limitResolveRef.current!("stop");
         limitResolveRef.current = null;
         setLimitModal(null);
       }
@@ -1346,7 +1346,7 @@ function App({
           setPerm(null);
         }
         if (limitResolveRef.current) {
-          limitResolveRef.current("summarize");
+          limitResolveRef.current("stop");
           limitResolveRef.current = null;
           setLimitModal(null);
         }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -30,6 +30,7 @@ import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
+import { LimitModal, type LimitDecision } from "./ui/limit-modal.js";
 import { ResumePicker } from "./ui/resume-picker.js";
 import { TaskList } from "./ui/task-list.js";
 import type { Task } from "./tasks-state.js";
@@ -512,6 +513,7 @@ function App({
   const [cloudBudget, setCloudBudget] = useState<{ remaining: number; limit: number } | null>(null);
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
+  const [limitModal, setLimitModal] = useState<{ limit: number; resolve: (d: LimitDecision) => void } | null>(null);
   const [queue, setQueue] = useState<Array<{ full: string; display: string }>>([]);
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
@@ -573,6 +575,7 @@ function App({
   const activeAsstIdRef = useRef<number | null>(null);
   const activeControllerRef = useRef<AbortController | null>(null);
   const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
+  const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
   const sessionIdRef = useRef<string | null>(null);
   const modeRef = useRef<Mode>(mode);
@@ -774,7 +777,8 @@ function App({
       showCommandList ||
       showLspWizard ||
       resumeSessions !== null ||
-      perm !== null;
+      perm !== null ||
+      limitModal !== null;
     if (modalActive && activePicker !== null) {
       setActivePicker(null);
     }
@@ -787,6 +791,7 @@ function App({
     showLspWizard,
     resumeSessions,
     perm,
+    limitModal,
     activePicker,
   ]);
 
@@ -1304,16 +1309,22 @@ function App({
   useInput((inputChar, key) => {
     if (key.ctrl && inputChar === "c") {
       const hadPerm = permResolveRef.current !== null;
+      const hadLimit = limitResolveRef.current !== null;
       if (hadPerm) {
         permResolveRef.current!("deny");
         permResolveRef.current = null;
         setPerm(null);
       }
+      if (hadLimit) {
+        limitResolveRef.current!("summarize");
+        limitResolveRef.current = null;
+        setLimitModal(null);
+      }
       if (busy && activeControllerRef.current) {
         activeControllerRef.current.abort();
         setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
-      } else if (!hadPerm) {
+      } else if (!hadPerm && !hadLimit) {
         void lspManagerRef.current.stopAll().finally(() => exit());
       }
       return;
@@ -1321,6 +1332,7 @@ function App({
     if (key.escape) {
       const modalOpen =
         perm !== null ||
+        limitModal !== null ||
         showHelpMenu ||
         showLspWizard ||
         showCommandList ||
@@ -1332,6 +1344,11 @@ function App({
           permResolveRef.current("deny");
           permResolveRef.current = null;
           setPerm(null);
+        }
+        if (limitResolveRef.current) {
+          limitResolveRef.current("summarize");
+          limitResolveRef.current = null;
+          setLimitModal(null);
         }
         activeControllerRef.current.abort();
         setQueue([]);
@@ -1506,6 +1523,7 @@ function App({
       setTurnStartedAt(null);
       activeControllerRef.current = null;
       permResolveRef.current = null;
+      limitResolveRef.current = null;
       pendingToolCallsRef.current.clear();
     }
   }, [cfg, busy, saveSessionSafe]);
@@ -1724,6 +1742,7 @@ function App({
       activeAsstIdRef.current = null;
       activeControllerRef.current = null;
       permResolveRef.current = null;
+      limitResolveRef.current = null;
       pendingToolCallsRef.current.clear();
     }
   }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
@@ -2801,6 +2820,11 @@ function App({
             permResolveRef.current = resolve;
             setPerm({ tool: req.tool, args: req.args, resolve });
           }),
+        onToolLimitReached: () =>
+          new Promise<LimitDecision>((resolve) => {
+            limitResolveRef.current = resolve;
+            setLimitModal({ limit: 50, resolve });
+          }),
       };
 
       try {
@@ -2975,6 +2999,7 @@ function App({
         activeAsstIdRef.current = null;
         activeControllerRef.current = null;
         permResolveRef.current = null;
+        limitResolveRef.current = null;
         pendingToolCallsRef.current.clear();
       }
     },
@@ -3279,6 +3304,15 @@ function App({
               perm.resolve(d);
               permResolveRef.current = null;
               setPerm(null);
+            }}
+          />
+        ) : limitModal ? (
+          <LimitModal
+            limit={limitModal.limit}
+            onDecide={(d) => {
+              limitModal.resolve(d);
+              limitResolveRef.current = null;
+              setLimitModal(null);
             }}
           />
         ) : (

--- a/src/ui/limit-modal.tsx
+++ b/src/ui/limit-modal.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import { useTheme } from "./theme-context.js";
+
+export type LimitDecision = "continue" | "summarize";
+
+interface Props {
+  limit: number;
+  onDecide: (decision: LimitDecision) => void;
+}
+
+export function LimitModal({ limit, onDecide }: Props) {
+  const theme = useTheme();
+  const items = [
+    { label: "Continue", value: "continue" as const },
+    { label: "Present findings so far", value: "summarize" as const },
+  ];
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.error} paddingX={1}>
+      <Text color={theme.error} bold>
+        Tool-call limit reached ({limit})
+      </Text>
+      <Text dimColor>
+        This session has made {limit} tool calls. What would you like to do?
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => onDecide(item.value)}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/limit-modal.tsx
+++ b/src/ui/limit-modal.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 
-export type LimitDecision = "continue" | "summarize";
+export type LimitDecision = "continue" | "stop";
 
 interface Props {
   limit: number;
@@ -14,7 +14,7 @@ export function LimitModal({ limit, onDecide }: Props) {
   const theme = useTheme();
   const items = [
     { label: "Continue", value: "continue" as const },
-    { label: "Present findings so far", value: "summarize" as const },
+    { label: "Stop", value: "stop" as const },
   ];
 
   return (


### PR DESCRIPTION
Instead of throwing an inline error that users can miss, this change presents a sticky, full-width modal at the bottom of the terminal when the agent hits the tool-call iteration limit (default 50).

The modal offers two options:
- **Continue** — reset the counter and keep working
- **Present findings so far** — ask the model to synthesize and summarize

This reuses the same UX pattern as the permission modal (red border, ink-select-input for keyboard navigation, blocks input until decided).