### PR TITLE
feat(ui): restore shift+tab mode-cycle hint in status bar

### DIFF
--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -116,6 +116,13 @@ export function StatusBar({ usage, sessionUsage, thinking, turnStartedAt, mode, 
           ) : null}
         </Box>
       )}
+      {!thinking && (
+        <Box>
+          <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim}>
+            tip: shift+tab cycles mode
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
Brings back the subtle idle tip reminding users that shift+tab cycles between edit/plan/auto modes. This was previously removed in the status bar density cleanup (#333).