### PR TITLE
fix(ui): preserve original list numbers in markdown rendering

### DIFF
--- a/src/ui/markdown.test.tsx
+++ b/src/ui/markdown.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import React from "react";
+import { renderToString } from "ink";
+import { MD } from "./markdown.js";
+import { ThemeProvider } from "./theme-context.js";
+import { resolveTheme } from "./theme.js";
+
+const testTheme = resolveTheme();
+
+function renderMarkdown(text: string): string {
+  return renderToString(
+    <ThemeProvider theme={testTheme}>
+      <MD text={text} />
+    </ThemeProvider>,
+  );
+}
+
+describe("MD numbered lists", () => {
+  it("renders lazy numbering sequentially (1. 1. 1. → 1. 2. 3.)", () => {
+    const text = "1. First\n1. Second\n1. Third";
+    const out = renderMarkdown(text);
+    assert.ok(out.includes("1. First"), "should show 1. for first item");
+    assert.ok(out.includes("2. Second"), "should show 2. for second item");
+    assert.ok(out.includes("3. Third"), "should show 3. for third item");
+  });
+
+  it("preserves explicit source numbers", () => {
+    const text = "1. First\n5. Second\n10. Third";
+    const out = renderMarkdown(text);
+    assert.ok(out.includes("1. First"), "should show 1. for first item");
+    assert.ok(out.includes("5. Second"), "should show 5. for second item");
+    assert.ok(out.includes("10. Third"), "should show 10. for third item");
+  });
+
+  it("renders mixed lazy/explicit with source numbers", () => {
+    const text = "2. First\n3. Second\n4. Third";
+    const out = renderMarkdown(text);
+    assert.ok(out.includes("2. First"), "should show 2. for first item");
+    assert.ok(out.includes("3. Second"), "should show 3. for second item");
+    assert.ok(out.includes("4. Third"), "should show 4. for third item");
+  });
+});

--- a/src/ui/markdown.tsx
+++ b/src/ui/markdown.tsx
@@ -29,7 +29,7 @@ type Block =
   | { kind: "paragraph"; text: string }
   | { kind: "heading"; level: 1 | 2 | 3; text: string }
   | { kind: "bullet"; items: string[] }
-  | { kind: "numbered"; items: string[] }
+  | { kind: "numbered"; items: { text: string; num: number }[] }
   | { kind: "quote"; text: string }
   | { kind: "code"; lang?: string; text: string }
   | { kind: "table"; headers: string[]; rows: string[][] }
@@ -73,9 +73,12 @@ function parseBlocks(src: string): Block[] {
     }
     // Numbered list
     if (/^\s*\d+\.\s+/.test(line)) {
-      const items: string[] = [];
+      const items: { text: string; num: number }[] = [];
       while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i]!)) {
-        items.push(lines[i]!.replace(/^\s*\d+\.\s+/, ""));
+        const m = lines[i]!.match(/^\s*(\d+)\.\s+(.*)$/);
+        if (m) {
+          items.push({ num: Number(m[1]), text: m[2]! });
+        }
         i++;
       }
       out.push({ kind: "numbered", items });
@@ -156,12 +159,13 @@ const Block = React.memo(function Block({ block }: { block: Block }) {
     );
   }
   if (block.kind === "numbered") {
+    const allOnes = block.items.every((it) => it.num === 1);
     return (
       <Box flexDirection="column">
         {block.items.map((item, idx) => (
           <Box key={idx}>
-            <Text color={theme.accent}>  {idx + 1}. </Text>
-            <Text>{renderInline(item, theme)}</Text>
+            <Text color={theme.accent}>  {allOnes ? idx + 1 : item.num}. </Text>
+            <Text>{renderInline(item.text, theme)}</Text>
           </Box>
         ))}
       </Box>


### PR DESCRIPTION
Fixes a bug where numbered lists in markdown rendering showed duplicate `1.` labels instead of sequential numbering.

## Problem

The custom markdown parser stripped the original list number during parsing and always re-rendered with `idx + 1`. When a list was split into multiple blocks (e.g., by soft-wrapped lines or nested content), each block started counting from 1 again, producing duplicate `1.` labels.

## Changes

- Update `Block` type to store `{ text: string; num: number }[]`
- Capture the matched number in the parser
- Use sequential numbering (`idx + 1`) only when all items are lazy `1.` (standard markdown behavior); otherwise render the actual source number
- Add tests for lazy, explicit, and mixed numbering

## Testing

```bash
npm test -- src/ui/markdown.test.tsx
```

All 3 tests pass.

Co-authored-by: kimiflare <kimiflare@proton.me>