### PR TITLE
feat(tools): OS-aware shell selection for bash tool

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -78,6 +78,8 @@ export interface AgentTurnOpts {
   cloudMode?: boolean;
   cloudToken?: string;
   cloudDeviceId?: string;
+  /** Shell override for the bash tool. If omitted, the tool auto-detects based on platform. */
+  shell?: string;
 }
 
 export class BudgetExhaustedError extends Error {
@@ -571,7 +573,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         const result = await opts.executor.run(
           { id: tc.id, name: tc.function.name, arguments: tc.function.arguments },
           opts.callbacks.askPermission,
-          { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId, githubToken: opts.githubToken },
+          { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId, githubToken: opts.githubToken, shell: opts.shell },
           opts.onFileChange,
         );
         let content = result.content;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -22,6 +22,7 @@ import {
 } from "./agent/session-state.js";
 import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/executor.js";
 import type { ToolSpec } from "./tools/registry.js";
+import { getShellCommand } from "./tools/bash.js";
 import { McpManager } from "./mcp/manager.js";
 import { LspManager } from "./lsp/manager.js";
 import { makeLspTools } from "./tools/lsp.js";
@@ -332,6 +333,7 @@ interface Cfg {
   githubRepo?: string;
   cloudMode?: boolean;
   cloudToken?: string;
+  shell?: string;
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
@@ -1808,6 +1810,7 @@ function App({
         cloudMode: cfg.cloudMode,
         cloudToken: cloudToken ?? initialCloudToken,
         cloudDeviceId: cloudDeviceId ?? initialCloudDeviceId,
+        shell: cfg.shell,
         onIterationEnd,
         onFileChange: (path, content) => {
           if (content) {
@@ -2292,6 +2295,35 @@ function App({
               { kind: "error", key: mkKey(), text: `cost report failed: ${(err as Error).message}` },
             ]);
           });
+        return true;
+      }
+      if (c === "/shell") {
+        if (!cfg) return true;
+        const valid = ["auto", "bash", "cmd", "powershell"];
+        if (arg === "auto" || arg === "bash" || arg === "cmd" || arg === "powershell") {
+          const next = { ...cfg, shell: arg === "auto" ? undefined : arg };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `shell set to ${arg}` }]);
+          return true;
+        }
+        if (arg) {
+          // Allow absolute paths as custom shells
+          const next = { ...cfg, shell: arg };
+          setCfg(next);
+          void saveConfig(next).catch(() => {});
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `shell set to ${arg}` }]);
+          return true;
+        }
+        const detected = getShellCommand(cfg.shell);
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "info",
+            key: mkKey(),
+            text: `shell: ${cfg.shell ?? "auto"} (${detected.shell} ${detected.args.join(" ")})`,
+          },
+        ]);
         return true;
       }
       if (c === "/model") {

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -30,6 +30,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "remote", argHint: "<prompt>", description: "Run a remote session on Cloudflare", source: "builtin" },
   { name: "update", description: "Check for updates", source: "builtin" },
   { name: "hello", description: "Send a voice note to the creator", source: "builtin" },
+  { name: "shell", argHint: "[auto|bash|cmd|powershell|<path>]", description: "Show or set shell for bash tool", source: "builtin" },
   { name: "logout", description: "Clear stored credentials", source: "builtin" },
   { name: "exit", description: "Exit kimiflare", source: "builtin" },
   { name: "quit", description: "Alias for /exit", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,8 @@ export interface KimiConfig {
   githubRepo?: string;
   /** Enable cloud mode: use api.kimiflare.com instead of direct Workers AI. */
   cloudMode?: boolean;
+  /** Shell override for the bash tool. "auto" (default) detects the platform, or specify "bash", "cmd", "powershell", or an absolute path. */
+  shell?: string;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";
@@ -182,6 +184,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envCostAttribution = readBooleanEnv("KIMI_COST_ATTRIBUTION");
   const envFilePicker = readBooleanEnv("KIMIFLARE_FILE_PICKER");
   const envCloudMode = readBooleanEnv("KIMIFLARE_CLOUD");
+  const envShell = process.env.KIMIFLARE_SHELL;
 
   if (envCloudMode) {
     return {
@@ -205,6 +208,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       codeMode: envCodeMode,
       costAttribution: envCostAttribution ?? false,
       filePicker: envFilePicker ?? true,
+      shell: envShell,
     };
   }
 
@@ -235,6 +239,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       codeMode: envCodeMode ?? true,
       costAttribution: envCostAttribution ?? true,
       filePicker: envFilePicker ?? true,
+      shell: envShell,
     };
   }
 
