### PR TITLE
fix(app): update /hello feedback worker URL to hello.kimiflare.com

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -349,7 +349,7 @@ function gatewayUsageLookupFromConfig(
   };
 }
 
-const FEEDBACK_WORKER_URL = "https://kimiflare-feedback.sina-b35.workers.dev";
+const FEEDBACK_WORKER_URL = "https://hello.kimiflare.com";
 
 function openBrowser(url: string): void {
   const cmd = platform() === "darwin" ? "open" : platform() === "win32" ? "start" : "xdg-open";


### PR DESCRIPTION
Updates the hardcoded feedback worker URL from the `.workers.dev` subdomain to the custom domain `hello.kimiflare.com`.