### PR TITLE
fix(cloud): bind JWT to CLI device ID instead of browser fingerprint

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -28,6 +28,7 @@ export interface RunKimiOpts {
   gateway?: AiGatewayOptions;
   cloudMode?: boolean;
   cloudToken?: string;
+  cloudDeviceId?: string;
 }
 
 export interface AiGatewayOptions {
@@ -155,9 +156,11 @@ export function validateModelId(model: string): void {
 function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Record<string, string> } {
   validateModelId(opts.model);
   if (opts.cloudMode) {
+    const headers: Record<string, string> = opts.cloudToken ? { Authorization: `Bearer ${opts.cloudToken}` } : {};
+    if (opts.cloudDeviceId) headers["X-Device-ID"] = opts.cloudDeviceId;
     return {
       url: "https://api.kimiflare.com/v1/chat",
-      headers: opts.cloudToken ? { Authorization: `Bearer ${opts.cloudToken}` } : {},
+      headers,
     };
   }
   if (!opts.gateway?.id) {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -65,6 +65,7 @@ export interface AgentTurnOpts {
   onIterationEnd?: (messages: ChatMessage[], signal: AbortSignal) => Promise<ChatMessage[]>;
   cloudMode?: boolean;
   cloudToken?: string;
+  cloudDeviceId?: string;
 }
 
 export class BudgetExhaustedError extends Error {
@@ -249,6 +250,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       gateway: opts.gateway,
       cloudMode: opts.cloudMode,
       cloudToken: opts.cloudToken,
+      cloudDeviceId: opts.cloudDeviceId,
     });
 
     for await (const ev of events) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -484,18 +484,21 @@ function App({
   initialLspScope,
   initialLspProjectPath,
   initialCloudToken,
+  initialCloudDeviceId,
 }: {
   initialCfg: Cfg | null;
   initialUpdateResult?: UpdateCheckResult;
   initialLspScope: "project" | "global";
   initialLspProjectPath: string | null;
   initialCloudToken?: string;
+  initialCloudDeviceId?: string;
 }) {
   const { exit } = useApp();
   const [cfg, setCfg] = useState<Cfg | null>(initialCfg);
   const [lspScope, setLspScope] = useState<"project" | "global">(initialLspScope);
   const [lspProjectPath, setLspProjectPath] = useState<string | null>(initialLspProjectPath);
   const [cloudToken, setCloudToken] = useState(initialCloudToken);
+  const [cloudDeviceId, setCloudDeviceId] = useState(initialCloudDeviceId);
   const [events, setRawEvents] = useState<ChatEvent[]>([]);
   const setEvents = useCallback(
     (updater: React.SetStateAction<ChatEvent[]>) => {
@@ -552,7 +555,7 @@ function App({
     let cancelled = false;
     const fetchBudget = async () => {
       const { fetchCloudUsage } = await import("./cloud/auth.js");
-      const usage = await fetchCloudUsage(initialCloudToken);
+      const usage = await fetchCloudUsage(initialCloudToken, cloudDeviceId ?? initialCloudDeviceId);
       if (usage && !cancelled) {
         setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
       }
@@ -1587,6 +1590,7 @@ function App({
         codeMode: effectiveCodeMode,
         cloudMode: cfg.cloudMode,
         cloudToken: cloudToken ?? initialCloudToken,
+        cloudDeviceId: cloudDeviceId ?? initialCloudDeviceId,
         onIterationEnd,
         onFileChange: (path, content) => {
           if (content) {
@@ -2855,6 +2859,7 @@ function App({
           codeMode: effectiveCodeMode,
           cloudMode: cfg.cloudMode,
           cloudToken: cloudToken ?? initialCloudToken,
+          cloudDeviceId: cloudDeviceId ?? initialCloudDeviceId,
           onIterationEnd,
           intentClassification: classification,
           onFileChange: (path, content) => {
@@ -3436,6 +3441,7 @@ export async function renderApp(
   lspScope: "project" | "global" = "global",
   lspProjectPath: string | null = null,
   cloudToken?: string,
+  cloudDeviceId?: string,
 ) {
   const instance = render(
     <App
@@ -3444,6 +3450,7 @@ export async function renderApp(
       initialLspScope={lspScope}
       initialLspProjectPath={lspProjectPath}
       initialCloudToken={cloudToken}
+      initialCloudDeviceId={cloudDeviceId}
     />,
     {
       incrementalRendering: true,

--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -20,12 +20,14 @@ export const POLL_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes (RFC 8628 standard)
 export interface CloudCredentials {
   accessToken: string;
   expiresAt: number;
+  deviceId: string;
 }
 
 export interface DeviceCodes {
   deviceCode: string;
   userCode: string;
   authUrl: string;
+  deviceId: string;
 }
 
 function cloudCredPath(): string {
@@ -42,18 +44,25 @@ function generateCode(): string {
   return out;
 }
 
+function generateDeviceId(): string {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
 export function generateDeviceCodes(): DeviceCodes {
   const deviceCode = `device-${generateCode()}-${Date.now()}`;
   const userCode = `${generateCode()}-${generateCode()}`;
   const authUrl = `${CLOUD_API_URL}/auth/github?code=${encodeURIComponent(userCode)}`;
-  return { deviceCode, userCode, authUrl };
+  const deviceId = generateDeviceId();
+  return { deviceCode, userCode, authUrl, deviceId };
 }
 
 export async function registerDevice(codes: DeviceCodes): Promise<void> {
   const registerRes = await fetch(`${CLOUD_API_URL}/auth/device`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ device_code: codes.deviceCode, user_code: codes.userCode }),
+    body: JSON.stringify({ device_code: codes.deviceCode, user_code: codes.userCode, device_id: codes.deviceId }),
   });
 
   if (!registerRes.ok) {
@@ -62,7 +71,7 @@ export async function registerDevice(codes: DeviceCodes): Promise<void> {
   }
 }
 
-export async function pollForToken(deviceCode: string): Promise<CloudCredentials | null> {
+export async function pollForToken(deviceCode: string, deviceId: string): Promise<CloudCredentials | null> {
   const pollRes = await fetch(`${CLOUD_API_URL}/auth/poll`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -76,6 +85,7 @@ export async function pollForToken(deviceCode: string): Promise<CloudCredentials
     const creds: CloudCredentials = {
       accessToken: pollData.access_token,
       expiresAt: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60, // 7 days
+      deviceId,
     };
     await saveCloudCredentials(creds);
     return creds;
@@ -83,15 +93,15 @@ export async function pollForToken(deviceCode: string): Promise<CloudCredentials
   return null;
 }
 
-export async function fetchCloudUsage(token: string): Promise<{
+export async function fetchCloudUsage(token: string, deviceId?: string): Promise<{
   input_token_limit: number;
   input_tokens_used: number;
   remaining: number;
   expires_at: string;
 } | null> {
-  const res = await fetch(`${CLOUD_API_URL}/v1/usage`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+  if (deviceId) headers["X-Device-ID"] = deviceId;
+  const res = await fetch(`${CLOUD_API_URL}/v1/usage`, { headers });
   if (!res.ok) return null;
   const data = (await res.json()) as Record<string, unknown>;
   if (
@@ -114,7 +124,7 @@ export async function loadCloudCredentials(): Promise<CloudCredentials | null> {
   try {
     const raw = await readFile(cloudCredPath(), "utf8");
     const parsed = JSON.parse(raw) as CloudCredentials;
-    if (parsed.expiresAt && parsed.expiresAt > Date.now() / 1000) {
+    if (parsed.expiresAt && parsed.expiresAt > Date.now() / 1000 && parsed.accessToken) {
       return parsed;
     }
   } catch {
@@ -150,7 +160,7 @@ export async function authenticateDevice(
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
     onStatus({ url: codes.authUrl, userCode: codes.userCode, polling: true });
 
-    const creds = await pollForToken(codes.deviceCode);
+    const creds = await pollForToken(codes.deviceCode, codes.deviceId);
     if (creds) return creds;
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,7 +62,7 @@ program
       process.exit(1);
     }
     const { fetchCloudUsage } = await import("./cloud/auth.js");
-    const usage = await fetchCloudUsage(creds.accessToken);
+    const usage = await fetchCloudUsage(creds.accessToken, creds.deviceId);
     if (!usage) {
       console.error("Failed to fetch usage: invalid response from server");
       process.exit(1);
@@ -111,7 +111,7 @@ program
 
           // Fetch usage info
           const { fetchCloudUsage } = await import("./cloud/auth.js");
-          const usage = await fetchCloudUsage(creds.accessToken);
+          const usage = await fetchCloudUsage(creds.accessToken, creds.deviceId);
           if (usage) {
             console.log(`\nToken budget: ${usage.remaining.toLocaleString()} / ${usage.input_token_limit.toLocaleString()} remaining`);
             console.log(`Grant expires: ${usage.expires_at}`);
@@ -160,6 +160,7 @@ async function main() {
   // Handle cloud mode
   const cloudMode = opts.cloud ?? cfg?.cloudMode ?? false;
   let cloudToken: string | undefined;
+  let cloudDeviceId: string | undefined;
   if (cloudMode) {
     const { loadCloudCredentials, authenticateDevice } = await import("./cloud/auth.js");
     let cloudCreds = await loadCloudCredentials();
@@ -168,6 +169,7 @@ async function main() {
       process.exit(2);
     }
     cloudToken = cloudCreds.accessToken;
+    cloudDeviceId = cloudCreds.deviceId;
     cfg = {
       ...(cfg ?? { accountId: "", apiToken: "", model: DEFAULT_MODEL }),
       cloudMode: true,
@@ -194,6 +196,7 @@ async function main() {
       showReasoning: !!opts.reasoning,
       codeMode: cfg.codeMode,
       cloudToken,
+      cloudDeviceId,
       continueOnLimit: !!opts.continueOnLimit,
       maxInputTokens: opts.maxInputTokens,
       updateResult,
@@ -211,9 +214,9 @@ async function main() {
   const { renderApp } = await import("./app.js");
   if (cfg) {
     const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;
-    await renderApp({ ...cfg, model }, updateResult, lspScope, lspProjectPath, cloudToken);
+    await renderApp({ ...cfg, model }, updateResult, lspScope, lspProjectPath, cloudToken, cloudDeviceId);
   } else {
-    await renderApp(null, updateResult, lspScope, lspProjectPath, cloudToken);
+    await renderApp(null, updateResult, lspScope, lspProjectPath, cloudToken, cloudDeviceId);
   }
 }
 
@@ -238,6 +241,7 @@ interface PrintOpts {
   maxInputTokens?: number;
   cloudMode?: boolean;
   cloudToken?: string;
+  cloudDeviceId?: string;
 }
 
 function gatewayFromPrintOpts(opts: PrintOpts): AiGatewayOptions | undefined {
@@ -291,6 +295,7 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
       maxInputTokens: opts.maxInputTokens,
       cloudMode: opts.cloudMode,
       cloudToken: opts.cloudToken,
+      cloudDeviceId: opts.cloudDeviceId,
       coauthor:
         opts.coauthor !== false
           ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "kimiflare@proton.me" }

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -85,9 +85,9 @@ export function Onboarding({ onDone, onCancel }: Props) {
         }
 
         try {
-          const creds = await pollForToken(cloudAuth.codes.deviceCode);
+          const creds = await pollForToken(cloudAuth.codes.deviceCode, cloudAuth.codes.deviceId);
           if (creds && !cancelled) {
-            const usage = await fetchCloudUsage(creds.accessToken);
+            const usage = await fetchCloudUsage(creds.accessToken, creds.deviceId);
             if (usage && !cancelled) {
               setCloudAuth({
                 phase: "success",


### PR DESCRIPTION
## Problem

Authenticating on a new laptop appeared to succeed (browser showed 'Authenticated', CLI showed token budget) but every chat request immediately 403'd with 'token bound to a different device'.

The root cause: the server was computing a device fingerprint from the **browser's** User-Agent + IP during the GitHub OAuth callback, then comparing it against the **CLI's** User-Agent + IP on every  request. Browsers and Node.js send completely different UAs, so the check always failed for legitimate multi-device usage.

## Solution

Replace the broken browser fingerprint with a proper CLI-generated device ID:

1. **CLI** generates a persistent 128-bit random device ID, stores it in 
2. **CLI** sends the device ID during auth registration () and on every API request via  header
3. **Server** stores the CLI device ID in 
4. **Server** embeds the CLI device ID () in the JWT instead of the browser fingerprint
5. **Server** validates  against JWT  on  and 

## Security Model

- **Single session enforced**: new login still revokes all previous JWTs via 
- **Anti-sharing**: a stolen JWT is useless without the matching  header
- **Backward compatible**: JWTs without  are still accepted (for existing sessions during deployment transition)

## Changes

-  — generate device ID, send it in registration and requests
-  — send  header in cloud mode
-  — pass  through to client
-  — manage and pass device ID state
-  — extract device ID from credentials, pass to print mode and TUI
-  — pass device ID through auth flow

Requires matching server PR: sinameraji/kimiflare-cloud#2