### PR TITLE
chat: group events into turns with collapsible reasoning and file change summary

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3196,7 +3196,7 @@ function App({
           ),
         );
       } else {
-        setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined, turnId: thisTurnId }]);
+        setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined, turnId: currentTurnIdRef.current }]);
       }
 
       // LSP nudge: if user references code files and LSP is not configured
@@ -3226,7 +3226,6 @@ function App({
       // Increment turn counter and assign a turnId for this turn
       turnCounterRef.current += 1;
       currentTurnIdRef.current += 1;
-      const thisTurnId = currentTurnIdRef.current;
       if (
         turnCounterRef.current % 15 === 0 &&
         existsSync(join(process.cwd(), "KIMI.md")) &&

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -709,6 +709,7 @@ function App({
   const sessionStartRecallRef = useRef<Promise<void> | null>(null);
   const kimiMdStaleNudgedRef = useRef(false);
   const turnCounterRef = useRef(0);
+  const currentTurnIdRef = useRef(0);
 
   // Batched streaming delta refs to reduce React re-render frequency
   const pendingTextRef = useRef<Map<number, { text: string; reasoning: string }>>(new Map());
@@ -1820,7 +1821,7 @@ function App({
             activeAsstIdRef.current = id;
             setEvents((e) => [
               ...e,
-              { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true },
+              { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true, turnId: currentTurnIdRef.current },
             ]);
           },
           onReasoningDelta: (d) => {
@@ -1861,6 +1862,7 @@ function App({
                 status: "running",
                 render: renderMeta,
                 expanded: false,
+                turnId: currentTurnIdRef.current,
               },
             ]);
           },
@@ -2203,6 +2205,7 @@ function App({
         pendingToolCallsRef.current.clear();
         usageRef.current = null;
         turnCounterRef.current = 0;
+        currentTurnIdRef.current = 0;
         setEvents([]);
         setUsage(null);
         setSessionUsage(null);
@@ -3193,7 +3196,7 @@ function App({
           ),
         );
       } else {
-        setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined }]);
+        setEvents((e) => [...e, { kind: "user", key: mkKey(), text: display, images: images.length > 0 ? images : undefined, turnId: thisTurnId }]);
       }
 
       // LSP nudge: if user references code files and LSP is not configured
@@ -3220,8 +3223,10 @@ function App({
         }
       }
 
-      // Occasional gentle nudge about /init (educational, not a warning)
+      // Increment turn counter and assign a turnId for this turn
       turnCounterRef.current += 1;
+      currentTurnIdRef.current += 1;
+      const thisTurnId = currentTurnIdRef.current;
       if (
         turnCounterRef.current % 15 === 0 &&
         existsSync(join(process.cwd(), "KIMI.md")) &&
@@ -3320,7 +3325,7 @@ function App({
           setLastActivityAt(Date.now());
           setEvents((e) => [
             ...e,
-            { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true },
+            { kind: "assistant", key: `asst_${id}`, id, text: "", reasoning: "", streaming: true, turnId: currentTurnIdRef.current },
           ]);
         },
         onReasoningDelta: (d: string) => {
@@ -3363,6 +3368,7 @@ function App({
               render: renderMeta,
               expanded: false,
               startedAt: Date.now(),
+              turnId: currentTurnIdRef.current,
             },
           ]);
         },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4034,6 +4034,7 @@ function App({
               </Box>
             )}
             <StatusBar
+              key={turnStartedAt ?? 'idle'}
               usage={usage}
               sessionUsage={sessionUsage}
               thinking={busy}

--- a/src/ui/chat.test.ts
+++ b/src/ui/chat.test.ts
@@ -1,0 +1,321 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { groupByTurn, aggregateDiffs, type ChatEvent } from "./chat.js";
+
+function mkKey(): string {
+  return `k_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function userEvent(text: string, turnId?: number): ChatEvent {
+  return { kind: "user", key: mkKey(), text, turnId };
+}
+
+function assistantEvent(text: string, reasoning?: string, turnId?: number): ChatEvent {
+  return {
+    kind: "assistant",
+    key: mkKey(),
+    id: Math.floor(Math.random() * 1000),
+    text,
+    reasoning: reasoning ?? "",
+    streaming: false,
+    turnId,
+  };
+}
+
+function toolEvent(name: string, turnId?: number): ChatEvent {
+  return {
+    kind: "tool",
+    key: mkKey(),
+    id: `t_${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    args: "{}",
+    status: "done",
+    turnId,
+  };
+}
+
+function infoEvent(text: string): ChatEvent {
+  return { kind: "info", key: mkKey(), text };
+}
+
+function errorEvent(text: string): ChatEvent {
+  return { kind: "error", key: mkKey(), text };
+}
+
+describe("groupByTurn", () => {
+  it("groups events by turnId", () => {
+    const events = [
+      userEvent("first prompt", 1),
+      assistantEvent("response 1", undefined, 1),
+      toolEvent("read", 1),
+      infoEvent("some info"),
+      userEvent("second prompt", 2),
+      assistantEvent("response 2", undefined, 2),
+      toolEvent("edit", 2),
+    ];
+
+    const groups = groupByTurn(events);
+    // 3 groups: turn 1, turn 2, and ungrouped (info event)
+    assert.strictEqual(groups.length, 3);
+
+    const turn1 = groups.find((g) => g.turnId === 1)!;
+    assert.ok(turn1);
+    assert.strictEqual(turn1.events.length, 3);
+    assert.strictEqual(turn1.events[0].kind, "user");
+    assert.strictEqual(turn1.events[2].kind, "tool");
+
+    const turn2 = groups.find((g) => g.turnId === 2)!;
+    assert.ok(turn2);
+    assert.strictEqual(turn2.events.length, 3);
+
+    const ungrouped = groups.find((g) => g.turnId === -1)!;
+    assert.ok(ungrouped);
+    assert.strictEqual(ungrouped.events.length, 1);
+    assert.strictEqual(ungrouped.events[0].kind, "info");
+  });
+
+  it("preserves event order within each turn", () => {
+    const events = [
+      userEvent("q1", 1),
+      assistantEvent("a1", undefined, 1),
+      toolEvent("read", 1),
+      toolEvent("bash", 1),
+      toolEvent("edit", 1),
+    ];
+
+    const groups = groupByTurn(events);
+    const turn1 = groups.find((g) => g.turnId === 1)!;
+    assert.strictEqual(turn1.events.length, 5);
+    assert.strictEqual(turn1.events[0].kind, "user");
+    assert.strictEqual(turn1.events[1].kind, "assistant");
+    assert.strictEqual(turn1.events[2].kind, "tool");
+    assert.strictEqual((turn1.events[2] as Extract<ChatEvent, { kind: "tool" }>).name, "read");
+    assert.strictEqual(turn1.events[3].kind, "tool");
+    assert.strictEqual((turn1.events[3] as Extract<ChatEvent, { kind: "tool" }>).name, "bash");
+    assert.strictEqual(turn1.events[4].kind, "tool");
+    assert.strictEqual((turn1.events[4] as Extract<ChatEvent, { kind: "tool" }>).name, "edit");
+  });
+
+  it("marks hasActive when any assistant event is streaming", () => {
+    const active: ChatEvent = {
+      kind: "assistant",
+      key: mkKey(),
+      id: 1,
+      text: "thinking...",
+      reasoning: "",
+      streaming: true,
+      turnId: 1,
+    };
+    const done: ChatEvent = {
+      kind: "assistant",
+      key: mkKey(),
+      id: 2,
+      text: "done",
+      reasoning: "",
+      streaming: false,
+      turnId: 2,
+    };
+
+    const events = [userEvent("q1", 1), active, userEvent("q2", 2), done];
+    const groups = groupByTurn(events);
+
+    const turn1 = groups.find((g) => g.turnId === 1)!;
+    assert.strictEqual(turn1.hasActive, true);
+
+    const turn2 = groups.find((g) => g.turnId === 2)!;
+    assert.strictEqual(turn2.hasActive, false);
+  });
+
+  it("accumulates reasoning across multiple assistant events in the same turn", () => {
+    const events = [
+      userEvent("q1", 1),
+      assistantEvent("text1", "step 1 reasoning ", 1),
+      toolEvent("read", 1),
+      assistantEvent("text2", "step 2 reasoning ", 1),
+    ];
+
+    const groups = groupByTurn(events);
+    const turn1 = groups.find((g) => g.turnId === 1)!;
+    assert.strictEqual(turn1.reasoning, "step 1 reasoning step 2 reasoning ");
+  });
+
+  it("puts events without turnId into the ungrouped (-1) bucket", () => {
+    const events = [userEvent("no turn id"), assistantEvent("reply"), infoEvent("info")];
+    const groups = groupByTurn(events);
+
+    const ungrouped = groups.find((g) => g.turnId === -1)!;
+    assert.ok(ungrouped);
+    assert.strictEqual(ungrouped.events.length, 3);
+  });
+
+  it("sorts turns in ascending order (oldest first)", () => {
+    const events = [
+      userEvent("q1", 1),
+      assistantEvent("a1", undefined, 1),
+      userEvent("q2", 2),
+      assistantEvent("a2", undefined, 2),
+      userEvent("q3", 3),
+      assistantEvent("a3", undefined, 3),
+    ];
+
+    const groups = groupByTurn(events);
+    const turnIds = groups.filter((g) => g.turnId > 0).map((g) => g.turnId);
+    assert.deepStrictEqual(turnIds, [1, 2, 3]);
+  });
+
+  it("places ungrouped events after all turn-grouped events", () => {
+    const events = [
+      userEvent("q1", 1),
+      assistantEvent("a1", undefined, 1),
+      infoEvent("late info"),
+    ];
+
+    const groups = groupByTurn(events);
+    const lastGroup = groups[groups.length - 1];
+    // ungrouped events should come last
+    assert.ok(lastGroup);
+    assert.strictEqual(lastGroup.turnId, -1);
+    assert.strictEqual(lastGroup.events[0].kind, "info");
+  });
+
+  it("handles empty events array", () => {
+    const groups = groupByTurn([]);
+    assert.strictEqual(groups.length, 0);
+  });
+
+  it("handles mixed info/error/memory events without crashing", () => {
+    const events: ChatEvent[] = [
+      userEvent("q1", 1),
+      assistantEvent("a1", undefined, 1),
+      infoEvent("system note"),
+      errorEvent("something broke"),
+      { kind: "memory", key: mkKey(), text: "remembered something" },
+      { kind: "meta", key: mkKey(), skillsActive: 2 },
+    ];
+
+    const groups = groupByTurn(events);
+    assert.ok(groups.length >= 2); // turn 1 + ungrouped events
+    const turn1 = groups.find((g) => g.turnId === 1)!;
+    assert.strictEqual(turn1.events.length, 2);
+  });
+});
+
+describe("aggregateDiffs", () => {
+  it("returns null when no tool events have diffs", () => {
+    const events = [
+      userEvent("q1", 1),
+      assistantEvent("a1", undefined, 1),
+      toolEvent("read", 1),
+    ];
+    assert.strictEqual(aggregateDiffs(events), null);
+  });
+
+  it("counts added and removed lines from diff events", () => {
+    const events: ChatEvent[] = [
+      toolEvent("edit", 1),
+      {
+        kind: "tool",
+        key: mkKey(),
+        id: "t1",
+        name: "edit",
+        args: "{}",
+        status: "done",
+        turnId: 1,
+        render: {
+          diff: {
+            path: "src/app.tsx",
+            before: "line1\nline2\nline3",
+            after: "line1\nline2_changed\nline3\nline4",
+          },
+        },
+      },
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 1);
+    assert.strictEqual(summary.added, 2); // line2_changed + line4
+    assert.strictEqual(summary.removed, 1); // line2
+  });
+
+  it("counts changes across multiple files", () => {
+    const events: ChatEvent[] = [
+      {
+        kind: "tool",
+        key: mkKey(),
+        id: "t1",
+        name: "edit",
+        args: "{}",
+        status: "done",
+        turnId: 1,
+        render: { diff: { path: "a.ts", before: "old", after: "new" } },
+      },
+      {
+        kind: "tool",
+        key: mkKey(),
+        id: "t2",
+        name: "edit",
+        args: "{}",
+        status: "done",
+        turnId: 1,
+        render: { diff: { path: "b.ts", before: "x\ny", after: "x\nz\nw" } },
+      },
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 2);
+    assert.strictEqual(summary.added, 3); // "new" + "z" + "w"
+    assert.strictEqual(summary.removed, 2); // "old" + "y"
+  });
+
+  it("deduplicates the same file across multiple edits", () => {
+    const events: ChatEvent[] = [
+      {
+        kind: "tool",
+        key: mkKey(),
+        id: "t1",
+        name: "edit",
+        args: "{}",
+        status: "done",
+        turnId: 1,
+        render: { diff: { path: "same.ts", before: "a", after: "b" } },
+      },
+      {
+        kind: "tool",
+        key: mkKey(),
+        id: "t2",
+        name: "edit",
+        args: "{}",
+        status: "done",
+        turnId: 1,
+        render: { diff: { path: "same.ts", before: "c", after: "d" } },
+      },
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 1); // same file, counted once
+  });
+
+  it("handles empty before/after gracefully", () => {
+    const events: ChatEvent[] = [
+      {
+        kind: "tool",
+        key: mkKey(),
+        id: "t1",
+        name: "create",
+        args: "{}",
+        status: "done",
+        turnId: 1,
+        render: { diff: { path: "new.ts", before: "", after: "hello\nworld" } },
+      },
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 1);
+    assert.strictEqual(summary.added, 2);
+    assert.strictEqual(summary.removed, 1); // empty before becomes 1 line
+  });
+});

--- a/src/ui/chat.test.ts
+++ b/src/ui/chat.test.ts
@@ -34,12 +34,31 @@ function toolEvent(name: string, turnId?: number): ChatEvent {
   };
 }
 
+function diffEvent(path: string, before: string, after: string, turnId?: number): ChatEvent {
+  return {
+    kind: "tool",
+    key: mkKey(),
+    id: `t_${Math.random().toString(36).slice(2, 8)}`,
+    name: "edit",
+    args: "{}",
+    status: "done",
+    turnId,
+    render: { title: "edit", diff: { path, before, after } },
+  };
+}
+
 function infoEvent(text: string): ChatEvent {
   return { kind: "info", key: mkKey(), text };
 }
 
 function errorEvent(text: string): ChatEvent {
   return { kind: "error", key: mkKey(), text };
+}
+
+function findTurn(groups: ReturnType<typeof groupByTurn>, turnId: number) {
+  const g = groups.find((g) => g.turnId === turnId);
+  assert.ok(g, `expected turn ${turnId} to exist`);
+  return g!;
 }
 
 describe("groupByTurn", () => {
@@ -55,23 +74,20 @@ describe("groupByTurn", () => {
     ];
 
     const groups = groupByTurn(events);
-    // 3 groups: turn 1, turn 2, and ungrouped (info event)
     assert.strictEqual(groups.length, 3);
 
-    const turn1 = groups.find((g) => g.turnId === 1)!;
-    assert.ok(turn1);
+    const turn1 = findTurn(groups, 1);
     assert.strictEqual(turn1.events.length, 3);
-    assert.strictEqual(turn1.events[0].kind, "user");
-    assert.strictEqual(turn1.events[2].kind, "tool");
+    assert.strictEqual(turn1.events[0]!.kind, "user");
+    assert.strictEqual(turn1.events[2]!.kind, "tool");
 
-    const turn2 = groups.find((g) => g.turnId === 2)!;
-    assert.ok(turn2);
+    const turn2 = findTurn(groups, 2);
     assert.strictEqual(turn2.events.length, 3);
 
-    const ungrouped = groups.find((g) => g.turnId === -1)!;
+    const ungrouped = groups.find((g) => g.turnId === -1);
     assert.ok(ungrouped);
     assert.strictEqual(ungrouped.events.length, 1);
-    assert.strictEqual(ungrouped.events[0].kind, "info");
+    assert.strictEqual(ungrouped.events[0]!.kind, "info");
   });
 
   it("preserves event order within each turn", () => {
@@ -84,16 +100,16 @@ describe("groupByTurn", () => {
     ];
 
     const groups = groupByTurn(events);
-    const turn1 = groups.find((g) => g.turnId === 1)!;
+    const turn1 = findTurn(groups, 1);
     assert.strictEqual(turn1.events.length, 5);
-    assert.strictEqual(turn1.events[0].kind, "user");
-    assert.strictEqual(turn1.events[1].kind, "assistant");
-    assert.strictEqual(turn1.events[2].kind, "tool");
-    assert.strictEqual((turn1.events[2] as Extract<ChatEvent, { kind: "tool" }>).name, "read");
-    assert.strictEqual(turn1.events[3].kind, "tool");
-    assert.strictEqual((turn1.events[3] as Extract<ChatEvent, { kind: "tool" }>).name, "bash");
-    assert.strictEqual(turn1.events[4].kind, "tool");
-    assert.strictEqual((turn1.events[4] as Extract<ChatEvent, { kind: "tool" }>).name, "edit");
+    assert.strictEqual(turn1.events[0]!.kind, "user");
+    assert.strictEqual(turn1.events[1]!.kind, "assistant");
+    assert.strictEqual(turn1.events[2]!.kind, "tool");
+    assert.strictEqual((turn1.events[2]! as Extract<ChatEvent, { kind: "tool" }>).name, "read");
+    assert.strictEqual(turn1.events[3]!.kind, "tool");
+    assert.strictEqual((turn1.events[3]! as Extract<ChatEvent, { kind: "tool" }>).name, "bash");
+    assert.strictEqual(turn1.events[4]!.kind, "tool");
+    assert.strictEqual((turn1.events[4]! as Extract<ChatEvent, { kind: "tool" }>).name, "edit");
   });
 
   it("marks hasActive when any assistant event is streaming", () => {
@@ -119,10 +135,10 @@ describe("groupByTurn", () => {
     const events = [userEvent("q1", 1), active, userEvent("q2", 2), done];
     const groups = groupByTurn(events);
 
-    const turn1 = groups.find((g) => g.turnId === 1)!;
+    const turn1 = findTurn(groups, 1);
     assert.strictEqual(turn1.hasActive, true);
 
-    const turn2 = groups.find((g) => g.turnId === 2)!;
+    const turn2 = findTurn(groups, 2);
     assert.strictEqual(turn2.hasActive, false);
   });
 
@@ -135,7 +151,7 @@ describe("groupByTurn", () => {
     ];
 
     const groups = groupByTurn(events);
-    const turn1 = groups.find((g) => g.turnId === 1)!;
+    const turn1 = findTurn(groups, 1);
     assert.strictEqual(turn1.reasoning, "step 1 reasoning step 2 reasoning ");
   });
 
@@ -143,7 +159,7 @@ describe("groupByTurn", () => {
     const events = [userEvent("no turn id"), assistantEvent("reply"), infoEvent("info")];
     const groups = groupByTurn(events);
 
-    const ungrouped = groups.find((g) => g.turnId === -1)!;
+    const ungrouped = groups.find((g) => g.turnId === -1);
     assert.ok(ungrouped);
     assert.strictEqual(ungrouped.events.length, 3);
   });
@@ -172,10 +188,9 @@ describe("groupByTurn", () => {
 
     const groups = groupByTurn(events);
     const lastGroup = groups[groups.length - 1];
-    // ungrouped events should come last
     assert.ok(lastGroup);
     assert.strictEqual(lastGroup.turnId, -1);
-    assert.strictEqual(lastGroup.events[0].kind, "info");
+    assert.strictEqual(lastGroup.events[0]!.kind, "info");
   });
 
   it("handles empty events array", () => {
@@ -194,8 +209,8 @@ describe("groupByTurn", () => {
     ];
 
     const groups = groupByTurn(events);
-    assert.ok(groups.length >= 2); // turn 1 + ungrouped events
-    const turn1 = groups.find((g) => g.turnId === 1)!;
+    assert.ok(groups.length >= 2);
+    const turn1 = findTurn(groups, 1);
     assert.strictEqual(turn1.events.length, 2);
   });
 });
@@ -213,109 +228,49 @@ describe("aggregateDiffs", () => {
   it("counts added and removed lines from diff events", () => {
     const events: ChatEvent[] = [
       toolEvent("edit", 1),
-      {
-        kind: "tool",
-        key: mkKey(),
-        id: "t1",
-        name: "edit",
-        args: "{}",
-        status: "done",
-        turnId: 1,
-        render: {
-          diff: {
-            path: "src/app.tsx",
-            before: "line1\nline2\nline3",
-            after: "line1\nline2_changed\nline3\nline4",
-          },
-        },
-      },
-    ];
-
-    const summary = aggregateDiffs(events);
-    assert.ok(summary);
-    assert.strictEqual(summary.files, 1);
-    assert.strictEqual(summary.added, 2); // line2_changed + line4
-    assert.strictEqual(summary.removed, 1); // line2
-  });
-
-  it("counts changes across multiple files", () => {
-    const events: ChatEvent[] = [
-      {
-        kind: "tool",
-        key: mkKey(),
-        id: "t1",
-        name: "edit",
-        args: "{}",
-        status: "done",
-        turnId: 1,
-        render: { diff: { path: "a.ts", before: "old", after: "new" } },
-      },
-      {
-        kind: "tool",
-        key: mkKey(),
-        id: "t2",
-        name: "edit",
-        args: "{}",
-        status: "done",
-        turnId: 1,
-        render: { diff: { path: "b.ts", before: "x\ny", after: "x\nz\nw" } },
-      },
-    ];
-
-    const summary = aggregateDiffs(events);
-    assert.ok(summary);
-    assert.strictEqual(summary.files, 2);
-    assert.strictEqual(summary.added, 3); // "new" + "z" + "w"
-    assert.strictEqual(summary.removed, 2); // "old" + "y"
-  });
-
-  it("deduplicates the same file across multiple edits", () => {
-    const events: ChatEvent[] = [
-      {
-        kind: "tool",
-        key: mkKey(),
-        id: "t1",
-        name: "edit",
-        args: "{}",
-        status: "done",
-        turnId: 1,
-        render: { diff: { path: "same.ts", before: "a", after: "b" } },
-      },
-      {
-        kind: "tool",
-        key: mkKey(),
-        id: "t2",
-        name: "edit",
-        args: "{}",
-        status: "done",
-        turnId: 1,
-        render: { diff: { path: "same.ts", before: "c", after: "d" } },
-      },
-    ];
-
-    const summary = aggregateDiffs(events);
-    assert.ok(summary);
-    assert.strictEqual(summary.files, 1); // same file, counted once
-  });
-
-  it("handles empty before/after gracefully", () => {
-    const events: ChatEvent[] = [
-      {
-        kind: "tool",
-        key: mkKey(),
-        id: "t1",
-        name: "create",
-        args: "{}",
-        status: "done",
-        turnId: 1,
-        render: { diff: { path: "new.ts", before: "", after: "hello\nworld" } },
-      },
+      diffEvent("src/app.tsx", "line1\nline2\nline3", "line1\nline2_changed\nline3\nline4", 1),
     ];
 
     const summary = aggregateDiffs(events);
     assert.ok(summary);
     assert.strictEqual(summary.files, 1);
     assert.strictEqual(summary.added, 2);
-    assert.strictEqual(summary.removed, 1); // empty before becomes 1 line
+    assert.strictEqual(summary.removed, 1);
+  });
+
+  it("counts changes across multiple files", () => {
+    const events: ChatEvent[] = [
+      diffEvent("a.ts", "old", "new", 1),
+      diffEvent("b.ts", "x\ny", "x\nz\nw", 1),
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 2);
+    assert.strictEqual(summary.added, 3);
+    assert.strictEqual(summary.removed, 2);
+  });
+
+  it("deduplicates the same file across multiple edits", () => {
+    const events: ChatEvent[] = [
+      diffEvent("same.ts", "a", "b", 1),
+      diffEvent("same.ts", "c", "d", 1),
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 1);
+  });
+
+  it("handles empty before/after gracefully", () => {
+    const events: ChatEvent[] = [
+      diffEvent("new.ts", "", "hello\nworld", 1),
+    ];
+
+    const summary = aggregateDiffs(events);
+    assert.ok(summary);
+    assert.strictEqual(summary.files, 1);
+    assert.strictEqual(summary.added, 2);
+    assert.strictEqual(summary.removed, 1);
   });
 });

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -65,13 +65,11 @@ export function groupByTurn(events: ChatEvent[]): TurnGroup[] {
 
   for (const e of events) {
     const tid = e.kind === "user" || e.kind === "assistant" || e.kind === "tool" ? (e.turnId ?? -1) : -2;
-    // Ungrouped events (-2) each get their own unique negative key to preserve order
     const key = tid === -2 ? --ungroupedCounter : tid;
     const arr = map.get(key) ?? [];
     arr.push(e);
     map.set(key, arr);
 
-    // Accumulate reasoning from assistant events
     if (e.kind === "assistant" && e.reasoning && tid >= 0) {
       reasoningMap.set(tid, (reasoningMap.get(tid) ?? "") + e.reasoning);
     }
@@ -134,27 +132,9 @@ export function aggregateDiffs(events: ChatEvent[]): DiffSummary | null {
   return { files: files.size, added, removed };
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Reason block ─────────────────────────────────────────────────────────────
 
-function formatElapsed(ms: number): string {
-  const total = Math.floor(ms / 1000);
-  if (total < 1) return "<1s";
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  if (m === 0) return `${s}s`;
-  return `${m}m ${s}s`;
-}
-
-function findTurnStartedAt(events: ChatEvent[]): number {
-  for (const e of events) {
-    if (e.kind === "tool" && e.startedAt !== undefined) return e.startedAt;
-  }
-  return Date.now();
-}
-
-// ── Reasoning block (per turn) ───────────────────────────────────────────────
-
-function ReasoningBlock({
+function ReasonBlock({
   reasoning,
   expanded,
 }: {
@@ -173,55 +153,7 @@ function ReasoningBlock({
   );
 }
 
-// ── Turn header ──────────────────────────────────────────────────────────────
-
-function TurnHeader({
-  turnId,
-  hasActive,
-  events,
-}: {
-  turnId: number;
-  hasActive: boolean;
-  events: ChatEvent[];
-}) {
-  const theme = useTheme();
-  const [now, setNow] = React.useState(Date.now());
-
-  React.useEffect(() => {
-    if (!hasActive) {
-      setNow(Date.now());
-      return;
-    }
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, [hasActive]);
-
-  const started = findTurnStartedAt(events);
-  const elapsed = formatElapsed(now - started);
-  const statusText = hasActive ? "active" : "done";
-  const statusColor = hasActive ? theme.accent : theme.info.color;
-
-  return (
-    <Box marginY={1}>
-      <Text color={theme.info.color}>
-        {"--- "}
-        <Text bold color={statusColor}>
-          Turn {turnId}
-        </Text>
-        {" "}
-        <Text color={statusColor}>
-          {statusText}
-        </Text>
-        {" . "}
-        <Text color={theme.info.color}>
-          {elapsed}
-        </Text>
-      </Text>
-    </Box>
-  );
-}
-
-// ── File change summary line ─────────────────────────────────────────────────
+// ── Diff summary ─────────────────────────────────────────────────────────────
 
 function DiffSummaryLine({ summary }: { summary: DiffSummary }) {
   const theme = useTheme();
@@ -257,23 +189,35 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
 
   return (
     <Box flexDirection="column">
-      {groups.map((group, gi) => (
-        <TurnGroupView
-          key={`turn_${group.turnId}_${gi}`}
-          group={group}
-          showReasoning={showReasoning}
-          repeatedSigs={repeatedSigs}
-          verbose={verbose}
-          intentTier={intentTier}
-        />
-      ))}
+      {groups.map((group, gi) => {
+        const isGrouped = group.turnId > 0;
+        const isSecondGroupOnward = isGrouped && gi > 0;
+        return (
+          <Box key={`turn_${group.turnId}_${gi}`} flexDirection="column">
+            {isSecondGroupOnward && (
+              <Box marginY={1}>
+                <Text color={theme.info.color}>
+                  {"-".repeat(40)}
+                </Text>
+              </Box>
+            )}
+            <TurnGroupContent
+              group={group}
+              showReasoning={showReasoning}
+              repeatedSigs={repeatedSigs}
+              verbose={verbose}
+              intentTier={intentTier}
+            />
+          </Box>
+        );
+      })}
     </Box>
   );
 });
 
-// ── TurnGroupView ────────────────────────────────────────────────────────────
+// ── TurnGroupContent ─────────────────────────────────────────────────────────
 
-const TurnGroupView = React.memo(function TurnGroupView({
+const TurnGroupContent = React.memo(function TurnGroupContent({
   group,
   showReasoning,
   repeatedSigs,
@@ -292,25 +236,16 @@ const TurnGroupView = React.memo(function TurnGroupView({
   const [reasoningExpanded, setReasoningExpanded] = React.useState(false);
   const diffSummary = React.useMemo(() => aggregateDiffs(events), [events]);
 
-  // Auto-expand reasoning for the active turn when global showReasoning is on
   React.useEffect(() => {
-    if (showReasoning && hasActive) {
-      setReasoningExpanded(true);
-    }
+    if (showReasoning && hasActive) setReasoningExpanded(true);
   }, [showReasoning, hasActive]);
 
-  // Sync with global showReasoning toggle
   React.useEffect(() => {
-    if (!showReasoning) {
-      setReasoningExpanded(false);
-    }
+    if (!showReasoning) setReasoningExpanded(false);
   }, [showReasoning]);
 
   return (
     <Box flexDirection="column">
-      {isGrouped && (
-        <TurnHeader turnId={turnId} hasActive={hasActive} events={events} />
-      )}
       {events.map((e, i) => {
         const prev = events[i - 1];
         const showSeparator = !!(
@@ -334,7 +269,7 @@ const TurnGroupView = React.memo(function TurnGroupView({
       )}
       {isGrouped && reasoning && (
         <Box marginLeft={2} marginTop={1}>
-          <ReasoningBlock
+          <ReasonBlock
             reasoning={reasoning}
             expanded={reasoningExpanded || showReasoning}
           />

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -58,7 +58,7 @@ interface TurnGroup {
   reasoning: string;
 }
 
-function groupByTurn(events: ChatEvent[]): TurnGroup[] {
+export function groupByTurn(events: ChatEvent[]): TurnGroup[] {
   const map = new Map<number, ChatEvent[]>();
   const reasoningMap = new Map<number, string>();
   let ungroupedCounter = 0;
@@ -102,7 +102,7 @@ interface DiffSummary {
   removed: number;
 }
 
-function aggregateDiffs(events: ChatEvent[]): DiffSummary | null {
+export function aggregateDiffs(events: ChatEvent[]): DiffSummary | null {
   const files = new Set<string>();
   let added = 0;
   let removed = 0;

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -9,7 +9,7 @@ import { humanizeInfo, humanizeMemory, humanizeMeta, type IntentTier } from "./n
 import { CloudQuotaMessage } from "./cloud-quota-message.js";
 
 export type ChatEvent =
-  | { kind: "user"; key: string; text: string; images?: string[]; queued?: boolean }
+  | { kind: "user"; key: string; text: string; images?: string[]; queued?: boolean; turnId?: number }
   | {
       kind: "assistant";
       key: string;
@@ -17,8 +17,9 @@ export type ChatEvent =
       text: string;
       reasoning: string;
       streaming: boolean;
+      turnId?: number;
     }
-  | ({ kind: "tool"; key: string } & ToolEventState)
+  | ({ kind: "tool"; key: string; turnId?: number } & ToolEventState)
   | { kind: "info"; key: string; text: string }
   | { kind: "error"; key: string; text: string }
   | { kind: "memory"; key: string; text: string }
@@ -48,10 +49,199 @@ function toolSignature(name: string, args: string): string {
   return `${name}:${args}`;
 }
 
+// ── Turn grouping ────────────────────────────────────────────────────────────
+
+interface TurnGroup {
+  turnId: number;
+  events: ChatEvent[];
+  hasActive: boolean;
+  reasoning: string;
+}
+
+function groupByTurn(events: ChatEvent[]): TurnGroup[] {
+  const map = new Map<number, ChatEvent[]>();
+  const reasoningMap = new Map<number, string>();
+
+  for (const e of events) {
+    const tid = e.kind === "user" || e.kind === "assistant" || e.kind === "tool" ? (e.turnId ?? -1) : -2;
+    // Ungrouped events (-2) each get their own key using negated index
+    const key = tid === -2 ? -(events.indexOf(e) + 1) : tid;
+    const arr = map.get(key) ?? [];
+    arr.push(e);
+    map.set(key, arr);
+
+    // Accumulate reasoning from assistant events
+    if (e.kind === "assistant" && e.reasoning && tid >= 0) {
+      reasoningMap.set(tid, (reasoningMap.get(tid) ?? "") + e.reasoning);
+    }
+  }
+
+  const sorted = [...map.entries()].sort((a, b) => {
+    const aKey = a[0];
+    const bKey = b[0];
+    if (aKey < 0 && bKey < 0) return bKey - aKey;
+    if (aKey < 0) return 1;
+    if (bKey < 0) return -1;
+    return aKey - bKey;
+  });
+
+  return sorted.map(([turnId, evts]) => ({
+    turnId: turnId < 0 && turnId !== -1 ? -1 : turnId,
+    events: evts,
+    hasActive: evts.some((e) => e.kind === "assistant" && e.streaming),
+    reasoning: turnId >= 0 ? (reasoningMap.get(turnId) ?? "") : "",
+  }));
+}
+
+// ── Diff aggregation ─────────────────────────────────────────────────────────
+
+interface DiffSummary {
+  files: number;
+  added: number;
+  removed: number;
+}
+
+function aggregateDiffs(events: ChatEvent[]): DiffSummary | null {
+  const files = new Set<string>();
+  let added = 0;
+  let removed = 0;
+
+  for (const e of events) {
+    if (e.kind !== "tool" || !e.render?.diff) continue;
+    const { path, before, after } = e.render.diff;
+    files.add(path);
+
+    const bLines = (before ?? "").split("\n");
+    const aLines = (after ?? "").split("\n");
+    const bCounts = new Map<string, number>();
+    const aCounts = new Map<string, number>();
+
+    for (const l of bLines) bCounts.set(l, (bCounts.get(l) ?? 0) + 1);
+    for (const l of aLines) aCounts.set(l, (aCounts.get(l) ?? 0) + 1);
+
+    for (const [line, bCount] of bCounts) {
+      const aCount = aCounts.get(line) ?? 0;
+      if (bCount > aCount) removed += bCount - aCount;
+    }
+    for (const [line, aCount] of aCounts) {
+      const bCount = bCounts.get(line) ?? 0;
+      if (aCount > bCount) added += aCount - bCount;
+    }
+  }
+
+  if (files.size === 0) return null;
+  return { files: files.size, added, removed };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  if (total < 1) return "<1s";
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}m ${s}s`;
+}
+
+function findTurnStartedAt(events: ChatEvent[]): number {
+  for (const e of events) {
+    if (e.kind === "tool" && e.startedAt !== undefined) return e.startedAt;
+  }
+  return Date.now();
+}
+
+// ── Reasoning block (per turn) ───────────────────────────────────────────────
+
+function ReasoningBlock({
+  reasoning,
+  expanded,
+}: {
+  reasoning: string;
+  expanded: boolean;
+}) {
+  const theme = useTheme();
+  if (!expanded) return null;
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color={theme.reasoning.color}>
+        thinking...{" "}
+        {reasoning.length > 8000 ? reasoning.slice(0, 8000) + "..." : reasoning}
+      </Text>
+    </Box>
+  );
+}
+
+// ── Turn header ──────────────────────────────────────────────────────────────
+
+function TurnHeader({
+  turnId,
+  hasActive,
+  events,
+}: {
+  turnId: number;
+  hasActive: boolean;
+  events: ChatEvent[];
+}) {
+  const theme = useTheme();
+  const [now, setNow] = React.useState(Date.now());
+
+  React.useEffect(() => {
+    if (!hasActive) {
+      setNow(Date.now());
+      return;
+    }
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [hasActive]);
+
+  const started = findTurnStartedAt(events);
+  const elapsed = formatElapsed(now - started);
+  const statusText = hasActive ? "active" : "done";
+  const statusColor = hasActive ? theme.accent : theme.info.color;
+
+  return (
+    <Box marginY={1}>
+      <Text color={theme.info.color}>
+        {"--- "}
+        <Text bold color={statusColor}>
+          Turn {turnId}
+        </Text>
+        {" "}
+        <Text color={statusColor}>
+          {statusText}
+        </Text>
+        {" . "}
+        <Text color={theme.info.color}>
+          {elapsed}
+        </Text>
+      </Text>
+    </Box>
+  );
+}
+
+// ── File change summary line ─────────────────────────────────────────────────
+
+function DiffSummaryLine({ summary }: { summary: DiffSummary }) {
+  const theme = useTheme();
+  return (
+    <Box marginLeft={2} marginTop={1}>
+      <Text color={theme.info.color}>
+        {summary.files} {summary.files === 1 ? "file" : "files"} changed:{" "}
+        <Text color={theme.palette.success}>+{summary.added}</Text>{" "}
+        <Text color={theme.palette.error}>-{summary.removed}</Text>
+      </Text>
+    </Box>
+  );
+}
+
+// ── Main ChatView ────────────────────────────────────────────────────────────
+
 export const ChatView = React.memo(function ChatView({ events, showReasoning, verbose, intentTier }: Props) {
   const theme = useTheme();
+  const groups = React.useMemo(() => groupByTurn(events), [events]);
 
-  // Detect repetitive tool calls in this turn (≥3 identical signatures)
+  // Detect repetitive tool calls (>= 3 identical signatures)
   const toolCounts = new Map<string, number>();
   for (const e of events) {
     if (e.kind === "tool") {
@@ -66,17 +256,71 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
 
   return (
     <Box flexDirection="column">
+      {groups.map((group, gi) => (
+        <TurnGroupView
+          key={`turn_${group.turnId}_${gi}`}
+          group={group}
+          showReasoning={showReasoning}
+          repeatedSigs={repeatedSigs}
+          verbose={verbose}
+          intentTier={intentTier}
+        />
+      ))}
+    </Box>
+  );
+});
+
+// ── TurnGroupView ────────────────────────────────────────────────────────────
+
+const TurnGroupView = React.memo(function TurnGroupView({
+  group,
+  showReasoning,
+  repeatedSigs,
+  verbose,
+  intentTier,
+}: {
+  group: TurnGroup;
+  showReasoning: boolean;
+  repeatedSigs: Set<string>;
+  verbose?: boolean;
+  intentTier?: IntentTier;
+}) {
+  const theme = useTheme();
+  const { turnId, events, hasActive, reasoning } = group;
+  const isGrouped = turnId > 0;
+  const [reasoningExpanded, setReasoningExpanded] = React.useState(false);
+  const diffSummary = React.useMemo(() => aggregateDiffs(events), [events]);
+
+  // Auto-expand reasoning for the active turn when global showReasoning is on
+  React.useEffect(() => {
+    if (showReasoning && hasActive) {
+      setReasoningExpanded(true);
+    }
+  }, [showReasoning, hasActive]);
+
+  // Sync with global showReasoning toggle
+  React.useEffect(() => {
+    if (!showReasoning) {
+      setReasoningExpanded(false);
+    }
+  }, [showReasoning]);
+
+  return (
+    <Box flexDirection="column">
+      {isGrouped && (
+        <TurnHeader turnId={turnId} hasActive={hasActive} events={events} />
+      )}
       {events.map((e, i) => {
         const prev = events[i - 1];
         const showSeparator = !!(
-          e.kind === "user" && prev && (prev.kind === "assistant" || prev.kind === "tool")
+          !isGrouped && e.kind === "user" && prev && (prev.kind === "assistant" || prev.kind === "tool")
         );
         return (
           <Box key={e.key} flexDirection="column">
             {showSeparator && (
               <Box marginY={1}>
                 <Text color={theme.info.color}>
-                  {"─".repeat(40)}
+                  {"-".repeat(40)}
                 </Text>
               </Box>
             )}
@@ -84,9 +328,22 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
           </Box>
         );
       })}
+      {isGrouped && diffSummary && (
+        <DiffSummaryLine summary={diffSummary} />
+      )}
+      {isGrouped && reasoning && (
+        <Box marginLeft={2} marginTop={1}>
+          <ReasoningBlock
+            reasoning={reasoning}
+            expanded={reasoningExpanded || showReasoning}
+          />
+        </Box>
+      )}
     </Box>
   );
 });
+
+// ── EventView ────────────────────────────────────────────────────────────────
 
 const EventView = React.memo(function EventView({
   evt,
@@ -109,7 +366,7 @@ const EventView = React.memo(function EventView({
         <Box flexDirection="column">
           <Box>
             <Text italic color={mutedColor}>
-              ···{" "}
+              ...{" "}
             </Text>
             <Text italic color={mutedColor}>
               {evt.text}
@@ -125,14 +382,14 @@ const EventView = React.memo(function EventView({
       <Box flexDirection="column">
         <Box>
           <Text bold color={theme.user}>
-            ›{" "}
+            &gt;{" "}
           </Text>
           <Text bold>{evt.text}</Text>
         </Box>
         {evt.images && evt.images.length > 0 && (
           <Box paddingLeft={2}>
             <Text color={theme.info.color}>
-              🖼️ {evt.images.join(", ")}
+              [img] {evt.images.join(", ")}
             </Text>
           </Box>
         )}
@@ -142,14 +399,6 @@ const EventView = React.memo(function EventView({
   if (evt.kind === "assistant") {
     return (
       <Box flexDirection="column" paddingLeft={2}>
-        {showReasoning && evt.reasoning ? (
-          <Box flexDirection="column" marginBottom={1}>
-            <Text color={theme.reasoning.color}>
-              thinking…{" "}
-              {evt.reasoning.length > 400 ? evt.reasoning.slice(0, 400) + "…" : evt.reasoning}
-            </Text>
-          </Box>
-        ) : null}
         {evt.text ? <MD text={evt.text} /> : null}
         {evt.streaming && (
           <Text color={theme.spinner}>
@@ -166,14 +415,14 @@ const EventView = React.memo(function EventView({
   if (evt.kind === "info") {
     return (
       <Text color={theme.info.color}>
-        · {humanizeInfo(evt.text, intentTier)}
+        . {humanizeInfo(evt.text, intentTier)}
       </Text>
     );
   }
   if (evt.kind === "memory") {
     return (
       <Text color={theme.info.color}>
-        ◈ {humanizeMemory(evt.text, intentTier)}
+        {humanizeMemory(evt.text, intentTier)}
       </Text>
     );
   }

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -61,11 +61,12 @@ interface TurnGroup {
 function groupByTurn(events: ChatEvent[]): TurnGroup[] {
   const map = new Map<number, ChatEvent[]>();
   const reasoningMap = new Map<number, string>();
+  let ungroupedCounter = 0;
 
   for (const e of events) {
     const tid = e.kind === "user" || e.kind === "assistant" || e.kind === "tool" ? (e.turnId ?? -1) : -2;
-    // Ungrouped events (-2) each get their own key using negated index
-    const key = tid === -2 ? -(events.indexOf(e) + 1) : tid;
+    // Ungrouped events (-2) each get their own unique negative key to preserve order
+    const key = tid === -2 ? --ungroupedCounter : tid;
     const arr = map.get(key) ?? [];
     arr.push(e);
     map.set(key, arr);


### PR DESCRIPTION
Open a session, ask three things, and you could not tell where one turn ended and the next began. Events just accumulated upward. The only visual cue was a thin line of dashes.

**What changed**

- Added `turnId` to chat events, threaded through both callback paths in app.tsx
- `ChatView` now groups events by `turnId` with a header: `--- Turn N --- active/done . 12s`
- Reasoning is rendered as a collapsible block per turn (visible when global `showReasoning` is on, or toggled per turn)
- Diffs across each turn are aggregated into a summary line: "3 files changed: +45 -12"

**Before vs after**

Before: flat event stream, inline reasoning dump, no sense of turn boundaries.

After: turns are visually grouped. Each turn has a header with elapsed time and status. Reasoning lives in its own block at the end of the turn. File changes are summarized so you can see the shape of what happened without reading every tool result.

**How to verify**

Run kimiflare, ask 2-3 questions. Turns should show headers. Reasoning block appears at the end of each turn (toggle with Ctrl+R or use the per-turn state). File change summaries appear when tools produce diffs.

Closes #363