### PR TITLE
fix(ui): correct notify domain from kimiflare.dev to kimiflare.com

### DIFF
--- a/src/ui/cloud-quota-message.tsx
+++ b/src/ui/cloud-quota-message.tsx
@@ -65,7 +65,7 @@ export function CloudQuotaMessage({ used, limit, expiresAt }: Props) {
           Or wait for hosted plans — drop your email at
         </Text>
         <Text color={theme.info.color}>
-          kimiflare.dev/notify and I'll ping you when they're live.
+          kimiflare.com and I'll ping you when they're live.
         </Text>
       </Box>
 


### PR DESCRIPTION
When users exhaust their tokens in cloud mode, the message incorrectly points them to `kimiflare.dev/notify`. The actual domain is `kimiflare.com`.