### PR TITLE
fix(agent): retry 429 rate limits and surface Cloudflare error codes

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -61,6 +61,7 @@ function cleanErrorMessage(msg: string): string {
 function isRetryable(err: KimiApiError, attempt: number): boolean {
   if (attempt >= MAX_ATTEMPTS - 1) return false;
   if (err.code !== undefined && RETRYABLE_CODES.has(err.code)) return true;
+  if (err.httpStatus === 429) return true;
   if (err.httpStatus !== undefined && err.httpStatus >= 500 && err.httpStatus < 600) return true;
   if (err.message.includes("Internal server error")) return true;
   return false;
@@ -135,7 +136,10 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
       const msg = cleanErrorMessage(rawMsg);
       const apiErr = new KimiApiError(`kimiflare: ${msg}`, err?.code, res.status);
       if (isRetryable(apiErr, attempt)) {
-        const delay = 500 * 2 ** attempt + Math.random() * 250;
+        const isRateLimit = apiErr.httpStatus === 429;
+        const baseDelay = isRateLimit ? 2000 : 500;
+        const delay = baseDelay * 2 ** attempt + Math.random() * 250;
+        logger.warn("runKimi:retrying", { requestId, attempt, code: apiErr.code, httpStatus: apiErr.httpStatus, delay });
         await sleep(delay, opts.signal);
         continue;
       }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2039,6 +2039,20 @@ function App({
           ...es,
           { kind: "error", key: mkKey(), text: "The agent got stuck repeating the same actions. Here's what we know so far." },
         ]);
+      } else if (
+        e instanceof KimiApiError &&
+        (e.httpStatus === 429 || e.code === 3040 || (e.httpStatus !== undefined && e.httpStatus >= 500))
+      ) {
+        setEvents((es) => [
+          ...es,
+          {
+            kind: "api_error",
+            key: mkKey(),
+            httpStatus: e.httpStatus,
+            code: e.code,
+            message: humanizeCloudflareError(e),
+          },
+        ]);
       } else {
         const displayText =
           e instanceof KimiApiError
@@ -3705,6 +3719,20 @@ function App({
               setEvents((es) => [
                 ...es,
                 { kind: "cloud_quota_exhausted", key: mkKey(), used, limit, expiresAt },
+              ]);
+            } else if (
+              e instanceof KimiApiError &&
+              (e.httpStatus === 429 || e.code === 3040 || (e.httpStatus !== undefined && e.httpStatus >= 500))
+            ) {
+              setEvents((es) => [
+                ...es,
+                {
+                  kind: "api_error",
+                  key: mkKey(),
+                  httpStatus: e.httpStatus,
+                  code: e.code,
+                  message: humanizeCloudflareError(e),
+                },
               ]);
             } else {
               const displayText =

--- a/src/ui/api-error-message.tsx
+++ b/src/ui/api-error-message.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { useTheme } from "./theme-context.js";
+
+interface Props {
+  httpStatus?: number;
+  code?: number;
+  message: string;
+}
+
+export function ApiErrorMessage({ httpStatus, code, message }: Props) {
+  const theme = useTheme();
+
+  const parts: string[] = [];
+  if (httpStatus !== undefined) parts.push(`HTTP ${httpStatus}`);
+  if (code !== undefined) parts.push(`code: ${code}`);
+  const meta = parts.join(" · ");
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.error} paddingX={1} marginY={1}>
+      <Text bold color={theme.error}>
+        ⚠ {message}
+      </Text>
+      {meta && (
+        <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
+          {meta}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
 import { humanizeInfo, humanizeMemory, humanizeMeta, type IntentTier } from "./narrator.js";
 import { CloudQuotaMessage } from "./cloud-quota-message.js";
+import { ApiErrorMessage } from "./api-error-message.js";
 
 export type ChatEvent =
   | { kind: "user"; key: string; text: string; images?: string[]; queued?: boolean }
@@ -35,6 +36,13 @@ export type ChatEvent =
       used: number;
       limit: number;
       expiresAt: string;
+    }
+  | {
+      kind: "api_error";
+      key: string;
+      httpStatus?: number;
+      code?: number;
+      message: string;
     };
 
 interface Props {
@@ -200,6 +208,15 @@ const EventView = React.memo(function EventView({
       <Text color={theme.info.color} dimColor>
         {metaText}
       </Text>
+    );
+  }
+  if (evt.kind === "api_error") {
+    return (
+      <ApiErrorMessage
+        httpStatus={evt.httpStatus}
+        code={evt.code}
+        message={evt.message}
+      />
     );
   }
   return (

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -31,39 +31,44 @@ export function humanizeCloudflareError(err: KimiApiError): string {
 
   // Cloudflare-specific error codes
   if (code === 3040) {
-    return "Cloudflare Workers AI is at capacity. Retrying automatically…";
+    return "Cloudflare Workers AI is at capacity (code: 3040). Please wait a moment and try again.";
   }
 
   // HTTP-status-based buckets
   if (httpStatus === 429) {
-    return "Rate limit hit. Please wait a moment and try again.";
+    const codeStr = code !== undefined ? ` (code: ${code})` : "";
+    return `Rate limit hit${codeStr}. Please wait a moment and try again.`;
   }
 
   if (httpStatus === 403 || code === 10000) {
+    const codeStr = code !== undefined ? ` (code: ${code})` : "";
     return (
-      "Authentication failed. Check that your Cloudflare API token has the 'Workers AI' permission.\n" +
+      `Authentication failed${codeStr}. Check that your Cloudflare API token has the 'Workers AI' permission.\n` +
       "Get a new token: https://dash.cloudflare.com/profile/api-tokens"
     );
   }
 
   if (httpStatus === 401) {
+    const codeStr = code !== undefined ? ` (code: ${code})` : "";
     return (
-      "Authentication required. Please check your API token or run `kimiflare auth cloud` if using cloud mode."
+      `Authentication required${codeStr}. Please check your API token or run \`kimiflare auth cloud\` if using cloud mode.`
     );
   }
 
   if (httpStatus === 400) {
+    const codeStr = code !== undefined ? ` (code: ${code})` : "";
     if (message.includes("invalid escaped character")) {
-      return "API rejected request (invalid JSON in conversation history). Run /clear to reset if it persists.";
+      return `API rejected request${codeStr} (invalid JSON in conversation history). Run /clear to reset if it persists.`;
     }
     if (message.includes("Invalid model ID")) {
       return message; // already human-friendly
     }
-    return "Bad request. The conversation may be too long or contain invalid characters. Run /compact or /clear.";
+    return `Bad request${codeStr}. The conversation may be too long or contain invalid characters. Run /compact or /clear.`;
   }
 
   if (httpStatus && httpStatus >= 500) {
-    return "Cloudflare servers are experiencing issues. Retrying automatically…";
+    const codeStr = code !== undefined ? ` (code: ${code})` : "";
+    return `Cloudflare servers are experiencing issues${codeStr}. Please wait a moment and try again.`;
   }
 
   // Fallback: strip any embedded JSON so we don't dump raw objects to the user


### PR DESCRIPTION
## Problem

Users were seeing "Rate limit hit" and "Cloudflare servers are experiencing issues" messages without any actionable error codes. Additionally, HTTP 429 (rate limit) errors were not being retried, while the embeddings client already had retry logic for 429.

## Changes

- **Retry 429s**: Added HTTP 429 to  in  with a longer backoff (2s base instead of 500ms) since rate limits need more time to clear.
- **Log error codes**: When retrying, we now log  and  via  so the exact Cloudflare error code is visible in logs.
- **Surface codes to users**: Updated  to include the internal Cloudflare error code (e.g., ) in messages for 429, 3040, and 5xx errors.
- **Graceful TUI display**: Added a new  component that renders API errors in a bordered box with the error code and HTTP status clearly visible, instead of the plain  fallback.
- **Structured events**: Added a new  chat event kind so 429/3040/5xx errors get the graceful treatment instead of generic plain-text errors.

## Testing

- 
> kimiflare@0.54.0 typecheck
> tsc --noEmit passes
- 
> kimiflare@0.54.0 test
> tsx --test src/**/*.test.ts src/**/*.test.tsx

▶ shouldCompact
  ✔ returns false for short history (0.561375ms)
  ✔ returns true when turn count exceeds threshold (0.143916ms)
✔ shouldCompact (1.321209ms)
▶ compactMessagesViaArtifacts
  ✔ returns same messages when below keep threshold (0.265958ms)
  ✔ collapses older turns and archives artifacts (1.980958ms)
  ✔ preserves system prefix (0.147708ms)
  ✔ extracts decisions from assistant text (0.151917ms)
  ✔ extracts failures from bash errors (0.157959ms)
✔ compactMessagesViaArtifacts (2.8935ms)
▶ recallArtifacts
  ✔ recalls artifacts by file path reference (0.211209ms)
  ✔ returns empty when no match (0.080917ms)
  ✔ does not pull unrelated bash artifacts when failure keyword matches text (0.580583ms)
✔ recallArtifacts (1.004042ms)
▶ runKimi session affinity header
  ✔ sends X-Session-ID and x-session-affinity headers when sessionId is provided (16.534333ms)
  ✔ does not send session headers when sessionId is omitted (0.606125ms)
  ✔ uses the direct Workers AI endpoint by default (0.501667ms)
  ✔ routes through native AI Gateway when configured (0.452666ms)
  ✔ emits gateway metadata from response headers (0.853208ms)
✔ runKimi session affinity header (19.889208ms)
▶ runAgentTurn
  ✔ exits gracefully when signal aborts during streaming (60.275125ms)
  ✔ throws AbortError when signal aborts after streaming but before tool execution (1.168625ms)
✔ runAgentTurn (62.403167ms)
▶ stableStringify
  ✔ produces identical strings for objects with different key insertion orders (0.496834ms)
  ✔ handles nested objects (0.096084ms)
  ✔ handles arrays consistently (0.084834ms)
  ✔ differs when values differ (0.083875ms)
  ✔ works with a replacer (0.116667ms)
  ✔ works with indentation (0.078042ms)
✔ stableStringify (1.572875ms)
▶ stripOldImages
  ✔ keeps images in recent turns (0.6885ms)
  ✔ strips images from older turns while keeping text (0.13475ms)
  ✔ leaves string-only messages untouched (0.083792ms)
  ✔ replaces image-only messages with fallback text (0.127125ms)
  ✔ does not mutate the original array (0.079375ms)
  ✔ returns input unchanged when keepLastTurns is negative (0.060875ms)
  ✔ keeps images when user message count is below keepLastTurns (0.062791ms)
✔ stripOldImages (1.467ms)
▶ emptySessionState
  ✔ returns a state with empty arrays and no task (0.779834ms)
  ✔ accepts an initial task (0.0785ms)
✔ emptySessionState (2.307458ms)
▶ ArtifactStore
  ✔ stores and retrieves artifacts (1.174458ms)
  ✔ evicts oldest when maxArtifacts is reached (0.154542ms)
  ✔ evicts when total chars exceed maxTotalChars (0.079625ms)
  ✔ recall returns only existing artifacts (0.111958ms)
✔ ArtifactStore (1.675333ms)
▶ formatRecalledArtifacts
  ✔ returns empty string for empty array (0.118459ms)
  ✔ formats artifacts with headers (0.078667ms)
✔ formatRecalledArtifacts (0.302666ms)
▶ serializeSessionState
  ✔ includes task and non-empty fields only (0.185042ms)
  ✔ includes artifact index when present (0.108ms)
✔ serializeSessionState (0.360291ms)
▶ buildSessionStateMessage
  ✔ produces a system message (0.347541ms)
✔ buildSessionStateMessage (0.550916ms)
▶ serializeArtifactStore
  ✔ returns an empty array for an empty store (0.484167ms)
  ✔ serializes artifacts in timestamp order (0.322416ms)
  ✔ truncates raw content to 50 KB (0.083208ms)
✔ serializeArtifactStore (1.026375ms)
▶ deserializeArtifactStore
  ✔ restores an empty store from an empty array (0.074709ms)
  ✔ restores artifacts and respects store limits (0.054625ms)
  ✔ is the inverse of serializeArtifactStore (0.082083ms)
✔ deserializeArtifactStore (0.262208ms)
▶ stripHistoricalReasoning
  ✔ leaves system and user messages untouched (0.937167ms)
  ✔ preserves reasoning on the most recent assistant message by default (0.1235ms)
  ✔ strips reasoning from all assistant messages when keepLast=0 (0.078375ms)
  ✔ preserves text-only messages when text is substantive (>200 chars) (0.086041ms)
  ✔ strips text-only messages when text is short (≤200 chars) (0.070166ms)
  ✔ strips text but preserves multiple tool_calls (0.082ms)
  ✔ handles array content correctly (0.087417ms)
  ✔ does not modify tool messages (1.223125ms)
  ✔ preserves the last N assistant messages based on keepLast (0.149084ms)
✔ stripHistoricalReasoning (3.580833ms)
▶ buildStaticPrefix
  ✔ is byte-for-byte identical across different dates (0.446542ms)
  ✔ does not contain volatile metadata (1.155875ms)
✔ buildStaticPrefix (2.203ms)
▶ buildSessionPrefix
  ✔ changes when mode changes (1.547625ms)
  ✔ contains environment and tools (0.145583ms)
  ✔ includes LSP guidance when LSP tools are present (0.138959ms)
  ✔ excludes LSP guidance when no LSP tools are present (0.114333ms)
✔ buildSessionPrefix (2.111166ms)
▶ buildSystemMessages
  ✔ produces two system messages when cacheStable is used (0.347292ms)
  ✔ static message is identical across different modes (0.17875ms)
✔ buildSystemMessages (0.65825ms)
▶ buildSystemPrompt
  ✔ concatenates static and session prefixes (0.203917ms)
✔ buildSystemPrompt (0.255875ms)
▶ generateTypeScriptApi
  ✔ produces identical output for the same tools in different property-key order (12.88ms)
  ✔ produces identical output when called twice with the same tools (0.129ms)
  ✔ sorts tools by name for stable output (0.1095ms)
  ✔ generates expected declarations for a simple tool (0.1265ms)
  ✔ handles tools with no parameters (0.07875ms)
  ✔ handles nested object properties in sorted order (0.1265ms)
✔ generateTypeScriptApi (14.954167ms)
▶ stripTypescript
  ✔ strips basic type annotations (0.805458ms)
  ✔ strips function parameter types (0.099834ms)
  ✔ fails on nested parenthesis types (documented limitation) (0.075042ms)
✔ stripTypescript (1.544917ms)
▶ runInSandbox
  ✔ executes plain JS without types (813.579834ms)
  ✔ executes TS with nested types when typescript is available (18.539667ms)
  ✔ finds typescript even with a non-existent cwd (24.269666ms)
✔ runInSandbox (856.956042ms)
▶ buildFallbackWarning
  ✔ suggests installing isolated-vm for missing module errors (0.1335ms)
  ✔ suggests rebuild for native binding errors (0.08075ms)
  ✔ provides a generic message for unknown errors (0.06ms)
✔ buildFallbackWarning (0.412375ms)
▶ fallback warning deduplication
  ✔ only emits the fallback warning once per process (117.200834ms)
✔ fallback warning deduplication (117.337125ms)
▶ parseFrontmatter
  ✔ returns whole input as body when no frontmatter fence (0.947583ms)
  ✔ parses simple flat keys (0.271208ms)
  ✔ strips matched double-quote pairs (0.073417ms)
  ✔ strips matched single-quote pairs (0.069708ms)
  ✔ does not strip mismatched quotes (0.070541ms)
  ✔ ignores comment lines and blank lines (0.085375ms)
  ✔ flags unparseable lines with errors (0.120875ms)
  ✔ flags unclosed frontmatter (0.071125ms)
  ✔ supports CRLF line endings (0.1555ms)
  ✔ trims trailing whitespace from values (0.123417ms)
  ✔ accepts keys with hyphens, digits, and underscores (0.081666ms)
✔ parseFrontmatter (3.581083ms)
▶ filenameToCommandName
  ✔ strips extension (0.487791ms)
  ✔ uses subdir as namespace (0.13625ms)
  ✔ rejects path traversal (0.077417ms)
  ✔ rejects empty stem (0.062125ms)
✔ filenameToCommandName (1.380291ms)
▶ loadCustomCommands
  ✔ returns empty when no dirs exist (12.942541ms)
  ✔ parses frontmatter and body (52.997167ms)
  ✔ treats agent as alias for mode and maps build->edit (65.53775ms)
  ✔ namespaces commands by subdir (34.071667ms)
  ✔ warns on unknown mode and ignores it (11.960834ms)
  ✔ skips files with unclosed frontmatter and warns (13.47525ms)
  ✔ project commands override global on name collision (10.965209ms)
  ✔ skips files with unparseable frontmatter lines (12.420584ms)
  ✔ rejects project commands dir when it is a symlink escaping cwd (17.720459ms)
  ✔ returns commands sorted by name (39.791417ms)
  ✔ parses shell and files frontmatter flags (20.723542ms)
  ✔ warns when template contains ungated shell substitution (35.658208ms)
  ✔ warns when template contains ungated file inclusion (15.4355ms)
  ✔ warns when project command shadows global command (9.061625ms)
✔ loadCustomCommands (353.924416ms)
▶ renderer
  ✔ tokenizes bare words (1.147792ms)
  ✔ keeps double-quoted words together (0.09575ms)
  ✔ keeps mixed quoted words together (0.067542ms)
  ✔ $ARGUMENTS raw substitution preserves quotes/whitespace (0.437375ms)
  ✔ $1 $2 substitutes first/second token (0.192375ms)
  ✔ highest $N absorbs trailing tokens (0.152292ms)
  ✔ implicitly appends args when template has no placeholders (0.077541ms)
  ✔ does not append when template has $ARGUMENTS even if rendered args are empty (0.102125ms)
  ✔ does not append when args are empty (0.103125ms)
  ✔ substitutes shell output when shell: true (10.608833ms)
  ✔ warns and substitutes empty string on shell timeout when shell: true (107.128209ms)
  ✔ substitutes existing temp file contents when files: true (16.462125ms)
  ✔ warns and substitutes empty string for missing file when files: true (5.519833ms)
  ✔ warns and substitutes empty string for oversize file when files: true (22.064959ms)
  ✔ does not treat email addresses as file inclusions (0.844042ms)
  ✔ does not include backtick-wrapped @ paths (0.123125ms)
  ✔ warns when rendered prompt is empty (0.068667ms)
  ✔ strips leading slash command name before substitution (0.098125ms)
  ✔ treats args-only input as args (0.0475ms)
  ✔ single $N absorbs all remaining tokens (0.059667ms)
  ✔ rejects @file paths outside cwd (parent traversal) when files: true (1.316083ms)
  ✔ rejects @file paths with absolute prefix when files: true (2.472542ms)
  ✔ rejects @file paths with ~ prefix when files: true (1.224416ms)
  ✔ preserves trailing sentence punctuation outside @file path when files: true (12.219375ms)
  ✔ allows filenames that begin with two dots inside cwd when files: true (18.722208ms)
  ✔ rejects symlinks inside cwd that point outside when files: true (10.82875ms)
  ✔ uses a default shell timeout to bound renders when shell: true (5001.604209ms)
  ✔ blocks shell substitution when shell: false (0.258958ms)
  ✔ blocks file inclusion when files: false (1.404334ms)
  ✔ does not execute shell command injected via $ARGUMENTS (0.126792ms)
  ✔ does not resolve @file injected via $ARGUMENTS (0.759583ms)
  ✔ blocks secret file patterns even with files: true (0.557583ms)
  ✔ blocks id_rsa secret file pattern even with files: true (0.707416ms)
✔ renderer (5219.963625ms)
▶ classifyTurn
  ✔ classifies read_file on .ts as reading-source-code (0.638916ms)
  ✔ classifies write_file on .md as writing-documentation (0.467083ms)
  ✔ classifies str_replace on .ts as editing-source-code (0.136875ms)
  ✔ classifies bash npm test as running-tests (0.222ms)
  ✔ classifies web_fetch as reading-web-content (0.18425ms)
  ✔ classifies grep as searching-code (0.288ms)
  ✔ returns empty for unknown tools (0.153125ms)
✔ classifyTurn (3.975666ms)
▶ classifySession
  ✔ picks dominant category by weighted score (0.428ms)
  ✔ falls back to other for short sessions (0.09025ms)
  ✔ classifies mixed writing signals (0.131334ms)
✔ classifySession (0.898791ms)
▶ needsLlmFallback
  ✔ returns true for low confidence (0.092458ms)
  ✔ returns true for other category (0.065ms)
  ✔ returns false for high confidence non-other (0.146375ms)
✔ needsLlmFallback (0.453333ms)
▶ renderTerminal
  ✔ renders category rows (17.961708ms)
  ✔ renders total row (0.272792ms)
  ✔ renders top sessions (0.161292ms)
  ✔ renders reconciliation verified (0.136917ms)
  ✔ renders reconciliation drift (0.150208ms)
  ✔ renders reconciliation error (0.155333ms)
  ✔ renders local-only (1.1645ms)
✔ renderTerminal (20.724959ms)
▶ renderJson
  ✔ produces valid JSON (0.146625ms)
✔ renderJson (0.23175ms)
▶ buildReport
  ✔ aggregates sessions by category (0.840917ms)
  ✔ computes week-over-week change (0.168375ms)
  ✔ filters by category (0.101042ms)
  ✔ includes top sessions (0.109583ms)
  ✔ omits empty categories (0.1215ms)
✔ buildReport (2.62575ms)
▶ formatLocation
  ✔ formats a location with relative path (0.508125ms)
  ✔ falls back to absolute path when outside cwd (0.117209ms)
✔ formatLocation (1.223ms)
▶ formatLocations
  ✔ returns fallback for null (0.337542ms)
  ✔ returns fallback for empty array (0.08225ms)
  ✔ formats multiple locations (0.116458ms)
  ✔ formats single location (0.0725ms)
✔ formatLocations (0.954875ms)
▶ formatHover
  ✔ returns fallback for null (0.114125ms)
  ✔ formats string contents (0.073375ms)
  ✔ formats array of strings (0.071625ms)
  ✔ formats MarkupContent (0.102875ms)
  ✔ formats mixed array (0.05925ms)
✔ formatHover (0.580583ms)
▶ formatDocumentSymbols
  ✔ returns fallback for null (0.122916ms)
  ✔ returns fallback for empty array (0.048ms)
  ✔ formats flat symbols (0.11625ms)
  ✔ formats nested symbols (0.06875ms)
✔ formatDocumentSymbols (0.447833ms)
▶ formatWorkspaceSymbols
  ✔ returns fallback for null (0.113208ms)
  ✔ formats symbols with container (0.098459ms)
✔ formatWorkspaceSymbols (0.284875ms)
▶ formatDiagnostics
  ✔ returns fallback for empty array (0.08625ms)
  ✔ formats error diagnostic (0.08875ms)
  ✔ formats warning without code or source (0.050084ms)
✔ formatDiagnostics (0.28475ms)
▶ formatWorkspaceEdit
  ✔ returns fallback for null (0.094416ms)
  ✔ formats changes (0.072542ms)
  ✔ returns fallback when no changes (0.039041ms)
✔ formatWorkspaceEdit (0.256666ms)
▶ formatCodeActions
  ✔ returns fallback for null (0.080167ms)
  ✔ returns fallback for empty array (0.038083ms)
  ✔ formats actions with kind (0.064166ms)
✔ formatCodeActions (0.233541ms)
▶ deterministicTopicKey
  ✔ lowercases and snake_cases a simple phrase (0.580417ms)
  ✔ strips non-alphanumeric characters (0.082167ms)
  ✔ collapses multiple spaces into a single underscore (0.063833ms)
  ✔ truncates to 60 characters (0.063417ms)
  ✔ returns empty string for empty input (0.0645ms)
  ✔ returns empty string for input with only special chars (0.065083ms)
✔ deterministicTopicKey (1.623208ms)
▶ pickTopicKey
  ✔ returns a new key when no existing keys match (0.130084ms)
  ✔ reuses an existing key when it is a substring of the new key (0.071334ms)
  ✔ reuses an existing key when the new key is a substring of it (0.073625ms)
  ✔ returns null for empty content (0.092583ms)
  ✔ picks the first matching existing key (0.078875ms)
✔ pickTopicKey (0.6025ms)
▶ SDK RPC
  ✔ responds to new_session command (21.741125ms)
  ✔ responds to get_state command (1.739583ms)
  ✔ responds to set_model command (1.495958ms)
  ✔ responds to set_mode command (1.229042ms)
  ✔ responds with error for unknown command (0.456833ms)
  ✔ responds with error for invalid JSON (0.408375ms)
✔ SDK RPC (29.35025ms)
▶ SDK Session
  ✔ creates a session with default options (22.360791ms)
  ✔ emits events via subscribe (0.440958ms)
  ✔ setModel changes the model (0.297417ms)
  ✔ setMode changes the mode (0.574208ms)
  ✔ setReasoningEffort changes the effort level (0.318042ms)
  ✔ abort does not throw when not streaming (0.254583ms)
  ✔ getUsage returns initial zeros (0.221167ms)
  ✔ getStatus returns correct initial state (0.719667ms)
  ✔ save persists session to disk (14.707459ms)
  ✔ dispose cleans up without error (0.964625ms)
  ✔ steer does not queue when not streaming (1.2865ms)
  ✔ followUp queues messages (0.282541ms)
  ✔ resolvePermission does not throw for unknown requestId (0.240416ms)
✔ SDK Session (48.313041ms)
▶ selectSkills
  ✔ returns empty when no skills match (0.558958ms)
  ✔ selects skills that match prompt keywords (0.119958ms)
  ✔ respects tier budget and drops oversized skills (0.085459ms)
  ✔ respects maxSkillTokens ceiling below tier budget (0.075541ms)
  ✔ detects memory conflicts by name overlap (0.076666ms)
  ✔ ignores disabled skills (0.070875ms)
✔ selectSkills (1.649375ms)
▶ browser_fetch
  ✔ gracefully reports when Playwright is not installed (2.108125ms)
✔ browser_fetch (3.138291ms)
▶ isDiffCommand
  ✔ matches `git show` and its argument forms (0.56175ms)
  ✔ does not match `git show-ref` or `git show-branch` (0.282667ms)
  ✔ matches `git diff` with various flags (0.067708ms)
  ✔ does not match commands that merely start with `git diff` as a substring (0.057417ms)
  ✔ matches `git log` only when -p / --patch is present (0.070791ms)
  ✔ matches `git format-patch` (0.052667ms)
  ✔ matches `git stash show` only when -p / --patch is present (0.065083ms)
  ✔ rejects unrelated commands (0.053875ms)
✔ isDiffCommand (1.87125ms)
▶ github_read_pr
  ✔ returns PR details (15.602042ms)
✔ github_read_pr (16.132458ms)
▶ github_read_issue
  ✔ returns issue details with comments (0.523625ms)
✔ github_read_issue (0.593125ms)
▶ github_read_code
  ✔ returns file content (2.854792ms)
  ✔ returns directory listing (0.350333ms)
✔ github_read_code (3.337875ms)
▶ ToolArtifactStore
  ✔ stores and retrieves artifacts (0.503459ms)
  ✔ evicts oldest when maxArtifacts reached (0.104958ms)
  ✔ evicts when total chars exceed maxTotalChars (0.091417ms)
  ✔ clears all artifacts (0.073ms)
  ✔ produces unique IDs (0.274ms)
✔ ToolArtifactStore (1.679917ms)
▶ reduceToolOutput — grep
  ✔ returns file paths and hit counts in discovery mode (0.45725ms)
  ✔ shows sample matches per file (0.148208ms)
  ✔ passes through files-only mode compactly (0.123875ms)
  ✔ expansion restores full raw content (0.107916ms)
✔ reduceToolOutput — grep (1.003042ms)
▶ reduceToolOutput — read
  ✔ returns structure outline for full file reads (0.474291ms)
  ✔ returns slice directly when offset/limit provided (0.091542ms)
  ✔ caps large slices (0.131417ms)
✔ reduceToolOutput — read (0.788875ms)
▶ reduceToolOutput — bash
  ✔ passes through short outputs unchanged (0.172125ms)
  ✔ returns compact failure summary for errors (0.61825ms)
  ✔ deduplicates repeated lines (0.116208ms)
  ✔ preserves stack trace frames in error block (0.135625ms)
✔ reduceToolOutput — bash (1.139334ms)
▶ reduceToolOutput — web_fetch
  ✔ returns title, URL, headings, and excerpt (0.183584ms)
✔ reduceToolOutput — web_fetch (0.221417ms)
▶ reduceToolOutput — lsp
  ✔ passes through short LSP outputs unchanged (0.089583ms)
  ✔ truncates long LSP outputs by line count (0.087ms)
  ✔ truncates long LSP outputs by char count (0.063625ms)
  ✔ stores artifact for truncated LSP output (0.051167ms)
✔ reduceToolOutput — lsp (0.354459ms)
▶ reduceToolOutput — disabled
  ✔ returns raw content when enabled is false (0.056333ms)
✔ reduceToolOutput — disabled (0.107458ms)
▶ reduceToolOutput — unknown tool
  ✔ passes through unknown tools unchanged (0.064334ms)
✔ reduceToolOutput — unknown tool (0.095625ms)
▶ search_web
  ✔ returns results for a query (15.834125ms)
  ✔ handles no results gracefully (0.340541ms)
  ✔ handles HTTP errors gracefully (0.180833ms)
✔ search_web (16.967083ms)
▶ FilePicker
  ✔ renders empty state (81.670334ms)
  ✔ renders items with selection indicator (5.61775ms)
  ✔ renders query header when filtering (5.503542ms)
  ✔ shows 'and N more' when items exceed visible limit (5.049792ms)
  ✔ uses stable keys by item name (1.562625ms)
✔ FilePicker (100.193958ms)
▶ MD numbered lists
  ✔ renders lazy numbering sequentially (1. 1. 1. → 1. 2. 3.) (52.560083ms)
  ✔ preserves explicit source numbers (2.073334ms)
  ✔ renders mixed lazy/explicit with source numbers (2.114792ms)
✔ MD numbered lists (57.494833ms)
▶ MD trailing blank lines
  ✔ strips trailing blank lines (4.770167ms)
  ✔ preserves internal blank lines (2.528125ms)
✔ MD trailing blank lines (7.422916ms)
▶ SlashPicker
  ✔ renders empty state (54.151292ms)
  ✔ renders items with selection indicator and arg hint (5.861333ms)
  ✔ renders query header when filtering (8.725083ms)
  ✔ shows project/global source badge for custom commands (3.107417ms)
  ✔ does not render a badge for built-ins (3.558917ms)
  ✔ keeps a separator between long labels and the description (2.151ms)
  ✔ shows 'more above' / 'more below' on overflow (3.154875ms)
✔ SlashPicker (82.163375ms)
▶ status gateway cache formatting
  ✔ shows gateway cache status separately from token cache (1.040667ms)
  ✔ omits gateway cache status when Cloudflare does not return it (0.231083ms)
✔ status gateway cache formatting (1.841875ms)
▶ built-in theme contrast compliance
  ✔ every color must be readable on its intended terminal background (1.980959ms)
✔ built-in theme contrast compliance (2.526333ms)
▶ loadThemesFromDir
  ✔ loads valid theme JSON (6.664875ms)
  ✔ reports invalid hex colors (3.047042ms)
  ✔ reports WCAG issues for low contrast (5.224125ms)
✔ loadThemesFromDir (15.741209ms)
▶ contrastRatio
  ✔ returns null for invalid hex (0.784625ms)
  ✔ computes black on white as 21:1 (0.20825ms)
  ✔ computes white on white as 1:1 (0.115291ms)
  ✔ flags low contrast (0.174542ms)
  ✔ passes high contrast (0.084208ms)
✔ contrastRatio (2.196375ms)
▶ AbortScope
  ✔ creates a standalone scope that can be aborted (0.573083ms)
  ✔ propagates abort from parent to child (0.118083ms)
  ✔ propagates abort from grandparent to grandchild (0.093917ms)
  ✔ does not propagate abort from child to parent (0.09175ms)
  ✔ detaches child from parent (0.116709ms)
  ✔ returns an already-aborted child when parent is already aborted (0.072417ms)
  ✔ idempotent abort (0.075333ms)
✔ AbortScope (2.503875ms)
▶ loadConfig AI Gateway fields
  ✔ loads AI Gateway settings from env credentials (1.400208ms)
  ✔ loads AI Gateway settings from config file (9.706125ms)
✔ loadConfig AI Gateway fields (11.850625ms)
▶ fuzzyMatch
  ✔ matches empty query with score 0 (0.946417ms)
  ✔ rejects when query longer than text (0.155625ms)
  ✔ matches when chars appear in order (0.1205ms)
  ✔ rejects when chars are out of order (0.103333ms)
  ✔ scores exact prefix better than gappy match (1.88125ms)
  ✔ rewards word-boundary matches (0.159375ms)
  ✔ is case-insensitive (0.079ms)
  ✔ swaps letters/digits to match (0.082708ms)
  ✔ gives exact match the best score (0.086292ms)
✔ fuzzyMatch (4.36675ms)
▶ fuzzyFilter
  ✔ returns all items unchanged for empty query (0.198958ms)
  ✔ filters out non-matching items (0.161667ms)
  ✔ ranks tighter matches above gappier ones (0.113167ms)
  ✔ requires all space-separated tokens to match (0.081292ms)
✔ fuzzyFilter (0.687084ms)
▶ findProjectLspConfigPath
  ✔ finds config in cwd (8.004208ms)
  ✔ finds config in parent when missing in cwd (3.755417ms)
  ✔ stops at git root (13.00025ms)
  ✔ returns null when no config exists (0.938083ms)
✔ findProjectLspConfigPath (26.469042ms)
▶ loadProjectLspConfig
  ✔ loads lspEnabled and lspServers (8.746834ms)
  ✔ returns null when file is missing (4.400167ms)
✔ loadProjectLspConfig (13.396458ms)
▶ saveProjectLspConfig
  ✔ writes config and appends to .gitignore (10.64025ms)
  ✔ does not duplicate gitignore entry (20.470375ms)
✔ saveProjectLspConfig (31.542ms)
▶ resolveLspConfig
  ✔ falls back to global when no project config (4.629292ms)
  ✔ uses project config when present (12.417041ms)
  ✔ falls back to global lspEnabled when project omits it (12.861209ms)
  ✔ falls back to global lspServers when project omits it (5.145292ms)
✔ resolveLspConfig (35.429708ms)
▶ maybeLspNudge
  ✔ returns null when LSP is already configured (0.565583ms)
  ✔ returns null for non-code messages (1.995542ms)
  ✔ nudges for TypeScript files (0.829958ms)
  ✔ nudges for Python files (0.107083ms)
  ✔ nudges for Rust files (0.092ms)
  ✔ nudges for Go files (1.2105ms)
  ✔ combines multiple detected languages (0.109667ms)
  ✔ nudges when LSP is enabled but no servers are configured (0.080667ms)
✔ maybeLspNudge (5.823958ms)
▶ readSSE
  ✔ exits gracefully when signal aborts during pending read (14.837042ms)
  ✔ yields events when stream completes normally (1.187417ms)
✔ readSSE (17.196208ms)
▶ AI Gateway usage enrichment
  ✔ fetches a gateway log by cf-aig-log-id (18.964958ms)
  ✔ records local usage with gateway metadata as best-effort enrichment (15.90925ms)
✔ AI Gateway usage enrichment (35.969084ms)
▶ Persistent history.jsonl
  ✔ writes daily usage to history.jsonl on recordUsage (3.486208ms)
  ✔ deduplicates same-day entries in history.jsonl (5.281ms)
  ✔ includes history data in allTime and month totals (3.431458ms)
  ✔ gives usage.json precedence over history for overlapping dates (2.654583ms)
✔ Persistent history.jsonl (15.3725ms)
ℹ tests 348
ℹ suites 81
ℹ pass 348
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5772.177459 passes (348/348)

Co-authored-by: kimiflare <kimiflare@proton.me>