### PR TITLE
fix(ui): defensive tool renders and diff view to prevent crashes on malformed args

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -31,7 +31,7 @@ export const bashTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: true,
-  render: (args) => ({ title: formatBashTitle(args.command) }),
+  render: (args) => ({ title: formatBashTitle(String(args.command ?? "")) }),
   run: (args, ctx) => runBash(args, ctx),
 };
 

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -42,7 +42,7 @@ export const browserFetchTool: ToolSpec<Args> = {
   },
   needsPermission: false,
   render: (args) => ({
-    title: `browser ${args.url}${args.screenshot ? " (screenshot)" : ""}`,
+    title: `browser ${args.url ?? ""}${args.screenshot ? " (screenshot)" : ""}`,
   }),
   async run(args, ctx): Promise<ToolOutput> {
     let playwright: typeof import("playwright") | undefined;

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -26,8 +26,8 @@ export const editTool: ToolSpec<Args> = {
   },
   needsPermission: true,
   render: (args) => ({
-    title: `edit ${collapsePath(args.path, process.cwd())}${args.replace_all ? " (replace_all)" : ""}`,
-    diff: { path: args.path, before: args.old_string, after: args.new_string },
+    title: `edit ${collapsePath(String(args.path ?? ""), process.cwd())}${args.replace_all ? " (replace_all)" : ""}`,
+    diff: { path: String(args.path ?? ""), before: String(args.old_string ?? ""), after: String(args.new_string ?? "") },
   }),
   async run(args, ctx) {
     const abs = resolvePath(ctx.cwd, args.path);

--- a/src/tools/expand-artifact.ts
+++ b/src/tools/expand-artifact.ts
@@ -22,7 +22,7 @@ export function makeExpandArtifactTool(store: ToolArtifactStore): ToolSpec<Args>
       additionalProperties: false,
     },
     needsPermission: false,
-    render: (args) => ({ title: `expand ${args.artifact_id}` }),
+    render: (args) => ({ title: `expand ${args.artifact_id ?? ""}` }),
     run: async (args): Promise<string> => {
       const raw = store.retrieve(args.artifact_id);
       if (!raw) {

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -68,7 +68,7 @@ export const githubReadPrTool: ToolSpec<ReadPrArgs> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `GitHub PR ${args.owner}/${args.repo}#${args.number}` }),
+  render: (args) => ({ title: `GitHub PR ${args.owner ?? ""}/${args.repo ?? ""}#${args.number ?? ""}` }),
   async run(args, ctx): Promise<ToolOutput> {
     const token = getToken(ctx);
     const pr = await githubFetch(`/repos/${args.owner}/${args.repo}/pulls/${args.number}`, token) as {
@@ -140,7 +140,7 @@ export const githubReadIssueTool: ToolSpec<ReadIssueArgs> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `GitHub issue ${args.owner}/${args.repo}#${args.number}` }),
+  render: (args) => ({ title: `GitHub issue ${args.owner ?? ""}/${args.repo ?? ""}#${args.number ?? ""}` }),
   async run(args, ctx): Promise<ToolOutput> {
     const token = getToken(ctx);
     const issue = await githubFetch(`/repos/${args.owner}/${args.repo}/issues/${args.number}`, token) as {
@@ -218,7 +218,7 @@ export const githubReadCodeTool: ToolSpec<ReadCodeArgs> = {
   },
   needsPermission: false,
   render: (args) => ({
-    title: `GitHub code ${args.owner}/${args.repo}/${args.path}${args.ref ? `@${args.ref}` : ""}`,
+    title: `GitHub code ${args.owner ?? ""}/${args.repo ?? ""}/${args.path ?? ""}${args.ref ? `@${args.ref}` : ""}`,
   }),
   async run(args, ctx): Promise<ToolOutput> {
     const token = getToken(ctx);

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -21,7 +21,7 @@ export const globTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `glob ${args.pattern}${args.path ? ` in ${collapsePath(args.path, process.cwd())}` : ""}` }),
+  render: (args) => ({ title: `glob ${args.pattern ?? ""}${args.path ? ` in ${collapsePath(String(args.path), process.cwd())}` : ""}` }),
   async run(args, ctx) {
     const root = args.path ? resolvePath(ctx.cwd, args.path) : ctx.cwd;
     const entries = (await fg(args.pattern, {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -48,7 +48,7 @@ export const grepTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `grep ${args.pattern}${args.glob ? ` (${args.glob})` : ""}` }),
+  render: (args) => ({ title: `grep ${args.pattern ?? ""}${args.glob ? ` (${args.glob})` : ""}` }),
   async run(args, ctx) {
     const root = args.path ? resolvePath(ctx.cwd, args.path) : ctx.cwd;
     const mode = args.output_mode ?? "content";

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -41,7 +41,7 @@ export const memoryRememberTool: ToolSpec = {
   needsPermission: false,
   render: (args: { content: string; category: string; importance: number }) => ({
     title: "memory_remember",
-    body: `[${args.category}] ${args.content} (importance: ${args.importance})`,
+    body: `[${args.category ?? "unknown"}] ${args.content ?? ""} (importance: ${args.importance ?? 1})`,
   }),
   run: async (args: { content: string; category: string; importance: number }, ctx: ToolContext): Promise<ToolOutput> => {
     if (!isMemoryCtx(ctx) || !ctx.memoryManager) {
@@ -101,7 +101,7 @@ export const memoryRecallTool: ToolSpec = {
   needsPermission: false,
   render: (args: { query: string; limit?: number }) => ({
     title: "memory_recall",
-    body: `Query: "${args.query}"`,
+    body: `Query: "${args.query ?? ""}"`,
   }),
   run: async (args: { query: string; limit?: number }, ctx: ToolContext): Promise<ToolOutput> => {
     if (!isMemoryCtx(ctx) || !ctx.memoryManager) {
@@ -150,7 +150,7 @@ export const memoryForgetTool: ToolSpec = {
   needsPermission: false,
   render: (args: { memory_id: string }) => ({
     title: "memory_forget",
-    body: `Forgetting memory ${args.memory_id}`,
+    body: `Forgetting memory ${args.memory_id ?? ""}`,
   }),
   run: async (args: { memory_id: string }, ctx: ToolContext): Promise<ToolOutput> => {
     if (!isMemoryCtx(ctx) || !ctx.memoryManager) {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -40,12 +40,15 @@ export const tasksSetTool: ToolSpec<TasksSetArgs> = {
     required: ["tasks"],
   },
   needsPermission: false,
-  render: (args) => ({
-    title: `tasks (${args.tasks.length} items)`,
-    body: args.tasks
-      .map((t) => `${t.status === "completed" ? "✓" : t.status === "in_progress" ? "▸" : "·"} ${t.title}`)
-      .join("\n"),
-  }),
+  render: (args) => {
+    const tasks = Array.isArray(args.tasks) ? args.tasks : [];
+    return {
+      title: `tasks (${tasks.length} items)`,
+      body: tasks
+        .map((t) => `${t.status === "completed" ? "✓" : t.status === "in_progress" ? "▸" : "·"} ${t.title}`)
+        .join("\n"),
+    };
+  },
   run: async (args, ctx) => {
     let tasks: Task[];
     try {

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -22,7 +22,7 @@ export const webFetchTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `GET ${args.url}` }),
+  render: (args) => ({ title: `GET ${args.url ?? ""}` }),
   async run(args): Promise<ToolOutput> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -40,7 +40,7 @@ export const searchWebTool: ToolSpec<Args> = {
     additionalProperties: false,
   },
   needsPermission: false,
-  render: (args) => ({ title: `search web: ${args.query}` }),
+  render: (args) => ({ title: `search web: ${args.query ?? ""}` }),
   async run(args): Promise<ToolOutput> {
     const count = Math.min(Math.max(args.count ?? DEFAULT_RESULTS, 1), MAX_RESULTS);
     try {

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -23,8 +23,8 @@ export const writeTool: ToolSpec<Args> = {
   },
   needsPermission: true,
   render: (args) => ({
-    title: `write ${collapsePath(args.path, process.cwd())} (${args.content.length} chars)`,
-    diff: { path: args.path, before: "", after: args.content },
+    title: `write ${collapsePath(String(args.path ?? ""), process.cwd())} (${String(args.content ?? "").length} chars)`,
+    diff: { path: String(args.path ?? ""), before: "", after: String(args.content ?? "") },
   }),
   async run(args, ctx) {
     const abs = resolvePath(ctx.cwd, args.path);

--- a/src/ui/diff-view.tsx
+++ b/src/ui/diff-view.tsx
@@ -13,7 +13,9 @@ interface Props {
 
 export function DiffView({ path, before, after, maxLines = 40 }: Props) {
   const theme = useTheme();
-  const patch = createTwoFilesPatch(path, path, before, after, "", "", { context: 2 });
+  const safeBefore = before ?? "";
+  const safeAfter = after ?? "";
+  const patch = createTwoFilesPatch(path, path, safeBefore, safeAfter, "", "", { context: 2 });
   const raw = patch.split("\n").slice(4);
   const lines = raw.filter((l) => {
     if (l.startsWith("--- ") || l.startsWith("+++ ")) return false;

--- a/src/ui/permission.tsx
+++ b/src/ui/permission.tsx
@@ -15,7 +15,13 @@ interface Props {
 
 export function PermissionModal({ tool, args, onDecide }: Props) {
   const theme = useTheme();
-  const render = tool.render?.(args);
+  let render: { title?: string; body?: string; diff?: { path: string; before: string; after: string } } | undefined;
+  try {
+    render = tool.render?.(args);
+  } catch {
+    // Malformed args from the model can crash typed render functions.
+    // Fall back to raw JSON display below.
+  }
   const items = [
     { label: "Allow once", value: "allow" as const },
     { label: "Allow for this session", value: "allow_session" as const },


### PR DESCRIPTION
When the LLM emits malformed tool calls (missing required fields like `content`, `old_string`, `path`, etc.), the typed `render` functions would crash before the permission modal even rendered. This caused two common errors:

1. `Cannot read properties of undefined (reading 'length')` — from `write.ts` render accessing `args.content.length`
2. `Cannot read properties of undefined (reading 'split')` — from `DiffView` passing `undefined` to the diff library

### Changes
- Wrap `tool.render()` in `PermissionModal` with try-catch so any render crash falls back to raw JSON display instead of killing the TUI
- Coerce `before`/`after` to strings in `DiffView` as a safety net
- Add nullish coalescing to all tool render functions (write, edit, bash, tasks, memory, browser, github, glob, grep, web-fetch, web-search, expand-artifact)

Co-authored-by: kimiflare <kimiflare@proton.me>