### PR TITLE
feat(ui): add loop-detected modal with continue/stop choices

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -35,6 +35,9 @@ export interface AgentCallbacks {
   /** Called when the tool-call iteration limit is reached. Return "continue" to
    *  reset the counter and keep going, or "stop" to end the turn immediately. */
   onToolLimitReached?: () => Promise<"continue" | "stop">;
+  /** Called when the agent is detected repeating identical tool calls (loop). Return "continue" to
+   *  reset the guardrail and keep going, or "stop" to end the turn immediately. */
+  onLoopDetected?: () => Promise<"continue" | "stop">;
   /** Called when accumulated high-signal memories suggest KIMI.md may be stale. */
   onKimiMdStale?: () => void;
 }
@@ -698,6 +701,22 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       throw new BudgetExhaustedError();
     }
     if (loopExhausted) {
+      if (opts.callbacks.onLoopDetected) {
+        const decision = await opts.callbacks.onLoopDetected();
+        if (decision === "continue") {
+          opts.messages.push({
+            role: "system",
+            content:
+              "You were stuck calling the same tools with identical arguments. " +
+              "The guardrail has been reset so you can continue. Try a different approach.",
+          });
+          loopExhausted = false;
+          recentToolCalls.length = 0;
+          continue;
+        } else {
+          return;
+        }
+      }
       throw new AgentLoopError();
     }
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -555,6 +555,7 @@ function App({
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
   const [limitModal, setLimitModal] = useState<{ limit: number; resolve: (d: LimitDecision) => void } | null>(null);
+  const [loopModal, setLoopModal] = useState<{ resolve: (d: LimitDecision) => void } | null>(null);
   const [queue, setQueue] = useState<Array<{ full: string; display: string; key: string }>>([]);
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
@@ -702,6 +703,7 @@ function App({
   const sigintHandlerRef = useRef<(() => void) | null>(null);
   const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
   const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
+  const loopResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
   const sessionIdRef = useRef<string | null>(null);
   const sessionCreatedAtRef = useRef<string | null>(null);
@@ -925,7 +927,8 @@ function App({
       resumeSessions !== null ||
       checkpointSession !== null ||
       perm !== null ||
-      limitModal !== null;
+      limitModal !== null ||
+      loopModal !== null;
     if (modalActive && activePicker !== null) {
       setActivePicker(null);
     }
@@ -938,6 +941,7 @@ function App({
     resumeSessions,
     perm,
     limitModal,
+    loopModal,
     activePicker,
   ]);
 
@@ -1509,6 +1513,7 @@ function App({
       });
       const hadPerm = permResolveRef.current !== null;
       const hadLimit = limitResolveRef.current !== null;
+      const hadLoop = loopResolveRef.current !== null;
       if (hadPerm) {
         permResolveRef.current!("deny");
         permResolveRef.current = null;
@@ -1518,6 +1523,11 @@ function App({
         limitResolveRef.current!("stop");
         limitResolveRef.current = null;
         setLimitModal(null);
+      }
+      if (hadLoop) {
+        loopResolveRef.current!("stop");
+        loopResolveRef.current = null;
+        setLoopModal(null);
       }
       if (busyRef.current && activeScopeRef.current && !isAbortingRef.current) {
         isAbortingRef.current = true;
@@ -1536,7 +1546,7 @@ function App({
         setTasksStartedAt(null);
         setTasksStartTokens(0);
         tasksRef.current = [];
-      } else if (!hadPerm && !hadLimit) {
+      } else if (!hadPerm && !hadLimit && !hadLoop) {
         logger.info("input:ctrl+c:exiting");
         void lspManagerRef.current.stopAll().finally(() => exit());
       }
@@ -1547,6 +1557,7 @@ function App({
       const modalOpen =
         perm !== null ||
         limitModal !== null ||
+        loopModal !== null ||
         showLspWizard ||
         showCommandList ||
         commandWizard !== null ||
@@ -1567,6 +1578,11 @@ function App({
           limitResolveRef.current("stop");
           limitResolveRef.current = null;
           setLimitModal(null);
+        }
+        if (loopResolveRef.current) {
+          loopResolveRef.current("stop");
+          loopResolveRef.current = null;
+          setLoopModal(null);
         }
         activeScopeRef.current.abort("user_stopped");
         setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
@@ -1607,9 +1623,11 @@ function App({
       isAborting: isAbortingRef.current,
       hasPerm: permResolveRef.current !== null,
       hasLimit: limitResolveRef.current !== null,
+      hasLoop: loopResolveRef.current !== null,
     });
     const hadPerm = permResolveRef.current !== null;
     const hadLimit = limitResolveRef.current !== null;
+    const hadLoop = loopResolveRef.current !== null;
     if (hadPerm) {
       permResolveRef.current!("deny");
       permResolveRef.current = null;
@@ -1619,6 +1637,11 @@ function App({
       limitResolveRef.current!("stop");
       limitResolveRef.current = null;
       setLimitModal(null);
+    }
+    if (hadLoop) {
+      loopResolveRef.current!("stop");
+      loopResolveRef.current = null;
+      setLoopModal(null);
     }
     if (busyRef.current && activeScopeRef.current && !isAbortingRef.current) {
       isAbortingRef.current = true;
@@ -2144,6 +2167,8 @@ function App({
       isAbortingRef.current = false;
       permResolveRef.current = null;
       limitResolveRef.current = null;
+      loopResolveRef.current = null;
+      setLoopModal(null);
       pendingToolCallsRef.current.clear();
     }
   }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
@@ -3661,6 +3686,11 @@ function App({
             limitResolveRef.current = resolve;
             setLimitModal({ limit: 50, resolve });
           }),
+        onLoopDetected: () =>
+          new Promise<LimitDecision>((resolve) => {
+            loopResolveRef.current = resolve;
+            setLoopModal({ resolve });
+          }),
         onKimiMdStale: () => {
           if (!kimiMdStaleNudgedRef.current) {
             kimiMdStaleNudgedRef.current = true;
@@ -3689,6 +3719,8 @@ function App({
         isAbortingRef.current = false;
         permResolveRef.current = null;
         limitResolveRef.current = null;
+        loopResolveRef.current = null;
+        setLoopModal(null);
         pendingToolCallsRef.current.clear();
 
         // Clear task list so it doesn't linger into the next turn
@@ -4230,6 +4262,17 @@ function App({
               limitModal.resolve(d);
               limitResolveRef.current = null;
               setLimitModal(null);
+            }}
+          />
+        ) : loopModal ? (
+          <LimitModal
+            limit={50}
+            title="Agent stuck in a loop"
+            description="The agent kept calling the same tools with identical arguments. What would you like to do?"
+            onDecide={(d) => {
+              loopModal.resolve(d);
+              loopResolveRef.current = null;
+              setLoopModal(null);
             }}
           />
         ) : (

--- a/src/ui/limit-modal.tsx
+++ b/src/ui/limit-modal.tsx
@@ -8,9 +8,11 @@ export type LimitDecision = "continue" | "stop";
 interface Props {
   limit: number;
   onDecide: (decision: LimitDecision) => void;
+  title?: string;
+  description?: string;
 }
 
-export function LimitModal({ limit, onDecide }: Props) {
+export function LimitModal({ limit, onDecide, title, description }: Props) {
   const theme = useTheme();
   const items = [
     { label: "Continue", value: "continue" as const },
@@ -20,10 +22,10 @@ export function LimitModal({ limit, onDecide }: Props) {
   return (
     <Box flexDirection="column" borderStyle="round" borderColor={theme.error} paddingX={1}>
       <Text color={theme.error} bold>
-        Tool-call limit reached ({limit})
+        {title ?? `Tool-call limit reached (${limit})`}
       </Text>
       <Text dimColor>
-        This session has made {limit} tool calls. What would you like to do?
+        {description ?? `This session has made ${limit} tool calls. What would you like to do?`}
       </Text>
       <Box marginTop={1}>
         <SelectInput


### PR DESCRIPTION
When the agent repeats identical tool calls, instead of throwing a hard AgentLoopError, the TUI now shows a modal similar to the tool-call limit modal. Users can choose 'Continue' to reset the guardrail and let the agent try a different approach, or 'Stop' to end the turn gracefully.

### Changes
- Generalize LimitModal with optional title/description props
- Add onLoopDetected callback to AgentCallbacks
- Wire loop modal state, refs, and cleanup in app.tsx
- Preserve AgentLoopError throw for SDK/print-mode consumers

Co-authored-by: kimiflare <kimiflare@proton.me>