### PR TITLE
docs: refresh README and landing page for v0.47.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,51 +13,44 @@
 
 <p align="center">
   <strong>A terminal coding agent powered by <a href="https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/">Kimi-K2.6</a> on Cloudflare Workers AI.</strong><br>
-  Moonshot's 1T-parameter open-source model, running directly on your Cloudflare account.
+  Moonshot's 1T-parameter open-source model, running directly in your terminal.
 </p>
-
-> 💸 **Heads up — this runs on your Cloudflare account.**
-> We recommend setting a [budget cap](https://developers.cloudflare.com/workers-ai/platform/pricing/) on Workers AI and checking your [Cloudflare billing](https://dash.cloudflare.com/) regularly while using KimiFlare.
->
-> 🚀 **Stay up to date.** Newer versions are significantly more token-efficient and cheaper to run. Run `/update` inside KimiFlare or `npm update -g kimiflare` to get the latest release.
 
 <p align="center">
   <img src="docs/screenshot.png" alt="kimiflare TUI" width="900">
 </p>
 
-## Stay in the loop
+## Two ways to run
 
-Kimiflare is shipping quickly.
+| Mode | How it works | Best for |
+|------|-------------|----------|
+| **BYOK** | Bring your own Cloudflare Account ID + API Token. Traffic goes straight to Workers AI from your account. | Power users who want full control and direct billing. |
+| **Kimiflare Cloud** | Device auth — no API key needed. We proxy requests through our managed endpoint. | Getting started quickly without a Cloudflare account. |
 
-Get:
-- release notes,
-- technical write-ups,
-- early experimental features,
-- architecture notes on building coding agents on Cloudflare.
+> 🎁 **Try Kimiflare Cloud free** — sign up and get **5 million tokens** on us until May 14, 2026. Run `kimiflare --cloud` or pick "Cloud (managed)" during onboarding.
 
-→ Get updates: https://kimiflare.com
-
-## Shipping fast
-
-Recently shipped:
-- Cloudflare Code Mode support
-- Local agent memory
-- Major token cost reductions (70–90% lower)
-- Better session compaction
-
-Coming next:
-- OpenCode parity improvements
-- Cost attribution dashboard
-- Cloudflare Artifacts experiments
-
-Full changelog and notes at https://kimiflare.com
-
-## Why kimiflare
+## What to remember
 
 - **262k context window** — Read entire modules, large configs, and full stack traces without the model losing track.
-- **Image understanding** — Drop image paths into your prompt (PNG, JPG, WebP, GIF, BMP). The model sees them inline — great for UI reviews, diagrams, screenshots, and mockups.
-- **Direct by default** — No proxy, no OpenAI SDK. Your traffic goes straight to Workers AI from your account, with optional AI Gateway routing for user-owned logging, caching, and analytics.
-- **Plan mode** — Ask the agent to research and produce a plan without touching your filesystem. Review it, then exit plan mode to execute.
+- **Image understanding** — Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. Great for UI reviews, diagrams, and screenshots.
+- **Plan / Edit / Auto modes** — `plan` blocks mutating tools for safe research. `edit` (default) prompts per mutating call. `auto` approves everything for trusted tasks.
+- **Live cost tracking** — Status bar shows real-time spend based on Cloudflare pricing. Know exactly what each turn costs.
+- **LSP + MCP** — Semantic code intelligence (hover, go-to-definition, references, diagnostics) via Language Server Protocol. Extend with external tools via Model Context Protocol.
+- **Local structured memory** — SQLite + embeddings cross-session memory. The agent recalls facts, instructions, and preferences across sessions via `remember`, `recall`, and `forget` tools.
+- **Web search, GitHub, and headless browser** — Research the web, read GitHub repos, and fetch JavaScript-rendered pages without leaving your terminal.
+
+## Recently shipped
+
+- **Turn supervisor architecture** — graceful preemption, visual cleanup, and better multi-step task management.
+- **Web search, GitHub read-only, and headless browser tools** — research without leaving the terminal.
+- **Tiered skill routing** — the agent picks the right skill depth for the task, with visible TUI indicators.
+- **Extensible JSON themes** — WCAG contrast-validated, fully customizable color palettes.
+- **KIMI.md drift detection** — memory-based staleness indicators warn when your project context file is out of date.
+- **Fuzzy @ file picker** — type `@` to mention files with fuzzy matching and inline filtering.
+- **Kimiflare Cloud mode** — device auth, no API key needed, with real-time token budget tracking.
+- **Context-window guardrails** — prevents runs that would exceed the model's limit before they start.
+
+See the full changelog at [github.com/sinameraji/kimiflare/releases](https://github.com/sinameraji/kimiflare/releases).
 
 ## Quick start
 
@@ -66,7 +59,7 @@ npm install -g kimiflare
 kimiflare
 ```
 
-On first run, an interactive onboarding wizard asks for your Cloudflare Account ID and API Token. That's it — you're ready.
+On first run, an interactive onboarding wizard asks how you want to connect — BYOK or Cloud. That's it.
 
 Or run without installing:
 
@@ -76,176 +69,7 @@ npx kimiflare
 
 Requires Node.js ≥ 20.
 
-> For release notes and rapid feature drops: https://kimiflare.com
-
-## Features
-
-| Feature | What it does |
-|---------|-------------|
-| **Plan / Edit / Auto modes** | `plan` blocks all mutating tools for safe research. `edit` (default) prompts per mutating call. `auto` approves everything for trusted tasks. |
-| **Live task panel** | For multi-step work, the agent publishes a task list with progress icons (■ active, ☐ pending, ✓ done), elapsed time, and token deltas. |
-| **14 terminal themes** | dark, light, high-contrast, dracula, nord, one-dark, monokai, solarized-dark/light, tokyo-night, gruvbox-dark/light, catppuccin-mocha, rose-pine. Interactive picker with live preview (`Ctrl+T`). |
-| **Paste collapse** | Large pastes (≥200 chars or ≥2 newlines) collapse to `[pasted N lines #id]`. Full content still goes to the model — scrollback stays clean. |
-| **Type-ahead queue** | Type your next prompt while the model is still working. Queued prompts show as `⏳ …` and fire in order. `Ctrl-C` aborts current + clears queue. |
-| **Auto-compaction** | At ~80% context usage, kimiflare nudges you to run `/compact`. It summarizes older turns into a dense summary, keeping the last 4 turns intact. |
-| **Streaming reasoning** | Toggle the model's chain-of-thought with `/reasoning` or `Ctrl-R`. See how it thinks in real time. |
-| **Image understanding** | Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. The model sees them inline — perfect for UI reviews, diagrams, and screenshots. |
-| **Live cost tracking** | Status bar shows real-time cost based on Cloudflare pricing: `$0.95/M input`, `$0.16/M cached`, `$4.00/M output`. |
-| **Optional AI Gateway** | Route Workers AI traffic through your own Cloudflare AI Gateway for request logs, cache status, and analytics while keeping your API token local. |
-| **Session persistence** | Every turn is auto-saved. `/resume` lists past sessions (with message counts) in a paginated picker. |
-| **Smart permissions** | Bash session-allow is keyed by the first token (e.g., allow all `git` commands). Write/edit show a unified diff before you approve. |
-| **Project context (`/init`)** | Scans your repo and writes a concise `KIMI.md` — build commands, layout, conventions. Auto-loaded on every launch. |
-| **MCP server integration** | Plug in external tools via the Model Context Protocol — local stdio servers or remote SSE endpoints. GitHub, Sentry, docs search, databases, etc. |
-| **Co-author auto-append** | Detects `git commit` commands and auto-injects `Co-authored-by: kimiflare <kimiflare@proton.me>`. |
-| **Local structured memory** | SQLite + embeddings cross-session memory. Extracts facts, instructions, and preferences at compaction time; recalls them via hybrid search (FTS5 + vector + exact) in future sessions. Team-shareable via `.kimiflare/memory.db`. |
-| **Resilient transport** | Retries Cloudflare capacity errors (code 3040) and 5xx with exponential backoff up to 5 attempts. |
-
-## Configure
-
-Get credentials from Cloudflare:
-
-1. https://dash.cloudflare.com → your account → copy **Account ID**.
-2. https://dash.cloudflare.com/profile/api-tokens → **Create Token** → Custom token with **Account › Workers AI › Read** on your account → **Create** → copy.
-
-Then either export them each shell:
-
-```sh
-export CLOUDFLARE_ACCOUNT_ID=...
-export CLOUDFLARE_API_TOKEN=...
-# Optional: route through a Cloudflare AI Gateway you own
-export KIMIFLARE_AI_GATEWAY_ID=...
-# Optional: enable local structured memory
-export KIMIFLARE_MEMORY_ENABLED=1
-export KIMIFLARE_MEMORY_DB_PATH=.kimiflare/memory.db
-export KIMIFLARE_MEMORY_MAX_AGE_DAYS=90
-export KIMIFLARE_MEMORY_MAX_ENTRIES=1000
-```
-
-or save them once (`chmod 600` automatically):
-
-```sh
-mkdir -p ~/.config/kimiflare
-cat > ~/.config/kimiflare/config.json <<'EOF'
-{
-  "accountId": "YOUR_ACCOUNT_ID",
-  "apiToken":  "YOUR_API_TOKEN",
-  "model":     "@cf/moonshotai/kimi-k2.6",
-  "aiGatewayId": "YOUR_GATEWAY_NAME"
-}
-EOF
-chmod 600 ~/.config/kimiflare/config.json
-```
-
-### Optional AI Gateway
-
-kimiflare talks directly to Workers AI unless `aiGatewayId` is configured. When set, chat completions are sent to Cloudflare's native Workers AI Gateway endpoint:
-
-```text
-https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/workers-ai/{model_id}
-```
-
-Create a gateway in the Cloudflare dashboard under **AI > AI Gateway**, then set `aiGatewayId` in `~/.config/kimiflare/config.json` or export `KIMIFLARE_AI_GATEWAY_ID`. The same Workers AI API token stays on your machine and is sent to Cloudflare.
-
-Optional per-request controls:
-
-```json
-{
-  "aiGatewayCacheTtl": 3600,
-  "aiGatewaySkipCache": false,
-  "aiGatewayCollectLogPayload": false,
-  "aiGatewayMetadata": { "tool": "kimiflare" }
-}
-```
-
-`cf-aig-cache-status` from AI Gateway is shown separately from Workers AI prompt-token caching (`cached_tokens`). If you enable gateway logs, kimiflare records metadata such as log id, cache hit/miss, tokens, duration, and status when Cloudflare returns it; prompt and response bodies are not stored by kimiflare.
-
-## MCP servers (Model Context Protocol)
-
-kimiflare supports external tools via MCP. Add servers to your `~/.config/kimiflare/config.json`:
-
-```json
-{
-  "accountId": "YOUR_ACCOUNT_ID",
-  "apiToken": "YOUR_API_TOKEN",
-  "mcpServers": {
-    "github": {
-      "type": "local",
-      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
-      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxx" }
-    },
-    "fetch": {
-      "type": "local",
-      "command": ["uvx", "mcp-server-fetch"]
-    },
-    "my-remote": {
-      "type": "remote",
-      "url": "https://example.com/mcp",
-      "headers": { "Authorization": "Bearer token123" }
-    }
-  }
-}
-```
-
-- `type`: `"local"` (stdio subprocess) or `"remote"` (SSE/HTTP endpoint)
-- `command`: array with executable and args (local only)
-- `url`: endpoint URL (remote only)
-- `env`: environment variables for local servers
-- `headers`: HTTP headers for remote servers
-- `enabled`: set to `false` to skip a server
-
-MCP tools appear prefixed as `mcp_<server>_<tool>` alongside built-in tools.
-
-**Commands:**
-- `/mcp list` — show connected servers and tool counts
-- `/mcp reload` — disconnect and reconnect all configured servers
-
-## Local structured memory
-
-kimiflare can remember facts, instructions, and preferences across sessions using a local SQLite database with vector search.
-
-**How it works:**
-- At compaction time, the agent extracts structured memories from the conversation
-- Memories are stored with embeddings (`@cf/baai/bge-base-en-v1.5`) in a local SQLite database
-- On future sessions, relevant memories are recalled via hybrid search (FTS5 full-text + vector similarity + exact file-path matching)
-- Supports team-shared memory: `.kimiflare/memory.db` in your repo root (add to `.gitignore`)
-
-**Enable:**
-```sh
-export KIMIFLARE_MEMORY_ENABLED=1
-```
-
-Or in `~/.config/kimiflare/config.json`:
-```json
-{
-  "memoryEnabled": true,
-  "memoryDbPath": ".kimiflare/memory.db",
-  "memoryMaxAgeDays": 90,
-  "memoryMaxEntries": 1000,
-  "memoryEmbeddingModel": "@cf/baai/bge-base-en-v1.5"
-}
-```
-
-**Commands:**
-- `/memory` — show memory stats (total count, DB size, by category)
-- `/memory search <query>` — manual hybrid search over stored memories
-- `/memory clear` — wipe all memories for the current repo
-
-**Storage & cleanup:**
-- Default retention: 90 days, 1000 memories per repo
-- Automatic deduplication of near-identical memories
-- Cleanup runs on startup and after every compaction
-- Typical size: ~4–5 KB per memory; ~15 MB/month under heavy use
-
-## Usage
-
-### Interactive TUI
-
-```sh
-kimiflare                             # launch TUI
-kimiflare --model @cf/moonshotai/kimi-k2.6   # override model
-```
-
-### Print mode (one-shot, non-interactive)
+### One-shot mode
 
 ```sh
 kimiflare -p "summarize PLAN.md"                    # stream answer to stdout
@@ -255,57 +79,30 @@ kimiflare -p "..." --reasoning                      # include chain-of-thought i
 
 ### Image understanding
 
-Reference image files directly in your prompt — the model sees them inline:
-
 ```sh
 kimiflare
 › fix the layout bug in this screenshot docs/bug.png
 › convert this mockup design.png to Tailwind HTML
-› explain this architecture diagram.png
 ```
-
-Supported formats: PNG, JPG, JPEG, WebP, GIF, BMP (up to 5 MB each, 10 per message).
-
-### CLI flags
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--print <prompt>` | `-p` | One-shot mode: send prompt, stream reply, exit |
-| `--model <id>` | `-m` | Model ID (default: `@cf/moonshotai/kimi-k2.6`) |
-| `--dangerously-allow-all` | — | Auto-approve every permission prompt (print mode only) |
-| `--reasoning` | — | Stream chain-of-thought to stderr (print mode only) |
-| `--version` | `-V` | Show version |
-| `--help` | `-h` | Show help |
 
 ## Slash commands
 
 | Command | Effect |
 |---------|--------|
-| `/mode edit\|plan\|auto` | Switch mode. `edit` prompts for permission (default), `plan` is read-only research, `auto` auto-approves every tool call. |
-| `/plan` `/auto` `/edit` | Shortcuts for the three modes. |
-| `/thinking low\|medium\|high` | Reasoning effort. `low` = fastest, shallow; `medium` = balanced (default); `high` = deepest, slowest. Saved to config. |
-| `/theme` | Interactive theme picker with live preview (`Ctrl+T`). Saved to config. |
-| `/theme NAME` | Set theme by name directly. |
-| `/resume` | Pick a past conversation to restore. |
-| `/compact` | Summarize older turns to free context. Suggested automatically at ~80% full. Extracts memories if memory is enabled. |
-| `/init` | Scan the repo and write a `KIMI.md` so future agents have project context. |
-| `/memory` | Show memory stats (total count, DB size, by category). |
-| `/memory search <query>` | Search stored memories manually. |
-| `/memory clear` | Wipe all memories for the current repo. |
-| `/mcp list` | List connected MCP servers and their tools. |
-| `/mcp reload` | Disconnect and reconnect all configured MCP servers. |
-| `/reasoning` | Toggle chain-of-thought display. |
-| `/clear` | Reset the current conversation. |
-| `/cost` | Show token usage for the current turn. |
-| `/model` | Show current model. |
-| `/update` | Check for updates manually. |
-| `/logout` | Clear saved credentials. |
-| `/help` | List all commands. |
-| `/exit` | Quit. |
+| `/mode edit\|plan\|auto` | Switch permission mode |
+| `/thinking low\|medium\|high` | Reasoning effort (persists) |
+| `/theme` | Interactive theme picker (`Ctrl+T`) |
+| `/resume` | Pick a past conversation to restore |
+| `/compact` | Summarize older turns to free context |
+| `/init` | Scan repo and write `KIMI.md` project context |
+| `/memory` | Show memory stats and search |
+| `/mcp list` / `/mcp reload` | Manage MCP servers |
+| `/reasoning` | Toggle chain-of-thought display |
+| `/cost` | Show token usage for current turn |
+| `/update` | Check for updates |
+| `/help` | List all commands |
 
 ## Keyboard shortcuts
-
-### Global
 
 | Shortcut | Action |
 |----------|--------|
@@ -316,70 +113,6 @@ Supported formats: PNG, JPG, JPEG, WebP, GIF, BMP (up to 5 MB each, 10 per messa
 | `Shift+Tab` | Cycle mode (edit → plan → auto) |
 | `↑` / `↓` | Walk prompt history |
 
-### Editing (macOS / Linux)
-
-| Shortcut | Action |
-|----------|--------|
-| `⌥←` / `⌥→` | Jump word left/right |
-| `⌘←` / `⌘→` | Jump to start / end of line |
-| `⌥⌫` | Delete word backward |
-| `⌘⌫` | Delete to start of line |
-| `⌥⌦` | Delete word forward |
-| `Ctrl+A` / `Ctrl+E` | Start / end of line |
-| `Ctrl+W` / `Ctrl+U` / `Ctrl+K` | Delete word backward / to start / to end of line |
-
-## Modes
-
-- **edit** — default. The agent calls tools freely for read-only work; mutating tools (`write`, `edit`, `bash`) pause for your approval.
-- **plan** — read-only. Mutating tools are hard-blocked. Ask "plan a refactor" and the agent will investigate and produce a plan without touching the filesystem. Exit plan mode to execute.
-- **auto** — autonomous. Every tool call is auto-approved. Use for trusted, well-scoped tasks.
-
-## Thinking level (quality vs speed)
-
-Kimi-K2.6 always reasons, but you can cap the effort:
-
-- **low** — fastest. Best for chat, small edits, running commands.
-- **medium** — balanced (default). Solid reasoning on real edits without the latency of deep thinking on trivial prompts.
-- **high** — deepest. Best for multi-file refactors, subtle bugs, architectural decisions.
-
-Set with `/thinking medium` (persists), or per-launch via `KIMI_REASONING_EFFORT=high`.
-
-## Tools
-
-All tool calls show inline; mutating ones require per-call approval the first time, with an option to allow for the rest of the session.
-
-| Tool | Permission | What it does |
-|------|------------|--------------|
-| `read` | auto | Read a text file (≤ 2MB) with optional line range. |
-| `write` | prompt | Create or overwrite a file. Shows a unified diff before you approve. |
-| `edit` | prompt | Replace an exact substring. Fails unless `old_string` is unique (or `replace_all=true`). |
-| `bash` | prompt | Run a shell command via `bash -lc`. Session-allow is keyed by the first token of the command. |
-| `glob` | auto | Match files by pattern (`**/*.ts`), sorted by mtime. |
-| `grep` | auto | Regex search. Uses `rg` if installed; falls back to a JS walk. |
-| `web_fetch` | auto | Fetch a URL, convert HTML → markdown (≤ 100KB). |
-| `tasks_set` | auto | Publish a live task list for multi-step work. |
-
-## How it works
-
-```
-           ┌───────────────────────────────────────────────────────────┐
-           │ kimiflare (Node.js TUI)                                   │
- user ─▶   │                                                           │
-           │   user msg ─▶ agent loop ─▶ runKimi() ──[POST SSE]──▶     │
-           │                       ▲                                   │
-           │                       │                                   │
-           │      tool result ◀──tool executor──◀ tool_calls           │
-           │           (permission modal for write / edit / bash)      │
-           └───────────────────────────────────────────────────────────┘
-                                                          │
-                                                          ▼
-                                       api.cloudflare.com/client/v4
-                                       /accounts/{ID}/ai/run/
-                                       @cf/moonshotai/kimi-k2.6
-```
-
-Direct `fetch` to Workers AI by default, or the native Workers AI AI Gateway endpoint when `aiGatewayId` is configured. The payload remains OpenAI-compatible `messages` + `tools`, with an SSE stream containing reasoning + content + tool-call deltas accumulated by index.
-
 ## Development
 
 ```sh
@@ -387,114 +120,24 @@ git clone https://github.com/sinameraji/kimiflare
 cd kimiflare
 npm install
 npm run build
-npm link          # or: ln -s "$PWD/bin/kimiflare.mjs" ~/.local/bin/kimiflare
+npm link
 ```
 
 Scripts:
-- `npm run build` — bundle with tsup (`dist/` + `bin/kimiflare.mjs`)
-- `npm run dev` — run via tsx (`tsx src/index.tsx`)
+- `npm run build` — bundle with tsup
+- `npm run dev` — run via tsx
 - `npm run typecheck` — `tsc --noEmit`
-- `npm start` — run compiled bin
+- `npm test` — run tests
 
 ## Contributing
-
-Contributions are welcome!
 
 1. Fork the repository
 2. Create a branch: `git checkout -b feat/your-feature`
 3. Make your changes
 4. Run `npm run typecheck` and `npm run build`
-5. Commit: `git commit -m "feat: description"`
-6. Push: `git push origin feat/your-feature`
-7. Open a Pull Request
+5. Commit with [Conventional Commits](https://www.conventionalcommits.org/)
+6. Open a Pull Request
 
-## Testing MCP locally
+---
 
-You don't need a real MCP server to test the integration. Here's a minimal test server you can save as `test-mcp-server.js`:
-
-```js
-// test-mcp-server.js — a minimal MCP server for testing
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-
-const server = new Server({ name: "test-server", version: "1.0.0" }, { capabilities: { tools: {} } });
-
-server.setRequestHandler("tools/list", async () => ({
-  tools: [
-    {
-      name: "greet",
-      description: "Greet someone by name",
-      inputSchema: {
-        type: "object",
-        properties: { name: { type: "string" } },
-        required: ["name"],
-      },
-    },
-    {
-      name: "add",
-      description: "Add two numbers",
-      inputSchema: {
-        type: "object",
-        properties: { a: { type: "number" }, b: { type: "number" } },
-        required: ["a", "b"],
-      },
-    },
-  ],
-}));
-
-server.setRequestHandler("tools/call", async (req) => {
-  if (req.params.name === "greet") {
-    return { content: [{ type: "text", text: `Hello, ${req.params.arguments.name}!` }] };
-  }
-  if (req.params.name === "add") {
-    const sum = req.params.arguments.a + req.params.arguments.b;
-    return { content: [{ type: "text", text: String(sum) }] };
-  }
-  throw new Error("Unknown tool");
-});
-
-const transport = new StdioServerTransport();
-await server.connect(transport);
-```
-
-Then add it to your config:
-
-```json
-{
-  "mcpServers": {
-    "test": {
-      "type": "local",
-      "command": ["node", "/path/to/test-mcp-server.js"]
-    }
-  }
-}
-```
-
-Launch kimiflare and try:
-- `/mcp list` — should show `test (local) — 2 tools`
-- `use mcp_test_greet with name "kimiflare"` — should return `Hello, kimiflare!`
-- `use mcp_test_add with a 3 and b 5` — should return `8`
-
-For a real-world test, try the [official GitHub MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/github):
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "type": "local",
-      "command": ["npx", "-y", "@modelcontextprotocol/server-github"],
-      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxx" }
-    }
-  }
-}
-```
-
-Then ask: `search for issues labeled bug in sinameraji/kimiflare`
-
-## Credits
-
-- **Cloudflare Agent Memory** — This feature was inspired by [Cloudflare's Agent Memory](https://blog.cloudflare.com/introducing-agent-memory/) announcement. While Cloudflare's managed service requires a platform binding, kimiflare implements a local self-hosted equivalent using SQLite + Workers AI embeddings so you can use it today with your own account.
-
-## License
-
-[MIT](LICENSE) © Sina Meraji
+Built by [Sina Meraji](https://github.com/sinameraji) and [contributors](https://github.com/sinameraji/kimiflare/graphs/contributors) · MIT License

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
       "url": "https://github.com/sinameraji"
     },
     "codeRepository": "https://github.com/sinameraji/kimiflare",
-    "softwareVersion": "0.1.0",
+    "softwareVersion": "0.47.0",
     "programmingLanguage": "TypeScript",
     "license": "https://github.com/sinameraji/kimiflare/blob/main/LICENSE"
   }
@@ -714,7 +714,7 @@
       Claude Code alternative, on your own Cloudflare account.
     </h1>
     <p class="hero-subtitle fade-in delay-2">
-      An open-source terminal coding agent powered by Kimi K2.6, MCP tools, local memory, and direct Workers AI execution — no API middleman.
+      An open-source terminal coding agent powered by Kimi K2.6. Run on your own Cloudflare account (BYOK) or try Kimiflare Cloud — no API key needed.
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
@@ -725,6 +725,12 @@
       <a href="https://www.producthunt.com/products/kimiflare?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-kimiflare" target="_blank" rel="noopener noreferrer">
         <img alt="kimiflare - kimi k2.6 cli code editor hosted on cloudflare workers AI | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1129412&theme=light&t=1776822277935">
       </a>
+    </div>
+
+    <div class="fade-in delay-3" style="margin-top: 1.5rem; padding: 0.75rem 1rem; background: var(--accent-dim); border: 1px solid var(--accent); border-radius: 8px; max-width: 480px;">
+      <p style="font-size: 0.85rem; color: var(--text); margin: 0;">
+        <strong>Try Kimiflare Cloud free</strong> — sign up and get <strong>5 million tokens</strong> on us until May 14, 2026. No Cloudflare account needed.
+      </p>
     </div>
 
     <!-- Email Capture -->
@@ -841,18 +847,22 @@
         <div class="changelog-list">
           <h4>Recently shipped</h4>
           <ul>
-            <li>Cloudflare Code Mode support</li>
-            <li>Local structured agent memory</li>
-            <li>70–90% token cost reduction work</li>
-            <li>Session compaction improvements</li>
+            <li>Turn supervisor architecture with graceful preemption</li>
+            <li>Web search, GitHub read-only, and headless browser tools</li>
+            <li>Tiered skill routing with TUI visibility</li>
+            <li>Extensible JSON themes with WCAG contrast validation</li>
+            <li>KIMI.md drift detection with memory-based staleness</li>
+            <li>Fuzzy @ file picker with inline filtering</li>
+            <li>Kimiflare Cloud mode — device auth, no API key</li>
+            <li>Context-window guardrails</li>
           </ul>
         </div>
         <div class="changelog-list">
           <h4>Coming next</h4>
           <ul>
-            <li>OpenCode parity features</li>
+            <li>Session tree for branching conversations</li>
             <li>Cost attribution dashboard</li>
-            <li>Cloudflare Artifacts parallel agents</li>
+            <li>More MCP server integrations</li>
           </ul>
         </div>
       </div>
@@ -885,23 +895,23 @@
       </div>
       <div class="feature-item">
         <span class="feature-num">04</span>
-        <h3>14 terminal themes</h3>
-        <p>dark, light, high-contrast, dracula, nord, one-dark, monokai, solarized, tokyo-night, gruvbox, catppuccin, rose-pine. Live preview with Ctrl+T.</p>
+        <h3>Extensible JSON themes</h3>
+        <p>Fully customizable color palettes with WCAG contrast validation. Pick from built-in presets or define your own. Live preview with Ctrl+T.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">05</span>
-        <h3>Paste collapse</h3>
-        <p>Large pastes collapse to <code>[pasted N lines #id]</code>. Full content still goes to the model — scrollback stays clean.</p>
+        <h3>Web search, GitHub, and headless browser</h3>
+        <p>Research the web, read GitHub repos, and fetch JavaScript-rendered pages — all without leaving your terminal.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">06</span>
-        <h3>Type-ahead queue</h3>
-        <p>Type your next prompt while the model is still working. Queued prompts fire in order. Ctrl-C aborts current and clears queue.</p>
+        <h3>LSP semantic code intelligence</h3>
+        <p>Hover, go-to-definition, references, and diagnostics via Language Server Protocol. Auto-configured per project with an interactive wizard.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">07</span>
-        <h3>Smart context management</h3>
-        <p>Compiled context extracts structured state and archives raw tool outputs as recallable artifacts. Auto-compaction kicks in at ~80% usage. The model never loses track of what it learned.</p>
+        <h3>Turn supervisor with tiered skills</h3>
+        <p>The agent picks the right skill depth for the task — from quick edits to deep research — with graceful preemption and visible TUI indicators.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">08</span>
@@ -930,8 +940,8 @@
       </div>
       <div class="feature-item">
         <span class="feature-num">13</span>
-        <h3>Prefix cache optimization</h3>
-        <p>Deterministic system prompts, stable JSON serialization, and session-affinity headers maximize Workers AI prefix-cache hits. Cached tokens are billed at a discount — cost drops as the conversation grows.</p>
+        <h3>Kimiflare Cloud mode</h3>
+        <p>Device auth — no API key needed. Get started in seconds with a managed proxy and real-time token budget tracking. 5 million free tokens until May 14, 2026.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">14</span>
@@ -995,8 +1005,11 @@
 <span class="c"># Install</span><br>
 <span class="v">npm</span> install -g kimiflare<br>
 <br>
-<span class="c"># Run — onboarding will ask for your Cloudflare credentials</span><br>
-<span class="v">kimiflare</span>
+<span class="c"># Run — onboarding asks BYOK or Cloud</span><br>
+<span class="v">kimiflare</span><br>
+<br>
+<span class="c"># Or start in Cloud mode directly</span><br>
+<span class="v">kimiflare</span> --cloud
       </div>
     </div>
 
@@ -1083,6 +1096,21 @@
           <td>web_fetch</td>
           <td>auto</td>
           <td>Fetch a URL, convert HTML → markdown (≤ 100KB)</td>
+        </tr>
+        <tr>
+          <td>web_search</td>
+          <td>auto</td>
+          <td>Search the web and return summarized results</td>
+        </tr>
+        <tr>
+          <td>github_read</td>
+          <td>auto</td>
+          <td>Read files and issues from public GitHub repos</td>
+        </tr>
+        <tr>
+          <td>browser_fetch</td>
+          <td>auto</td>
+          <td>Headless browser for JavaScript-rendered pages</td>
         </tr>
         <tr>
           <td>tasks_set</td>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kimiflare",
   "version": "0.47.0",
-  "description": "Kimiflare — a terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. Image understanding, plan mode, MCP server integration, 262k context.",
+  "description": "A terminal coding agent powered by Kimi-K2.6 on Cloudflare Workers AI. BYOK or Cloud mode. Web search, GitHub, headless browser, LSP, MCP, local memory, 262k context.",
   "keywords": [
     "ai",
     "cli",


### PR DESCRIPTION
## Summary

Refreshes our public-facing docs to reflect what we have actually shipped.

### README.md
- Cut from ~500 lines to ~180 lines
- Added prominent **Two ways to run** section (BYOK vs Kimiflare Cloud)
- Added **5 million free tokens until May 14, 2026** promo
- Replaced stale "Recently shipped" with actual v0.35–v0.47 features
- Condensed slash commands and keyboard shortcuts
- Removed outdated sections: exhaustive tools table, architecture ASCII diagram, MCP test server, memory deep-dive, AI Gateway deep-dive

### docs/index.html (landing page)
- Updated JSON-LD  from  → 
- Added Kimiflare Cloud promo banner in hero
- Replaced stale changelog with real recent ships
- Added feature cards: web search/GitHub/browser, LSP, turn supervisor, extensible themes, Kimiflare Cloud
- Updated install instructions to mention 
- Added new tools to the tools table

### package.json
- Updated description to mention Cloud mode, web search, GitHub, headless browser, LSP

---

**Files changed:** 3  
**Net reduction:** ~329 lines  
**Build:** ✅ passes