### PR TITLE
docs(landing): soften cloud promo wording

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -729,7 +729,7 @@
 
     <div class="fade-in delay-3" style="margin-top: 1.5rem; padding: 0.75rem 1rem; background: var(--accent-dim); border: 1px solid var(--accent); border-radius: 8px; max-width: 480px;">
       <p style="font-size: 0.85rem; color: var(--text); margin: 0;">
-        <strong>Try Kimiflare Cloud free</strong> — sign up and get <strong>5 million tokens</strong> on us until May 14, 2026. No Cloudflare account needed.
+        <strong>Try Kimiflare Cloud free</strong> — get <strong>5 million tokens</strong> on us until May 14, 2026. After that, bring your own Cloudflare key.
       </p>
     </div>
 


### PR DESCRIPTION
Clarifies that the 5M free tokens are a trial, after which users bring their own Cloudflare key. Removes the 'No Cloudflare account needed' phrasing.