### PR TITLE
feat(usage): persistent history.jsonl for never-pruned daily usage

### DIFF
--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -76,6 +76,10 @@ function usagePath(): string {
   return join(usageDir(), "usage.json");
 }
 
+function historyPath(): string {
+  return join(usageDir(), "history.jsonl");
+}
+
 function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
@@ -99,6 +103,44 @@ async function loadLog(): Promise<UsageLog> {
 async function saveLog(log: UsageLog): Promise<void> {
   await mkdir(usageDir(), { recursive: true });
   await writeFile(usagePath(), JSON.stringify(log, null, 2), "utf8");
+}
+
+/** Load the append-only history JSONL file. Never pruned. */
+async function loadHistory(): Promise<DailyUsage[]> {
+  try {
+    const raw = await readFile(historyPath(), "utf8");
+    const lines = raw.split("\n").filter((l) => l.trim());
+    const entries: DailyUsage[] = [];
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as DailyUsage;
+        if (parsed.date) entries.push(parsed);
+      } catch {
+        /* skip malformed line */
+      }
+    }
+    return entries;
+  } catch {
+    /* no file or unreadable */
+  }
+  return [];
+}
+
+/** Append or update a day's entry in the history JSONL file.
+ *  Reads the whole file (it's tiny), updates the matching day or appends,
+ *  then writes back. This keeps the file compact and deduplicated by date.
+ */
+async function upsertHistoryDay(day: DailyUsage): Promise<void> {
+  const entries = await loadHistory();
+  const idx = entries.findIndex((e) => e.date === day.date);
+  if (idx >= 0) {
+    entries[idx] = day;
+  } else {
+    entries.push(day);
+  }
+  const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  await mkdir(usageDir(), { recursive: true });
+  await writeFile(historyPath(), lines, "utf8");
 }
 
 function getOrCreateDay(log: UsageLog, date: string): DailyUsage {
@@ -227,6 +269,9 @@ export async function recordUsage(
   }
 
   await saveLog(log);
+
+  // Also persist to the append-only history log (never pruned)
+  await upsertHistoryDay(day);
 }
 
 export interface CostReport {
@@ -236,8 +281,18 @@ export interface CostReport {
   allTime: DailyUsage;
 }
 
+/** Merge usage.json days with history.jsonl days. usage.json takes precedence for overlapping dates. */
+function mergeDays(usageDays: DailyUsage[], historyDays: DailyUsage[]): DailyUsage[] {
+  const map = new Map<string, DailyUsage>();
+  for (const d of historyDays) map.set(d.date, d);
+  for (const d of usageDays) map.set(d.date, d); // overwrite with fresher usage.json data
+  return Array.from(map.values()).sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+}
+
 export async function getCostReport(sessionId?: string): Promise<CostReport> {
   const log = pruneUsageLog(await loadLog());
+  const history = await loadHistory();
+  const allDays = mergeDays(log.days, history);
   const date = today();
   const currentMonth = date.slice(0, 7); // YYYY-MM
 
@@ -257,7 +312,7 @@ export async function getCostReport(sessionId?: string): Promise<CostReport> {
     cachedTokens: 0,
     cost: 0,
   };
-  for (const d of log.days) {
+  for (const d of allDays) {
     if (d.date.startsWith(currentMonth)) {
       monthUsage.promptTokens += d.promptTokens;
       monthUsage.completionTokens += d.completionTokens;
@@ -277,7 +332,7 @@ export async function getCostReport(sessionId?: string): Promise<CostReport> {
     cachedTokens: 0,
     cost: 0,
   };
-  for (const d of log.days) {
+  for (const d of allDays) {
     allTime.promptTokens += d.promptTokens;
     allTime.completionTokens += d.completionTokens;
     allTime.cachedTokens += d.cachedTokens;

--- a/src/util/usage-tracker.test.ts
+++ b/src/util/usage-tracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fetchGatewayUsageSnapshot, getCostReport, recordUsage } from "../usage-tracker.js";
@@ -95,6 +95,172 @@ describe("AI Gateway usage enrichment", () => {
       assert.strictEqual(report.session.gatewayCachedRequests, 1);
       assert.strictEqual(report.session.gatewayCost, 0.00001);
       assert.strictEqual(report.session.cost, 0.00001);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Persistent history.jsonl", () => {
+  let originalXdgDataHome: string | undefined;
+
+  before(() => {
+    originalXdgDataHome = process.env.XDG_DATA_HOME;
+  });
+
+  after(() => {
+    if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = originalXdgDataHome;
+  });
+
+  it("writes daily usage to history.jsonl on recordUsage", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-history-"));
+    process.env.XDG_DATA_HOME = dir;
+    try {
+      await recordUsage(
+        "session_a",
+        {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          prompt_tokens_details: { cached_tokens: 10 },
+        },
+        undefined,
+      );
+
+      const historyRaw = await readFile(join(dir, "kimiflare", "history.jsonl"), "utf8");
+      const lines = historyRaw.trim().split("\n");
+      assert.strictEqual(lines.length, 1);
+      assert.ok(lines[0]);
+      const entry = JSON.parse(lines[0]);
+      assert.strictEqual(entry.promptTokens, 100);
+      assert.strictEqual(entry.completionTokens, 50);
+      assert.strictEqual(entry.cachedTokens, 10);
+      assert.ok(entry.date);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates same-day entries in history.jsonl", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-history-"));
+    process.env.XDG_DATA_HOME = dir;
+    try {
+      await recordUsage(
+        "session_a",
+        {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          prompt_tokens_details: { cached_tokens: 0 },
+        },
+        undefined,
+      );
+      await recordUsage(
+        "session_a",
+        {
+          prompt_tokens: 200,
+          completion_tokens: 100,
+          total_tokens: 300,
+          prompt_tokens_details: { cached_tokens: 0 },
+        },
+        undefined,
+      );
+
+      const historyRaw = await readFile(join(dir, "kimiflare", "history.jsonl"), "utf8");
+      const lines = historyRaw.trim().split("\n");
+      assert.strictEqual(lines.length, 1);
+      assert.ok(lines[0]);
+      const entry = JSON.parse(lines[0]);
+      assert.strictEqual(entry.promptTokens, 300);
+      assert.strictEqual(entry.completionTokens, 150);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes history data in allTime and month totals", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-history-"));
+    process.env.XDG_DATA_HOME = dir;
+    try {
+      // Seed history with an old day
+      const historyDir = join(dir, "kimiflare");
+      await mkdir(historyDir, { recursive: true });
+      const historyPath = join(historyDir, "history.jsonl");
+      await writeFile(
+        historyPath,
+        JSON.stringify({
+          date: "2025-01-01",
+          promptTokens: 1000,
+          completionTokens: 500,
+          cachedTokens: 100,
+          cost: 0.5,
+        }) + "\n",
+        "utf8",
+      );
+
+      // Record usage for today
+      await recordUsage(
+        "session_b",
+        {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          prompt_tokens_details: { cached_tokens: 0 },
+        },
+        undefined,
+      );
+
+      const report = await getCostReport("session_b");
+      // Today's session should only reflect today's usage
+      assert.strictEqual(report.session.promptTokens, 100);
+      // All time should include the old history entry
+      assert.strictEqual(report.allTime.promptTokens, 1100);
+      assert.strictEqual(report.allTime.completionTokens, 550);
+      assert.strictEqual(report.allTime.cost, 0.5 + report.today.cost);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("gives usage.json precedence over history for overlapping dates", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kimiflare-history-"));
+    process.env.XDG_DATA_HOME = dir;
+    try {
+      const today = new Date().toISOString().slice(0, 10);
+
+      // Seed history with today's data (simulating stale data)
+      const historyDir = join(dir, "kimiflare");
+      await mkdir(historyDir, { recursive: true });
+      const historyPath = join(historyDir, "history.jsonl");
+      await writeFile(
+        historyPath,
+        JSON.stringify({
+          date: today,
+          promptTokens: 9999,
+          completionTokens: 9999,
+          cachedTokens: 0,
+          cost: 9.99,
+        }) + "\n",
+        "utf8",
+      );
+
+      // Record fresh usage for today
+      await recordUsage(
+        "session_c",
+        {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          prompt_tokens_details: { cached_tokens: 0 },
+        },
+        undefined,
+      );
+
+      const report = await getCostReport("session_c");
+      // Today's total should reflect the fresh usage.json data, not stale history
+      assert.strictEqual(report.today.promptTokens, 100);
+      assert.strictEqual(report.allTime.promptTokens, 100);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Adds an append-only `history.jsonl` file that stores one deduplicated entry per day. This file is **never pruned, rotated, or overwritten** on version changes, giving `/cost` true all-time and monthly totals that survive across mode switches, API key changes, and app updates.

## Problem

The existing `usage.json` is aggressively pruned (90 days for daily entries, 30 days for sessions) and gets completely rewritten on every API call. If it gets corrupted, version-mismatched, or wiped, all history is gone. The "all-time" figure in `/cost` is actually just "all-time within the 90-day retention window."

## Solution

- **`history.jsonl`** — append-only JSONL file, one line per day, stored alongside `usage.json`
- `loadHistory()` reads the JSONL file, skipping malformed lines
- `upsertHistoryDay()` updates existing day or appends new one (keeps file compact and deduplicated)
- `recordUsage()` now persists each day's totals to `history.jsonl`
- `getCostReport()` merges `usage.json` days with `history.jsonl` days, with `usage.json` taking precedence for overlapping dates

## Size

At ~100 bytes/day, this file will stay in the low kilobytes even for months of usage.

## Backward Compatibility

- `usage.json` continues to serve session-level detail and cost attribution unchanged
- All existing features (`/cost`, `kimiflare cost`, cost attribution, status bar) work as before
- The history file is additive — old installations will simply start populating it

## Tests

4 new test cases covering:
- history.jsonl is created and updated by recordUsage
- same-day entries are deduplicated
- getCostReport merges history with usage.json for allTime/month
- usage.json takes precedence over history for overlapping dates

Co-authored-by: kimiflare <kimiflare@proton.me>