### PR TITLE
feat(agent): hard-stop loop guardrail following BudgetExhaustedError pattern

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -82,6 +82,13 @@ export class BudgetExhaustedError extends Error {
   }
 }
 
+export class AgentLoopError extends Error {
+  constructor(message = "Agent got stuck repeating the same tool calls") {
+    super(message);
+    this.name = "AgentLoopError";
+  }
+}
+
 const codeModeApiCache = new Map<string, string>();
 
 /** Per-session accumulator for high-signal memories that may indicate KIMI.md drift. */
@@ -176,6 +183,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   let cumulativePromptTokens = 0;
   let iter = 0;
   let budgetExhausted = false;
+  let loopExhausted = false;
 
   while (true) {
     // Budget enforcement: before starting a new turn, if we've already hit the
@@ -186,6 +194,15 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         content:
           "You have reached the cumulative input token budget for this session. " +
           "Please synthesize your findings and provide a final summary of what was accomplished.",
+      });
+    }
+
+    if (loopExhausted) {
+      opts.messages.push({
+        role: "system",
+        content:
+          "You have repeatedly called the same tools with identical arguments and are stuck in a loop. " +
+          "Please synthesize what you know from the conversation history and provide a final answer.",
       });
     }
 
@@ -397,6 +414,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       return;
     }
 
+    let blockedCount = 0;
     for (const tc of toolCalls) {
       if (opts.signal.aborted) throw new DOMException("aborted", "AbortError");
 
@@ -421,6 +439,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         opts.callbacks.onToolResult?.(loopResult);
         recentToolCalls.push(loopSignature);
         if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+        blockedCount++;
         continue;
       }
 
@@ -451,6 +470,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
             opts.callbacks.onToolResult?.(budgetResult);
             recentToolCalls.push(loopSignature);
             if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+            blockedCount++;
             continue;
           }
 
@@ -472,6 +492,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
             opts.callbacks.onToolResult?.(loopResult);
             recentToolCalls.push(loopSignature);
             if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+            blockedCount++;
             continue;
           }
 
@@ -626,6 +647,10 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       }
     }
 
+    if (blockedCount === toolCalls.length && toolCalls.length > 0) {
+      loopExhausted = true;
+    }
+
     // Decay drift accumulator at end of turn (clustered changes = drift,
     // spread-out changes = incremental and not worth nagging)
     if (opts.sessionId) {
@@ -659,6 +684,9 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
     if (budgetExhausted) {
       throw new BudgetExhaustedError();
+    }
+    if (loopExhausted) {
+      throw new AgentLoopError();
     }
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Text, useApp, useInput, render } from "ink";
 import SelectInput from "ink-select-input";
 
-import { runAgentTurn } from "./agent/loop.js";
+import { runAgentTurn, AgentLoopError } from "./agent/loop.js";
 import { TurnSupervisor } from "./agent/supervisor.js";
 import type { AiGatewayOptions, GatewayMeta } from "./agent/client.js";
 import { buildSystemPrompt, buildSystemMessages, buildSessionPrefix } from "./agent/system-prompt.js";
@@ -2004,6 +2004,11 @@ function App({
         setEvents((es) => [
           ...es,
           { kind: "cloud_quota_exhausted", key: mkKey(), used, limit, expiresAt },
+        ]);
+      } else if (e instanceof AgentLoopError) {
+        setEvents((es) => [
+          ...es,
+          { kind: "error", key: mkKey(), text: "The agent got stuck repeating the same actions. Here's what we know so far." },
         ]);
       } else {
         const displayText =

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { loadConfig, DEFAULT_MODEL } from "./config.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
-import { runAgentTurn, BudgetExhaustedError } from "./agent/loop.js";
+import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
 import { KimiApiError, humanizeCloudflareError } from "./util/errors.js";
 import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
@@ -347,6 +347,11 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
     if (err instanceof BudgetExhaustedError) {
       process.stderr.write("\n\x1b[33m[Budget exhausted — exiting with code 42]\x1b[0m\n");
       process.exitCode = 42;
+      return;
+    }
+    if (err instanceof AgentLoopError) {
+      process.stderr.write("\n\x1b[33m[Agent loop detected — exiting with code 43]\x1b[0m\n");
+      process.exitCode = 43;
       return;
     }
     if (err instanceof KimiApiError) {

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
-import { runAgentTurn, BudgetExhaustedError } from "../agent/loop.js";
+import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "../agent/loop.js";
 import type { AgentCallbacks } from "../agent/loop.js";
 import type { ChatMessage, ContentPart, Usage } from "../agent/messages.js";
 import { buildSystemPrompt, buildSystemMessages, buildSessionPrefix } from "../agent/system-prompt.js";
@@ -277,7 +277,7 @@ class InternalSession implements KimiFlareSession {
       if ((err as Error).name === "AbortError") {
         this.emit({ type: "session.end", reason: "aborted" });
         this.emit({ type: "status", status: "idle" });
-      } else if (err instanceof BudgetExhaustedError) {
+      } else if (err instanceof BudgetExhaustedError || err instanceof AgentLoopError) {
         this.emit({ type: "session.end", reason: "error", error: (err as Error).message });
         this.emit({ type: "status", status: "error" });
         throw err;


### PR DESCRIPTION
## Problem

The anti-loop guardrail was too passive — it warned the model but never stopped the turn, causing infinite token-burning cycles like the one shown in the issue.

## Solution

Follow the exact two-phase pattern used by `BudgetExhaustedError`:

1. When **all** tool calls in an iteration are blocked (anti-loop or web-fetch spiral), set `loopExhausted = true`.
2. On the next iteration, inject a system message asking the model to synthesize what it knows.
3. After the model responds with text-only, throw `AgentLoopError`.
4. Callers catch it and present a clean message to the user.

## Files changed

- `src/agent/loop.ts`: add `AgentLoopError`, `blockedCount` tracking, `loopExhausted` flag
- `src/app.tsx`: catch `AgentLoopError`, show clean error event
- `src/index.tsx`: catch `AgentLoopError`, exit with code 43
- `src/sdk/session.ts`: catch `AgentLoopError` alongside `BudgetExhaustedError`

## Testing

- Pre-existing `sandbox.test.ts` failures are unrelated to this change
- `loop.test.ts` passes
- Type-check passes for modified files

Co-authored-by: kimiflare <kimiflare@proton.me>