### PR TITLE
feat(ui): narrative activity layer, plan-mode suppression, and interruption cleanup

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,6 +29,7 @@ import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
 import { KimiApiError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
+import { generateActivityText, narrativizeInfo, type ToolBatchItem } from "./ui/narrative.js";
 import { PermissionModal } from "./ui/permission.js";
 import { LimitModal, type LimitDecision } from "./ui/limit-modal.js";
 import { ResumePicker } from "./ui/resume-picker.js";
@@ -580,6 +581,8 @@ function App({
   const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
   const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
+  const toolBatchRef = useRef<ToolBatchItem[]>([]);
+  const toolBatchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const modeRef = useRef<Mode>(mode);
   const effortRef = useRef<ReasoningEffort>(effort);
@@ -883,7 +886,7 @@ function App({
             messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
             setEvents((e) => [
               ...e,
-              { kind: "memory", key: mkKey(), text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} about this repo` },
+              { kind: "activity", key: mkKey(), text: "Remembering what we know about this repo…", feature: "memory" },
             ]);
           }
         } catch {
@@ -1116,7 +1119,7 @@ function App({
       }
       setEvents((e) => [
         ...e,
-        { kind: "info", key: mkKey(), text: `MCP connected — ${totalTools} external tool${totalTools === 1 ? "" : "s"} available` },
+        { kind: "activity", key: mkKey(), text: "Plugging in external tools…" },
       ]);
     }
   }, [cfg]);
@@ -1175,7 +1178,7 @@ function App({
       }
       setEvents((e) => [
         ...e,
-        { kind: "info", key: mkKey(), text: `LSP ready — ${totalServers} server${totalServers === 1 ? "" : "s"} active` },
+        { kind: "activity", key: mkKey(), text: "Waking up the language servers…" },
       ]);
     } else {
       setEvents((e) => [
@@ -1442,6 +1445,17 @@ function App({
     [],
   );
 
+  const flushToolBatch = useCallback(() => {
+    toolBatchTimerRef.current = null;
+    const batch = toolBatchRef.current;
+    toolBatchRef.current = [];
+    if (batch.length === 0) return;
+    const text = generateActivityText(batch, { mode: modeRef.current });
+    if (text) {
+      setEvents((e) => [...e, { kind: "activity", key: mkKey(), text, feature: "explore" }]);
+    }
+  }, []);
+
   const updateGatewayMeta = useCallback((meta: GatewayMeta) => {
     gatewayMetaRef.current = meta;
     setGatewayMeta(meta);
@@ -1629,12 +1643,19 @@ function App({
             pendingToolCallsRef.current.set(call.id, call.function.name);
             const spec = executorRef.current.list().find((t) => t.name === call.function.name);
             let renderMeta: ToolRender | undefined;
+            let argsParsed: Record<string, unknown> = {};
             try {
-              const args = call.function.arguments ? JSON.parse(call.function.arguments) : {};
-              renderMeta = spec?.render?.(args);
+              argsParsed = call.function.arguments ? JSON.parse(call.function.arguments) : {};
+              renderMeta = spec?.render?.(argsParsed);
             } catch {
               /* ignore */
             }
+            // Batch for narrative activity line
+            toolBatchRef.current.push({ name: call.function.name, args: argsParsed });
+            if (toolBatchTimerRef.current) clearTimeout(toolBatchTimerRef.current);
+            toolBatchTimerRef.current = setTimeout(flushToolBatch, 120);
+            // In plan mode, suppress the individual tool card
+            if (modeRef.current === "plan") return;
             setEvents((e) => [
               ...e,
               {
@@ -1765,8 +1786,17 @@ function App({
       permResolveRef.current = null;
       limitResolveRef.current = null;
       pendingToolCallsRef.current.clear();
+      // Clear task state so timers and spinners stop
+      tasksRef.current = [];
+      setTasks([]);
+      setTasksStartedAt(null);
+      setTasksStartTokens(0);
+      // Final sweep: force any still-running tools to error
+      setEvents((evts) =>
+        evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
+      );
     }
-  }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
+  }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta, flushToolBatch]);
 
   const handleThemePick = useCallback(
     (picked: Theme | null) => {
@@ -2728,6 +2758,12 @@ function App({
       const effectiveCodeMode = classification.tier === "heavy";
       setCodeMode(effectiveCodeMode);
 
+      // Narrative: triage + code mode
+      const triageActivity = narrativizeInfo("", { tier: classification.tier, codeMode: effectiveCodeMode });
+      if (triageActivity) {
+        setEvents((e) => [...e, { kind: "activity", key: mkKey(), text: triageActivity.text, feature: triageActivity.feature }]);
+      }
+
       const controller = new AbortController();
       activeControllerRef.current = controller;
 
@@ -2756,12 +2792,19 @@ function App({
           pendingToolCallsRef.current.set(call.id, call.function.name);
           const spec = executorRef.current.list().find((t) => t.name === call.function.name);
           let renderMeta: ToolRender | undefined;
+          let argsParsed: Record<string, unknown> = {};
           try {
-            const args = call.function.arguments ? JSON.parse(call.function.arguments) : {};
-            renderMeta = spec?.render?.(args);
+            argsParsed = call.function.arguments ? JSON.parse(call.function.arguments) : {};
+            renderMeta = spec?.render?.(argsParsed);
           } catch {
             /* ignore render failure */
           }
+          // Batch for narrative activity line
+          toolBatchRef.current.push({ name: call.function.name, args: argsParsed });
+          if (toolBatchTimerRef.current) clearTimeout(toolBatchTimerRef.current);
+          toolBatchTimerRef.current = setTimeout(flushToolBatch, 120);
+          // In plan mode, suppress the individual tool card
+          if (modeRef.current === "plan") return;
           setEvents((e) => [
             ...e,
             {
@@ -2910,9 +2953,10 @@ function App({
               setEvents((e) => [
                 ...e,
                 {
-                  kind: "info",
+                  kind: "activity",
                   key: mkKey(),
-                  text: `auto-compacted: ${result.metrics.estimatedTokensBefore} → ${result.metrics.estimatedTokensAfter} tokens (${result.metrics.archivedArtifacts} artifacts)`,
+                  text: "Making room by summarizing older turns…",
+                  feature: "compact",
                 },
               ]);
               await saveSessionSafe();
@@ -2932,9 +2976,10 @@ function App({
                 setEvents((e) => [
                   ...e,
                   {
-                    kind: "info",
+                    kind: "activity",
                     key: mkKey(),
-                    text: `auto-compacted: ${result.replacedCount} messages summarized`,
+                    text: "Making room by summarizing older turns…",
+                    feature: "compact",
                   },
                 ]);
                 await saveSessionSafe();
@@ -2971,9 +3016,10 @@ function App({
               setEvents((e) => [
                 ...e,
                 {
-                  kind: "memory",
+                  kind: "activity",
                   key: mkKey(),
-                  text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
+                  text: "Remembering what we learned before…",
+                  feature: "memory",
                 },
               ]);
               await saveSessionSafe();
@@ -3030,9 +3076,18 @@ function App({
         permResolveRef.current = null;
         limitResolveRef.current = null;
         pendingToolCallsRef.current.clear();
+        // Clear task state so timers and spinners stop
+        tasksRef.current = [];
+        setTasks([]);
+        setTasksStartedAt(null);
+        setTasksStartTokens(0);
+        // Final sweep: force any still-running tools to error
+        setEvents((evts) =>
+          evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
+        );
       }
     },
-    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe, updateGatewayMeta],
+    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe, updateGatewayMeta, flushToolBatch],
   );
 
   useEffect(() => {
@@ -3324,7 +3379,7 @@ function App({
         {!hasConversation && events.length === 0 ? (
           <Welcome accountId={cfg.accountId} />
         ) : (
-          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} />
+          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} suppressTools={mode === "plan"} />
         )}
         {perm ? (
           <PermissionModal

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -19,12 +19,14 @@ export type ChatEvent =
   | ({ kind: "tool"; key: string } & ToolEventState)
   | { kind: "info"; key: string; text: string }
   | { kind: "error"; key: string; text: string }
-  | { kind: "memory"; key: string; text: string };
+  | { kind: "memory"; key: string; text: string }
+  | { kind: "activity"; key: string; text: string; feature?: "memory" | "code" | "triage" | "compact" | "explore" };
 
 interface Props {
   events: ChatEvent[];
   showReasoning: boolean;
   verbose?: boolean;
+  suppressTools?: boolean;
 }
 
 interface StaticItem {
@@ -33,13 +35,14 @@ interface StaticItem {
   showSeparator: boolean;
 }
 
-export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose }: Props) {
+export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, suppressTools }: Props) {
   const theme = useTheme();
   const finalized: StaticItem[] = [];
   const active: ChatEvent[] = [];
 
   for (let i = 0; i < events.length; i++) {
     const e = events[i]!;
+    if (suppressTools && e.kind === "tool") continue;
     const isStreaming = e.kind === "assistant" && e.streaming;
     if (isStreaming) {
       active.push(e);
@@ -152,6 +155,13 @@ const EventView = React.memo(function EventView({
     return (
       <Text color={theme.info.color} >
         ◈ {evt.text}
+      </Text>
+    );
+  }
+  if (evt.kind === "activity") {
+    return (
+      <Text italic color={theme.info.dim ? theme.info.color : theme.palette.secondary}>
+        ~ {evt.text}
       </Text>
     );
   }

--- a/src/ui/narrative.ts
+++ b/src/ui/narrative.ts
@@ -1,0 +1,220 @@
+/**
+ * Narrative layer: turns dry tool calls and system events into
+ * short stage-direction prose so the UI feels intentional rather
+ * than a raw syscall trace.
+ */
+
+export interface ToolBatchItem {
+  name: string;
+  args?: Record<string, unknown>;
+}
+
+export interface ActivityContext {
+  mode?: "edit" | "plan" | "auto";
+  tier?: "light" | "medium" | "heavy";
+  codeMode?: boolean;
+}
+
+const READING_TOOLS = new Set(["read", "glob", "grep", "lsp_hover", "lsp_definition", "lsp_references", "lsp_implementation", "lsp_typeDefinition", "lsp_documentSymbols", "lsp_workspaceSymbol"]);
+const WRITING_TOOLS = new Set(["write", "edit", "lsp_rename", "lsp_codeAction"]);
+const SHELL_TOOLS = new Set(["bash"]);
+const WEB_TOOLS = new Set(["web_fetch"]);
+const MEMORY_TOOLS = new Set(["memory_remember", "memory_recall", "memory_forget"]);
+
+function countByCategory(items: ToolBatchItem[]) {
+  let reads = 0;
+  let writes = 0;
+  let shells = 0;
+  let webs = 0;
+  let memories = 0;
+  let others = 0;
+  for (const t of items) {
+    if (READING_TOOLS.has(t.name)) reads++;
+    else if (WRITING_TOOLS.has(t.name)) writes++;
+    else if (SHELL_TOOLS.has(t.name)) shells++;
+    else if (WEB_TOOLS.has(t.name)) webs++;
+    else if (MEMORY_TOOLS.has(t.name)) memories++;
+    else others++;
+  }
+  return { reads, writes, shells, webs, memories, others };
+}
+
+function pickOne<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+/** Generate a narrative line for a batch of tools that arrived close together. */
+export function generateActivityText(items: ToolBatchItem[], _ctx?: ActivityContext): string | null {
+  if (items.length === 0) return null;
+
+  const { reads, writes, shells, webs, memories } = countByCategory(items);
+  const total = items.length;
+
+  // Single-tool narratives
+  if (total === 1) {
+    const t = items[0]!;
+    if (t.name === "read") {
+      const path = typeof t.args?.path === "string" ? t.args.path : "a file";
+      return pickOne([`Reading ${path}…`, `Opening ${path}…`, `Taking a look at ${path}…`]);
+    }
+    if (t.name === "grep") {
+      const pattern = typeof t.args?.pattern === "string" ? `"${t.args.pattern}"` : "for patterns";
+      return pickOne([`Searching for ${pattern}…`, `Hunting for ${pattern}…`]);
+    }
+    if (t.name === "glob") {
+      const pattern = typeof t.args?.pattern === "string" ? t.args.pattern : "files";
+      return pickOne([`Finding ${pattern}…`, `Gathering ${pattern}…`]);
+    }
+    if (t.name === "write") {
+      const path = typeof t.args?.path === "string" ? t.args.path : "a file";
+      return pickOne([`Creating ${path}…`, `Writing ${path}…`]);
+    }
+    if (t.name === "edit") {
+      const path = typeof t.args?.path === "string" ? t.args.path : "a file";
+      return pickOne([`Patching ${path}…`, `Editing ${path}…`]);
+    }
+    if (t.name === "bash") {
+      return pickOne([`Running a shell command…`, `Executing something in the terminal…`]);
+    }
+    if (t.name === "web_fetch") {
+      return pickOne([`Fetching docs…`, `Checking a reference…`, `Looking something up…`]);
+    }
+    if (t.name === "memory_remember") {
+      return pickOne([`Taking notes for next time…`, `Committing that to memory…`]);
+    }
+    if (t.name === "memory_recall") {
+      return pickOne([`Recalling what we know…`, `Searching past notes…`]);
+    }
+    return null; // fall back to individual tool card
+  }
+
+  // Multi-tool narratives
+  if (webs >= 2) {
+    return pickOne([`Digging through documentation…`, `Cross-referencing sources…`, `Reading up on this…`]);
+  }
+  if (reads >= 2 && writes === 0 && shells === 0) {
+    return pickOne([`Surveying the landscape…`, `Getting the lay of the land…`, `Mapping out the files…`]);
+  }
+  if (reads >= 1 && (writes >= 1 || shells >= 1)) {
+    return pickOne([`Reading, then making changes…`, `Exploring and editing…`, `Survey and patch…`]);
+  }
+  if (writes >= 1 && shells >= 1) {
+    return pickOne([`Committing the changes…`, `Writing and verifying…`, `Editing and checking…`]);
+  }
+  if (reads >= 1 && webs >= 1) {
+    return pickOne([`Exploring the codebase and docs…`, `Cross-referencing code with references…`]);
+  }
+  if (memories >= 1) {
+    return pickOne([`Jogging the memory…`, `Checking past notes…`]);
+  }
+  if (shells >= 1) {
+    return pickOne([`Running some commands…`, `Working in the shell…`]);
+  }
+
+  return null;
+}
+
+/** Turn a dry info string into an activity line when we recognise the event. */
+export function narrativizeInfo(text: string, ctx?: ActivityContext): { kind: "activity"; text: string; feature?: ActivityContext["mode"] extends string ? never : "memory" | "code" | "triage" | "compact" | "explore" } | null {
+  // Triage / intent classification
+  if (ctx?.tier === "heavy") {
+    return { kind: "activity", text: "Sizing this up… feels like a deep one.", feature: "triage" };
+  }
+  if (ctx?.tier === "light") {
+    return { kind: "activity", text: "Quick check — this looks light.", feature: "triage" };
+  }
+  if (ctx?.tier === "medium") {
+    return { kind: "activity", text: "This one feels medium weight.", feature: "triage" };
+  }
+
+  // Code mode
+  if (ctx?.codeMode) {
+    return { kind: "activity", text: "The toolbox feels right for this. Switching to code mode…", feature: "code" };
+  }
+
+  // Compaction
+  if (text.includes("auto-compacted") || text.includes("compacted")) {
+    return { kind: "activity", text: "Making room by summarizing older turns…", feature: "compact" };
+  }
+
+  // Memory recall
+  if (text.includes("recalled") && text.includes("memory")) {
+    return { kind: "activity", text: "Remembering what we learned before…", feature: "memory" };
+  }
+
+  // Memory extraction (silent in current UI, but if it ever logs)
+  if (text.includes("memory cleanup") || text.includes("memory backfill")) {
+    return null; // keep these as literal info — they're background maintenance
+  }
+
+  // LSP
+  if (text.startsWith("LSP ready")) {
+    return { kind: "activity", text: "Waking up the language servers…" };
+  }
+  if (text.startsWith("LSP reload complete")) {
+    return null; // too noisy
+  }
+
+  // MCP
+  if (text.startsWith("MCP connected")) {
+    return { kind: "activity", text: "Plugging in external tools…" };
+  }
+
+  // Exploration / research
+  if (text.includes("research budget") || text.includes("web request")) {
+    return { kind: "activity", text: "Researching… gathering what we can from the web.", feature: "explore" };
+  }
+
+  return null;
+}
+
+/** Human-readable title for a single tool call (used by ToolView fallback). */
+export function humanizeToolTitle(name: string, args?: Record<string, unknown>): string {
+  const path = typeof args?.path === "string" ? args.path : undefined;
+  const pattern = typeof args?.pattern === "string" ? args.pattern : undefined;
+  const command = typeof args?.command === "string" ? args.command : undefined;
+  const url = typeof args?.url === "string" ? args.url : undefined;
+
+  switch (name) {
+    case "read":
+      return path ? `Reading ${path}` : "Reading a file…";
+    case "grep":
+      return pattern ? `Searching for "${pattern}"` : "Searching…";
+    case "glob":
+      return pattern ? `Finding ${pattern}` : "Finding files…";
+    case "write":
+      return path ? `Creating ${path}` : "Creating a file…";
+    case "edit":
+      return path ? `Patching ${path}` : "Patching a file…";
+    case "bash":
+      return command ? `Running: ${command.split(/\s+/).slice(0, 4).join(" ")}${command.split(/\s+/).length > 4 ? "…" : ""}` : "Running shell command…";
+    case "web_fetch":
+      return url ? `Fetching ${url.replace(/^https?:\/\//, "").split("/")[0]}` : "Fetching docs…";
+    case "memory_remember":
+      return "Committing to memory…";
+    case "memory_recall":
+      return "Recalling memories…";
+    case "memory_forget":
+      return "Forgetting a memory…";
+    case "lsp_hover":
+      return "Inspecting symbol…";
+    case "lsp_definition":
+      return "Jumping to definition…";
+    case "lsp_references":
+      return "Finding references…";
+    case "lsp_implementation":
+      return "Finding implementations…";
+    case "lsp_typeDefinition":
+      return "Finding type definition…";
+    case "lsp_documentSymbols":
+      return "Listing symbols…";
+    case "lsp_workspaceSymbol":
+      return "Searching workspace symbols…";
+    case "lsp_rename":
+      return "Renaming symbol…";
+    case "lsp_codeAction":
+      return "Applying quick fix…";
+    default:
+      return name;
+  }
+}

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -5,6 +5,7 @@ import { DiffView } from "./diff-view.js";
 import { collapsePathsInText } from "../util/paths.js";
 import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
+import { humanizeToolTitle } from "./narrative.js";
 
 export interface ToolEventState {
   id: string;
@@ -33,7 +34,16 @@ export const ToolView = React.memo(function ToolView({ evt, verbose }: Props) {
     ) : (
       <Text color={theme.palette.success}>✓</Text>
     );
-  const title = evt.render?.title ?? `${evt.name}(${compactArgs(evt.args)})`;
+  const title =
+    evt.render?.title ??
+    (() => {
+      try {
+        const args = evt.args ? JSON.parse(evt.args) : {};
+        return humanizeToolTitle(evt.name, args);
+      } catch {
+        return humanizeToolTitle(evt.name);
+      }
+    })();
   const expand = Boolean(evt.expanded || verbose);
   const lines = evt.result ? evt.result.split("\n") : [];
   const showLimit = verbose ? 200 : 20;


### PR DESCRIPTION
## Summary

This PR polishes the TUI logging experience across all modes by introducing a narrative "activity" layer, suppressing noisy plan-mode tool cards, and fixing stale spinner/timer state on interruption.

### What's new

- **Activity events** — a new `kind: "activity"` ChatEvent renders as italic dim prose (e.g. ). These act as stage directions between the literal tool cards.
- **Tool batching** — rapid sequences of tools (e.g. 3× read, grep + read) are debounced (~120ms) and summarized into a single activity line instead of spawning a card for every syscall.
- **Plan-mode suppression** — in plan mode, individual tool cards are hidden from the chat stream. The user sees only activity lines + assistant text, while the model still receives all tool results.
- **Humanized tool titles** — ToolView fallback titles are now readable ( instead of ).
- **Interruption cleanup** — pressing Esc now properly clears the task list, stops the elapsed timer, and forces any still-running tools to error state so spinners don't linger.

### Narrative replacements

| Old info log | New activity line |
|---|---|
|  |  |
|  |  |
|  |  |
|  |  |
| (silent) |  (heavy triage) |

### Files changed

- `src/ui/chat.tsx` — add `kind: "activity"` to ChatEvent union, render it, add `suppressTools` prop
- `src/ui/narrative.ts` — new helper module for generating activity text and humanizing tool titles
- `src/ui/tool-view.tsx` — use humanized fallback titles
- `src/app.tsx` — wire batching, suppression, activity events, and interruption cleanup

### Testing

- `npm run typecheck` passes (pre-existing sandbox.test.ts errors unrelated)
- 283/285 tests pass (2 pre-existing failures in sandbox.test.ts)