### PR TITLE
fix(cloud): use cloudToken state instead of stale prop in runAgentTurn

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -62,6 +62,9 @@ function isRetryable(err: KimiApiError, attempt: number): boolean {
 }
 
 export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, void, void> {
+  if (opts.cloudMode && !opts.cloudToken) {
+    throw new KimiApiError("kimiflare: cloud mode requires a cloud token. Run `kimiflare auth cloud` to authenticate.", undefined, 401);
+  }
   const { url, headers: gatewayHeaders } = buildKimiRequestTarget(opts);
   const body: Record<string, unknown> = {
     messages: sanitizeMessagesForApi(opts.messages),

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -495,6 +495,7 @@ function App({
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
   const [lspScope, setLspScope] = useState<"project" | "global">(initialLspScope);
   const [lspProjectPath, setLspProjectPath] = useState<string | null>(initialLspProjectPath);
+  const [cloudToken, setCloudToken] = useState(initialCloudToken);
   const [events, setRawEvents] = useState<ChatEvent[]>([]);
   const setEvents = useCallback(
     (updater: React.SetStateAction<ChatEvent[]>) => {
@@ -1585,7 +1586,7 @@ function App({
         memoryManager: memoryManagerRef.current,
         codeMode: effectiveCodeMode,
         cloudMode: cfg.cloudMode,
-        cloudToken: initialCloudToken,
+        cloudToken: cloudToken ?? initialCloudToken,
         onIterationEnd,
         onFileChange: (path, content) => {
           if (content) {
@@ -2853,7 +2854,7 @@ function App({
           keepLastImageTurns: cfg.imageHistoryTurns ?? 2,
           codeMode: effectiveCodeMode,
           cloudMode: cfg.cloudMode,
-          cloudToken: initialCloudToken,
+          cloudToken: cloudToken ?? initialCloudToken,
           onIterationEnd,
           intentClassification: classification,
           onFileChange: (path, content) => {
@@ -3072,6 +3073,7 @@ function App({
             const { loadCloudCredentials } = await import("./cloud/auth.js");
             const creds = await loadCloudCredentials();
             if (creds) {
+              setCloudToken(creds.accessToken);
               setEvents((e) => [
                 ...e,
                 { kind: "info", key: mkKey(), text: "configuration saved — welcome to kimiflare! (cloud mode)" },


### PR DESCRIPTION
When a user starts kimiflare without cloud mode, goes through onboarding, and selects cloud mode, the runAgentTurn calls were using initialCloudToken (the prop, undefined at mount time) instead of the cloudToken state that gets updated after successful auth. This caused chat requests to be sent without a valid cloud token, resulting in 401 errors.

Also add a defensive guard in runKimi to throw a clear error when cloudMode is true but cloudToken is missing.