### PR TITLE
feat: KIMI.md drift detection with memory-based staleness indicators

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -28,6 +28,8 @@ export interface AgentCallbacks {
   /** Called when the tool-call iteration limit is reached. Return "continue" to
    *  reset the counter and keep going, or "stop" to end the turn immediately. */
   onToolLimitReached?: () => Promise<"continue" | "stop">;
+  /** Called when accumulated high-signal memories suggest KIMI.md may be stale. */
+  onKimiMdStale?: () => void;
 }
 
 export interface AgentTurnOpts {
@@ -76,6 +78,25 @@ export class BudgetExhaustedError extends Error {
 }
 
 const codeModeApiCache = new Map<string, string>();
+
+/** Per-session accumulator for high-signal memories that may indicate KIMI.md drift. */
+const driftAccumulator = new Map<string, number>();
+const DRIFT_THRESHOLD = 5;
+
+function isHighSignalMemory(memory: {
+  topicKey: string;
+  category: string;
+  importance: number;
+}): boolean {
+  return (
+    memory.topicKey === "project_dependencies" ||
+    memory.topicKey === "project_tsconfig" ||
+    memory.topicKey === "project_entry_point" ||
+    memory.category === "instruction" ||
+    memory.category === "preference" ||
+    (memory.category === "event" && memory.importance >= 3)
+  );
+}
 
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const turnStart = performance.now();
@@ -537,6 +558,17 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
                       undefined,
                       memory.topicKey,
                     );
+
+                    // Real-time drift detection (Trigger B)
+                    if (isHighSignalMemory(memory)) {
+                      const sid = opts.sessionId ?? "default";
+                      const current = (driftAccumulator.get(sid) ?? 0) + 1;
+                      driftAccumulator.set(sid, current);
+                      if (current >= DRIFT_THRESHOLD) {
+                        opts.callbacks.onKimiMdStale?.();
+                        driftAccumulator.set(sid, 0);
+                      }
+                    }
                   }
                 } catch {
                   // Swallow auto-extraction errors so they never break the loop
@@ -548,6 +580,15 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
         recentToolCalls.push(loopSignature);
         if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+      }
+    }
+
+    // Decay drift accumulator at end of turn (clustered changes = drift,
+    // spread-out changes = incremental and not worth nagging)
+    if (opts.sessionId) {
+      const current = driftAccumulator.get(opts.sessionId) ?? 0;
+      if (current > 0) {
+        driftAccumulator.set(opts.sessionId, Math.max(0, current - 1));
       }
     }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -548,6 +548,7 @@ function App({
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
   const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
   const [showThemePicker, setShowThemePicker] = useState(false);
+  const [kimiMdStale, setKimiMdStale] = useState(false);
 
   // Fetch cloud token budget on startup
   useEffect(() => {
@@ -605,7 +606,8 @@ function App({
   const busyRef = useRef(busy);
   const memoryManagerRef = useRef<MemoryManager | null>(null);
   const sessionStartRecallRef = useRef<Promise<void> | null>(null);
-
+  const kimiMdStaleNudgedRef = useRef(false);
+  const turnCounterRef = useRef(0);
 
   // Batched streaming delta refs to reduce React re-render frequency
   const pendingTextRef = useRef<Map<number, { text: string; reasoning: string }>>(new Map());
@@ -893,6 +895,16 @@ function App({
           // Non-fatal: session works fine without recalled memories
         }
       })();
+
+      // Session-start drift check (Trigger A): if KIMI.md exists and high-signal
+      // memories have been learned since the last refresh, mark as stale.
+      if (existsSync(join(cwd, "KIMI.md"))) {
+        const lastRefresh = manager.getLastKimiMdRefreshTime(cwd);
+        const driftCount = manager.countHighSignalMemoriesSince(cwd, lastRefresh);
+        if (driftCount >= 5) {
+          setKimiMdStale(true);
+        }
+      }
     } else {
       memoryManagerRef.current?.close();
       memoryManagerRef.current = null;
@@ -1726,6 +1738,16 @@ function App({
               permResolveRef.current = resolve;
               setPerm({ tool: req.tool, args: req.args, resolve });
             }),
+          onKimiMdStale: () => {
+            if (!kimiMdStaleNudgedRef.current) {
+              kimiMdStaleNudgedRef.current = true;
+              setKimiMdStale(true);
+              setEvents((e) => [
+                ...e,
+                { kind: "info", key: mkKey(), text: "Project context may be stale. Run /init to refresh KIMI.md based on recent changes." },
+              ]);
+            }
+          },
         },
       });
 
@@ -1755,6 +1777,10 @@ function App({
           ...e,
           { kind: "info", key: mkKey(), text: "KIMI.md generated; context loaded for future turns" },
         ]);
+        // Record refresh so drift detection knows this snapshot is current
+        void memoryManagerRef.current?.recordKimiMdRefresh(cwd, ensureSessionId());
+        setKimiMdStale(false);
+        kimiMdStaleNudgedRef.current = false;
       }
     } catch (e) {
       if ((e as Error).name === "AbortError") {
@@ -2743,6 +2769,19 @@ function App({
         }
       }
 
+      // Occasional gentle nudge about /init (educational, not a warning)
+      turnCounterRef.current += 1;
+      if (
+        turnCounterRef.current % 15 === 0 &&
+        existsSync(join(process.cwd(), "KIMI.md")) &&
+        !kimiMdStale
+      ) {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "Tip: Rerunning /init occasionally helps KimiFlare stay accurate as your project evolves." },
+        ]);
+      }
+
       setBusy(true);
       gatewayMetaRef.current = null;
       setGatewayMeta(null);
