### PR TITLE
feat(ui): tool states show queued, rejected, cancelled

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -20,6 +20,9 @@ export interface AgentCallbacks {
   onToolCallStart?: (index: number, id: string, name: string) => void;
   onToolCallArgs?: (index: number, delta: string) => void;
   onToolCallFinalized?: (call: ToolCall) => void;
+  /** Called right before a tool call is handed to the executor for actual execution.
+   *  Fires after onToolCallFinalized, one at a time, as tools are dequeued. */
+  onToolWillExecute?: (toolCallId: string, name: string) => void;
   onUsage?: (usage: Usage) => void;
   onUsageFinal?: (usage: Usage, gatewayMeta?: GatewayMeta) => void;
   onGatewayMeta?: (meta: GatewayMeta) => void;
@@ -557,6 +560,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         recentToolCalls.push(loopSignature);
         if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
       } else {
+        opts.callbacks.onToolWillExecute?.(tc.id, tc.function.name);
         logger.debug("turn:tool_start", { sessionId: opts.sessionId, tool: tc.function.name, toolCallId: tc.id });
         const result = await opts.executor.run(
           { id: tc.id, name: tc.function.name, arguments: tc.function.arguments },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1476,6 +1476,11 @@ function App({
         activeScopeRef.current.abort("user_stopped");
         setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
+        // Mark all in-flight tool events as cancelled
+        for (const [toolId] of pendingToolCallsRef.current) {
+          updateTool(toolId, { status: "cancelled" });
+        }
+        pendingToolCallsRef.current.clear();
         // Save session so interrupted turn is not lost
         void saveSessionSafe();
         // Clear task list immediately so it doesn't keep spinning
@@ -1518,6 +1523,11 @@ function App({
         activeScopeRef.current.abort("user_stopped");
         setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
+        // Mark all in-flight tool events as cancelled
+        for (const [toolId] of pendingToolCallsRef.current) {
+          updateTool(toolId, { status: "cancelled" });
+        }
+        pendingToolCallsRef.current.clear();
         // Clear task list immediately so it doesn't keep spinning
         setTasks([]);
         setTasksStartedAt(null);
@@ -1858,15 +1868,27 @@ function App({
                 id: call.id,
                 name: call.function.name,
                 args: call.function.arguments,
-                status: "running",
+                status: "queued",
                 render: renderMeta,
                 expanded: false,
               },
             ]);
           },
+          onToolWillExecute: (id: string) => {
+            setTurnPhase("executing");
+            setCurrentToolName(pendingToolCallsRef.current.get(id) ?? null);
+            setLastActivityAt(Date.now());
+            updateTool(id, { status: "running", startedAt: Date.now() });
+          },
           onToolResult: (r) => {
             pendingToolCallsRef.current.delete(r.tool_call_id);
-            updateTool(r.tool_call_id, { status: r.ok ? "done" : "error", result: r.content });
+            setLastActivityAt(Date.now());
+            if (pendingToolCallsRef.current.size === 0) {
+              setTurnPhase("waiting");
+              setCurrentToolName(null);
+            }
+            const isDenied = typeof r.content === "string" && r.content.startsWith("Permission denied");
+            updateTool(r.tool_call_id, { status: isDenied ? "rejected" : r.ok ? "done" : "error", result: r.content });
           },
           onUsage: (u) => {
             usageRef.current = u;
@@ -3359,12 +3381,17 @@ function App({
               id: call.id,
               name: call.function.name,
               args: call.function.arguments,
-              status: "running",
+              status: "queued",
               render: renderMeta,
               expanded: false,
-              startedAt: Date.now(),
             },
           ]);
+        },
+        onToolWillExecute: (id: string, name: string) => {
+          setTurnPhase("executing");
+          setCurrentToolName(name);
+          setLastActivityAt(Date.now());
+          updateTool(id, { status: "running", startedAt: Date.now() });
         },
         onToolResult: (r: import("./tools/executor.js").ToolResult) => {
           pendingToolCallsRef.current.delete(r.tool_call_id);
@@ -3374,7 +3401,7 @@ function App({
             setCurrentToolName(null);
           }
           updateTool(r.tool_call_id, {
-            status: r.ok ? "done" : "error",
+            status: !r.ok && typeof r.content === "string" && r.content.startsWith("Permission denied") ? "rejected" : r.ok ? "done" : "error",
             result: r.content,
           });
         },

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -11,7 +11,7 @@ export interface ToolEventState {
   id: string;
   name: string;
   args: string;
-  status: "running" | "done" | "error";
+  status: "queued" | "running" | "done" | "error" | "cancelled" | "rejected";
   result?: string;
   render?: { title: string; body?: string; diff?: { path: string; before: string; after: string } };
   expanded?: boolean;
@@ -49,20 +49,40 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated,
   }, [evt.status, evt.startedAt]);
 
   const statusIcon =
-    evt.status === "running" ? (
-      <Text color={theme.info.color} >
+    evt.status === "queued" ? (
+      <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
+        [ ]
+      </Text>
+    ) : evt.status === "running" ? (
+      <Text color={theme.info.color}>
         <Spinner type="dots" />
       </Text>
     ) : evt.status === "error" ? (
-      <Text color={theme.palette.error}>✗</Text>
+      <Text color={theme.palette.error}>[err]</Text>
+    ) : evt.status === "cancelled" ? (
+      <Text color={theme.info.color}>
+        [x]
+      </Text>
+    ) : evt.status === "rejected" ? (
+      <Text color={theme.palette.error}>[!]</Text>
     ) : (
-      <Text color={theme.palette.success}>✓</Text>
+      <Text color={theme.palette.success}>[ok]</Text>
     );
   const rawTitle = evt.render?.title ?? `${evt.name}(${compactArgs(evt.args)})`;
   let title = humanizeToolTitle(evt.name, rawTitle, intentTier);
-  if (evt.startedAt !== undefined) {
-    title += ` · ${formatElapsed(now - evt.startedAt)}`;
+  if (evt.startedAt !== undefined && (evt.status === "running" || evt.status === "done" || evt.status === "error")) {
+    title += ` \u00b7 ${formatElapsed(now - evt.startedAt)}`;
   }
+
+  const statusLabel =
+    evt.status === "rejected" ? (
+      <Text color={theme.palette.error}> rejected</Text>
+    ) : evt.status === "cancelled" ? (
+      <Text color={theme.info.color}> cancelled</Text>
+    ) : null;
+
+  const showDim = evt.status === "queued" || evt.status === "cancelled" || evt.status === "rejected";
+
   const expand = Boolean(evt.expanded || verbose);
   const lines = evt.result ? evt.result.split("\n") : [];
   const showLimit = verbose ? 200 : 20;
@@ -71,9 +91,10 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated,
     <Box flexDirection="column" marginLeft={2}>
       <Text>
         {statusIcon}{" "}
-        <Text color={theme.info.color}>{title}</Text>
+        <Text color={theme.info.color} dimColor={showDim}>{title}</Text>
+        {statusLabel}
         {isRepeated ? (
-          <Text color={theme.warn}> ⚠ repeated</Text>
+          <Text color={theme.warn}> [warn] repeated</Text>
         ) : null}
       </Text>
       {evt.render?.diff ? (
@@ -102,7 +123,7 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated,
           )}
         </Box>
       ) : null}
-      {evt.result && !expand && evt.status !== "running" ? (
+      {evt.result && !expand && evt.status !== "running" && evt.status !== "queued" && evt.status !== "cancelled" && evt.status !== "rejected" ? (
         <Text color={theme.info.color}>
           {"  "}{firstLine(evt.result)}
         </Text>

--- a/src/ui/tool-view.tsx
+++ b/src/ui/tool-view.tsx
@@ -50,7 +50,7 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated,
 
   const statusIcon =
     evt.status === "queued" ? (
-      <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
+      <Text color={theme.muted?.color ?? theme.info.color}>
         [ ]
       </Text>
     ) : evt.status === "running" ? (
@@ -81,7 +81,7 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated,
       <Text color={theme.info.color}> cancelled</Text>
     ) : null;
 
-  const showDim = evt.status === "queued" || evt.status === "cancelled" || evt.status === "rejected";
+  const showItalic = evt.status === "queued" || evt.status === "cancelled" || evt.status === "rejected";
 
   const expand = Boolean(evt.expanded || verbose);
   const lines = evt.result ? evt.result.split("\n") : [];
@@ -91,7 +91,7 @@ export const ToolView = React.memo(function ToolView({ evt, verbose, isRepeated,
     <Box flexDirection="column" marginLeft={2}>
       <Text>
         {statusIcon}{" "}
-        <Text color={theme.info.color} dimColor={showDim}>{title}</Text>
+        <Text color={theme.info.color} italic={showItalic}>{title}</Text>
         {statusLabel}
         {isRepeated ? (
           <Text color={theme.warn}> [warn] repeated</Text>


### PR DESCRIPTION
agent returns 5 tools, all 5 appear as spinners at once. only one is actually running. the rest havent started yet. denied tools just vanish. cancelled tools disappear. invisible state everywhere.

### what changed

- `onToolCallFinalized` emits `queued` instead of `running`
- new `onToolWillExecute` callback in agent loop transitions queued to running
- permission denial content detected in `onToolResult` — emits `rejected` instead of `error`
- ctrl+c and escape abort handlers cancel all in-flight tool events
- `ToolView` renders each terminal state: dimmed for queued, labels for rejected/cancelled

queued tools show `[ ]` dimmed. rejected tools show `[!] rejected`. cancelled tools show `[x] cancelled`.

Closes #364