### PR TITLE
fix: handle Escape abort gracefully and prevent crashes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -596,6 +596,7 @@ function App({
   const lspManagerRef = useRef(new LspManager());
   const lspToolsRef = useRef<ToolSpec[]>([]);
   const lspInitRef = useRef(false);
+  const busyRef = useRef(busy);
   const memoryManagerRef = useRef<MemoryManager | null>(null);
   const sessionStartRecallRef = useRef<Promise<void> | null>(null);
 
@@ -605,6 +606,10 @@ function App({
   const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const customCommandsRef = useRef<CustomCommand[]>([]);
   const pickerCancelRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    busyRef.current = busy;
+  }, [busy]);
 
   // ── Picker logic (file mention `@` and slash command `/`) ──────────────
   // Depend on stable fields (kind, anchor) — not the activePicker reference,
@@ -1320,7 +1325,7 @@ function App({
         limitResolveRef.current = null;
         setLimitModal(null);
       }
-      if (busy && activeControllerRef.current) {
+      if (busyRef.current && activeControllerRef.current) {
         activeControllerRef.current.abort();
         setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
@@ -1339,7 +1344,7 @@ function App({
         commandWizard !== null ||
         commandToDelete !== null ||
         resumeSessions !== null;
-      if (!modalOpen && busy && activeControllerRef.current) {
+      if (!modalOpen && busyRef.current && activeControllerRef.current) {
         if (permResolveRef.current) {
           permResolveRef.current("deny");
           permResolveRef.current = null;
@@ -2922,6 +2927,8 @@ function App({
                     text: `auto-compact failed: ${(compactErr as Error).message ?? String(compactErr)}`,
                   },
                 ]);
+              } else {
+                throw compactErr;
               }
             }
           }

--- a/src/util/sse.ts
+++ b/src/util/sse.ts
@@ -15,11 +15,9 @@ export async function* readSSE(
   let buffer = "";
 
   const onAbort = () => {
-    try {
-      reader.cancel(new DOMException("aborted", "AbortError"));
-    } catch {
-      /* reader may already be closed */
-    }
+    reader.cancel(new DOMException("aborted", "AbortError")).catch(() => {
+      /* reader may already be closed or stream may have errored */
+    });
   };
   signal?.addEventListener("abort", onAbort, { once: true });
 


### PR DESCRIPTION
This PR fixes three related issues where pressing Escape during a long-running session could crash the process or be silently ignored.

## Changes

### 1. Fix uncaught promise rejection in `readSSE` (crash)
`reader.cancel()` returns a Promise that can reject when it races with the fetch stream's own abort error. The previous code used `try/catch` which only catches synchronous throws, not async rejections. Now we use `.catch(() => {})` to swallow the rejection properly.

### 2. Fix stale `busy` closure in `useInput`
Ink's `useInput` registers the handler once, so it closes over the initial `busy` value. Added a `busyRef` that mirrors the `busy` state via `useEffect`, and the handler now reads `busyRef.current` to see live state.

### 3. Fix auto-compaction swallowing `AbortError`
After `runAgentTurn` returns, post-turn auto-compaction was called with the same signal. If Escape was pressed during compaction, the `AbortError` was silently swallowed. Now it is re-thrown so it propagates to the outer catch block that injects synthetic tool results and shows the interrupted state.

## Testing
- Type-check passes (pre-existing errors in `sandbox.test.ts` are unrelated).
- Manual: start a long turn, press Escape — should show "interrupted" and clean up without crashing.

Fixes #276

Co-authored-by: kimiflare <kimiflare@proton.me>