### PR TITLE
feat(cloud): graceful quota-exhausted message in TUI

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,7 +26,7 @@ import { LspManager } from "./lsp/manager.js";
 import { makeLspTools } from "./tools/lsp.js";
 import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
-import { KimiApiError } from "./util/errors.js";
+import { KimiApiError, isCloudQuotaExhaustedError } from "./util/errors.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
@@ -1819,6 +1819,34 @@ function App({
         setEvents((evts) =>
           evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
         );
+      } else if (cfg?.cloudMode && isCloudQuotaExhaustedError(e)) {
+        const token = cloudToken ?? initialCloudToken;
+        const did = cloudDeviceId ?? initialCloudDeviceId;
+        let used = 0;
+        let limit = 0;
+        let expiresAt = "";
+        if (token) {
+          try {
+            const { fetchCloudUsage } = await import("./cloud/auth.js");
+            const usage = await fetchCloudUsage(token, did);
+            if (usage) {
+              used = usage.input_tokens_used;
+              limit = usage.input_token_limit;
+              expiresAt = usage.expires_at;
+            }
+          } catch { /* ignore */ }
+        }
+        if (!limit) {
+          const m = (e as KimiApiError).message.match(/Used ([\d,]+)\s*\/\s*([\d,]+)/);
+          if (m && m[1] && m[2]) {
+            used = parseInt(m[1].replace(/,/g, ""), 10);
+            limit = parseInt(m[2].replace(/,/g, ""), 10);
+          }
+        }
+        setEvents((es) => [
+          ...es,
+          { kind: "cloud_quota_exhausted", key: mkKey(), used, limit, expiresAt },
+        ]);
       } else {
         setEvents((es) => [
           ...es,
@@ -3295,6 +3323,34 @@ function App({
           setEvents((evts) =>
             evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(interrupted)" } : e)),
           );
+        } else if (cfg?.cloudMode && isCloudQuotaExhaustedError(e)) {
+          const token = cloudToken ?? initialCloudToken;
+          const did = cloudDeviceId ?? initialCloudDeviceId;
+          let used = 0;
+          let limit = 0;
+          let expiresAt = "";
+          if (token) {
+            try {
+              const { fetchCloudUsage } = await import("./cloud/auth.js");
+              const usage = await fetchCloudUsage(token, did);
+              if (usage) {
+                used = usage.input_tokens_used;
+                limit = usage.input_token_limit;
+                expiresAt = usage.expires_at;
+              }
+            } catch { /* ignore */ }
+          }
+          if (!limit) {
+            const m = (e as KimiApiError).message.match(/Used ([\d,]+)\s*\/\s*([\d,]+)/);
+            if (m && m[1] && m[2]) {
+              used = parseInt(m[1].replace(/,/g, ""), 10);
+              limit = parseInt(m[2].replace(/,/g, ""), 10);
+            }
+          }
+          setEvents((es) => [
+            ...es,
+            { kind: "cloud_quota_exhausted", key: mkKey(), used, limit, expiresAt },
+          ]);
         } else {
           const isInvalidJson400 =
             e instanceof KimiApiError &&

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -6,6 +6,7 @@ import { MD } from "./markdown.js";
 import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
 import { humanizeInfo, humanizeMemory, humanizeMeta, type IntentTier } from "./narrator.js";
+import { CloudQuotaMessage } from "./cloud-quota-message.js";
 
 export type ChatEvent =
   | { kind: "user"; key: string; text: string; images?: string[] }
@@ -27,6 +28,13 @@ export type ChatEvent =
       intentTier?: "light" | "medium" | "heavy";
       skillsActive?: number;
       memoryRecalled?: boolean;
+    }
+  | {
+      kind: "cloud_quota_exhausted";
+      key: string;
+      used: number;
+      limit: number;
+      expiresAt: string;
     };
 
 interface Props {
@@ -184,6 +192,15 @@ const EventView = React.memo(function EventView({
       <Text color={theme.info.color} >
         ◈ {humanizeMemory(evt.text, intentTier)}
       </Text>
+    );
+  }
+  if (evt.kind === "cloud_quota_exhausted") {
+    return (
+      <CloudQuotaMessage
+        used={evt.used}
+        limit={evt.limit}
+        expiresAt={evt.expiresAt}
+      />
     );
   }
   if (evt.kind === "meta") {

--- a/src/ui/cloud-quota-message.tsx
+++ b/src/ui/cloud-quota-message.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { useTheme } from "./theme-context.js";
+
+interface Props {
+  used: number;
+  limit: number;
+  expiresAt: string;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+export function CloudQuotaMessage({ used, limit, expiresAt }: Props) {
+  const theme = useTheme();
+
+  const expires = expiresAt ? new Date(expiresAt) : null;
+  const start = expires
+    ? new Date(expires.getTime() - 7 * 24 * 60 * 60 * 1000)
+    : null;
+
+  const fmt = (d: Date) =>
+    d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+
+  const dateRange = start && expires ? `${fmt(start)} → ${fmt(expires)}` : "this week";
+
+  return (
+    <Box flexDirection="column" marginY={1}>
+      <Text bold color={theme.accent}>
+        You've used your free allocation for this week.
+      </Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color={theme.info.color}>
+          Free tier ran from {dateRange}, courtesy of Cloudflare
+        </Text>
+        <Text color={theme.info.color}>
+          Workers AI credits. Thanks for trying kimiflare.
+        </Text>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text bold>Keep going with your own Cloudflare API key:</Text>
+        <Box paddingLeft={2} flexDirection="column">
+          <Text color={theme.info.color}>
+            → Set one: kimiflare config set-key &lt;your-key&gt;
+          </Text>
+          <Text color={theme.info.color}>
+            → Get one: https://dash.cloudflare.com/profile/api-tokens
+          </Text>
+          <Text color={theme.info.color}>
+            → Pricing: https://developers.cloudflare.com/workers-ai/platform/pricing/
+          </Text>
+          <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
+            (~$0.95/M input tokens, ~$4.00/M output tokens)
+          </Text>
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color={theme.info.color}>
+          Or wait for hosted plans — drop your email at
+        </Text>
+        <Text color={theme.info.color}>
+          kimiflare.dev/notify and I'll ping you when they're live.
+        </Text>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color={theme.info.color}>
+          Want a bit more credit? DM me on X: x.com/sinasanm
+        </Text>
+        <Text color={theme.info.color}>
+          Chances are I might be able to hook you up.
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
+          Used: {formatTokens(used)} / {formatTokens(limit)} tokens this week.
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -15,3 +15,11 @@ export class PermissionDeniedError extends Error {
     this.name = "PermissionDeniedError";
   }
 }
+
+export function isCloudQuotaExhaustedError(err: unknown): err is KimiApiError {
+  return (
+    err instanceof KimiApiError &&
+    err.httpStatus === 429 &&
+    /token quota exhausted/i.test(err.message)
+  );
+}


### PR DESCRIPTION
Replace the raw HTTP 429 error with a friendly Ink component when cloud-mode users hit their free token allocation.

### Changes
- **src/util/errors.ts** — Add `isCloudQuotaExhaustedError()` helper
- **src/ui/cloud-quota-message.tsx** — New Ink component showing:
  - Free-tier date range
  - Real Cloudflare Workers AI pricing (~$0.95/M input, ~$4.00/M output)
  - Setup instructions with `kimiflare config set-key`
  - Link to x.com/sinasanm for extra credit
- **src/ui/chat.tsx** — Extend `ChatEvent` union with `cloud_quota_exhausted`
- **src/app.tsx** — Wire both `runAgentTurn` catch blocks to detect the error and emit the new event instead of a raw error line