### PR TITLE
feat(ui): fuzzy matching for @ file picker

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -228,8 +228,7 @@ export function buildFilePickerIgnoreList(cwd: string): string[] {
 }
 
 export function filterPickerItems(items: FilePickerItem[], query: string): FilePickerItem[] {
-  const q = query.toLowerCase();
-  return items.filter((item) => item.name.toLowerCase().includes(q)).slice(0, 50);
+  return fuzzyFilter(items, query, (item) => item.name).slice(0, 50);
 }
 
 export function shouldOpenMentionPicker(

--- a/src/util/fuzzy.test.ts
+++ b/src/util/fuzzy.test.ts
@@ -36,9 +36,18 @@ describe("fuzzyMatch", () => {
     assert.strictEqual(fuzzyMatch("MoD", "model").matches, true);
   });
 
-  // Letters and digits are not swapped to match — keep matching simple.
-  it("does NOT swap letters/digits to match", () => {
-    assert.strictEqual(fuzzyMatch("2k", "k2").matches, false);
+  // Swapped letters and digits are tolerated (matches pi-tui behavior).
+  it("swaps letters/digits to match", () => {
+    assert.strictEqual(fuzzyMatch("2k", "k2").matches, true);
+    assert.strictEqual(fuzzyMatch("k2", "2k").matches, true);
+    assert.strictEqual(fuzzyMatch("a1", "1a").matches, true);
+  });
+
+  it("gives exact match the best score", () => {
+    const exact = fuzzyMatch("model", "model");
+    const prefix = fuzzyMatch("mod", "model");
+    assert.ok(exact.matches && prefix.matches);
+    assert.ok(exact.score < prefix.score, `exact(${exact.score}) should beat prefix(${prefix.score})`);
   });
 });
 

--- a/src/util/fuzzy.ts
+++ b/src/util/fuzzy.ts
@@ -1,5 +1,5 @@
 /**
- * Fuzzy matching utilities (trimmed port of pi-mono's fuzzy.ts).
+ * Fuzzy matching utilities (port of pi-mono's fuzzy.ts).
  * Match if all query characters appear in `text` in order (not necessarily
  * consecutive). Lower score = better match.
  */
@@ -10,39 +10,59 @@ export interface FuzzyMatch {
 }
 
 export function fuzzyMatch(query: string, text: string): FuzzyMatch {
-  const q = query.toLowerCase();
-  const t = text.toLowerCase();
+  const queryLower = query.toLowerCase();
+  const textLower = text.toLowerCase();
 
-  if (q.length === 0) return { matches: true, score: 0 };
-  if (q.length > t.length) return { matches: false, score: 0 };
+  const matchQuery = (normalizedQuery: string): FuzzyMatch => {
+    if (normalizedQuery.length === 0) return { matches: true, score: 0 };
+    if (normalizedQuery.length > textLower.length) return { matches: false, score: 0 };
 
-  let qi = 0;
-  let score = 0;
-  let lastMatch = -1;
-  let consecutive = 0;
+    let queryIndex = 0;
+    let score = 0;
+    let lastMatchIndex = -1;
+    let consecutiveMatches = 0;
 
-  for (let i = 0; i < t.length && qi < q.length; i++) {
-    if (t[i] !== q[qi]) continue;
+    for (let i = 0; i < textLower.length && queryIndex < normalizedQuery.length; i++) {
+      if (textLower[i] !== normalizedQuery[queryIndex]) continue;
 
-    const isWordBoundary = i === 0 || /[\s\-_./:]/.test(t[i - 1]!);
+      const isWordBoundary = i === 0 || /[\s\-_./:]/.test(textLower[i - 1]!);
 
-    if (lastMatch === i - 1) {
-      consecutive++;
-      score -= consecutive * 5;
-    } else {
-      consecutive = 0;
-      if (lastMatch >= 0) score += (i - lastMatch - 1) * 2;
+      if (lastMatchIndex === i - 1) {
+        consecutiveMatches++;
+        score -= consecutiveMatches * 5;
+      } else {
+        consecutiveMatches = 0;
+        if (lastMatchIndex >= 0) score += (i - lastMatchIndex - 1) * 2;
+      }
+
+      if (isWordBoundary) score -= 10;
+      score += i * 0.1;
+
+      lastMatchIndex = i;
+      queryIndex++;
     }
 
-    if (isWordBoundary) score -= 10;
-    score += i * 0.1;
+    if (queryIndex < normalizedQuery.length) return { matches: false, score: 0 };
+    if (normalizedQuery === textLower) score -= 100;
+    return { matches: true, score };
+  };
 
-    lastMatch = i;
-    qi++;
-  }
+  const primaryMatch = matchQuery(queryLower);
+  if (primaryMatch.matches) return primaryMatch;
 
-  if (qi < q.length) return { matches: false, score: 0 };
-  return { matches: true, score };
+  const alphaNumericMatch = queryLower.match(/^(?<letters>[a-z]+)(?<digits>[0-9]+)$/);
+  const numericAlphaMatch = queryLower.match(/^(?<digits>[0-9]+)(?<letters>[a-z]+)$/);
+  const swappedQuery = alphaNumericMatch
+    ? `${alphaNumericMatch.groups?.digits ?? ""}${alphaNumericMatch.groups?.letters ?? ""}`
+    : numericAlphaMatch
+      ? `${numericAlphaMatch.groups?.letters ?? ""}${numericAlphaMatch.groups?.digits ?? ""}`
+      : "";
+
+  if (!swappedQuery) return primaryMatch;
+
+  const swappedMatch = matchQuery(swappedQuery);
+  if (!swappedMatch.matches) return primaryMatch;
+  return { matches: true, score: swappedMatch.score + 5 };
 }
 
 /**
@@ -58,7 +78,9 @@ export function fuzzyFilter<T>(
   const trimmed = query.trim();
   if (trimmed.length === 0) return items;
 
-  const tokens = trimmed.split(/\s+/);
+  const tokens = trimmed.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length === 0) return items;
+
   const scored: { item: T; score: number }[] = [];
 
   for (const item of items) {


### PR DESCRIPTION
## feat(ui): fuzzy matching for @ file picker

### Why

the @ file picker only did substring matching, which felt broken.
typing "app" would find "app.tsx" but skip "src/app.tsx" when the
query was "sapp". i had `fuzzyFilter` imported but `filterPickerItems`
was still using `.includes()` like i forgot to wire it up.

my coding agent ported the full scoring from pi-tui. works now.

### What changed

- `filterPickerItems` now routes through `fuzzyFilter` instead of substring `.includes()`
- `fuzzyMatch` ported from upstream: exact match bonus (-100), word boundary
  rewards (-10), consecutive match rewards, gap penalties
- letter/digit swap tolerance: "2k" now matches "k2"
- `fuzzyFilter`: space-separated token support, empty token guard

### How to verify

`npx tsx --test src/util/fuzzy.test.ts src/app.test.tsx src/ui/file-picker.test.tsx`