### PR TITLE
feat(sandbox): improve fallback warning UX and SDK integration

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -26,6 +26,8 @@ export interface AgentCallbacks {
   onAssistantFinal?: (msg: ChatMessage) => void;
   onToolResult?: (result: ToolResult) => void;
   onTasks?: (tasks: Task[]) => void;
+  /** Called once per session when the sandbox falls back to node:vm. */
+  onWarning?: (message: string) => void;
   askPermission: PermissionAsker;
   /** Called when the tool-call iteration limit is reached. Return "continue" to
    *  reset the counter and keep going, or "stop" to end the turn immediately. */
@@ -528,12 +530,16 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           opts.callbacks.onToolResult?.(toolResult);
         }
 
-        const warningPrefix = sandboxResult.warnings?.length
-          ? `Warning: ${sandboxResult.warnings.join(" ")}\n\n`
-          : "";
+        // Surface sandbox warnings (e.g. isolated-vm fallback) as a separate UI notice
+        if (sandboxResult.warnings && sandboxResult.warnings.length > 0) {
+          for (const w of sandboxResult.warnings) {
+            opts.callbacks.onWarning?.(w);
+          }
+        }
+
         let resultContent = sandboxResult.error
-          ? `${warningPrefix}Error: ${sandboxResult.error}\n\nOutput:\n${sandboxResult.output}`
-          : `${warningPrefix}${sandboxResult.output}`;
+          ? `Error: ${sandboxResult.error}\n\nOutput:\n${sandboxResult.output}`
+          : sandboxResult.output;
         if (resultContent.length > MAX_TOOL_CONTENT_CHARS) {
           resultContent =
             resultContent.slice(0, MAX_TOOL_CONTENT_CHARS) +

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1868,6 +1868,16 @@ function App({
             pendingToolCallsRef.current.delete(r.tool_call_id);
             updateTool(r.tool_call_id, { status: r.ok ? "done" : "error", result: r.content });
           },
+          onWarning: (msg) => {
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "info",
+                key: mkKey(),
+                text: msg,
+              },
+            ]);
+          },
           onUsage: (u) => {
             usageRef.current = u;
             setUsage(u);

--- a/src/code-mode/sandbox.test.ts
+++ b/src/code-mode/sandbox.test.ts
@@ -1,21 +1,24 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { stripTypescript, runInSandbox } from "./sandbox.js";
+import { stripTypescript, runInSandbox, buildFallbackWarning, resetFallbackWarningFlag } from "./sandbox.js";
 import type { ToolSpec } from "../tools/registry.js";
+import type { ToolExecutor, PermissionAsker } from "../tools/executor.js";
+import type { ToolContext } from "../tools/registry.js";
 
 const mockTools: ToolSpec[] = [];
 
 const mockExecutor = {
+  list: () => [],
   run: async () => ({ content: "ok", ok: true }),
-};
+} as unknown as ToolExecutor;
 
-const mockAskPermission = async () => true;
+const mockAskPermission: PermissionAsker = async () => "allow";
 
