### PR TITLE
feat(ui): show mode-cycle tip in status bar

### DIFF
--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -96,6 +96,13 @@ export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt,
           ) : null}
         </Box>
       )}
+      {!thinking && (
+        <Box>
+          <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim}>
+            tip: shift+tab cycles mode
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
Adds a subtle tip to the status bar reminding users that shift+tab cycles between edit/plan/auto modes.