@@ -2894,6 +2933,16 @@ function App({
             limitResolveRef.current = resolve;
             setLimitModal({ limit: 50, resolve });
           }),
+        onKimiMdStale: () => {
+          if (!kimiMdStaleNudgedRef.current) {
+            kimiMdStaleNudgedRef.current = true;
+            setKimiMdStale(true);
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: "Project context may be stale. Run /init to refresh KIMI.md based on recent changes." },
+            ]);
+          }
+        },
       };
 
       try {
@@ -3433,6 +3482,7 @@ function App({
               codeMode={codeMode}
               cloudMode={cfg.cloudMode}
               cloudBudget={cloudBudget}
+              kimiMdStale={kimiMdStale}
             />
             {activePicker?.kind === "file" && (
               <FilePicker

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -441,3 +441,23 @@ export function getMemoryById(db: Database.Database, id: string): Memory | null 
     | undefined;
   return row ? rowToMemory(row) : null;
 }
+
+export function countHighSignalMemoriesSince(
+  db: Database.Database,
+  repoPath: string,
+  since: number,
+): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as count FROM memories
+       WHERE repo_path = ? AND created_at > ?
+       AND forgotten = 0 AND superseded_by IS NULL
+       AND (
+         topic_key IN ('project_dependencies', 'project_tsconfig', 'project_entry_point')
+         OR category IN ('instruction', 'preference')
+         OR (category = 'event' AND importance >= 3)
+       )`,
+    )
+    .get(repoPath, since) as { count: number } | undefined;
+  return row?.count ?? 0;
+}

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -3,6 +3,7 @@ import type { AiGatewayOptions } from "../agent/client.js";
 import { runKimi } from "../agent/client.js";
 import type { ChatMessage } from "../agent/messages.js";
 import type { MemoryInput, MemoryQuery, HybridResult, MemoryStats, MemoryCategory } from "./schema.js";
+import { DEFAULT_EMBEDDING_DIM } from "./schema.js";
 import {
   openMemoryDb,
   closeMemoryDb,
@@ -17,6 +18,7 @@ import {
   listUnvectorizedMemories,
   updateMemoryEmbedding,
   getMemoryById,
+  countHighSignalMemoriesSince,
 } from "./db.js";
 import { fetchEmbeddings } from "./embeddings.js";
 import { retrieveMemories } from "./retrieval.js";
@@ -268,6 +270,53 @@ export class MemoryManager {
     }
 
     return { id: memory.id, superseded: supersededIds.length > 0 ? supersededIds : undefined };
+  }
+
+  /**
+   * Count high-signal memories created since the given timestamp.
+   * Used for KIMI.md drift detection (Trigger A: session-start check).
+   */
+  countHighSignalMemoriesSince(repoPath: string, since: number): number {
+    if (!this.db) return 0;
+    return countHighSignalMemoriesSince(this.db, repoPath, since);
+  }
+
+  /**
+   * Get the timestamp of the most recent KIMI.md refresh memory.
+   * Returns 0 if none exists.
+   */
+  getLastKimiMdRefreshTime(repoPath: string): number {
+    if (!this.db) return 0;
+    const rows = this.db
+      .prepare(
+        `SELECT created_at FROM memories
+         WHERE repo_path = ? AND topic_key = 'kimi_md_refresh'
+         AND forgotten = 0 AND superseded_by IS NULL
+         ORDER BY created_at DESC LIMIT 1`,
+      )
+      .all(repoPath) as Array<{ created_at: number }>;
+    return rows[0]?.created_at ?? 0;
+  }
+
+  /**
+   * Record that KIMI.md was refreshed. Creates a lightweight memory
+   * so drift detection knows when the snapshot was last updated.
+   */
+  async recordKimiMdRefresh(repoPath: string, sessionId: string): Promise<void> {
+    if (!this.db) return;
+    const embedding = new Float32Array(DEFAULT_EMBEDDING_DIM);
+    insertMemory(
+      this.db,
+      {
+        content: `KIMI.md refreshed for ${repoPath}`,
+        category: "event",
+        sourceSessionId: sessionId,
+        repoPath,
+        importance: 2,
+        topicKey: "kimi_md_refresh",
+      },
+      embedding,
+    );
   }
 
   /**

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -25,9 +25,10 @@ interface Props {
   codeMode?: boolean;
   cloudMode?: boolean;
   cloudBudget?: { remaining: number; limit: number } | null;
+  kimiMdStale?: boolean;
 }
 
-export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode, cloudMode, cloudBudget }: Props) {
+export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode, cloudMode, cloudBudget, kimiMdStale }: Props) {
   const theme = useTheme();
   const [now, setNow] = useState(Date.now());
   const modeColor =
@@ -77,6 +78,11 @@ export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt,
           {hasUpdate ? (
             <Text color={theme.warn} bold>
               {"  ·  "}update available{latestVersion ? ` → ${latestVersion}` : ""} · run /update
+            </Text>
+          ) : null}
+          {kimiMdStale ? (
+            <Text color={theme.warn} bold>
+              {"  ·  "}⚠ KIMI.md stale · run /init
             </Text>
           ) : null}
         </Box>


### PR DESCRIPTION
Implements a two-trigger drift detection system that warns users when their KIMI.md context snapshot may be stale.

**Trigger A (session-start):** On startup, count high-signal memories (project dependencies, tsconfig, entry points, instructions, preferences, and high-importance edit events) created since the last KIMI.md refresh. If >= 5, mark KIMI.md as stale.

**Trigger B (real-time):** During the agent turn loop, accumulate high-signal memories as they're extracted from tool results. If 5+ cluster within a single turn, fire a stale callback. Decay by 1 per turn to avoid nagging on incremental changes.

**UI changes:**
- Status bar shows '⚠ KIMI.md stale · run /init' when drift detected
- Info event suggests running /init when stale
- Occasional gentle hint (every 15 turns) reminds users that /init helps keep KimiFlare accurate

After /init completes, a refresh memory is recorded so drift detection knows the snapshot is current.