### PR TITLE
feat(ui): extensible JSON themes with WCAG contrast validation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -91,6 +91,7 @@ import { LspWizard } from "./ui/lsp-wizard.js";
 import { ThemeProvider } from "./ui/theme-context.js";
 import { ThemePicker } from "./ui/theme-picker.js";
 import { resolveTheme, themeList, themeNames, DEFAULT_THEME_NAME } from "./ui/theme.js";
+import { loadAndMergeThemes } from "./ui/theme-loader.js";
 import type { Theme } from "./ui/theme.js";
 import { saveProjectLspConfig, type ResolvedLspConfig } from "./util/lsp-config.js";
 import { maybeLspNudge } from "./util/lsp-nudge.js";
@@ -548,6 +549,29 @@ function App({
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
   const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
   const [showThemePicker, setShowThemePicker] = useState(false);
+
+  // Load user and project themes at startup
+  useEffect(() => {
+    let cancelled = false;
+    loadAndMergeThemes().then(({ errors, wcagWarnings }) => {
+      if (cancelled) return;
+      if (errors.length > 0) {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: `theme load errors:\n${errors.join("\n")}` },
+        ]);
+      }
+      if (wcagWarnings.length > 0) {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `theme WCAG warnings:\n${wcagWarnings.join("\n")}` },
+        ]);
+      }
+      // Re-resolve current theme in case a user/project theme overrides the built-in
+      setTheme(resolveTheme(initialCfg?.theme));
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // Fetch cloud token budget on startup
   useEffect(() => {
@@ -1802,14 +1826,18 @@ function App({
     (picked: Theme | null) => {
       setShowThemePicker(false);
       if (!picked) return;
-      setCfg((c) => (c ? { ...c, theme: picked.name } : c));
-      if (cfg) void saveConfig({ ...cfg, theme: picked.name }).catch(() => {});
+      setCfg((c) => {
+        if (!c) return c;
+        const updated = { ...c, theme: picked.name };
+        void saveConfig(updated).catch(() => {});
+        return updated;
+      });
       setEvents((e) => [
         ...e,
         { kind: "info", key: mkKey(), text: `theme: ${picked.label} — restart to apply` },
       ]);
     },
-    [cfg],
+    [],
   );
 
   const handleResumePick = useCallback(
@@ -2142,8 +2170,12 @@ function App({
           ]);
           return true;
         }
-        setCfg((c) => (c ? { ...c, theme: next.name } : c));
-        if (cfg) void saveConfig({ ...cfg, theme: next.name }).catch(() => {});
+        setCfg((prev) => {
+          if (!prev) return prev;
+          const updated = { ...prev, theme: next.name };
+          void saveConfig(updated).catch(() => {});
+          return updated;
+        });
         setEvents((e) => [
           ...e,
           { kind: "info", key: mkKey(), text: `theme: ${next.label} — restart to apply` },

--- a/src/config.ts
+++ b/src/config.ts
@@ -264,6 +264,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         codeMode: envCodeMode ?? parsed.codeMode,
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? false,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
+        theme: parsed.theme,
       };
     }
     if (parsed.accountId && parsed.apiToken) {
@@ -296,6 +297,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? true,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
         cloudMode: envCloudMode ?? parsed.cloudMode,
+        theme: parsed.theme,
       };
     }
   } catch {

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -8,8 +8,9 @@ interface Props {
 }
 
 interface InlineSegment {
-  kind: "plain" | "bold" | "italic" | "code";
+  kind: "plain" | "bold" | "italic" | "code" | "strikethrough" | "link";
   text: string;
+  url?: string;
 }
 
 export function MD({ text }: Props) {
@@ -28,8 +29,10 @@ type Block =
   | { kind: "paragraph"; text: string }
   | { kind: "heading"; level: 1 | 2 | 3; text: string }
   | { kind: "bullet"; items: string[] }
+  | { kind: "numbered"; items: string[] }
   | { kind: "quote"; text: string }
   | { kind: "code"; lang?: string; text: string }
+  | { kind: "table"; headers: string[]; rows: string[][] }
   | { kind: "blank" };
 
 function parseBlocks(src: string): Block[] {
@@ -68,6 +71,16 @@ function parseBlocks(src: string): Block[] {
       out.push({ kind: "quote", text: quoteLines.join("\n") });
       continue;
     }
+    // Numbered list
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i]!)) {
+        items.push(lines[i]!.replace(/^\s*\d+\.\s+/, ""));
+        i++;
+      }
+      out.push({ kind: "numbered", items });
+      continue;
+    }
     if (/^\s*[-*]\s+/.test(line)) {
       const items: string[] = [];
       while (i < lines.length && /^\s*[-*]\s+/.test(lines[i]!)) {
@@ -77,6 +90,27 @@ function parseBlocks(src: string): Block[] {
       out.push({ kind: "bullet", items });
       continue;
     }
+    // Table
+    if (i + 1 < lines.length && /^\|/.test(line) && /^\|[\s\-:|]+\|$/.test(lines[i + 1]!)) {
+      const headerLine = line;
+      const headers = headerLine
+        .split("|")
+        .slice(1, -1)
+        .map((h) => h.trim());
+      i += 2; // skip header and separator
+      const rows: string[][] = [];
+      while (i < lines.length && /^\|/.test(lines[i]!)) {
+        rows.push(
+          lines[i]!
+            .split("|")
+            .slice(1, -1)
+            .map((c) => c.trim()),
+        );
+        i++;
+      }
+      out.push({ kind: "table", headers, rows });
+      continue;
+    }
     const paraLines: string[] = [line];
     i++;
     while (
@@ -84,8 +118,10 @@ function parseBlocks(src: string): Block[] {
       lines[i]!.trim() !== "" &&
       !/^(#{1,3})\s+/.test(lines[i]!) &&
       !/^\s*[-*]\s+/.test(lines[i]!) &&
+      !/^\s*\d+\.\s+/.test(lines[i]!) &&
       !/^\s*>\s?/.test(lines[i]!) &&
-      !/^```/.test(lines[i]!)
+      !/^```/.test(lines[i]!) &&
+      !/^\|/.test(lines[i]!)
     ) {
       paraLines.push(lines[i]!);
       i++;
@@ -119,22 +155,75 @@ const Block = React.memo(function Block({ block }: { block: Block }) {
       </Box>
     );
   }
+  if (block.kind === "numbered") {
+    return (
+      <Box flexDirection="column">
+        {block.items.map((item, idx) => (
+          <Box key={idx}>
+            <Text color={theme.accent}>  {idx + 1}. </Text>
+            <Text>{renderInline(item, theme)}</Text>
+          </Box>
+        ))}
+      </Box>
+    );
+  }
   if (block.kind === "quote") {
+    const quoteColor = theme.blockquote?.color ?? theme.info.color;
+    const dim = theme.blockquote?.dim ?? false;
     return (
       <Box marginLeft={2}>
-        <Text color={theme.info.color} italic>
+        <Text color={quoteColor} dimColor={dim} italic>
           {renderInline(block.text, theme)}
         </Text>
       </Box>
     );
   }
   if (block.kind === "code") {
+    const codeColor = theme.codeBlock ?? theme.tool;
     return (
       <Box flexDirection="column" marginLeft={2}>
         {block.text.split("\n").map((l, i) => (
-          <Text key={i} color={theme.tool}>
+          <Text key={i} color={codeColor}>
             {l}
           </Text>
+        ))}
+      </Box>
+    );
+  }
+  if (block.kind === "table") {
+    const borderColor = theme.tableBorder ?? theme.accent;
+    const headerColor = theme.tableHeader ?? theme.accent;
+    const cellColor = theme.tableCell ?? theme.palette.foreground;
+    const colCount = block.headers.length;
+    return (
+      <Box flexDirection="column" marginLeft={2}>
+        {/* Header row */}
+        <Box>
+          <Text color={borderColor}>│ </Text>
+          {block.headers.map((h, ci) => (
+            <React.Fragment key={ci}>
+              <Text bold color={headerColor}>{h}</Text>
+              {ci < colCount - 1 && <Text color={borderColor}> │ </Text>}
+            </React.Fragment>
+          ))}
+          <Text color={borderColor}> │</Text>
+        </Box>
+        {/* Separator */}
+        <Box>
+          <Text color={borderColor}>├{Array(colCount).fill("─".repeat(8)).join("┼")}┤</Text>
+        </Box>
+        {/* Data rows */}
+        {block.rows.map((row, ri) => (
+          <Box key={ri}>
+            <Text color={borderColor}>│ </Text>
+            {row.map((cell, ci) => (
+              <React.Fragment key={ci}>
+                <Text color={cellColor}>{cell}</Text>
+                {ci < colCount - 1 && <Text color={borderColor}> │ </Text>}
+              </React.Fragment>
+            ))}
+            <Text color={borderColor}> │</Text>
+          </Box>
         ))}
       </Box>
     );
@@ -147,7 +236,18 @@ function renderInline(src: string, theme: Theme): React.ReactNode {
   return segments.map((seg, i) => {
     if (seg.kind === "bold") return <Text key={i} bold>{seg.text}</Text>;
     if (seg.kind === "italic") return <Text key={i} italic>{seg.text}</Text>;
-    if (seg.kind === "code") return <Text key={i} color={theme.tool}>{seg.text}</Text>;
+    if (seg.kind === "code") {
+      const color = theme.codeInline ?? theme.tool;
+      return <Text key={i} color={color}>{seg.text}</Text>;
+    }
+    if (seg.kind === "strikethrough") {
+      const color = theme.strikethrough ?? theme.muted?.color ?? theme.palette.secondary;
+      return <Text key={i} strikethrough color={color}>{seg.text}</Text>;
+    }
+    if (seg.kind === "link") {
+      const color = theme.link ?? theme.accent;
+      return <Text key={i} underline color={color}>{seg.text}</Text>;
+    }
     return <Text key={i}>{seg.text}</Text>;
   });
 }
@@ -164,6 +264,7 @@ function parseInline(src: string): InlineSegment[] {
   };
   while (i < src.length) {
     const ch = src[i]!;
+    // Code: `text`
     if (ch === "`") {
       const end = src.indexOf("`", i + 1);
       if (end > i) {
@@ -173,6 +274,33 @@ function parseInline(src: string): InlineSegment[] {
         continue;
       }
     }
+    // Strikethrough: ~~text~~
+    if (ch === "~" && src[i + 1] === "~") {
+      const end = src.indexOf("~~", i + 2);
+      if (end > i + 1) {
+        flush();
+        out.push({ kind: "strikethrough", text: src.slice(i + 2, end) });
+        i = end + 2;
+        continue;
+      }
+    }
+    // Link: [text](url)
+    if (ch === "[") {
+      const closeBracket = src.indexOf("]", i + 1);
+      const openParen = closeBracket >= 0 ? src.indexOf("(", closeBracket) : -1;
+      const closeParen = openParen >= 0 ? src.indexOf(")", openParen) : -1;
+      if (closeParen > openParen && openParen === closeBracket + 1) {
+        flush();
+        out.push({
+          kind: "link",
+          text: src.slice(i + 1, closeBracket),
+          url: src.slice(openParen + 1, closeParen),
+        });
+        i = closeParen + 1;
+        continue;
+      }
+    }
+    // Bold: **text**
     if (ch === "*" && src[i + 1] === "*") {
       const end = src.indexOf("**", i + 2);
       if (end > i + 1) {
@@ -182,6 +310,7 @@ function parseInline(src: string): InlineSegment[] {
         continue;
       }
     }
+    // Bold: __text__
     if (ch === "_" && src[i + 1] === "_") {
       const end = src.indexOf("__", i + 2);
       if (end > i + 1) {
@@ -191,6 +320,7 @@ function parseInline(src: string): InlineSegment[] {
         continue;
       }
     }
+    // Italic: *text*
     if (ch === "*" && src[i + 1] !== "*") {
       const end = src.indexOf("*", i + 1);
       if (end > i) {
@@ -200,6 +330,7 @@ function parseInline(src: string): InlineSegment[] {
         continue;
       }
     }
+    // Italic: _text_
     if (ch === "_" && !/\w/.test(src[i - 1] ?? "") && src[i + 1] !== "_") {
       const end = src.indexOf("_", i + 1);
       if (end > i && !/\w/.test(src[end + 1] ?? "")) {

--- a/src/ui/theme-loader.test.ts
+++ b/src/ui/theme-loader.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadThemesFromDir, clearThemeCache } from "./theme-loader.js";
+
+describe("loadThemesFromDir", () => {
+  it("loads valid theme JSON", async () => {
+    const dir = join(tmpdir(), `kf-test-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "test-theme.json"),
+      JSON.stringify({
+        name: "test-theme",
+        label: "Test Theme",
+        palette: {
+          background: "#1a1b26",
+          foreground: "#a9b1d6",
+          primary: "#7aa2f7",
+          secondary: "#565f89",
+          success: "#9ece6a",
+          error: "#f7768e",
+        },
+        user: "#7aa2f7",
+      }),
+    );
+
+    const { themes, errors } = await loadThemesFromDir(dir, "user");
+    assert.strictEqual(errors.length, 0);
+    assert.strictEqual(themes.length, 1);
+    assert.strictEqual(themes[0]!.theme.name, "test-theme");
+    assert.strictEqual(themes[0]!.theme.palette.background, "#1a1b26");
+
+    await rm(dir, { recursive: true });
+  });
+
+  it("reports invalid hex colors", async () => {
+    const dir = join(tmpdir(), `kf-test-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "bad-theme.json"),
+      JSON.stringify({
+        name: "bad-theme",
+        label: "Bad Theme",
+        palette: {
+          background: "not-a-color",
+          foreground: "#a9b1d6",
+          primary: "#7aa2f7",
+          secondary: "#565f89",
+          success: "#9ece6a",
+          error: "#f7768e",
+        },
+      }),
+    );
+
+    const { themes, errors } = await loadThemesFromDir(dir, "user");
+    assert.strictEqual(themes.length, 0);
+    assert.ok(errors.some((e) => e.includes("not-a-color")));
+
+    await rm(dir, { recursive: true });
+  });
+
+  it("reports WCAG issues for low contrast", async () => {
+    const dir = join(tmpdir(), `kf-test-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "low-contrast.json"),
+      JSON.stringify({
+        name: "low-contrast",
+        label: "Low Contrast",
+        palette: {
+          background: "#ffffff",
+          foreground: "#eeeeee",
+          primary: "#dddddd",
+          secondary: "#cccccc",
+          success: "#bbbbbb",
+          error: "#aaaaaa",
+        },
+      }),
+    );
+
+    const { themes, errors } = await loadThemesFromDir(dir, "user");
+    assert.strictEqual(errors.length, 0);
+    assert.strictEqual(themes.length, 1);
+    assert.ok(themes[0]!.wcagIssues.length > 0, "expected WCAG issues for low contrast theme");
+
+    await rm(dir, { recursive: true });
+  });
+});

--- a/src/ui/theme-loader.ts
+++ b/src/ui/theme-loader.ts
@@ -1,0 +1,306 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { checkContrast, type ContrastIssue } from "./wcag.js";
+import { setThemes, THEMES, type Theme, type LoadedTheme } from "./theme.js";
+
+const USER_THEMES_DIR = join(
+  process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+  "kimiflare",
+  "themes",
+);
+
+function projectThemesDir(cwd = process.cwd()): string {
+  return join(cwd, ".kimiflare", "themes");
+}
+
+function isHexColor(c: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(c);
+}
+
+function validateHex(field: string, value: string | undefined, errors: string[]): void {
+  if (value === undefined) return;
+  if (!isHexColor(value)) {
+    errors.push(`${field}: "${value}" is not a valid #RRGGBB hex color`);
+  }
+}
+
+function validatePalette(p: unknown, errors: string[]): Theme["palette"] | null {
+  if (!p || typeof p !== "object") {
+    errors.push("palette must be an object");
+    return null;
+  }
+  const palette = p as Record<string, unknown>;
+  const required = ["background", "foreground", "primary", "secondary", "success", "error"];
+  for (const key of required) {
+    if (typeof palette[key] !== "string") {
+      errors.push(`palette.${key} is required and must be a string`);
+    } else {
+      validateHex(`palette.${key}`, palette[key] as string, errors);
+    }
+  }
+  if (errors.length > 0) return null;
+  return {
+    background: palette.background as string,
+    foreground: palette.foreground as string,
+    primary: palette.primary as string,
+    secondary: palette.secondary as string,
+    success: palette.success as string,
+    error: palette.error as string,
+  };
+}
+
+function validateDimColor(
+  field: string,
+  value: unknown,
+  errors: string[],
+): Theme["reasoning"] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") {
+    validateHex(field, value, errors);
+    return { color: value, dim: false };
+  }
+  if (!value || typeof value !== "object") {
+    errors.push(`${field} must be a string or { color, dim } object`);
+    return undefined;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.color !== "string") {
+    errors.push(`${field}.color is required`);
+    return undefined;
+  }
+  validateHex(`${field}.color`, obj.color, errors);
+  return {
+    color: obj.color,
+    dim: obj.dim === true,
+  };
+}
+
+function validateModeBadge(
+  value: unknown,
+  errors: string[],
+): Theme["modeBadge"] | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object") {
+    errors.push("modeBadge must be an object");
+    return undefined;
+  }
+  const obj = value as Record<string, unknown>;
+  const result: Record<string, string> = {};
+  for (const key of ["plan", "auto", "edit"]) {
+    if (typeof obj[key] !== "string") {
+      errors.push(`modeBadge.${key} is required`);
+    } else {
+      validateHex(`modeBadge.${key}`, obj[key] as string, errors);
+      result[key] = obj[key] as string;
+    }
+  }
+  return result as Theme["modeBadge"];
+}
+
+function normalizeColor(v: unknown): string | undefined {
+  if (v === undefined) return undefined;
+  if (typeof v === "string") return v;
+  const d = v as Record<string, unknown>;
+  return typeof d.color === "string" ? d.color : undefined;
+}
+
+export interface LoadResult {
+  themes: Record<string, LoadedTheme>;
+  errors: string[];
+}
+
+export async function loadThemesFromDir(
+  dir: string,
+  source: LoadedTheme["source"],
+): Promise<{ themes: LoadedTheme[]; errors: string[] }> {
+  const themes: LoadedTheme[] = [];
+  const errors: string[] = [];
+
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return { themes, errors };
+  }
+
+  for (const file of files.filter((f) => f.endsWith(".json"))) {
+    const path = join(dir, file);
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf-8");
+    } catch (e) {
+      errors.push(`${path}: ${e instanceof Error ? e.message : String(e)}`);
+      continue;
+    }
+
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch (e) {
+      errors.push(`${path}: invalid JSON — ${e instanceof Error ? e.message : String(e)}`);
+      continue;
+    }
+
+    if (!json || typeof json !== "object") {
+      errors.push(`${path}: root must be an object`);
+      continue;
+    }
+
+    const obj = json as Record<string, unknown>;
+    const fileErrors: string[] = [];
+
+    if (typeof obj.name !== "string" || obj.name.length === 0) {
+      fileErrors.push("name is required");
+    }
+    if (typeof obj.label !== "string" || obj.label.length === 0) {
+      fileErrors.push("label is required");
+    }
+
+    const palette = validatePalette(obj.palette, fileErrors);
+
+    if (fileErrors.length > 0) {
+      errors.push(...fileErrors.map((e) => `${path}: ${e}`));
+      continue;
+    }
+
+    if (!palette) continue;
+
+    const theme: Theme = {
+      name: obj.name as string,
+      label: obj.label as string,
+      palette,
+      user: (typeof obj.user === "string" ? obj.user : palette.primary) as string,
+      assistant: obj.assistant === null ? undefined : (typeof obj.assistant === "string" ? obj.assistant : undefined),
+      reasoning: validateDimColor("reasoning", obj.reasoning, fileErrors) ?? { color: palette.secondary, dim: false },
+      info: validateDimColor("info", obj.info, fileErrors) ?? { color: palette.secondary, dim: false },
+      error: (typeof obj.error === "string" ? obj.error : palette.error) as string,
+      warn: (typeof obj.warn === "string" ? obj.warn : palette.error) as string,
+      tool: (typeof obj.tool === "string" ? obj.tool : palette.secondary) as string,
+      spinner: (typeof obj.spinner === "string" ? obj.spinner : palette.primary) as string,
+      permission: (typeof obj.permission === "string" ? obj.permission : palette.error) as string,
+      queue: validateDimColor("queue", obj.queue, fileErrors) ?? { color: palette.secondary, dim: false },
+      accent: (typeof obj.accent === "string" ? obj.accent : palette.primary) as string,
+      modeBadge: validateModeBadge(obj.modeBadge, fileErrors) ?? {
+        plan: palette.primary,
+        auto: palette.success,
+        edit: palette.error,
+      },
+      blockquote: validateDimColor("blockquote", obj.blockquote, fileErrors),
+      codeInline: normalizeColor(obj.codeInline),
+      codeBlock: normalizeColor(obj.codeBlock),
+      link: normalizeColor(obj.link),
+      strikethrough: normalizeColor(obj.strikethrough),
+      tableBorder: normalizeColor(obj.tableBorder),
+      tableHeader: normalizeColor(obj.tableHeader),
+      tableCell: normalizeColor(obj.tableCell),
+      muted: validateDimColor("muted", obj.muted, fileErrors),
+    };
+
+    if (fileErrors.length > 0) {
+      errors.push(...fileErrors.map((e) => `${path}: ${e}`));
+      continue;
+    }
+
+    // WCAG contrast checks
+    const wcagIssues: ContrastIssue[] = [];
+    const bg = palette.background;
+
+    const check = (label: string, color: string | undefined) => {
+      if (!color) return;
+      const issue = checkContrast(color, bg);
+      if (issue) wcagIssues.push({ ...issue, pair: `${label} (${issue.pair})` });
+    };
+
+    check("foreground", palette.foreground);
+    check("user", theme.user);
+    check("assistant", theme.assistant);
+    check("reasoning", theme.reasoning.color);
+    check("info", theme.info.color);
+    check("error", theme.error);
+    check("warn", theme.warn);
+    check("tool", theme.tool);
+    check("accent", theme.accent);
+    check("link", theme.link);
+    check("codeInline", theme.codeInline);
+    check("codeBlock", theme.codeBlock);
+    check("tableHeader", theme.tableHeader);
+    check("tableCell", theme.tableCell);
+
+    themes.push({ theme, source, path, wcagIssues });
+  }
+
+  return { themes, errors };
+}
+
+let cachedResult: LoadResult | null = null;
+
+export async function loadAllThemes(cwd = process.cwd()): Promise<LoadResult> {
+  if (cachedResult) return cachedResult;
+
+  const themes: Record<string, LoadedTheme> = {};
+  const errors: string[] = [];
+
+  // Start with built-in themes
+  for (const [name, theme] of Object.entries(THEMES)) {
+    themes[name] = {
+      theme,
+      source: "built-in",
+      path: "<built-in>",
+      wcagIssues: [],
+    };
+  }
+
+  // 1. User themes (override built-in)
+  const user = await loadThemesFromDir(USER_THEMES_DIR, "user");
+  for (const t of user.themes) {
+    themes[t.theme.name] = t;
+  }
+  errors.push(...user.errors);
+
+  // 2. Project-local themes (override user)
+  const project = await loadThemesFromDir(projectThemesDir(cwd), "project");
+  for (const t of project.themes) {
+    themes[t.theme.name] = t;
+  }
+  errors.push(...project.errors);
+
+  cachedResult = { themes, errors };
+  return cachedResult;
+}
+
+export function clearThemeCache(): void {
+  cachedResult = null;
+}
+
+/** Load user and project themes and merge them into the global THEMES registry. */
+export async function loadAndMergeThemes(cwd = process.cwd()): Promise<{ errors: string[]; wcagWarnings: string[] }> {
+  clearThemeCache();
+  const { themes, errors } = await loadAllThemes(cwd);
+
+  const merged: Record<string, Theme> = {};
+  for (const [name, t] of Object.entries(THEMES)) {
+    merged[name] = t;
+  }
+  for (const t of Object.values(themes)) {
+    merged[t.theme.name] = t.theme;
+  }
+  setThemes(merged);
+
+  const wcagWarnings: string[] = [];
+  for (const t of Object.values(themes)) {
+    if (t.wcagIssues.length > 0 && t.source !== "built-in") {
+      wcagWarnings.push(
+        `Theme "${t.theme.label}" has WCAG contrast issues:\n` +
+          t.wcagIssues.map((i) => `  ${i.pair}: ${i.ratio}:1 (needs ${i.required}:1)`).join("\n"),
+      );
+    }
+  }
+
+  return { errors, wcagWarnings };
+}
+
+export async function getThemeWcagIssues(name: string, cwd?: string): Promise<ContrastIssue[]> {
+  const { themes } = await loadAllThemes(cwd);
+  return themes[name]?.wcagIssues ?? [];
+}

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,3 +1,20 @@
+import type { ContrastIssue } from "./wcag.js";
+
+// Built-in themes — imported as JSON so tsup bundles them.
+import everforestDarkJson from "./themes/everforest-dark.json" with { type: "json" };
+import everforestLightJson from "./themes/everforest-light.json" with { type: "json" };
+import kanagawaDarkJson from "./themes/kanagawa-dark.json" with { type: "json" };
+import draculaDarkJson from "./themes/dracula-dark.json" with { type: "json" };
+import tokyoNightJson from "./themes/tokyo-night.json" with { type: "json" };
+import catppuccinMochaJson from "./themes/catppuccin-mocha.json" with { type: "json" };
+import catppuccinLatteJson from "./themes/catppuccin-latte.json" with { type: "json" };
+import solarizedDarkJson from "./themes/solarized-dark.json" with { type: "json" };
+import solarizedLightJson from "./themes/solarized-light.json" with { type: "json" };
+import nordJson from "./themes/nord.json" with { type: "json" };
+import gruvboxDarkJson from "./themes/gruvbox-dark.json" with { type: "json" };
+import gruvboxLightJson from "./themes/gruvbox-light.json" with { type: "json" };
+import oneDarkJson from "./themes/one-dark.json" with { type: "json" };
+
 export type ColorName = string;
 
 export interface DimColor {
@@ -5,8 +22,10 @@ export interface DimColor {
   dim: boolean;
 }
 
-/** Raw palette — only 4 colors. Everything else derives from these. */
+/** Raw palette — now includes background and foreground for WCAG validation. */
 export interface ColorPalette {
+  background: string;
+  foreground: string;
   primary: string;
   secondary: string;
   success: string;
@@ -30,88 +49,101 @@ export interface Theme {
   queue: DimColor;
   accent: ColorName;
   modeBadge: { plan: ColorName; auto: ColorName; edit: ColorName };
+  /** Blockquote text color. */
+  blockquote?: DimColor;
+  /** Inline code color. */
+  codeInline?: ColorName;
+  /** Fenced code block color. */
+  codeBlock?: ColorName;
+  /** Hyperlink color. */
+  link?: ColorName;
+  /** Strikethrough text color. */
+  strikethrough?: ColorName;
+  /** Table border color. */
+  tableBorder?: ColorName;
+  /** Table header text color. */
+  tableHeader?: ColorName;
+  /** Table cell text color. */
+  tableCell?: ColorName;
+  /** Muted / secondary text. */
+  muted?: DimColor;
 }
 
-/** Optional overrides for any semantic slot beyond the palette defaults. */
-export type ThemeOverrides = Partial<
-  Omit<Theme, "name" | "label" | "palette">
->;
+function normalizeTheme(json: unknown): Theme {
+  const obj = json as Record<string, unknown>;
+  const palette = obj.palette as ColorPalette;
 
-/** Build a full Theme from a 4-color palette. */
-export function buildTheme(
-  name: string,
-  label: string,
-  palette: ColorPalette,
-  overrides?: ThemeOverrides,
-): Theme {
-  const base: Theme = {
-    name,
-    label,
+  const normalizeDim = (v: unknown): DimColor | undefined => {
+    if (v === undefined) return undefined;
+    if (typeof v === "string") return { color: v, dim: false };
+    const d = v as Record<string, unknown>;
+    return { color: String(d.color), dim: d.dim === true };
+  };
+
+  const normalizeColor = (v: unknown): string | undefined => {
+    if (v === undefined) return undefined;
+    if (typeof v === "string") return v;
+    const d = v as Record<string, unknown>;
+    return String(d.color);
+  };
+
+  return {
+    name: String(obj.name),
+    label: String(obj.label),
     palette,
-    user: palette.primary,
-    tool: palette.secondary,
-    spinner: palette.primary,
-    accent: palette.primary,
-    error: palette.error,
-    warn: palette.error,
-    info: { color: palette.secondary, dim: false },
-    reasoning: { color: palette.secondary, dim: false },
-    permission: palette.error,
-    queue: { color: palette.secondary, dim: false },
-    assistant: undefined,
-    modeBadge: {
+    user: String(obj.user ?? palette.primary),
+    assistant: obj.assistant === null ? undefined : (typeof obj.assistant === "string" ? obj.assistant : undefined),
+    reasoning: normalizeDim(obj.reasoning) ?? { color: palette.secondary, dim: false },
+    info: normalizeDim(obj.info) ?? { color: palette.secondary, dim: false },
+    error: String(obj.error ?? palette.error),
+    warn: String(obj.warn ?? palette.error),
+    tool: String(obj.tool ?? palette.secondary),
+    spinner: String(obj.spinner ?? palette.primary),
+    permission: String(obj.permission ?? palette.error),
+    queue: normalizeDim(obj.queue) ?? { color: palette.secondary, dim: false },
+    accent: String(obj.accent ?? palette.primary),
+    modeBadge: (obj.modeBadge as Theme["modeBadge"]) ?? {
       plan: palette.primary,
       auto: palette.success,
       edit: palette.error,
     },
-  };
-  if (!overrides) return base;
-  return {
-    ...base,
-    ...overrides,
-    modeBadge: overrides.modeBadge ?? base.modeBadge,
-    info: overrides.info ?? base.info,
-    reasoning: overrides.reasoning ?? base.reasoning,
-    queue: overrides.queue ?? base.queue,
+    blockquote: normalizeDim(obj.blockquote),
+    codeInline: normalizeColor(obj.codeInline),
+    codeBlock: normalizeColor(obj.codeBlock),
+    link: normalizeColor(obj.link),
+    strikethrough: normalizeColor(obj.strikethrough),
+    tableBorder: normalizeColor(obj.tableBorder),
+    tableHeader: normalizeColor(obj.tableHeader),
+    tableCell: normalizeColor(obj.tableCell),
+    muted: normalizeDim(obj.muted),
   };
 }
 
-const everforestDark = buildTheme("everforest-dark", "everforest-dark", {
-  primary: "#a7c080",
-  secondary: "#d3c6aa",
-  success: "#a7c080",
-  error: "#e67e80",
-});
-
-const everforestLight = buildTheme("everforest-light", "everforest-light", {
-  primary: "#c5e49a",
-  secondary: "#f0e6c8",
-  success: "#c5e49a",
-  error: "#e07070",
-});
-
-const kanagawaDark = buildTheme("kanagawa-dark", "kanagawa-dark", {
-  primary: "#8aadf4",
-  secondary: "#f0e6c8",
-  success: "#a6e3a1",
-  error: "#f38ba8",
-});
-
-const draculaDark = buildTheme("dracula-dark", "dracula-dark", {
-  primary: "#ff79c6",
-  secondary: "#f8f8f2",
-  success: "#50fa7b",
-  error: "#ff5555",
-});
-
-export const THEMES: Record<string, Theme> = {
-  "everforest-dark": everforestDark,
-  "everforest-light": everforestLight,
-  "kanagawa-dark": kanagawaDark,
-  "dracula-dark": draculaDark,
+const BUILT_IN_THEMES: Record<string, Theme> = {
+  "everforest-dark": normalizeTheme(everforestDarkJson),
+  "everforest-light": normalizeTheme(everforestLightJson),
+  "kanagawa-dark": normalizeTheme(kanagawaDarkJson),
+  "dracula-dark": normalizeTheme(draculaDarkJson),
+  "tokyo-night": normalizeTheme(tokyoNightJson),
+  "catppuccin-mocha": normalizeTheme(catppuccinMochaJson),
+  "catppuccin-latte": normalizeTheme(catppuccinLatteJson),
+  "solarized-dark": normalizeTheme(solarizedDarkJson),
+  "solarized-light": normalizeTheme(solarizedLightJson),
+  "nord": normalizeTheme(nordJson),
+  "gruvbox-dark": normalizeTheme(gruvboxDarkJson),
+  "gruvbox-light": normalizeTheme(gruvboxLightJson),
+  "one-dark": normalizeTheme(oneDarkJson),
 };
 
+/** Mutable theme registry — built-in themes plus any user/project themes loaded at runtime. */
+export let THEMES: Record<string, Theme> = { ...BUILT_IN_THEMES };
+
 export const DEFAULT_THEME_NAME = "everforest-dark";
+
+/** Replace the active theme registry (used after loading user/project themes). */
+export function setThemes(themes: Record<string, Theme>): void {
+  THEMES = themes;
+}
 
 export function resolveTheme(name?: string): Theme {
   if (!name) return THEMES[DEFAULT_THEME_NAME]!;
@@ -124,4 +156,11 @@ export function themeNames(): string[] {
 
 export function themeList(): Theme[] {
   return Object.values(THEMES);
+}
+
+export interface LoadedTheme {
+  theme: Theme;
+  source: "built-in" | "user" | "project";
+  path: string;
+  wcagIssues: ContrastIssue[];
 }

--- a/src/ui/themes/catppuccin-latte.json
+++ b/src/ui/themes/catppuccin-latte.json
@@ -1,0 +1,37 @@
+{
+  "name": "catppuccin-latte",
+  "label": "Catppuccin Latte",
+  "palette": {
+    "background": "#eff1f5",
+    "foreground": "#4c4f69",
+    "primary": "#1e66f5",
+    "secondary": "#8c8fa1",
+    "success": "#40a02b",
+    "error": "#d20f39"
+  },
+  "user": "#1e66f5",
+  "assistant": null,
+  "reasoning": { "color": "#8c8fa1", "dim": true },
+  "info": { "color": "#4c4f69", "dim": false },
+  "error": "#d20f39",
+  "warn": "#df8e1d",
+  "tool": "#8839ef",
+  "spinner": "#1e66f5",
+  "permission": "#d20f39",
+  "queue": { "color": "#8c8fa1", "dim": true },
+  "accent": "#1e66f5",
+  "modeBadge": {
+    "plan": "#1e66f5",
+    "auto": "#40a02b",
+    "edit": "#d20f39"
+  },
+  "blockquote": { "color": "#8c8fa1", "dim": true },
+  "codeInline": "#8839ef",
+  "codeBlock": "#8839ef",
+  "link": "#1e66f5",
+  "strikethrough": "#8c8fa1",
+  "tableBorder": "#bcc0cc",
+  "tableHeader": "#4c4f69",
+  "tableCell": "#4c4f69",
+  "muted": { "color": "#8c8fa1", "dim": true }
+}

--- a/src/ui/themes/catppuccin-mocha.json
+++ b/src/ui/themes/catppuccin-mocha.json
@@ -1,0 +1,37 @@
+{
+  "name": "catppuccin-mocha",
+  "label": "Catppuccin Mocha",
+  "palette": {
+    "background": "#1e1e2e",
+    "foreground": "#cdd6f4",
+    "primary": "#89b4fa",
+    "secondary": "#6c7086",
+    "success": "#a6e3a1",
+    "error": "#f38ba8"
+  },
+  "user": "#89b4fa",
+  "assistant": null,
+  "reasoning": { "color": "#6c7086", "dim": true },
+  "info": { "color": "#cdd6f4", "dim": false },
+  "error": "#f38ba8",
+  "warn": "#f9e2af",
+  "tool": "#cba6f7",
+  "spinner": "#89b4fa",
+  "permission": "#f38ba8",
+  "queue": { "color": "#6c7086", "dim": true },
+  "accent": "#89b4fa",
+  "modeBadge": {
+    "plan": "#89b4fa",
+    "auto": "#a6e3a1",
+    "edit": "#f38ba8"
+  },
+  "blockquote": { "color": "#6c7086", "dim": true },
+  "codeInline": "#cba6f7",
+  "codeBlock": "#cba6f7",
+  "link": "#89b4fa",
+  "strikethrough": "#6c7086",
+  "tableBorder": "#45475a",
+  "tableHeader": "#cdd6f4",
+  "tableCell": "#cdd6f4",
+  "muted": { "color": "#6c7086", "dim": true }
+}

--- a/src/ui/themes/dracula-dark.json
+++ b/src/ui/themes/dracula-dark.json
@@ -1,0 +1,37 @@
+{
+  "name": "dracula-dark",
+  "label": "Dracula Dark",
+  "palette": {
+    "background": "#282a36",
+    "foreground": "#f8f8f2",
+    "primary": "#ff79c6",
+    "secondary": "#6272a4",
+    "success": "#50fa7b",
+    "error": "#ff5555"
+  },
+  "user": "#ff79c6",
+  "assistant": null,
+  "reasoning": { "color": "#6272a4", "dim": true },
+  "info": { "color": "#f8f8f2", "dim": false },
+  "error": "#ff5555",
+  "warn": "#f1fa8c",
+  "tool": "#8be9fd",
+  "spinner": "#ff79c6",
+  "permission": "#ff5555",
+  "queue": { "color": "#6272a4", "dim": true },
+  "accent": "#ff79c6",
+  "modeBadge": {
+    "plan": "#ff79c6",
+    "auto": "#50fa7b",
+    "edit": "#ff5555"
+  },
+  "blockquote": { "color": "#6272a4", "dim": true },
+  "codeInline": "#8be9fd",
+  "codeBlock": "#8be9fd",
+  "link": "#ff79c6",
+  "strikethrough": "#6272a4",
+  "tableBorder": "#44475a",
+  "tableHeader": "#f8f8f2",
+  "tableCell": "#f8f8f2",
+  "muted": { "color": "#6272a4", "dim": true }
+}

--- a/src/ui/themes/everforest-dark.json
+++ b/src/ui/themes/everforest-dark.json
@@ -1,0 +1,37 @@
+{
+  "name": "everforest-dark",
+  "label": "Everforest Dark",
+  "palette": {
+    "background": "#2b3339",
+    "foreground": "#d3c6aa",
+    "primary": "#a7c080",
+    "secondary": "#7a8478",
+    "success": "#a7c080",
+    "error": "#e67e80"
+  },
+  "user": "#a7c080",
+  "assistant": null,
+  "reasoning": { "color": "#7a8478", "dim": true },
+  "info": { "color": "#d3c6aa", "dim": false },
+  "error": "#e67e80",
+  "warn": "#dbbc7f",
+  "tool": "#7fbbb3",
+  "spinner": "#a7c080",
+  "permission": "#e67e80",
+  "queue": { "color": "#7a8478", "dim": true },
+  "accent": "#a7c080",
+  "modeBadge": {
+    "plan": "#a7c080",
+    "auto": "#a7c080",
+    "edit": "#e67e80"
+  },
+  "blockquote": { "color": "#7a8478", "dim": true },
+  "codeInline": "#7fbbb3",
+  "codeBlock": "#7fbbb3",
+  "link": "#a7c080",
+  "strikethrough": "#7a8478",
+  "tableBorder": "#4b565c",
+  "tableHeader": "#d3c6aa",
+  "tableCell": "#d3c6aa",
+  "muted": { "color": "#7a8478", "dim": true }
+}

--- a/src/ui/themes/everforest-light.json
+++ b/src/ui/themes/everforest-light.json
@@ -1,0 +1,37 @@
+{
+  "name": "everforest-light",
+  "label": "Everforest Light",
+  "palette": {
+    "background": "#fdf6e3",
+    "foreground": "#5c6a72",
+    "primary": "#8da101",
+    "secondary": "#939f91",
+    "success": "#8da101",
+    "error": "#f85552"
+  },
+  "user": "#8da101",
+  "assistant": null,
+  "reasoning": { "color": "#939f91", "dim": true },
+  "info": { "color": "#5c6a72", "dim": false },
+  "error": "#f85552",
+  "warn": "#dfa000",
+  "tool": "#3a94c5",
+  "spinner": "#8da101",
+  "permission": "#f85552",
+  "queue": { "color": "#939f91", "dim": true },
+  "accent": "#8da101",
+  "modeBadge": {
+    "plan": "#8da101",
+    "auto": "#8da101",
+    "edit": "#f85552"
+  },
+  "blockquote": { "color": "#939f91", "dim": true },
+  "codeInline": "#3a94c5",
+  "codeBlock": "#3a94c5",
+  "link": "#8da101",
+  "strikethrough": "#939f91",
+  "tableBorder": "#bdc3af",
+  "tableHeader": "#5c6a72",
+  "tableCell": "#5c6a72",
+  "muted": { "color": "#939f91", "dim": true }
+}

--- a/src/ui/themes/gruvbox-dark.json
+++ b/src/ui/themes/gruvbox-dark.json
@@ -1,0 +1,37 @@
+{
+  "name": "gruvbox-dark",
+  "label": "Gruvbox Dark",
+  "palette": {
+    "background": "#282828",
+    "foreground": "#ebdbb2",
+    "primary": "#b8bb26",
+    "secondary": "#928374",
+    "success": "#b8bb26",
+    "error": "#fb4934"
+  },
+  "user": "#b8bb26",
+  "assistant": null,
+  "reasoning": { "color": "#928374", "dim": true },
+  "info": { "color": "#ebdbb2", "dim": false },
+  "error": "#fb4934",
+  "warn": "#fabd2f",
+  "tool": "#83a598",
+  "spinner": "#b8bb26",
+  "permission": "#fb4934",
+  "queue": { "color": "#928374", "dim": true },
+  "accent": "#b8bb26",
+  "modeBadge": {
+    "plan": "#b8bb26",
+    "auto": "#b8bb26",
+    "edit": "#fb4934"
+  },
+  "blockquote": { "color": "#928374", "dim": true },
+  "codeInline": "#83a598",
+  "codeBlock": "#83a598",
+  "link": "#b8bb26",
+  "strikethrough": "#928374",
+  "tableBorder": "#504945",
+  "tableHeader": "#ebdbb2",
+  "tableCell": "#ebdbb2",
+  "muted": { "color": "#928374", "dim": true }
+}

--- a/src/ui/themes/gruvbox-light.json
+++ b/src/ui/themes/gruvbox-light.json
@@ -1,0 +1,37 @@
+{
+  "name": "gruvbox-light",
+  "label": "Gruvbox Light",
+  "palette": {
+    "background": "#fbf1c7",
+    "foreground": "#3c3836",
+    "primary": "#79740e",
+    "secondary": "#928374",
+    "success": "#79740e",
+    "error": "#9d0006"
+  },
+  "user": "#79740e",
+  "assistant": null,
+  "reasoning": { "color": "#928374", "dim": true },
+  "info": { "color": "#3c3836", "dim": false },
+  "error": "#9d0006",
+  "warn": "#b57614",
+  "tool": "#076678",
+  "spinner": "#79740e",
+  "permission": "#9d0006",
+  "queue": { "color": "#928374", "dim": true },
+  "accent": "#79740e",
+  "modeBadge": {
+    "plan": "#79740e",
+    "auto": "#79740e",
+    "edit": "#9d0006"
+  },
+  "blockquote": { "color": "#928374", "dim": true },
+  "codeInline": "#076678",
+  "codeBlock": "#076678",
+  "link": "#79740e",
+  "strikethrough": "#928374",
+  "tableBorder": "#d5c4a1",
+  "tableHeader": "#3c3836",
+  "tableCell": "#3c3836",
+  "muted": { "color": "#928374", "dim": true }
+}

--- a/src/ui/themes/kanagawa-dark.json
+++ b/src/ui/themes/kanagawa-dark.json
@@ -1,0 +1,37 @@
+{
+  "name": "kanagawa-dark",
+  "label": "Kanagawa Dark",
+  "palette": {
+    "background": "#1f1f28",
+    "foreground": "#dcd7ba",
+    "primary": "#7e9cd8",
+    "secondary": "#727169",
+    "success": "#98bb6c",
+    "error": "#ff5d62"
+  },
+  "user": "#7e9cd8",
+  "assistant": null,
+  "reasoning": { "color": "#727169", "dim": true },
+  "info": { "color": "#dcd7ba", "dim": false },
+  "error": "#ff5d62",
+  "warn": "#e6c384",
+  "tool": "#7fb4ca",
+  "spinner": "#7e9cd8",
+  "permission": "#ff5d62",
+  "queue": { "color": "#727169", "dim": true },
+  "accent": "#7e9cd8",
+  "modeBadge": {
+    "plan": "#7e9cd8",
+    "auto": "#98bb6c",
+    "edit": "#ff5d62"
+  },
+  "blockquote": { "color": "#727169", "dim": true },
+  "codeInline": "#7fb4ca",
+  "codeBlock": "#7fb4ca",
+  "link": "#7e9cd8",
+  "strikethrough": "#727169",
+  "tableBorder": "#54546d",
+  "tableHeader": "#dcd7ba",
+  "tableCell": "#dcd7ba",
+  "muted": { "color": "#727169", "dim": true }
+}

--- a/src/ui/themes/nord.json
+++ b/src/ui/themes/nord.json
@@ -1,0 +1,37 @@
+{
+  "name": "nord",
+  "label": "Nord",
+  "palette": {
+    "background": "#2e3440",
+    "foreground": "#d8dee9",
+    "primary": "#88c0d0",
+    "secondary": "#4c566a",
+    "success": "#a3be8c",
+    "error": "#bf616a"
+  },
+  "user": "#88c0d0",
+  "assistant": null,
+  "reasoning": { "color": "#4c566a", "dim": true },
+  "info": { "color": "#d8dee9", "dim": false },
+  "error": "#bf616a",
+  "warn": "#ebcb8b",
+  "tool": "#81a1c1",
+  "spinner": "#88c0d0",
+  "permission": "#bf616a",
+  "queue": { "color": "#4c566a", "dim": true },
+  "accent": "#88c0d0",
+  "modeBadge": {
+    "plan": "#88c0d0",
+    "auto": "#a3be8c",
+    "edit": "#bf616a"
+  },
+  "blockquote": { "color": "#4c566a", "dim": true },
+  "codeInline": "#81a1c1",
+  "codeBlock": "#81a1c1",
+  "link": "#88c0d0",
+  "strikethrough": "#4c566a",
+  "tableBorder": "#434c5e",
+  "tableHeader": "#eceff4",
+  "tableCell": "#d8dee9",
+  "muted": { "color": "#4c566a", "dim": true }
+}

--- a/src/ui/themes/one-dark.json
+++ b/src/ui/themes/one-dark.json
@@ -1,0 +1,37 @@
+{
+  "name": "one-dark",
+  "label": "One Dark",
+  "palette": {
+    "background": "#282c34",
+    "foreground": "#abb2bf",
+    "primary": "#61afef",
+    "secondary": "#5c6370",
+    "success": "#98c379",
+    "error": "#e06c75"
+  },
+  "user": "#61afef",
+  "assistant": null,
+  "reasoning": { "color": "#5c6370", "dim": true },
+  "info": { "color": "#abb2bf", "dim": false },
+  "error": "#e06c75",
+  "warn": "#e5c07b",
+  "tool": "#c678dd",
+  "spinner": "#61afef",
+  "permission": "#e06c75",
+  "queue": { "color": "#5c6370", "dim": true },
+  "accent": "#61afef",
+  "modeBadge": {
+    "plan": "#61afef",
+    "auto": "#98c379",
+    "edit": "#e06c75"
+  },
+  "blockquote": { "color": "#5c6370", "dim": true },
+  "codeInline": "#c678dd",
+  "codeBlock": "#c678dd",
+  "link": "#61afef",
+  "strikethrough": "#5c6370",
+  "tableBorder": "#3e4451",
+  "tableHeader": "#abb2bf",
+  "tableCell": "#abb2bf",
+  "muted": { "color": "#5c6370", "dim": true }
+}

--- a/src/ui/themes/solarized-dark.json
+++ b/src/ui/themes/solarized-dark.json
@@ -1,0 +1,37 @@
+{
+  "name": "solarized-dark",
+  "label": "Solarized Dark",
+  "palette": {
+    "background": "#002b36",
+    "foreground": "#839496",
+    "primary": "#268bd2",
+    "secondary": "#586e75",
+    "success": "#859900",
+    "error": "#dc322f"
+  },
+  "user": "#268bd2",
+  "assistant": null,
+  "reasoning": { "color": "#586e75", "dim": true },
+  "info": { "color": "#839496", "dim": false },
+  "error": "#dc322f",
+  "warn": "#b58900",
+  "tool": "#2aa198",
+  "spinner": "#268bd2",
+  "permission": "#dc322f",
+  "queue": { "color": "#586e75", "dim": true },
+  "accent": "#268bd2",
+  "modeBadge": {
+    "plan": "#268bd2",
+    "auto": "#859900",
+    "edit": "#dc322f"
+  },
+  "blockquote": { "color": "#586e75", "dim": true },
+  "codeInline": "#2aa198",
+  "codeBlock": "#2aa198",
+  "link": "#268bd2",
+  "strikethrough": "#586e75",
+  "tableBorder": "#073642",
+  "tableHeader": "#93a1a1",
+  "tableCell": "#839496",
+  "muted": { "color": "#586e75", "dim": true }
+}

--- a/src/ui/themes/solarized-light.json
+++ b/src/ui/themes/solarized-light.json
@@ -1,0 +1,37 @@
+{
+  "name": "solarized-light",
+  "label": "Solarized Light",
+  "palette": {
+    "background": "#fdf6e3",
+    "foreground": "#657b83",
+    "primary": "#268bd2",
+    "secondary": "#93a1a1",
+    "success": "#859900",
+    "error": "#dc322f"
+  },
+  "user": "#268bd2",
+  "assistant": null,
+  "reasoning": { "color": "#93a1a1", "dim": true },
+  "info": { "color": "#657b83", "dim": false },
+  "error": "#dc322f",
+  "warn": "#b58900",
+  "tool": "#2aa198",
+  "spinner": "#268bd2",
+  "permission": "#dc322f",
+  "queue": { "color": "#93a1a1", "dim": true },
+  "accent": "#268bd2",
+  "modeBadge": {
+    "plan": "#268bd2",
+    "auto": "#859900",
+    "edit": "#dc322f"
+  },
+  "blockquote": { "color": "#93a1a1", "dim": true },
+  "codeInline": "#2aa198",
+  "codeBlock": "#2aa198",
+  "link": "#268bd2",
+  "strikethrough": "#93a1a1",
+  "tableBorder": "#eee8d5",
+  "tableHeader": "#586e75",
+  "tableCell": "#657b83",
+  "muted": { "color": "#93a1a1", "dim": true }
+}

--- a/src/ui/themes/tokyo-night.json
+++ b/src/ui/themes/tokyo-night.json
@@ -1,0 +1,37 @@
+{
+  "name": "tokyo-night",
+  "label": "Tokyo Night",
+  "palette": {
+    "background": "#1a1b26",
+    "foreground": "#a9b1d6",
+    "primary": "#7aa2f7",
+    "secondary": "#565f89",
+    "success": "#9ece6a",
+    "error": "#f7768e"
+  },
+  "user": "#7aa2f7",
+  "assistant": null,
+  "reasoning": { "color": "#565f89", "dim": true },
+  "info": { "color": "#a9b1d6", "dim": false },
+  "error": "#f7768e",
+  "warn": "#e0af68",
+  "tool": "#bb9af7",
+  "spinner": "#7aa2f7",
+  "permission": "#f7768e",
+  "queue": { "color": "#565f89", "dim": true },
+  "accent": "#7aa2f7",
+  "modeBadge": {
+    "plan": "#7aa2f7",
+    "auto": "#9ece6a",
+    "edit": "#f7768e"
+  },
+  "blockquote": { "color": "#565f89", "dim": true },
+  "codeInline": "#bb9af7",
+  "codeBlock": "#bb9af7",
+  "link": "#7aa2f7",
+  "strikethrough": "#565f89",
+  "tableBorder": "#414868",
+  "tableHeader": "#c0caf5",
+  "tableCell": "#a9b1d6",
+  "muted": { "color": "#565f89", "dim": true }
+}

--- a/src/ui/wcag.test.ts
+++ b/src/ui/wcag.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { contrastRatio, checkContrast } from "./wcag.js";
+
+describe("contrastRatio", () => {
+  it("returns null for invalid hex", () => {
+    assert.strictEqual(contrastRatio("not-a-color", "#000000"), null);
+    assert.strictEqual(contrastRatio("#000000", "bad"), null);
+  });
+
+  it("computes black on white as 21:1", () => {
+    const ratio = contrastRatio("#000000", "#ffffff");
+    assert.ok(ratio !== null);
+    assert.ok(Math.abs(ratio - 21) < 0.1, `expected ~21, got ${ratio}`);
+  });
+
+  it("computes white on white as 1:1", () => {
+    const ratio = contrastRatio("#ffffff", "#ffffff");
+    assert.ok(ratio !== null);
+    assert.ok(Math.abs(ratio - 1) < 0.01, `expected ~1, got ${ratio}`);
+  });
+
+  it("flags low contrast", () => {
+    const issue = checkContrast("#777777", "#ffffff", 4.5);
+    assert.ok(issue !== null);
+    assert.ok(issue.ratio < 4.5);
+  });
+
+  it("passes high contrast", () => {
+    const issue = checkContrast("#000000", "#ffffff", 4.5);
+    assert.strictEqual(issue, null);
+  });
+});

--- a/src/ui/wcag.ts
+++ b/src/ui/wcag.ts
@@ -1,0 +1,76 @@
+/**
+ * WCAG 2.1 contrast ratio utilities.
+ *
+ * AA thresholds:
+ *   - Normal text: 4.5:1
+ *   - Large text (18pt+ or 14pt+ bold): 3:1
+ *   - UI components / graphical objects: 3:1
+ *
+ * AAA thresholds:
+ *   - Normal text: 7:1
+ *   - Large text: 4.5:1
+ */
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const m = hex.match(/^#([0-9a-fA-F]{6})$/);
+  if (!m) return null;
+  const v = parseInt(m[1]!, 16);
+  return {
+    r: (v >> 16) & 0xff,
+    g: (v >> 8) & 0xff,
+    b: v & 0xff,
+  };
+}
+
+function relativeLuminance({ r, g, b }: { r: number; g: number; b: number }): number {
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+export function contrastRatio(a: string, b: string): number | null {
+  const rgbA = hexToRgb(a);
+  const rgbB = hexToRgb(b);
+  if (!rgbA || !rgbB) return null;
+  const l1 = relativeLuminance(rgbA);
+  const l2 = relativeLuminance(rgbB);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export interface ContrastIssue {
+  pair: string;
+  foreground: string;
+  background: string;
+  ratio: number;
+  required: number;
+}
+
+export function checkContrast(
+  foreground: string,
+  background: string,
+  required = 4.5,
+): ContrastIssue | null {
+  const ratio = contrastRatio(foreground, background);
+  if (ratio === null) return null;
+  if (ratio >= required) return null;
+  return {
+    pair: `${foreground} on ${background}`,
+    foreground,
+    background,
+    ratio: Math.round(ratio * 100) / 100,
+    required,
+  };
+}
+
+export function formatContrastIssues(issues: ContrastIssue[]): string {
+  return issues
+    .map(
+      (i) =>
+        `  ${i.pair}: ${i.ratio}:1 (needs ${i.required}:1)`,
+    )
+    .join("\n");
+}


### PR DESCRIPTION
feat(ui): extensible JSON themes with WCAG contrast validation

- Move built-in themes from hardcoded TS to JSON files in src/ui/themes/
- Add theme discovery: built-in → user (~/.config/kimiflare/themes/) → project-local (.kimiflare/themes/)
- Expand Theme interface with markdown/TUI semantic slots:
  blockquote, codeInline, codeBlock, link, strikethrough,
  tableBorder, tableHeader, tableCell, muted
- Add WCAG 2.1 contrast ratio validation at theme load time
- Add 9 new popular themes: tokyo-night, catppuccin-mocha/latte,
  solarized-dark/light, nord, gruvbox-dark/light, one-dark
- Fix theme persistence bugs: saveConfig now uses functional setCfg
  to avoid stale closure over cfg state
- Update markdown renderer to use new theme slots and support
  strikethrough, links, numbered lists, and tables
- Themes require restart to apply (no live re-render to avoid TUI freeze)

Co-authored-by: kimiflare <kimiflare@proton.me>