### PR TITLE
fix(cloud): validate fetchCloudUsage response to prevent crash

### DIFF
--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -93,11 +93,20 @@ export async function fetchCloudUsage(token: string): Promise<{
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) return null;
-  return (await res.json()) as {
-    input_token_limit: number;
-    input_tokens_used: number;
-    remaining: number;
-    expires_at: string;
+  const data = (await res.json()) as Record<string, unknown>;
+  if (
+    typeof data.remaining !== "number" ||
+    typeof data.input_token_limit !== "number" ||
+    typeof data.input_tokens_used !== "number" ||
+    typeof data.expires_at !== "string"
+  ) {
+    return null;
+  }
+  return {
+    input_token_limit: data.input_token_limit,
+    input_tokens_used: data.input_tokens_used,
+    remaining: data.remaining,
+    expires_at: data.expires_at,
   };
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,14 +61,12 @@ program
       console.error("Not authenticated with Kimiflare Cloud. Run: kimiflare auth cloud");
       process.exit(1);
     }
-    const res = await fetch("https://api.kimiflare.com/v1/usage", {
-      headers: { Authorization: `Bearer ${creds.accessToken}` },
-    });
-    if (!res.ok) {
-      console.error(`Failed to fetch usage: ${res.status} ${res.statusText}`);
+    const { fetchCloudUsage } = await import("./cloud/auth.js");
+    const usage = await fetchCloudUsage(creds.accessToken);
+    if (!usage) {
+      console.error("Failed to fetch usage: invalid response from server");
       process.exit(1);
     }
-    const usage = await res.json() as { input_token_limit: number; input_tokens_used: number; remaining: number; expires_at: string };
     console.log(`Token budget: ${usage.remaining.toLocaleString()} / ${usage.input_token_limit.toLocaleString()} remaining`);
     console.log(`Used: ${usage.input_tokens_used.toLocaleString()}`);
     console.log(`Grant expires: ${usage.expires_at}`);
@@ -112,11 +110,9 @@ program
           console.log(`Authenticated! Token expires at ${new Date(creds.expiresAt * 1000).toISOString()}`);
 
           // Fetch usage info
-          const usageRes = await fetch("https://api.kimiflare.com/v1/usage", {
-            headers: { Authorization: `Bearer ${creds.accessToken}` },
-          });
-          if (usageRes.ok) {
-            const usage = await usageRes.json() as { input_token_limit: number; input_tokens_used: number; remaining: number; expires_at: string };
+          const { fetchCloudUsage } = await import("./cloud/auth.js");
+          const usage = await fetchCloudUsage(creds.accessToken);
+          if (usage) {
             console.log(`\nToken budget: ${usage.remaining.toLocaleString()} / ${usage.input_token_limit.toLocaleString()} remaining`);
             console.log(`Grant expires: ${usage.expires_at}`);
           }


### PR DESCRIPTION
## Problem
After GitHub authentication, the app crashed with:
```
Cannot read properties of undefined (reading 'toLocaleString')
```
This happened when the server returned a 200 response with a missing or malformed `remaining` field in the usage payload.

## Solution
- Add runtime validation to `fetchCloudUsage()` to check that all expected fields are present and typed correctly before returning.
- DRY up inline `fetch` calls in `index.tsx` to use the validated helper.

## Changes
- `src/cloud/auth.ts`: validate response shape, return `null` if invalid
- `src/index.tsx`: use `fetchCloudUsage()` instead of raw fetch + cast

Co-authored-by: kimiflare <kimiflare@proton.me>