-const mockCtx = {
+const mockCtx: ToolContext = {
   cwd: process.cwd(),
-  signal: undefined as AbortSignal | undefined,
-  onTasks: undefined as ((tasks: { id: string; title: string; status: string }[]) => void) | undefined,
-  coauthor: false,
+  signal: undefined,
+  onTasks: undefined,
+  coauthor: undefined,
   memoryManager: undefined,
   sessionId: "test",
 };
@@ -25,7 +28,7 @@ describe("stripTypescript", () => {
     const ts = `const x: string = "hello";`;
     const js = stripTypescript(ts);
     assert.ok(!js.includes(": string"));
-    assert.ok(js.includes('const x'));
+    assert.ok(js.includes("const x"));
     assert.ok(js.includes('"hello"'));
   });
 
@@ -76,7 +79,7 @@ describe("runInSandbox", () => {
     // If typescript is installed in the project, this should work
     // If not, it falls back to stripTypescript and may emit a warning
     if (result.warnings && result.warnings.length > 0) {
-      assert.ok(result.warnings[0].includes("fallback parser"));
+      assert.ok(result.warnings[0]!.includes("fallback parser"));
     } else {
       assert.strictEqual(result.output, "42");
       assert.strictEqual(result.error, undefined);
@@ -98,5 +101,66 @@ describe("runInSandbox", () => {
     assert.strictEqual(result.output, "1");
     assert.strictEqual(result.error, undefined);
     assert.ok(!result.warnings || result.warnings.length === 0);
+  });
+});
+
+describe("buildFallbackWarning", () => {
+  it("suggests installing isolated-vm for missing module errors", () => {
+    const msg = buildFallbackWarning("Cannot find module 'isolated-vm'");
+    assert.ok(msg.includes("is not installed"));
+    assert.ok(msg.includes("npm install isolated-vm"));
+  });
+
+  it("suggests rebuild for native binding errors", () => {
+    const msg = buildFallbackWarning("bindings failed to load .node file");
+    assert.ok(msg.includes("native bindings are incompatible"));
+    assert.ok(msg.includes("npm rebuild isolated-vm"));
+  });
+
+  it("provides a generic message for unknown errors", () => {
+    const msg = buildFallbackWarning("something completely unexpected");
+    assert.ok(msg.includes("could not be loaded"));
+    assert.ok(msg.includes("Ensure build tools are installed"));
+  });
+});
+
+describe("fallback warning deduplication", () => {
+  it("only emits the fallback warning once per process", async () => {
+    resetFallbackWarningFlag();
+
+    // Force a fallback by passing code that will cause isolated-vm to fail
+    // We simulate this by using a code that works in node:vm but we need to
+    // trigger the fallback path. Since we can't easily make isolated-vm fail
+    // in a controlled way, we verify the deduplication by checking that
+    // after the first fallback, subsequent calls don't add warnings.
+    //
+    // We test this indirectly: the first call to runInSandbox when isolated-vm
+    // is unavailable will set fallbackWarningShown = true. The second call
+    // should not add a warning even if it also falls back.
+    //
+    // In test environments isolated-vm is usually not installed, so both calls
+    // will fall back. We just verify at most one warning is ever present.
+    const result1 = await runInSandbox({
+      code: `console.log("first");`,
+      tools: mockTools,
+      executor: mockExecutor,
+      askPermission: mockAskPermission,
+      ctx: mockCtx,
+    });
+
+    const result2 = await runInSandbox({
+      code: `console.log("second");`,
+      tools: mockTools,
+      executor: mockExecutor,
+      askPermission: mockAskPermission,
+      ctx: mockCtx,
+    });
+
+    // At most one of the results should have a fallback warning
+    const warningCount =
+      (result1.warnings?.filter((w) => w.includes("Code Mode is using")).length ?? 0) +
+      (result2.warnings?.filter((w) => w.includes("Code Mode is using")).length ?? 0);
+
+    assert.strictEqual(warningCount, 1);
   });
 });

--- a/src/code-mode/sandbox.ts
+++ b/src/code-mode/sandbox.ts
@@ -289,7 +289,12 @@ async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
 
 let fallbackWarningShown = false;
 
-function buildFallbackWarning(errMessage: string): string {
+/** @internal Reset the fallback warning flag for testing. */
+export function resetFallbackWarningFlag(): void {
+  fallbackWarningShown = false;
+}
+
+export function buildFallbackWarning(errMessage: string): string {
   let reason: string;
   let fix: string;
 

--- a/src/code-mode/sandbox.ts
+++ b/src/code-mode/sandbox.ts
@@ -287,23 +287,40 @@ async function runWithNodeVm(opts: SandboxOptions): Promise<SandboxResult> {
   return { output: logs.join("\n"), logs, toolCalls, warnings };
 }
 
-const ISOLATED_VM_FALLBACK_WARNING =
-  "⚠️  Code sandbox is running without memory limits or true process isolation " +
-  "(isolated-vm unavailable or failed to load). " +
-  "For a secure sandbox, install with Node 22 LTS: nvm install 22 && nvm use 22 && npm install -g kimiflare";
+let fallbackWarningShown = false;
+
+function buildFallbackWarning(errMessage: string): string {
+  let reason: string;
+  let fix: string;
+
+  if (errMessage.includes("Cannot find module") || errMessage.includes("isolated-vm")) {
+    reason = "The optional dependency `isolated-vm` is not installed.";
+    fix = "Run `npm install isolated-vm` in your project (or `npm install -g isolated-vm` if KimiFlare is installed globally).";
+  } else if (errMessage.includes("bindings") || errMessage.includes(".node")) {
+    reason = "The `isolated-vm` native bindings are incompatible with this Node version or architecture.";
+    fix = "Try `npm rebuild isolated-vm`, or switch to Node 22 LTS if you're on Apple Silicon.";
+  } else {
+    reason = "The secure sandbox (`isolated-vm`) could not be loaded.";
+    fix = "Ensure build tools are installed, then run `npm install isolated-vm`.";
+  }
+
+  return `Code Mode is using the built-in Node.js sandbox. Tool execution works normally, but without memory limits or full process isolation. ${reason} ${fix}`;
+}
 
 export async function runInSandbox(opts: SandboxOptions): Promise<SandboxResult> {
   try {
     return await runWithIsolatedVm(opts);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // If isolated-vm fails (e.g., not compiled), fall back to node:vm
-    if (message.includes("isolated-vm") || message.includes("Cannot find module") || message.includes("bindings")) {
-      const result = await runWithNodeVm(opts);
-      return { ...result, warnings: [ISOLATED_VM_FALLBACK_WARNING, ...(result.warnings ?? [])] };
-    }
-    // For other errors, also try fallback
     const result = await runWithNodeVm(opts);
-    return { ...result, warnings: [ISOLATED_VM_FALLBACK_WARNING, ...(result.warnings ?? [])] };
+
+    // Only emit the fallback warning once per process
+    if (!fallbackWarningShown) {
+      fallbackWarningShown = true;
+      const warning = buildFallbackWarning(message);
+      return { ...result, warnings: [warning, ...(result.warnings ?? [])] };
+    }
+
+    return result;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -334,6 +334,9 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
             result.content.length > 400 ? result.content.slice(0, 400) + "..." : result.content;
           process.stderr.write(`\x1b[2m[result: ${snippet.replace(/\n/g, " ⏎ ")}]\x1b[0m\n`);
         },
+        onWarning: (msg) => {
+          process.stderr.write(`\x1b[33mkimiflare: ${msg}\x1b[0m\n`);
+        },
         askPermission: async ({ tool, args }) => {
           if (opts.allowAll) return "allow";
           process.stderr.write(

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -433,6 +433,9 @@ class InternalSession implements KimiFlareSession {
       onTasks: (tasks) => {
         this.emit({ type: "tasks.update", tasks });
       },
+      onWarning: (_msg) => {
+        // SDK consumers can observe warnings via future event types if desired
+      },
       askPermission: async (req) => {
         if (mode === "auto") return "allow";
         if (mode === "plan") {

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -433,8 +433,8 @@ class InternalSession implements KimiFlareSession {
       onTasks: (tasks) => {
         this.emit({ type: "tasks.update", tasks });
       },
-      onWarning: (_msg) => {
-        // SDK consumers can observe warnings via future event types if desired
+      onWarning: (msg) => {
+        this.emit({ type: "warning", message: msg });
       },
       askPermission: async (req) => {
         if (mode === "auto") return "allow";

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -64,6 +64,9 @@ export type SessionEvent =
   // Tasks
   | { type: "tasks.update"; tasks: Task[] }
 
+  // Warnings
+  | { type: "warning"; message: string }
+
   // Status
   | { type: "status"; status: "idle" | "streaming" | "tool_executing" | "compacting" | "error" };
 


### PR DESCRIPTION
## Summary

This PR finishes the "better sandbox fallback warning" feature branch by adding tests, fixing type errors, and wiring warnings through the SDK event stream.

## Changes

- **sandbox.ts**: Export `buildFallbackWarning` and add `resetFallbackWarningFlag()` for testability.
- **sandbox.test.ts**: Fix pre-existing type errors in mocks (`PermissionDecision`, `ToolContext.coauthor`, `ToolExecutor`). Add tests for `buildFallbackWarning` logic (missing module, native bindings, generic errors) and deduplication (warning only emitted once per process).
- **sdk/types.ts**: Add `{ type: "warning"; message: string }` to `SessionEvent` union.
- **sdk/session.ts**: Wire `onWarning` to emit `warning` events instead of silently dropping them.

## Testing

- `npm run typecheck` ✅
- `npx tsx --test src/code-mode/sandbox.test.ts src/agent/loop.test.ts src/sdk/session.test.ts` — 25/25 pass ✅

## Local Testing Instructions

1. **Test the fallback warning message:**
   ```bash
   # Temporarily rename isolated-vm so it can't be found
   mv node_modules/isolated-vm node_modules/isolated-vm.bak
   npm run dev -- --print "Run some code"
   # You should see a yellow warning once, with actionable install instructions
   mv node_modules/isolated-vm.bak node_modules/isolated-vm
   ```

2. **Test deduplication:**
   ```bash
   # With isolated-vm hidden, run multiple code executions in one session
   # The warning should only appear on the first fallback, not every time
   ```

3. **Test SDK warning events:**
   ```bash
   npx tsx --test src/sdk/session.test.ts
   ```

4. **Test TUI warning display:**
   ```bash
   npm run dev
   # In the TUI, trigger code mode with isolated-vm unavailable
   # The warning should appear as an inline info event (not prepended to tool output)
   ```
