### PR TITLE
feat(ui): humanize system logs with tier-aware storytelling

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3605,7 +3605,7 @@ function App({
         {!hasConversation && events.length === 0 ? (
           <Welcome accountId={cfg.accountId} cloudMode={cfg.cloudMode} />
         ) : (
-          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} />
+          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} />
         )}
         {perm ? (
           <PermissionModal
@@ -3666,6 +3666,7 @@ function App({
               lastActivityAt={lastActivityAt}
               kimiMdStale={kimiMdStale}
               gitBranch={gitBranch}
+              intentTier={intentTier ?? undefined}
             />
             {activePicker?.kind === "file" && (
               <FilePicker

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -5,6 +5,7 @@ import { ToolView, type ToolEventState } from "./tool-view.js";
 import { MD } from "./markdown.js";
 import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
+import { humanizeInfo, humanizeMemory, humanizeMeta, type IntentTier } from "./narrator.js";
 
 export type ChatEvent =
   | { kind: "user"; key: string; text: string; images?: string[] }
@@ -32,6 +33,7 @@ interface Props {
   events: ChatEvent[];
   showReasoning: boolean;
   verbose?: boolean;
+  intentTier?: IntentTier;
 }
 
 interface StaticItem {
@@ -44,7 +46,7 @@ function toolSignature(name: string, args: string): string {
   return `${name}:${args}`;
 }
 
-export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose }: Props) {
+export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier }: Props) {
   const theme = useTheme();
   const finalized: StaticItem[] = [];
   const active: ChatEvent[] = [];
@@ -88,7 +90,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
                 </Text>
               </Box>
             )}
-            <EventView evt={item.evt} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} />
+            <EventView evt={item.evt} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} intentTier={intentTier} />
           </Box>
         )}
       </Static>
@@ -105,7 +107,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
                 </Text>
               </Box>
             )}
-            <EventView evt={e} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} />
+            <EventView evt={e} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} intentTier={intentTier} />
           </Box>
         );
       })}
