### PR TITLE
feat(ui): add chat scroll with shift+up/down and reduce render churn

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -586,6 +586,7 @@ function App({
   const [kimiMdStale, setKimiMdStale] = useState(false);
   const [gitBranch, setGitBranch] = useState<string | null>(null);
   const [lastSessionTopic, setLastSessionTopic] = useState<string | null>(null);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   useEffect(() => {
     setGitBranch(detectGitBranch());
@@ -1509,6 +1510,27 @@ function App({
       setVerbose((v) => !v);
       return;
     }
+    // Chat scroll: shift+up/down scrolls through history when not in a picker/modal
+    const modalOpen =
+      perm !== null ||
+      limitModal !== null ||
+      showLspWizard ||
+      showCommandList ||
+      commandWizard !== null ||
+      commandToDelete !== null ||
+      resumeSessions !== null ||
+      checkpointSession !== null ||
+      showThemePicker;
+    if (!modalOpen && activePicker === null) {
+      if (key.shift && key.upArrow) {
+        setScrollOffset((o) => Math.min(o + 3, Math.max(0, events.length - 1)));
+        return;
+      }
+      if (key.shift && key.downArrow) {
+        setScrollOffset((o) => Math.max(o - 3, 0));
+        return;
+      }
+    }
   });
 
   const flushAssistantUpdates = useCallback(() => {
@@ -1544,7 +1566,7 @@ function App({
           reasoning: existing.reasoning + (assistantResult.reasoning ?? ""),
         });
         if (!flushTimeoutRef.current) {
-          flushTimeoutRef.current = setTimeout(flushAssistantUpdates, 16); // ~60fps
+          flushTimeoutRef.current = setTimeout(flushAssistantUpdates, 100); // ~10fps, reduces terminal scrollback churn
         }
         return;
       }
@@ -3654,12 +3676,14 @@ function App({
         setHistory((h) => (h.length > 0 && h[h.length - 1] === historyEntry ? h : [...h, historyEntry]));
         setInput("");
         setHistoryIndex(-1);
+        setScrollOffset(0);
         return;
       }
 
       setHistory((h) => (h.length > 0 && h[h.length - 1] === historyEntry ? h : [...h, historyEntry]));
       setInput("");
       setHistoryIndex(-1);
+      setScrollOffset(0);
       processMessage(trimmedFull, trimmedDisplay !== trimmedFull ? trimmedDisplay : undefined);
     },
     [processMessage],
@@ -3918,7 +3942,7 @@ function App({
         {!hasConversation && events.length === 0 ? (
           <Welcome />
         ) : (
-          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} />
+          <ChatView events={events} showReasoning={showReasoning} verbose={verbose} intentTier={intentTier ?? undefined} scrollOffset={scrollOffset} />
         )}
         {perm ? (
           <PermissionModal

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -42,13 +42,14 @@ interface Props {
   showReasoning: boolean;
   verbose?: boolean;
   intentTier?: IntentTier;
+  scrollOffset?: number;
 }
 
 function toolSignature(name: string, args: string): string {
   return `${name}:${args}`;
 }
 
-export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier }: Props) {
+export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier, scrollOffset = 0 }: Props) {
   const theme = useTheme();
 
   // Detect repetitive tool calls in this turn (≥3 identical signatures)
@@ -64,9 +65,15 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
     if (count >= 3) repeatedSigs.add(sig);
   }
 
+  const visibleEvents = React.useMemo(() => {
+    if (scrollOffset <= 0 || events.length === 0) return events;
+    const hideCount = Math.min(scrollOffset, events.length - 1);
+    return events.slice(0, events.length - hideCount);
+  }, [events, scrollOffset]);
+
   return (
     <Box flexDirection="column">
-      {events.map((e, i) => {
+      {visibleEvents.map((e, i) => {
         const prev = events[i - 1];
         const showSeparator = !!(
           e.kind === "user" && prev && (prev.kind === "assistant" || prev.kind === "tool")


### PR DESCRIPTION
## Summary

Fixes the issue where users cannot scroll up in the TUI while the agent is thinking/streaming.

## Changes

- **Chat scroll**: Added `scrollOffset` state to App. Users can now scroll through chat history with **shift+↑** and **shift+↓**.
- **Auto-reset**: Scroll offset resets to bottom when the user submits a new message.
- **Render churn reduction**: Increased assistant text flush timeout from 16ms (~60fps) to 100ms (~10fps). This dramatically reduces stdout writes during streaming, making terminal scrollback much more stable.
- **Safe slicing**: `ChatView` uses `useMemo` to compute visible events, preserving `React.memo` benefits when browsing history.

## Testing

- `npm run typecheck` passes for modified files
- All UI tests pass (41/41)

## Risk Assessment

Low risk. No new unbounded allocations, no new timers, no breaking changes to existing behavior.

Co-authored-by: kimiflare <kimiflare@proton.me>