### PR TITLE
feat(ui): restore true message queuing — Enter queues, Esc interrupts

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1474,7 +1474,6 @@ function App({
         isAbortingRef.current = true;
         supervisorRef.current.killTurn();
         activeScopeRef.current.abort("user_stopped");
-        setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
         // Save session so interrupted turn is not lost
         void saveSessionSafe();
@@ -1516,7 +1515,6 @@ function App({
           setLimitModal(null);
         }
         activeScopeRef.current.abort("user_stopped");
-        setQueue([]);
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
         // Clear task list immediately so it doesn't keep spinning
         setTasks([]);
@@ -1567,7 +1565,6 @@ function App({
       isAbortingRef.current = true;
       supervisorRef.current.killTurn();
       activeScopeRef.current.abort("user_stopped");
-      setQueue([]);
       setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
       void saveSessionSafe();
       setTasks([]);
@@ -3707,18 +3704,6 @@ function App({
       const historyEntry = trimmedDisplay;
 
       if (busyRef.current) {
-        // Preempt current turn so user input is not blocked indefinitely
-        if (activeScopeRef.current && !isAbortingRef.current) {
-          isAbortingRef.current = true;
-          supervisorRef.current.killTurn();
-          activeScopeRef.current.abort("new_message");
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(preempted)" }]);
-          // Clear task list immediately so it doesn't keep spinning
-          setTasks([]);
-          setTasksStartedAt(null);
-          setTasksStartTokens(0);
-          tasksRef.current = [];
-        }
         const key = mkKey();
         setEvents((e) => [...e, { kind: "user", key, text: trimmedDisplay, queued: true }]);
         setQueue((q) => [...q, { full: trimmedFull, display: trimmedDisplay, key }]);


### PR DESCRIPTION
## Summary

Restores true message queuing behavior. Previously, submitting a message while the agent was busy would **preempt** the current turn via  + . This made it impossible to queue multiple messages; the latest message always won.

## New behavior

| Action | Before | After |
|--------|--------|-------|
| Enter while busy | Kills current turn, starts new one immediately | Message queues, current turn continues |
| Escape while busy | Kills current turn, **clears queue** | Interrupts current turn, queued messages **auto-drain** |
| Escape again | N/A (queue was cleared) | Interrupts the now-running queued turn |
| Ctrl+C / SIGINT | Same as Escape | Same as Escape (preserves queue) |

## Changes

- : Removed / preemption block. Enter while busy now just queues.
- Ctrl+C handler: Removed  so queued messages survive interrupt.
- Escape handler: Removed  so queued messages survive interrupt.
- SIGINT handler: Removed  so queued messages survive interrupt.

## Why this works with the supervisor

The existing  at ~line 3693 already drains the queue when . After Escape interrupts a turn,  sets  and the supervisor sets  (before callbacks, thanks to ). The effect fires and auto-starts queued messages.

## Testing

1. Ask the agent something long-running, then type a second message and press Enter → shows , first turn continues
2. Press Escape → first turn stops, queued message auto-starts
3. Press Escape again → queued turn stops
4. After Escape, submit a fresh message → starts immediately

---

Closes the queue-regression introduced in #323 (Turn Supervisor architecture).