### PR TITLE
feat(cloud): refresh token budget in real time after each turn

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1661,6 +1661,17 @@ function App({
             const sid = ensureSessionId();
             void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
             void getCostReport(sid).then((report) => setSessionUsage(report.session));
+            if (cfg?.cloudMode && (cloudToken ?? initialCloudToken)) {
+              const token = cloudToken ?? initialCloudToken!;
+              const did = cloudDeviceId ?? initialCloudDeviceId;
+              void (async () => {
+                const { fetchCloudUsage } = await import("./cloud/auth.js");
+                const usage = await fetchCloudUsage(token, did);
+                if (usage) {
+                  setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+                }
+              })();
+            }
           },
           onGatewayMeta: updateGatewayMeta,
           askPermission: (req) =>
@@ -2787,6 +2798,18 @@ function App({
           const sid = ensureSessionId();
           void recordUsage(sid, u, gatewayUsageLookupFromConfig(cfg, meta ?? gatewayMetaRef.current));
           void getCostReport(sid).then((report) => setSessionUsage(report.session));
+          // Refresh cloud budget so remaining tokens update in real time
+          if (cfg?.cloudMode && (cloudToken ?? initialCloudToken)) {
+            const token = cloudToken ?? initialCloudToken!;
+            const did = cloudDeviceId ?? initialCloudDeviceId;
+            void (async () => {
+              const { fetchCloudUsage } = await import("./cloud/auth.js");
+              const usage = await fetchCloudUsage(token, did);
+              if (usage) {
+                setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+              }
+            })();
+          }
         },
         onGatewayMeta: updateGatewayMeta,
         onTasks: (nextTasks: Task[]) => {

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -101,9 +101,9 @@ export function buildRightParts(
     parts.push(`out ${sessionUsage.completionTokens}`);
     parts.push(`ctx ${pct}%`);
     if (cloudMode) {
-      parts.push(`\x1b[9m${sessionUsage.cost.toFixed(5)}\x1b[29m`);
+      parts.push(`\x1b[9m$${sessionUsage.cost.toFixed(5)}\x1b[29m`);
     } else {
-      parts.push(`${sessionUsage.cost.toFixed(5)}`);
+      parts.push(`$${sessionUsage.cost.toFixed(5)}`);
     }
   } else {
     const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
@@ -112,9 +112,9 @@ export function buildRightParts(
     parts.push(`out ${usage.completion_tokens}`);
     parts.push(`ctx ${pct}%`);
     if (cloudMode) {
-      parts.push(`\x1b[9m${cost.total.toFixed(5)}\x1b[29m`);
+      parts.push(`\x1b[9m$${cost.total.toFixed(5)}\x1b[29m`);
     } else {
-      parts.push(`${cost.total.toFixed(5)}`);
+      parts.push(`$${cost.total.toFixed(5)}`);
     }
   }
   if (cloudMode && cloudBudget) {
@@ -126,6 +126,7 @@ export function buildRightParts(
 }
 
 function formatTokens(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);


### PR DESCRIPTION
The cloud budget in the status bar was only fetched once on startup and never updated. This caused the remaining tokens display to stay frozen while the user burned through their quota.

Now onUsageFinal re-fetches the budget from /v1/usage after every AI turn, so the status bar shows accurate remaining tokens in real time.