### PR TITLE
fix(ui): restore tool-card visibility in plan mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1711,8 +1711,6 @@ function App({
             toolBatchRef.current.push({ name: call.function.name, args: argsParsed });
             if (toolBatchTimerRef.current) clearTimeout(toolBatchTimerRef.current);
             toolBatchTimerRef.current = setTimeout(flushToolBatch, 120);
-            // In plan mode, suppress the individual tool card
-            if (modeRef.current === "plan") return;
             setEvents((e) => [
               ...e,
               {
@@ -3082,8 +3080,6 @@ function App({
           toolBatchRef.current.push({ name: call.function.name, args: argsParsed });
           if (toolBatchTimerRef.current) clearTimeout(toolBatchTimerRef.current);
           toolBatchTimerRef.current = setTimeout(flushToolBatch, 120);
-          // In plan mode, suppress the individual tool card
-          if (modeRef.current === "plan") return;
           setEvents((e) => [
             ...e,
             {
@@ -3660,7 +3656,7 @@ function App({
         {!hasConversation && events.length === 0 ? (
           <Welcome accountId={cfg.accountId} cloudMode={cfg.cloudMode} />
         ) : (
-          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} suppressTools={mode === "plan"} />
+          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} />
         )}
         {perm ? (
           <PermissionModal


### PR DESCRIPTION
## Summary

PR #300 introduced plan-mode tool suppression that completely hides every individual tool card behind vague activity narratives. In practice this leaves the user unable to see what the agent is doing during planning turns — paths, commands, and results all disappear, replaced by lines like \"Reading a file…\" with no further detail.

This is a surgical reversion of *only* the three plan-mode visibility gates that #300 added. Everything else from #300 (narrative activity layer, humanized tool titles, batched narrative lines, interruption cleanup) is preserved.

## What changed

- Removed the two \`if (modeRef.current === \"plan\") return;\` early returns inside \`onToolCallFinalized\` (one in the \`/init\` handler, one in the main \`runAgentTurn\` callback).
- Removed the \`suppressTools={mode === \"plan\"}\` prop on \`<ChatView>\`.

Net diff: 1 insertion, 5 deletions in \`src/app.tsx\`.

## Test plan

- [ ] Run kimiflare in plan mode, verify tool cards now render alongside activity narratives
- [ ] Run kimiflare in edit/auto modes, verify behavior is unchanged
- [ ] \`npm run typecheck\` (only pre-existing \`sandbox.test.ts\` errors, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)