### PR TITLE
fix: make isolated-vm optional with fallback warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,13 @@
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
-    "isolated-vm": "^6.1.2",
     "react": "^19.2.0",
     "turndown": "^7.2.0",
     "typescript": "^5.7.2",
     "vscode-languageserver-protocol": "^3.17.5"
+  },
+  "optionalDependencies": {
+    "isolated-vm": "^6.1.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/code-mode/sandbox.ts
+++ b/src/code-mode/sandbox.ts
@@ -287,6 +287,11 @@ async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
   return { output: logs.join("\n"), logs, toolCalls, warnings };
 }
 
+const ISOLATED_VM_FALLBACK_WARNING =
+  "⚠️  Code sandbox is running without memory limits or true process isolation " +
+  "(isolated-vm unavailable or failed to load). " +
+  "For a secure sandbox, install with Node 22 LTS: nvm install 22 && nvm use 22 && npm install -g kimiflare";
+
 export async function runInSandbox(opts: SandboxOptions): Promise<SandboxResult> {
   try {
     return await runWithIsolatedVm(opts);
@@ -294,9 +299,11 @@ export async function runInSandbox(opts: SandboxOptions): Promise<SandboxResult>
     const message = err instanceof Error ? err.message : String(err);
     // If isolated-vm fails (e.g., not compiled), fall back to node:vm
     if (message.includes("isolated-vm") || message.includes("Cannot find module") || message.includes("bindings")) {
-      return runWithNodeVm(opts);
+      const result = await runWithNodeVm(opts);
+      return { ...result, warnings: [ISOLATED_VM_FALLBACK_WARNING, ...(result.warnings ?? [])] };
     }
     // For other errors, also try fallback
-    return runWithNodeVm(opts);
+    const result = await runWithNodeVm(opts);
+    return { ...result, warnings: [ISOLATED_VM_FALLBACK_WARNING, ...(result.warnings ?? [])] };
   }
 }


### PR DESCRIPTION
isolated-vm frequently fails to compile on systems without prebuilt binaries (e.g. Node 25, exotic platforms). This PR moves it to `optionalDependencies` so `npm install` succeeds regardless.

When the fallback to `node:vm` is active, a loud runtime warning is emitted that explains the degraded sandbox and how to get the secure version (Node 22 LTS).

**Changes:**
- Move `isolated-vm` from `dependencies` to `optionalDependencies`
- Add `ISOLATED_VM_FALLBACK_WARNING` constant in `sandbox.ts`
- Inject the warning into `SandboxResult.warnings` whenever the `node:vm` fallback is used

**Testing:**
- Pre-existing type errors in `sandbox.test.ts` are unrelated to this change
- The fallback path is already covered by existing tests