@@ -118,11 +120,13 @@ const EventView = React.memo(function EventView({
   showReasoning,
   verbose,
   repeatedSigs,
+  intentTier,
 }: {
   evt: ChatEvent;
   showReasoning: boolean;
   verbose?: boolean;
   repeatedSigs?: Set<string>;
+  intentTier?: IntentTier;
 }) {
   const theme = useTheme();
   if (evt.kind === "user") {
@@ -166,39 +170,35 @@ const EventView = React.memo(function EventView({
   }
   if (evt.kind === "tool") {
     const isRepeated = repeatedSigs?.has(toolSignature(evt.name, evt.args)) ?? false;
-    return <ToolView evt={evt} verbose={verbose} isRepeated={isRepeated} />;
+    return <ToolView evt={evt} verbose={verbose} isRepeated={isRepeated} intentTier={intentTier} />;
   }
   if (evt.kind === "info") {
     return (
       <Text color={theme.info.color} >
-        · {evt.text}
+        · {humanizeInfo(evt.text, intentTier)}
       </Text>
     );
   }
   if (evt.kind === "memory") {
     return (
       <Text color={theme.info.color} >
-        ◈ {evt.text}
+        ◈ {humanizeMemory(evt.text, intentTier)}
       </Text>
     );
   }
   if (evt.kind === "meta") {
-    const parts: string[] = [];
-    if (evt.intentTier) {
-      parts.push(
-        evt.intentTier === "light" ? "Quick thought" : evt.intentTier === "medium" ? "Deep dive" : "Heavy lifting",
-      );
-    }
+    const metaParts: { label: string; value?: string | number }[] = [];
     if (evt.skillsActive !== undefined && evt.skillsActive > 0) {
-      parts.push(`${evt.skillsActive} skill${evt.skillsActive === 1 ? "" : "s"} on deck`);
+      metaParts.push({ label: `skill${evt.skillsActive === 1 ? "" : "s"} ready`, value: evt.skillsActive });
     }
     if (evt.memoryRecalled) {
-      parts.push("Memory recalled");
+      metaParts.push({ label: "memory recalled" });
     }
-    if (parts.length === 0) return null;
+    const metaText = humanizeMeta(metaParts, intentTier ?? evt.intentTier);
+    if (!metaText) return null;
     return (
       <Text color={theme.info.color} dimColor>
-        {parts.join(" · ")}
+        {metaText}
       </Text>
     );
   }

--- a/src/ui/narrator.ts
+++ b/src/ui/narrator.ts
@@ -1,0 +1,396 @@
+/**
+ * Narrator — humanizes KimiFlare's system chatter without hiding technical details.
+ *
+ * Design principles:
+ * - File names, paths, URLs, and numbers are preserved exactly.
+ * - Mechanical verbs are replaced with warmer, tier-appropriate language.
+ * - The tone adapts to intent tier: light (casual), medium (focused), heavy (deliberate).
+ * - Terminal space is respected — keep it concise.
+ */
+
+export type IntentTier = "light" | "medium" | "heavy";
+export type TurnPhase = "generating" | "executing" | "waiting";
+
+const TIER_VOICE: Record<IntentTier, { prefix: string; verb: string }> = {
+  light: { prefix: "", verb: "" },
+  medium: { prefix: "", verb: "" },
+  heavy: { prefix: "", verb: "" },
+};
+
+// ── Tool titles ──────────────────────────────────────────────────────────────
+
+export function humanizeToolTitle(
+  toolName: string,
+  originalTitle: string,
+  tier?: IntentTier,
+): string {
+  // Preserve exact titles for permission-critical or data-dense tools
+  if (toolName.startsWith("lsp_")) {
+    return humanizeLspTitle(toolName, originalTitle, tier);
+  }
+  if (toolName.startsWith("mcp_")) {
+    return humanizeMcpTitle(toolName, originalTitle, tier);
+  }
+
+  switch (toolName) {
+    case "read":
+      return pick(tier, {
+        light: `Taking a quick look at ${extractPath(originalTitle)}`,
+        medium: `Reading ${extractPath(originalTitle)}`,
+        heavy: `Digging into ${extractPath(originalTitle)}`,
+      });
+
+    case "write":
+      return pick(tier, {
+        light: `Creating ${extractPath(originalTitle)}`,
+        medium: `Writing ${extractPath(originalTitle)}`,
+        heavy: `Drafting ${extractPath(originalTitle)}`,
+      });
+
+    case "edit": {
+      const path = extractPath(originalTitle);
+      const suffix = originalTitle.includes("replace_all") ? " (replace all)" : "";
+      return pick(tier, {
+        light: `Tweaking ${path}${suffix}`,
+        medium: `Updating ${path}${suffix}`,
+        heavy: `Refining ${path}${suffix}`,
+      });
+    }
+
+    case "bash": {
+      const cmd = extractAfter(originalTitle, "bash ");
+      return pick(tier, {
+        light: `Running: ${cmd}`,
+        medium: `Executing: ${cmd}`,
+        heavy: `Running: ${cmd}`,
+      });
+    }
+
+    case "glob": {
+      const pattern = extractAfter(originalTitle, "glob ");
+      return pick(tier, {
+        light: `Finding files: ${pattern}`,
+        medium: `Searching for ${pattern}`,
+        heavy: `Mapping files: ${pattern}`,
+      });
+    }
+
+    case "grep": {
+      const pattern = extractAfter(originalTitle, "grep ");
+      return pick(tier, {
+        light: `Searching for "${pattern}"`,
+        medium: `Grepping for "${pattern}"`,
+        heavy: `Hunting for "${pattern}"`,
+      });
+    }
+
+    case "web_fetch": {
+      const url = extractAfter(originalTitle, "GET ");
+      return pick(tier, {
+        light: `Pulling up ${url}`,
+        medium: `Fetching ${url}`,
+        heavy: `Retrieving ${url}`,
+      });
+    }
+
+    case "tasks_set":
+      return pick(tier, {
+        light: "Updating the plan",
+        medium: "Planning the next steps",
+        heavy: "Structuring the work ahead",
+      });
+
+    case "memory_remember":
+      return pick(tier, {
+        light: "Jotting that down",
+        medium: "Noted",
+        heavy: "Committing to memory",
+      });
+
+    case "memory_recall":
+      return pick(tier, {
+        light: "Thinking back…",
+        medium: "Recalling memories…",
+        heavy: "Drawing from memory…",
+      });
+
+    case "memory_forget":
+      return pick(tier, {
+        light: "Letting that go",
+        medium: "Forgetting",
+        heavy: "Clearing from memory",
+      });
+
+    case "expand_artifact": {
+      const id = extractAfter(originalTitle, "expand ");
+      return pick(tier, {
+        light: `Opening ${id}`,
+        medium: `Expanding ${id}`,
+        heavy: `Retrieving full ${id}`,
+      });
+    }
+
+    default:
+      return originalTitle;
+  }
+}
+
+function humanizeLspTitle(
+  toolName: string,
+  originalTitle: string,
+  tier?: IntentTier,
+): string {
+  // LSP tools don't have render titles currently, so originalTitle is just the tool name
+  // We construct a friendly version from the tool name
+  const action = toolName.replace("lsp_", "").replace(/_/g, " ");
+  return pick(tier, {
+    light: `Checking ${action}`,
+    medium: `LSP: ${action}`,
+    heavy: `LSP deep-dive: ${action}`,
+  });
+}
+
+function humanizeMcpTitle(
+  _toolName: string,
+  originalTitle: string,
+  tier?: IntentTier,
+): string {
+  return pick(tier, {
+    light: `Using ${originalTitle}`,
+    medium: `Calling ${originalTitle}`,
+    heavy: `Invoking ${originalTitle}`,
+  });
+}
+
+// ── Info logs ────────────────────────────────────────────────────────────────
+
+export function humanizeInfo(text: string, tier?: IntentTier): string {
+  // Compaction
+  if (text.startsWith("auto-compacted:")) {
+    return text.replace("auto-compacted:", "Compacted context:");
+  }
+  if (text === "nothing to compact yet") {
+    return pick(tier, {
+      light: "Plenty of room left",
+      medium: "Context still has room",
+      heavy: "No compaction needed yet",
+    });
+  }
+  if (text.startsWith("compacted ") && text.includes(" turns")) {
+    return text; // already human enough
+  }
+  if (text.startsWith("··· ") && text.includes(" earlier messages compacted ")) {
+    return text;
+  }
+
+  // Memory
+  if (text.startsWith("memory cleanup: removed ")) {
+    const n = extractNumber(text);
+    return pick(tier, {
+      light: `Cleaned up ${n} stale memories`,
+      medium: `Forgot ${n} stale memories`,
+      heavy: `Pruned ${n} stale memories`,
+    });
+  }
+  if (text.startsWith("memory backfill: embedded ")) {
+    const n = extractNumber(text);
+    return pick(tier, {
+      light: `Indexed ${n} memories`,
+      medium: `Indexed ${n} un-vectorized memories`,
+      heavy: `Backfilled ${n} memory embeddings`,
+    });
+  }
+
+  // LSP
+  if (text.startsWith("LSP ready — ")) {
+    return text.replace("LSP ready — ", "LSP ready (").replace(" active", " active)");
+  }
+  if (text === "LSP reload complete — no servers started (check config or enabled status).") {
+    return pick(tier, {
+      light: "LSP reloaded — no servers running",
+      medium: "LSP reload complete — no servers started",
+      heavy: "LSP reload complete — no servers active (check configuration)",
+    });
+  }
+
+  // MCP
+  if (text === "reloading MCP servers...") {
+    return pick(tier, {
+      light: "Reconnecting MCP servers…",
+      medium: "Reloading MCP servers…",
+      heavy: "Reinitializing MCP servers…",
+    });
+  }
+
+  // Session
+  if (text.startsWith("pruned ")) {
+    const n = extractNumber(text);
+    return `Cleaned up ${n} old session files`;
+  }
+  if (text.startsWith("resumed session ")) {
+    return text.replace("resumed session", "Picked up session");
+  }
+
+  // Context fullness
+  if (text.startsWith("context ") && text.includes("% full — run /compact")) {
+    const pct = extractNumber(text);
+    return `Context is ${pct}% full — /compact when ready`;
+  }
+
+  // Interruption
+  if (text === "(interrupted)") {
+    return pick(tier, {
+      light: "Stopped",
+      medium: "Interrupted",
+      heavy: "Halted",
+    });
+  }
+
+  // Mode switches
+  if (text.startsWith("mode: ")) {
+    const mode = text.slice("mode: ".length);
+    return `Switched to ${mode} mode`;
+  }
+
+  // Reasoning toggle
+  if (text.startsWith("reasoning: ")) {
+    const state = text.slice("reasoning: ".length);
+    return `Reasoning ${state}`;
+  }
+
+  // Cost attribution
+  if (text === "cost attribution enabled") return "Cost tracking on";
+  if (text === "cost attribution disabled") return "Cost tracking off";
+
+  // Update
+  if (text === "no update available") {
+    return pick(tier, {
+      light: "You're on the latest version",
+      medium: "No update available",
+      heavy: "Running the latest version",
+    });
+  }
+
+  // KIMI.md
+  if (text === "KIMI.md generated; context loaded for future turns") {
+    return pick(tier, {
+      light: "Project context refreshed",
+      medium: "KIMI.md generated — context loaded",
+      heavy: "Project context snapshot updated",
+    });
+  }
+
+  // Theme
+  if (text.startsWith("theme: ") && text.includes(" — restart to apply")) {
+    return text; // already fine
+  }
+
+  // Config
+  if (text === "configuration saved — welcome to kimiflare!") {
+    return pick(tier, {
+      light: "All set — welcome to KimiFlare!",
+      medium: "Configuration saved — welcome to KimiFlare!",
+      heavy: "Configuration saved — welcome to KimiFlare!",
+    });
+  }
+
+  // Default: return as-is
+  return text;
+}
+
+// ── Memory logs ──────────────────────────────────────────────────────────────
+
+export function humanizeMemory(text: string, tier?: IntentTier): string {
+  if (text.startsWith("recalled ")) {
+    const n = extractNumber(text);
+    const rest = text.slice(text.indexOf("memory") + "memory".length);
+    return pick(tier, {
+      light: `Remembered ${n} thing${n === 1 ? "" : "s"}${rest}`,
+      medium: `Recalled ${n} memory${n === 1 ? "" : "ies"}${rest}`,
+      heavy: `Recalled ${n} memory${n === 1 ? "" : "ies"}${rest}`,
+    });
+  }
+  if (text === "memory enabled") return "Memory on";
+  if (text === "memory disabled") return "Memory off";
+  if (text.startsWith("cleared ")) {
+    const n = extractNumber(text);
+    return `Cleared ${n} memories for this repo`;
+  }
+  return text;
+}
+
+// ── Meta banners ─────────────────────────────────────────────────────────────
+
+export function humanizeMeta(
+  parts: { label: string; value?: string | number }[],
+  tier?: IntentTier,
+): string {
+  if (parts.length === 0) return "";
+
+  const tierLabel = pick(tier, {
+    light: "Quick one",
+    medium: "Digging in",
+    heavy: "Going deep",
+  });
+
+  const rest = parts
+    .filter((p) => p.label !== "tier")
+    .map((p) => (p.value !== undefined ? `${p.value} ${p.label}` : p.label))
+    .join(" · ");
+
+  return rest ? `${tierLabel} · ${rest}` : tierLabel;
+}
+
+// ── Status phases ────────────────────────────────────────────────────────────
+
+export function humanizePhase(phase: TurnPhase, tier?: IntentTier): string {
+  switch (phase) {
+    case "generating":
+      return pick(tier, {
+        light: "thinking",
+        medium: "thinking",
+        heavy: "reasoning",
+      });
+    case "executing":
+      return pick(tier, {
+        light: "running",
+        medium: "working",
+        heavy: "executing",
+      });
+    case "waiting":
+      return pick(tier, {
+        light: "ready",
+        medium: "ready",
+        heavy: "waiting",
+      });
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function pick<T>(tier: IntentTier | undefined, choices: Record<IntentTier, T>): T {
+  return choices[tier ?? "medium"];
+}
+
+function extractPath(title: string): string {
+  // Titles are like "read src/app.tsx" or "write src/app.tsx (1234 chars)"
+  const firstSpace = title.indexOf(" ");
+  if (firstSpace === -1) return title;
+  let rest = title.slice(firstSpace + 1);
+  // Strip trailing metadata like " (1234 chars)"
+  const paren = rest.indexOf(" (");
+  if (paren !== -1) rest = rest.slice(0, paren);
+  return rest;
+}
+
+function extractAfter(title: string, prefix: string): string {
+  if (title.startsWith(prefix)) return title.slice(prefix.length);
+  const idx = title.indexOf(prefix);
+  if (idx !== -1) return title.slice(idx + prefix.length);
+  return title;
+}
+
+function extractNumber(text: string): number {
+  const m = text.match(/(\d+)/);
+  return m ? parseInt(m[1]!, 10) : 0;
+}

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -9,6 +9,7 @@ import type { ReasoningEffort } from "../config.js";
 import type { Mode } from "../mode.js";
 import { calculateCost } from "../pricing.js";
 import type { DailyUsage } from "../usage-tracker.js";
+import { humanizePhase, type IntentTier } from "./narrator.js";
 
 export type TurnPhase = "generating" | "executing" | "waiting";
 
@@ -36,9 +37,10 @@ interface Props {
   lastActivityAt?: number | null;
   kimiMdStale?: boolean;
   gitBranch?: string | null;
+  intentTier?: IntentTier;
 }
 
-export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode, cloudMode, cloudBudget, skillsActive, memoryRecalled, phase, currentTool, lastActivityAt, kimiMdStale, gitBranch }: Props) {
+export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt, mode, effort, contextLimit, hasUpdate, latestVersion, gatewayMeta, codeMode, cloudMode, cloudBudget, skillsActive, memoryRecalled, phase, currentTool, lastActivityAt, kimiMdStale, gitBranch, intentTier }: Props) {
   const theme = useTheme();
   const [now, setNow] = useState(Date.now());
   const modeColor =
@@ -65,7 +67,13 @@ export function StatusBar({ model, usage, sessionUsage, thinking, turnStartedAt,
   if (memoryRecalled) {
     labelParts.push("Memory recalled");
   }
-  const phaseLabel = phase === "generating" ? "generating" : phase === "executing" ? `executing ${currentTool ?? ""}` : phase === "waiting" ? "waiting" : "thinking";
+  const phaseLabel = phase === "generating"
+    ? humanizePhase("generating", intentTier)
+    : phase === "executing"
+      ? `${humanizePhase("executing", intentTier)} ${currentTool ?? ""}`
+      : phase === "waiting"
+        ? humanizePhase("waiting", intentTier)
+        : humanizePhase("generating", intentTier);
   const idleMs = lastActivityAt && thinking ? now - lastActivityAt : 0;
   const idleLabel = idleMs > 30_000 ? ` (idle ${formatElapsed(Math.floor(idleMs / 1000))})` : "";
 

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -5,6 +5,7 @@ import { DiffView } from "./diff-view.js";
 import { collapsePathsInText } from "../util/paths.js";
 import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
+import { humanizeToolTitle, type IntentTier } from "./narrator.js";
 
 export interface ToolEventState {
   id: string;
@@ -21,6 +22,7 @@ interface Props {
   evt: ToolEventState;
   verbose?: boolean;
   isRepeated?: boolean;
+  intentTier?: IntentTier;
 }
 
 function formatElapsed(ms: number): string {
@@ -32,7 +34,7 @@ function formatElapsed(ms: number): string {
   return `${m}m ${s}s`;
 }
 
-export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated }: Props) {
+export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated, intentTier }: Props) {
   const theme = useTheme();
   const [now, setNow] = useState(Date.now());
 
@@ -56,7 +58,8 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated 
     ) : (
       <Text color={theme.palette.success}>✓</Text>
     );
-  let title = evt.render?.title ?? `${evt.name}(${compactArgs(evt.args)})`;
+  const rawTitle = evt.render?.title ?? `${evt.name}(${compactArgs(evt.args)})`;
+  let title = humanizeToolTitle(evt.name, rawTitle, intentTier);
   if (evt.startedAt !== undefined) {
     title += ` · ${formatElapsed(now - evt.startedAt)}`;
   }


### PR DESCRIPTION
This PR replaces mechanical tool titles, info logs, memory logs, meta banners, and status-bar phases with warmer, intent-tier-aware language.

## What's humanized

- **Tool execution cards** — read, write, edit, bash, grep, glob, web_fetch, memory_*, tasks_set, expand_artifact, LSP, MCP
- **Info logs** — compaction, memory cleanup/backfill, LSP/MCP status, session pruning, context fullness, mode switches, etc.
- **Memory logs** — recalled, enabled, disabled, cleared
- **Meta banners** — tier label + skills active + memory recalled
- **Status bar phases** — generating / executing / waiting adapt to light/medium/heavy tier

## Design principles

- File names, paths, URLs, and numbers are **always preserved exactly**
- Mechanical verbs replaced with warmer, tier-appropriate language
- Tone adapts to intent tier: light (casual), medium (focused), heavy (deliberate)
- Terminal space respected — keeps it concise

## New module

-  — centralizes all humanization logic as pure functions

## Files changed

-  (new)
- 
- 
- 
- 

Co-authored-by: kimiflare <kimiflare@proton.me>