### PR TITLE
fix(cloud): catch network errors in fetchCloudUsage to prevent crashes

### DIFF
--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -163,7 +163,12 @@ export async function fetchCloudUsage(token: string, deviceId?: string): Promise
 } | null> {
   const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
   if (deviceId) headers["X-Device-ID"] = deviceId;
-  const res = await fetch(`${CLOUD_API_URL}/v1/usage`, { headers });
+  let res: Response;
+  try {
+    res = await fetch(`${CLOUD_API_URL}/v1/usage`, { headers });
+  } catch {
+    return null;
+  }
   if (!res.ok) return null;
   const data = (await res.json()) as Record<string, unknown>;
   if (


### PR DESCRIPTION
Wraps the `fetch` call in `fetchCloudUsage` with a `try/catch` so DNS failures, timeouts, and other network-level errors return `null` instead of throwing an unhandled rejection.

This prevents the CLI from crashing when `api.kimiflare.com` is unreachable (e.g. `ENOTFOUND`, `ETIMEDOUT`, etc.).

**Before:**
- Network errors in `fetchCloudUsage` propagated as unhandled rejections
- Crashed the process at multiple call sites (`app.tsx` startup budget fetch, post-turn budget update, `index.tsx` usage command)

**After:**
- Network errors gracefully return `null`
- Call sites already handle `null` (they either skip the budget update or print an error message)
- Consistent with existing behavior for non-OK HTTP responses and invalid JSON

Fixes the crash reported when `api.kimiflare.com` cannot be resolved.