### PR TITLE
feat(cloud): add kill switch integration for KimiFlare Cloud

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -1,5 +1,5 @@
 import { readSSE } from "../util/sse.js";
-import { KimiApiError } from "../util/errors.js";
+import { KimiApiError, KillSwitchError, detectKillSwitch } from "../util/errors.js";
 import { getUserAgent } from "../util/version.js";
 import { jsonReplacer, sanitizeString, stableStringify } from "./messages.js";
 import type { ChatMessage, ToolDef, Usage } from "./messages.js";
@@ -107,7 +107,9 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
         body: stableStringify(body, jsonReplacer),
         signal: opts.signal,
       });
+      await detectKillSwitch(res);
     } catch (fetchErr) {
+      if (fetchErr instanceof KillSwitchError) throw fetchErr;
       const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
       logger.warn("runKimi:fetch_error", { requestId, attempt, error: msg });
       if (attempt < MAX_ATTEMPTS - 1) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -28,7 +28,7 @@ import { LspManager } from "./lsp/manager.js";
 import { makeLspTools } from "./tools/lsp.js";
 import { sanitizeString } from "./agent/messages.js";
 import type { ChatMessage, ContentPart, Usage } from "./agent/messages.js";
-import { KimiApiError, isCloudQuotaExhaustedError, humanizeCloudflareError } from "./util/errors.js";
+import { KimiApiError, isCloudQuotaExhaustedError, isKillSwitchError, humanizeCloudflareError } from "./util/errors.js";
 import { AbortScope } from "./util/abort-scope.js";
 import { logger } from "./util/logger.js";
 import { buildReport, sendReport } from "./cloud/report.js";
@@ -658,10 +658,22 @@ function App({
     if (!cfg?.cloudMode || !initialCloudToken) return;
     let cancelled = false;
     const fetchBudget = async () => {
-      const { fetchCloudUsage } = await import("./cloud/auth.js");
-      const usage = await fetchCloudUsage(initialCloudToken, cloudDeviceId ?? initialCloudDeviceId);
-      if (usage && !cancelled) {
-        setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+      try {
+        const { fetchCloudUsage } = await import("./cloud/auth.js");
+        const usage = await fetchCloudUsage(initialCloudToken, cloudDeviceId ?? initialCloudDeviceId);
+        if (usage && !cancelled) {
+          setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+        }
+      } catch (err) {
+        if (isKillSwitchError(err) && !cancelled) {
+          setCloudToken(undefined);
+          setCloudDeviceId(undefined);
+          setEvents((es) => [
+            ...es,
+            { kind: "service_ended", key: mkKey(), endedAt: err.endedAt },
+          ]);
+        }
+        // Other errors are non-fatal
       }
     };
     fetchBudget();
@@ -1947,10 +1959,22 @@ function App({
               const token = cloudToken ?? initialCloudToken!;
               const did = cloudDeviceId ?? initialCloudDeviceId;
               void (async () => {
-                const { fetchCloudUsage } = await import("./cloud/auth.js");
-                const usage = await fetchCloudUsage(token, did);
-                if (usage) {
-                  setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+                try {
+                  const { fetchCloudUsage } = await import("./cloud/auth.js");
+                  const usage = await fetchCloudUsage(token, did);
+                  if (usage) {
+                    setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+                  }
+                } catch (err) {
+                  if (isKillSwitchError(err)) {
+                    setCloudToken(undefined);
+                    setCloudDeviceId(undefined);
+                    setEvents((es) => [
+                      ...es,
+                      { kind: "service_ended", key: mkKey(), endedAt: err.endedAt },
+                    ]);
+                  }
+                  // Other errors are non-fatal
                 }
               })();
             }
@@ -2044,6 +2068,13 @@ function App({
         setEvents((evts) =>
           evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(stopped)" } : e)),
         );
+      } else if (isKillSwitchError(e)) {
+        setCloudToken(undefined);
+        setCloudDeviceId(undefined);
+        setEvents((es) => [
+          ...es,
+          { kind: "service_ended", key: mkKey(), endedAt: e.endedAt },
+        ]);
       } else if (cfg?.cloudMode && isCloudQuotaExhaustedError(e)) {
         const token = cloudToken ?? initialCloudToken;
         const did = cloudDeviceId ?? initialCloudDeviceId;
@@ -3563,10 +3594,22 @@ function App({
             const token = cloudToken ?? initialCloudToken!;
             const did = cloudDeviceId ?? initialCloudDeviceId;
             void (async () => {
-              const { fetchCloudUsage } = await import("./cloud/auth.js");
-              const usage = await fetchCloudUsage(token, did);
-              if (usage) {
-                setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+              try {
+                const { fetchCloudUsage } = await import("./cloud/auth.js");
+                const usage = await fetchCloudUsage(token, did);
+                if (usage) {
+                  setCloudBudget({ remaining: usage.remaining, limit: usage.input_token_limit });
+                }
+              } catch (err) {
+                if (isKillSwitchError(err)) {
+                  setCloudToken(undefined);
+                  setCloudDeviceId(undefined);
+                  setEvents((es) => [
+                    ...es,
+                    { kind: "service_ended", key: mkKey(), endedAt: err.endedAt },
+                  ]);
+                }
+                // Other errors are non-fatal
               }
             })();
           }
@@ -3815,6 +3858,13 @@ function App({
               setEvents((evts) =>
                 evts.map((e) => (e.kind === "tool" && e.status === "running" ? { ...e, status: "error" as const, result: "(stopped)" } : e)),
               );
+            } else if (isKillSwitchError(e)) {
+              setCloudToken(undefined);
+              setCloudDeviceId(undefined);
+              setEvents((es) => [
+                ...es,
+                { kind: "service_ended", key: mkKey(), endedAt: e.endedAt },
+              ]);
             } else if (cfg?.cloudMode && isCloudQuotaExhaustedError(e)) {
               const token = cloudToken ?? initialCloudToken;
               const did = cloudDeviceId ?? initialCloudDeviceId;

--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -13,6 +13,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { homedir, hostname, userInfo } from "node:os";
 import { join } from "node:path";
+import { detectKillSwitch } from "../util/errors.js";
 
 export const CLOUD_API_URL = "https://api.kimiflare.com";
 export const POLL_INTERVAL_MS = 5000;
@@ -127,6 +128,8 @@ export async function registerDevice(codes: DeviceCodes): Promise<void> {
     body: JSON.stringify({ device_code: codes.deviceCode, user_code: codes.userCode, device_id: codes.deviceId }),
   });
 
+  await detectKillSwitch(registerRes);
+
   if (!registerRes.ok) {
     const err = (await registerRes.json().catch(() => ({}))) as { error?: string };
     throw new Error(`Failed to register device: ${err.error || registerRes.statusText}`);
@@ -139,6 +142,8 @@ export async function pollForToken(deviceCode: string, deviceId: string): Promis
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ device_code: deviceCode }),
   });
+
+  await detectKillSwitch(pollRes);
 
   if (!pollRes.ok) return null;
 
@@ -169,6 +174,7 @@ export async function fetchCloudUsage(token: string, deviceId?: string): Promise
   } catch {
     return null;
   }
+  await detectKillSwitch(res);
   if (!res.ok) return null;
   const data = (await res.json()) as Record<string, unknown>;
   if (

--- a/src/cloud/report.ts
+++ b/src/cloud/report.ts
@@ -5,6 +5,7 @@
 
 import { getRecentLogs, type LogEntry } from "../util/logger.js";
 import { getAppVersion } from "../util/version.js";
+import { detectKillSwitch } from "../util/errors.js";
 
 const REPORT_URL = "https://api.kimiflare.com/v1/report";
 
@@ -85,6 +86,8 @@ export async function sendReport(payload: ReportPayload, token?: string): Promis
       headers,
       body: JSON.stringify(payload),
     });
+
+    await detectKillSwitch(res);
 
     if (res.ok) {
       return { ok: true, message: "Report sent. Thanks for helping improve KimiFlare!" };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { loadConfig, DEFAULT_MODEL } from "./config.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
 import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
-import { KimiApiError, humanizeCloudflareError } from "./util/errors.js";
+import { KimiApiError, isKillSwitchError, humanizeCloudflareError } from "./util/errors.js";
 import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
@@ -72,6 +72,7 @@ program
     console.log(`Token budget: ${usage.remaining.toLocaleString()} / ${usage.input_token_limit.toLocaleString()} remaining`);
     console.log(`Used: ${usage.input_tokens_used.toLocaleString()}`);
     console.log(`Grant expires: ${usage.expires_at}`);
+    console.log("Or when the global pool of free tokens runs out.");
   });
 
 program.addCommand(createRemoteCommand());
@@ -117,8 +118,20 @@ program
           if (usage) {
             console.log(`\nToken budget: ${usage.remaining.toLocaleString()} / ${usage.input_token_limit.toLocaleString()} remaining`);
             console.log(`Grant expires: ${usage.expires_at}`);
+            console.log("Or when the global pool of free tokens runs out.");
           }
         } catch (err) {
+          if (isKillSwitchError(err)) {
+            console.error(
+              "\nKimiFlare Cloud has reached its maximum budget across all users.\n" +
+                "The free credits period has ended.\n\n" +
+                "To continue using KimiFlare, switch to BYOK mode:\n" +
+                "  • kimiflare config set-key <your-cloudflare-api-key>\n" +
+                "  • kimiflare config set-account <your-account-id>\n" +
+                "  • Or re-run kimiflare and select BYOK\n",
+            );
+            process.exit(0);
+          }
           console.error("Authentication failed:", err instanceof Error ? err.message : String(err));
           process.exit(1);
         }
@@ -173,6 +186,26 @@ async function main() {
     }
     cloudToken = cloudCreds.accessToken;
     cloudDeviceId = cloudCreds.deviceId;
+
+    // Proactive health check: detect kill switch early before the first prompt
+    try {
+      const { fetchCloudUsage } = await import("./cloud/auth.js");
+      await fetchCloudUsage(cloudToken, cloudDeviceId);
+    } catch (err) {
+      if (isKillSwitchError(err)) {
+        console.error(
+          "\nKimiFlare Cloud has reached its maximum budget across all users.\n" +
+            "The free credits period has ended.\n\n" +
+            "To continue using KimiFlare, switch to BYOK mode:\n" +
+            "  • kimiflare config set-key <your-cloudflare-api-key>\n" +
+            "  • kimiflare config set-account <your-account-id>\n" +
+            "  • Or re-run kimiflare and select BYOK\n",
+        );
+        process.exit(0);
+      }
+      // Other errors (network, etc.) — don't block, let it retry on first request
+    }
+
     cfg = {
       ...(cfg ?? { accountId: "", apiToken: "", model: DEFAULT_MODEL, memoryEnabled: true }),
       cloudMode: true,
@@ -355,6 +388,23 @@ async function runPrintMode(opts: PrintOpts): Promise<void> {
     if (err instanceof AgentLoopError) {
       process.stderr.write("\n\x1b[33m[Agent loop detected — exiting with code 43]\x1b[0m\n");
       process.exitCode = 43;
+      return;
+    }
+    if (isKillSwitchError(err)) {
+      process.stderr.write(
+        "\n\x1b[31m" +
+          "╔══════════════════════════════════════════════════════════════╗\n" +
+          "║  KimiFlare Cloud has reached its maximum budget across       ║\n" +
+          "║  all users. The free credits period has ended.               ║\n" +
+          "║                                                              ║\n" +
+          "║  To continue using KimiFlare, switch to BYOK mode:           ║\n" +
+          "║  • kimiflare config set-key <your-cloudflare-api-key>        ║\n" +
+          "║  • kimiflare config set-account <your-account-id>            ║\n" +
+          "║  • Or re-run kimiflare and select BYOK                       ║\n" +
+          "╚══════════════════════════════════════════════════════════════╝\n" +
+          "\x1b[0m\n",
+      );
+      process.exitCode = 0;
       return;
     }
     if (err instanceof KimiApiError) {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -1,5 +1,6 @@
 import type { AiGatewayOptions } from "../agent/client.js";
 import { getUserAgent } from "../util/version.js";
+import { detectKillSwitch } from "../util/errors.js";
 
 export interface EmbedOpts {
   accountId: string;
@@ -34,6 +35,7 @@ async function fetchWithRetry(
   for (let i = 0; i < retries; i++) {
     try {
       const res = await fetch(url, init);
+      await detectKillSwitch(res);
       if (res.ok) return res;
       if (res.status === 429 || res.status >= 500) {
         // Rate limit or server error — retry with backoff

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -8,6 +8,7 @@ import type { Theme } from "./theme.js";
 import { humanizeInfo, humanizeMemory, humanizeMeta, type IntentTier } from "./narrator.js";
 import { CloudQuotaMessage } from "./cloud-quota-message.js";
 import { ApiErrorMessage } from "./api-error-message.js";
+import { ServiceEndedMessage } from "./service-ended-message.js";
 
 export type ChatEvent =
   | { kind: "user"; key: string; text: string; images?: string[]; queued?: boolean }
@@ -43,6 +44,11 @@ export type ChatEvent =
       httpStatus?: number;
       code?: number;
       message: string;
+    }
+  | {
+      kind: "service_ended";
+      key: string;
+      endedAt?: string;
     };
 
 interface Props {
@@ -218,6 +224,9 @@ const EventView = React.memo(function EventView({
         message={evt.message}
       />
     );
+  }
+  if (evt.kind === "service_ended") {
+    return <ServiceEndedMessage endedAt={evt.endedAt} />;
   }
   return (
     <Text color={theme.error}>

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -19,6 +19,7 @@ import {
   POLL_INTERVAL_MS,
   POLL_TIMEOUT_MS,
 } from "../cloud/auth.js";
+import { isKillSwitchError } from "../util/errors.js";
 
 const execAsync = promisify(exec);
 
@@ -99,8 +100,19 @@ export function Onboarding({ onDone, onCancel }: Props) {
             }
             return;
           }
-        } catch {
-          // Continue polling
+        } catch (err) {
+          if (isKillSwitchError(err)) {
+            if (!cancelled) {
+              setCloudAuth({
+                phase: "error",
+                message:
+                  "KimiFlare Cloud has reached its maximum budget across all users. " +
+                  "The free credits period has ended. Switch to BYOK mode to continue using KimiFlare.",
+              });
+            }
+            return;
+          }
+          // Continue polling on other errors
         }
 
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
@@ -307,6 +319,9 @@ export function Onboarding({ onDone, onCancel }: Props) {
               </Text>
               <Text color={theme.info.color}>
                 Grant expires: {cloudAuth.usage.expires_at}
+              </Text>
+              <Text color={theme.info.color}>
+                Or when the global pool of free tokens runs out.
               </Text>
             </Box>
             <Box marginTop={1}>

--- a/src/ui/service-ended-message.tsx
+++ b/src/ui/service-ended-message.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { useTheme } from "./theme-context.js";
+
+interface Props {
+  endedAt?: string;
+}
+
+export function ServiceEndedMessage({ endedAt }: Props) {
+  const theme = useTheme();
+
+  return (
+    <Box flexDirection="column" marginY={1}>
+      <Text bold color={theme.accent}>
+        KimiFlare Cloud has reached its maximum budget across all users.
+      </Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color={theme.info.color}>
+          The free credits period has ended{endedAt ? ` at ${new Date(endedAt).toLocaleString()}` : ""}.
+        </Text>
+        <Text color={theme.info.color}>
+          Thank you for using KimiFlare!
+        </Text>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text bold>To continue using KimiFlare, switch to Bring Your Own Key mode:</Text>
+        <Box paddingLeft={2} flexDirection="column">
+          <Text color={theme.info.color}>
+            → Set API token: kimiflare config set-key &lt;your-key&gt;
+          </Text>
+          <Text color={theme.info.color}>
+            → Set account ID: kimiflare config set-account &lt;your-account-id&gt;
+          </Text>
+          <Text color={theme.info.color}>
+            → Get a token: https://dash.cloudflare.com/profile/api-tokens
+          </Text>
+          <Text color={theme.info.color}>
+            → Or re-run kimiflare and select "BYOK — bring your own Cloudflare key"
+          </Text>
+        </Box>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text color={theme.muted?.color ?? theme.info.color} dimColor={theme.muted?.dim ?? true}>
+          You can no longer send messages or authenticate via KimiFlare Cloud.
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -16,6 +16,31 @@ export class PermissionDeniedError extends Error {
   }
 }
 
+export class KillSwitchError extends Error {
+  endedAt: string | undefined;
+  constructor(endedAt?: string) {
+    super("SERVICE_ENDED");
+    this.name = "KillSwitchError";
+    this.endedAt = endedAt;
+  }
+}
+
+export function isKillSwitchError(err: unknown): err is KillSwitchError {
+  return err instanceof KillSwitchError;
+}
+
+/** Detect the cloud kill-switch response (503 + {error: "SERVICE_ENDED"}).
+ *  Call this immediately after fetch() and before checking res.ok.
+ *  Throws KillSwitchError when matched; otherwise returns silently. */
+export async function detectKillSwitch(res: Response): Promise<void> {
+  if (res.status === 503) {
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (data.error === "SERVICE_ENDED") {
+      throw new KillSwitchError(typeof data.ended_at === "string" ? data.ended_at : undefined);
+    }
+  }
+}
+
 export function isCloudQuotaExhaustedError(err: unknown): err is KimiApiError {
   return (
     err instanceof KimiApiError &&


### PR DESCRIPTION
When the backend kill switch is activated (e.g. free credits run out), all user-facing endpoints return HTTP 503 + `{error: "SERVICE_ENDED"}`.

This change adds graceful handling across the CLI:

- New `KillSwitchError` class and `detectKillSwitch()` helper in `errors.ts`
- Instrumented all cloud API fetch points (chat, auth, usage, report, embeddings)
- Added `ServiceEndedMessage` Ink component for beautiful TUI rendering
- TUI shows graceful message and clears cloud token state on kill switch
- Print mode shows graceful message and exits cleanly (code 0)
- Auth flows (`auth cloud`, onboarding) show graceful message on kill switch
- Proactive health check on startup detects kill switch before first prompt
- Added "Or when the global pool of free tokens runs out" note to usage/onboarding output

**Testing:**
- `npm run typecheck` passes
- `npm test` passes (385 tests)

Co-authored-by: kimiflare <kimiflare@proton.me>