@@ -265,6 +270,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         costAttribution: envCostAttribution ?? parsed.costAttribution ?? false,
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
         theme: parsed.theme,
+        shell: envShell ?? parsed.shell,
       };
     }
     if (parsed.accountId && parsed.apiToken) {
@@ -298,6 +304,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         filePicker: envFilePicker ?? parsed.filePicker ?? true,
         cloudMode: envCloudMode ?? parsed.cloudMode,
         theme: parsed.theme,
+        shell: envShell ?? parsed.shell,
       };
     }
   } catch {

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { getShellCommand } from "./bash.js";
+
+describe("getShellCommand", () => {
+  it("returns bash for explicit 'bash'", () => {
+    const result = getShellCommand("bash");
+    assert.strictEqual(result.shell, "bash");
+    assert.deepStrictEqual(result.args, ["-lc"]);
+    assert.strictEqual(result.isPosix, true);
+  });
+
+  it("returns cmd for explicit 'cmd'", () => {
+    const result = getShellCommand("cmd");
+    assert.ok(result.shell.toLowerCase().includes("cmd"));
+    assert.deepStrictEqual(result.args, ["/c"]);
+    assert.strictEqual(result.isPosix, false);
+  });
+
+  it("returns powershell for explicit 'powershell'", () => {
+    const result = getShellCommand("powershell");
+    assert.strictEqual(result.shell, "powershell");
+    assert.deepStrictEqual(result.args, ["-Command"]);
+    assert.strictEqual(result.isPosix, false);
+  });
+
+  it("returns bash for undefined (auto on non-Windows)", () => {
+    const result = getShellCommand();
+    // On non-Windows platforms this should be bash
+    // On Windows it would be cmd.exe; we run tests on Unix CI
+    if (process.platform !== "win32") {
+      assert.strictEqual(result.shell, "bash");
+      assert.deepStrictEqual(result.args, ["-lc"]);
+      assert.strictEqual(result.isPosix, true);
+    }
+  });
+
+  it("returns bash for 'auto' on non-Windows", () => {
+    const result = getShellCommand("auto");
+    if (process.platform !== "win32") {
+      assert.strictEqual(result.shell, "bash");
+      assert.deepStrictEqual(result.args, ["-lc"]);
+      assert.strictEqual(result.isPosix, true);
+    }
+  });
+
+  it("treats absolute paths to bash-like shells as POSIX", () => {
+    const result = getShellCommand("/usr/bin/zsh");
+    assert.strictEqual(result.shell, "/usr/bin/zsh");
+    assert.deepStrictEqual(result.args, ["-lc"]);
+    assert.strictEqual(result.isPosix, true);
+  });
+
+  it("treats absolute paths to cmd as non-POSIX", () => {
+    const result = getShellCommand("C:\\Windows\\System32\\cmd.exe");
+    assert.strictEqual(result.shell, "C:\\Windows\\System32\\cmd.exe");
+    assert.deepStrictEqual(result.args, ["/c"]);
+    assert.strictEqual(result.isPosix, false);
+  });
+
+  it("treats absolute paths to powershell as non-POSIX", () => {
+    const result = getShellCommand("C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+    assert.strictEqual(result.shell, "C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+    assert.deepStrictEqual(result.args, ["-Command"]);
+    assert.strictEqual(result.isPosix, false);
+  });
+
+  it("is case-insensitive for named shells", () => {
+    const bash = getShellCommand("BASH");
+    assert.strictEqual(bash.shell, "bash");
+
+    const cmd = getShellCommand("CMD");
+    assert.ok(cmd.shell.toLowerCase().includes("cmd"));
+
+    const ps = getShellCommand("PowerShell");
+    assert.strictEqual(ps.shell, "powershell");
+  });
+});

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { tmpdir } from "node:os";
+import { tmpdir, platform } from "node:os";
 import { join } from "node:path";
 import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
 import { logger } from "../util/logger.js";
@@ -12,10 +12,68 @@ interface Args {
 const DEFAULT_TIMEOUT = 120_000;
 const MAX_TIMEOUT = 600_000;
 
+export interface ShellCommand {
+  shell: string;
+  args: string[];
+  isPosix: boolean;
+}
+
+/**
+ * Resolve the shell to use for executing commands.
+ *
+ * Priority:
+ * 1. Explicit `override` (from config or ToolContext)
+ * 2. Platform auto-detection when override is "auto" or undefined
+ *
+ * Supported named values:
+ * - "bash"        → bash -lc
+ * - "cmd"         → cmd /c
+ * - "powershell"  → powershell -Command
+ * - "auto"        → platform detection
+ *
+ * Any absolute path is treated as a custom shell. The flag is guessed from
+ * the basename: bash/sh/zsh/fish → -lc, cmd → /c, powershell/pwsh → -Command.
+ */
+export function getShellCommand(override?: string): ShellCommand {
+  const raw = override?.trim();
+
+  if (raw && raw !== "auto") {
+    const lower = raw.toLowerCase();
+
+    if (lower === "bash") {
+      return { shell: "bash", args: ["-lc"], isPosix: true };
+    }
+    if (lower === "cmd") {
+      return { shell: process.env.COMSPEC || "cmd.exe", args: ["/c"], isPosix: false };
+    }
+    if (lower === "powershell") {
+      return { shell: "powershell", args: ["-Command"], isPosix: false };
+    }
+
+    // Absolute path to a custom shell
+    const base = lower.replace(/\\/g, "/").split("/").pop() || "";
+    if (base.includes("cmd")) {
+      return { shell: raw, args: ["/c"], isPosix: false };
+    }
+    if (base.includes("powershell") || base.includes("pwsh")) {
+      return { shell: raw, args: ["-Command"], isPosix: false };
+    }
+    // Default to POSIX-style for unknown custom shells
+    return { shell: raw, args: ["-lc"], isPosix: true };
+  }
+
+  // Auto-detect based on platform
+  const isWindows = platform() === "win32";
+  if (isWindows) {
+    return { shell: process.env.COMSPEC || "cmd.exe", args: ["/c"], isPosix: false };
+  }
+  return { shell: "bash", args: ["-lc"], isPosix: true };
+}
+
 export const bashTool: ToolSpec<Args> = {
   name: "bash",
   description:
-    "Run a shell command via `bash -lc`. Prompts the user for permission before executing. stdout and stderr are captured and combined. Large outputs are reduced to a compact summary by default; use expand_artifact to retrieve the full log.",
+    "Run a shell command. On Unix the default shell is bash; on Windows it falls back to cmd.exe. Prompts the user for permission before executing. stdout and stderr are captured and combined. Large outputs are reduced to a compact summary by default; use expand_artifact to retrieve the full log.",
   parameters: {
     type: "object",
     properties: {
@@ -85,10 +143,12 @@ function injectCoauthor(command: string, coauthor?: { name: string; email: strin
 
 function runBash(args: Args, ctx: ToolContext): Promise<ToolOutput> {
   const timeout = Math.min(Math.max(1000, args.timeout_ms ?? DEFAULT_TIMEOUT), MAX_TIMEOUT);
-  const command = injectCoauthor(args.command, ctx.coauthor);
+  const { shell, args: shellArgs, isPosix } = getShellCommand(ctx.shell);
+  const command = isPosix ? injectCoauthor(args.command, ctx.coauthor) : args.command;
+
   return new Promise<ToolOutput>((resolve, reject) => {
-    logger.debug("bash:spawn", { command: args.command.slice(0, 200), cwd: ctx.cwd });
-    const child = spawn("bash", ["-lc", command], {
+    logger.debug("bash:spawn", { command: args.command.slice(0, 200), cwd: ctx.cwd, shell });
+    const child = spawn(shell, [...shellArgs, command], {
       cwd: ctx.cwd,
       env: {
         ...process.env,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -8,6 +8,8 @@ export interface ToolContext {
   memoryManager?: import("../memory/manager.js").MemoryManager | null;
   sessionId?: string;
   githubToken?: string;
+  /** Shell override for the bash tool. If omitted, the tool auto-detects based on platform. */
+  shell?: string;
 }
 
 export interface ToolRender {

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -155,6 +155,11 @@ const CATEGORIES: Category[] = [
     commands: [
       { command: "/init", description: "scan this repo and write a KIMI.md" },
       { command: "/logout", description: "clear credentials" },
+      { command: "/shell", description: "show current shell" },
+      { command: "/shell auto", description: "auto-detect shell (default)" },
+      { command: "/shell bash", description: "force bash" },
+      { command: "/shell cmd", description: "force cmd.exe (Windows)" },
+      { command: "/shell powershell", description: "force PowerShell" },
       { command: "filePicker", description: "enabled by default; disable with KIMIFLARE_FILE_PICKER=0 or filePicker: false in config", selectable: false },
     ],
   },

--- a/src/ui/lsp-wizard.tsx
+++ b/src/ui/lsp-wizard.tsx
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
 import type { LspServerConfig } from "../config.js";
+import { getShellCommand } from "../tools/bash.js";
 import { CustomTextInput } from "./text-input.js";
 
 interface Preset {
@@ -151,7 +152,8 @@ export function LspWizard({ servers, currentScope, hasProjectDir, onDone, onSave
   const runInstall = (command: string) => {
     setInstallState({ status: "running", output: "Installing..." });
 
-    const child = spawn("bash", ["-lc", command], {
+    const { shell, args } = getShellCommand();
+    const child = spawn(shell, [...args, command], {
       env: process.env,
     });
 


### PR DESCRIPTION
## Problem

The bash tool was hardcoded to use `bash -lc`, which fails on Windows unless the user has Bash in their PATH. This caused every node command to exit with code 1 and no output.

## Solution

- **Auto-detection**: On Windows, the tool now defaults to `cmd.exe /c`; on Unix it keeps `bash -lc`.
- **User override**: New `shell` config option and `KIMIFLARE_SHELL` env var let users force a specific shell (bash, cmd, powershell, or an absolute path).
- **TUI commands**: Added `/shell`, `/shell auto`, `/shell bash`, `/shell cmd`, `/shell powershell` slash commands.
- **Co-author safety**: Git co-author injection is skipped on non-POSIX shells since it uses bash-specific syntax.
- **LSP wizard**: Fixed the hardcoded `bash -lc` spawn in `lsp-wizard.tsx` as well.

## Testing

- Added `src/tools/bash.test.ts` with unit tests for `getShellCommand()`
- All 357 existing tests pass
- `npm run typecheck` clean

## Files changed

- `src/tools/bash.ts` — core shell selection logic
- `src/tools/registry.ts` — added `shell` to `ToolContext`
- `src/agent/loop.ts` — thread `shell` through to executor
- `src/app.tsx` — pass `shell` from config, add `/shell` commands
- `src/config.ts` — add `shell` field + `KIMIFLARE_SHELL` env var
- `src/ui/help-menu.tsx` — document `/shell` commands
- `src/ui/lsp-wizard.tsx` — use platform-aware shell
- `src/tools/bash.test.ts` — new tests

Co-authored-by: kimiflare <kimiflare@proton.me>