### PR TITLE
fix(app): add missing logger import

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,6 +29,7 @@ import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
 import { KimiApiError, isCloudQuotaExhaustedError } from "./util/errors.js";
 import { AbortScope } from "./util/abort-scope.js";
+import { logger } from "./util/logger.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";


### PR DESCRIPTION
cleanupTurn and several other callbacks in app.tsx referenced logger without importing it. This caused a ReferenceError at runtime whenever any of those callbacks fired — most notably cleanupTurn during turn error handling, which would crash the session with:

    ReferenceError: logger is not defined
        at cleanupTurn (.../dist/index.js:18628:9)

The fix adds the missing import { logger } from "./util/logger.js".

Co-authored-by: kimiflare <kimiflare@proton.me>