### PR TITLE
feat(auth): update CLI auth URL for generic portal

### DIFF
--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -4,7 +4,7 @@
  * Flow:
  * 1. CLI generates device_code + user_code
  * 2. POST /auth/device to register
- * 3. Show user URL: https://api.kimiflare.com/auth/github?code=<user_code>
+ * 3. Show user URL: https://api.kimiflare.com/auth?code=<user_code>
  * 4. Poll POST /auth/poll until approved
  * 5. Store JWT in config
  */
@@ -53,7 +53,7 @@ function generateDeviceId(): string {
 export function generateDeviceCodes(): DeviceCodes {
   const deviceCode = `device-${generateCode()}-${Date.now()}`;
   const userCode = `${generateCode()}-${generateCode()}`;
-  const authUrl = `${CLOUD_API_URL}/auth/github?code=${encodeURIComponent(userCode)}`;
+  const authUrl = `${CLOUD_API_URL}/auth?code=${encodeURIComponent(userCode)}`;
   const deviceId = generateDeviceId();
   return { deviceCode, userCode, authUrl, deviceId };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,7 +104,7 @@ program
               console.log(`\nKimiflare Cloud Authentication`);
               console.log(`\n1. Open this URL in your browser:`);
               console.log(`   ${url}`);
-              console.log(`\n2. Sign in with GitHub\n`);
+              console.log(`\n2. Sign in with GitHub or Email\n`);
             }
           });
           console.log(`Authenticated! Token expires at ${new Date(creds.expiresAt * 1000).toISOString()}`);


### PR DESCRIPTION
## Summary

Minimal CLI-side change to support the new email auth flow in Kimiflare Cloud.

## Changes
- Auth URL changed from /auth/github?code=... to /auth?code=... (generic portal)
- User-facing copy updated from 'Sign in with GitHub' to 'Sign in with GitHub or Email'

## Backward Compatibility
- Existing stored JWTs continue to work — the CLI runtime is purely JWT-based
- Old /auth/github?code=... URLs still work (server redirects to portal)

## Related
- Requires: sinameraji/kimiflare-cloud#5

Co-authored-by: kimiflare <kimiflare@proton.me>