### PR TITLE
fix(ui): hide Cloudflare billing link in cloud mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3458,7 +3458,7 @@ function App({
     <ThemeProvider theme={theme}>
       <Box flexDirection="column">
         {!hasConversation && events.length === 0 ? (
-          <Welcome accountId={cfg.accountId} />
+          <Welcome accountId={cfg.accountId} cloudMode={cfg.cloudMode} />
         ) : (
           <ChatView events={events} showReasoning={showReasoning} verbose={verbose} suppressTools={mode === "plan"} />
         )}

--- a/src/ui/welcome.tsx
+++ b/src/ui/welcome.tsx
@@ -5,6 +5,7 @@ import type { Theme } from "./theme.js";
 
 interface Props {
   accountId?: string;
+  cloudMode?: boolean;
 }
 
 const SUGGESTIONS = [
@@ -13,7 +14,7 @@ const SUGGESTIONS = [
   "Refactor a file",
 ];
 
-export function Welcome({ accountId }: Props) {
+export function Welcome({ accountId, cloudMode }: Props) {
   const theme = useTheme();
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -25,7 +26,7 @@ export function Welcome({ accountId }: Props) {
           {"  "}Ready when you are.
         </Text>
       </Box>
-      {accountId && (
+      {accountId && !cloudMode && (
         <Box marginBottom={1}>
           <Text color={theme.info.color} >
             {"  "}Check your Cloudflare billing: https://dash.cloudflare.com/{accountId}/billing/billable-usage


### PR DESCRIPTION
Hides the "Check your Cloudflare billing" link from the CLI welcome screen when running in KimiFlare Cloud mode. The link is still shown in BYOK mode.