### PR TITLE
feat(agent): move pre-turn memory recall and skill routing into supervisor lifecycle

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -6,12 +6,18 @@ import { sanitizeString, stableStringify, stripOldImages } from "./messages.js";
 import type { ChatMessage, ToolCall, Usage } from "./messages.js";
 import type { Task } from "../tools/registry.js";
 import type { MemoryManager } from "../memory/manager.js";
+import type { HybridResult } from "../memory/schema.js";
 import { logTurnDebug, analyzePrompt } from "../cost-debug.js";
 import { EXTRACTORS } from "../memory/extractors.js";
 import { stripHistoricalReasoning } from "./strip-reasoning.js";
 import { generateTypeScriptApi, runInSandbox } from "../code-mode/index.js";
 import { estimatePromptTokens } from "./artifact-compaction.js";
 import { logger } from "../util/logger.js";
+import { selectSkills } from "../skills/router.js";
+import type { SemanticSkillRoutingResult } from "../skills/types.js";
+import type Database from "better-sqlite3";
+import { buildSystemPrompt, buildSessionPrefix } from "./system-prompt.js";
+import type { Mode } from "../mode.js";
 
 export interface AgentCallbacks {
   onAssistantStart?: () => void;
@@ -40,6 +46,12 @@ export interface AgentCallbacks {
   onLoopDetected?: () => Promise<"continue" | "stop">;
   /** Called when accumulated high-signal memories suggest KIMI.md may be stale. */
   onKimiMdStale?: () => void;
+  /** Called when session-start memory recall succeeds and memories are injected. */
+  onMemoryRecalled?: (count: number) => void;
+  /** Called when semantic skill routing completes. */
+  onSkillsSelected?: (result: SemanticSkillRoutingResult) => void;
+  /** Called after pre-turn setup (memory + skills) to emit the meta banner. */
+  onMetaBanner?: (info: { intentTier: string; skillsActive: number; memoryRecalled: boolean }) => void;
 }
 
 export interface AgentTurnOpts {
@@ -83,6 +95,25 @@ export interface AgentTurnOpts {
   cloudDeviceId?: string;
   /** Shell override for the bash tool. If omitted, the tool auto-detects based on platform. */
   shell?: string;
+  /** Session-start memory recall promise. If provided, awaited at turn start and injected into messages. */
+  sessionStartRecall?: Promise<HybridResult[]>;
+  /** Skills DB for semantic skill routing. */
+  skillsDb?: Database.Database;
+  /** Config for skill routing. */
+  skillRoutingConfig?: {
+    accountId: string;
+    apiToken: string;
+    embeddingModel?: string;
+    gateway?: AiGatewayOptions;
+    cloudMode?: boolean;
+    cloudToken?: string;
+    cloudDeviceId?: string;
+    maxSkillTokens?: number;
+  };
+  /** Current mode for system prompt. */
+  mode?: Mode;
+  /** Whether to use cache-stable prompt assembly (dual system messages). */
+  cacheStable?: boolean;
 }
 
 export class BudgetExhaustedError extends Error {
@@ -128,11 +159,132 @@ const MAX_PROMPT_TOKENS = 240_000;
  *  ~10k chars ≈ 2,500 tokens — generous but prevents runaway growth. */
 const MAX_TOOL_CONTENT_CHARS = 10_000;
 
+function raceWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      if (signal.aborted) {
+        reject(new DOMException("aborted", "AbortError"));
+      } else {
+        signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+      }
+    }),
+  ]);
+}
+
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const turnStart = performance.now();
   logger.info("turn:start", { sessionId: opts.sessionId, codeMode: opts.codeMode ?? false });
   const max = opts.maxToolIterations ?? 50;
   const codeMode = opts.codeMode ?? false;
+
+  // --- Pre-turn async work (memory recall + skill routing) ---
+  let memoryRecalledCount = 0;
+  let skillResult: SemanticSkillRoutingResult | undefined;
+
+  if (opts.sessionStartRecall) {
+    try {
+      const results = await raceWithSignal(opts.sessionStartRecall, opts.signal);
+      if (results.length > 0 && opts.memoryManager) {
+        const text = await raceWithSignal(
+          opts.memoryManager.synthesizeRecalled(results, opts.signal),
+          opts.signal,
+        );
+        memoryRecalledCount = results.length;
+        // Insert after existing system messages, before any user messages
+        const lastSystemIdx = opts.messages.findLastIndex((m) => m.role === "system");
+        const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : opts.messages.length;
+        opts.messages.splice(insertIdx, 0, { role: "system", content: text });
+        opts.callbacks.onMemoryRecalled?.(results.length);
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      // Non-fatal: session works fine without recalled memories
+    }
+  }
+
+  if (opts.signal.aborted) {
+    throw new DOMException("aborted", "AbortError");
+  }
+
+  if (opts.skillsDb && opts.skillRoutingConfig && opts.intentClassification) {
+    try {
+      const lastUserMsg = [...opts.messages].reverse().find((m) => m.role === "user");
+      const prompt =
+        typeof lastUserMsg?.content === "string"
+          ? lastUserMsg.content
+          : Array.isArray(lastUserMsg?.content)
+            ? lastUserMsg.content
+                .filter((p): p is { type: "text"; text: string } => p.type === "text")
+                .map((p) => p.text)
+                .join(" ")
+            : "";
+      if (prompt) {
+        skillResult = await raceWithSignal(
+          selectSkills(
+            {
+              prompt,
+              tier: opts.intentClassification.tier,
+              maxSkillTokens: opts.skillRoutingConfig.maxSkillTokens ?? 250_000 - 10_000,
+            },
+            {
+              db: opts.skillsDb,
+              accountId: opts.skillRoutingConfig.accountId,
+              apiToken: opts.skillRoutingConfig.apiToken,
+              embeddingModel: opts.skillRoutingConfig.embeddingModel,
+              gateway: opts.skillRoutingConfig.gateway,
+              cloudMode: opts.skillRoutingConfig.cloudMode,
+              cloudToken: opts.skillRoutingConfig.cloudToken,
+              cloudDeviceId: opts.skillRoutingConfig.cloudDeviceId,
+            },
+          ),
+          opts.signal,
+        );
+        opts.callbacks.onSkillsSelected?.(skillResult);
+
+        // Rebuild system prompt with skill context
+        const allTools = opts.tools;
+        if (opts.cacheStable) {
+          // Index 1 = session prefix (index 0 = static prefix)
+          opts.messages[1] = {
+            role: "system",
+            content: buildSessionPrefix({
+              cwd: opts.cwd,
+              tools: allTools,
+              model: opts.model,
+              mode: opts.mode,
+              skillContext: skillResult.skillContext,
+            }),
+          };
+        } else {
+          // Index 0 = single system prompt
+          opts.messages[0] = {
+            role: "system",
+            content: buildSystemPrompt({
+              cwd: opts.cwd,
+              tools: allTools,
+              model: opts.model,
+              mode: opts.mode,
+              skillContext: skillResult.skillContext,
+            }),
+          };
+        }
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      // Non-fatal: skills are optional
+    }
+  }
+
+  if (opts.signal.aborted) {
+    throw new DOMException("aborted", "AbortError");
+  }
+
+  opts.callbacks.onMetaBanner?.({
+    intentTier: opts.intentClassification?.tier ?? "medium",
+    skillsActive: skillResult?.sectionCount ?? 0,
+    memoryRecalled: memoryRecalledCount > 0,
+  });
 
   let toolDefs: ReturnType<typeof toOpenAIToolDefs>;
   let codeModeApiString = "";

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -11,7 +11,7 @@ import { runAgentTurn } from "./loop.js";
 import type { AgentTurnOpts } from "./loop.js";
 import { logger } from "../util/logger.js";
 
-export type TurnPhase = "idle" | "streaming" | "executing" | "compacting" | "error";
+export type TurnPhase = "idle" | "preparing" | "streaming" | "executing" | "compacting" | "error";
 
 export interface SupervisorCallbacks {
   onDone?: () => void;
@@ -40,7 +40,7 @@ export class TurnSupervisor {
       logger.warn("supervisor:start_rejected", { reason: "turn_already_running", phase: this._phase });
       throw new Error("TurnSupervisor: turn already in progress");
     }
-    this._phase = "streaming";
+    this._phase = "preparing";
     this._killRequested = false;
     logger.debug("supervisor:turn_start", { sessionId: opts.sessionId });
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -729,7 +729,7 @@ function App({
   const lspInitRef = useRef(false);
   const busyRef = useRef(busy);
   const memoryManagerRef = useRef<MemoryManager | null>(null);
-  const sessionStartRecallRef = useRef<Promise<void> | null>(null);
+  const sessionStartRecallRef = useRef<Promise<import("./memory/schema.js").HybridResult[]> | null>(null);
   const kimiMdStaleNudgedRef = useRef(false);
   const turnCounterRef = useRef(0);
 
@@ -1011,27 +1011,11 @@ function App({
         }
       });
 
-      // Fire session-start recall so the model walks in with context.
-      // The promise is awaited in submit() before the first user message.
+      // Fire session-start recall in the background so results are ready by the
+      // time the first turn starts. Synthesis and injection happen inside
+      // runAgentTurn so they are covered by the turn's abort signal.
       const cwd = process.cwd();
-      sessionStartRecallRef.current = (async () => {
-        try {
-          const results = await manager.recall({ text: cwd, repoPath: cwd, limit: 5 });
-          if (results.length > 0) {
-            const text = await manager.synthesizeRecalled(results);
-            // Insert after existing system messages, before any user messages
-            const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
-            const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
-            messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
-            setEvents((e) => [
-              ...e,
-              { kind: "memory", key: mkKey(), text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} about this repo` },
-            ]);
-          }
-        } catch {
-          // Non-fatal: session works fine without recalled memories
-        }
-      })();
+      sessionStartRecallRef.current = manager.recall({ text: cwd, repoPath: cwd, limit: 5 });
 
       // Session-start drift check (Trigger A): if KIMI.md exists and high-signal
       // memories have been learned since the last refresh, mark as stale.
@@ -3458,34 +3442,6 @@ function App({
         sessionTitleRef.current = generateSessionTitle(trimmed, classification.intent);
       }
 
-      // Route skills based on intent tier (semantic search)
-      let skillResult: SemanticSkillRoutingResult | undefined;
-      try {
-        const db = getMemoryDb();
-        if (db) {
-          skillResult = await selectSkills(
-            {
-              prompt: trimmed,
-              tier: classification.tier,
-              maxSkillTokens: CONTEXT_LIMIT - 10_000, // leave headroom
-            },
-            {
-              db,
-              accountId: cfg.accountId,
-              apiToken: cfg.apiToken,
-              embeddingModel: cfg.memoryEmbeddingModel,
-              gateway: gatewayFromConfig(cfg),
-              cloudMode: cfg.cloudMode,
-              cloudToken: cloudToken ?? initialCloudToken,
-              cloudDeviceId: cloudDeviceId ?? initialCloudDeviceId,
-            },
-          );
-          setSkillsActive(skillResult.sectionCount);
-        }
-      } catch {
-        setSkillsActive(0);
-      }
-
       const effortForTier: Record<string, ReasoningEffort> = {
         light: "low",
         medium: "medium",
@@ -3495,45 +3451,12 @@ function App({
       const effectiveCodeMode = classification.tier === "heavy";
       setCodeMode(effectiveCodeMode);
 
-      // Inject selected skills into system prompt
-      if (cacheStableRef.current) {
-        messagesRef.current[1] = {
-          role: "system",
-          content: buildSessionPrefix({
-            cwd: process.cwd(),
-            tools: [...ALL_TOOLS, ...mcpToolsRef.current, ...lspToolsRef.current],
-            model: cfg.model,
-            mode: modeRef.current,
-            skillContext: skillResult?.skillContext,
-          }),
-        };
-      } else {
-        messagesRef.current[0] = {
-          role: "system",
-          content: buildSystemPrompt({
-            cwd: process.cwd(),
-            tools: [...ALL_TOOLS, ...mcpToolsRef.current, ...lspToolsRef.current],
-            model: cfg.model,
-            mode: modeRef.current,
-            skillContext: skillResult?.skillContext,
-          }),
-        };
-      }
-
-      // Emit metadata banner
-      setEvents((e) => [
-        ...e,
-        {
-          kind: "meta",
-          key: mkKey(),
-          intentTier: classification.tier,
-          skillsActive: skillResult?.sectionCount ?? 0,
-          memoryRecalled: false,
-        },
-      ]);
-
       const turnScope = sessionScopeRef.current.createChild();
       activeScopeRef.current = turnScope;
+
+      // Pre-turn async work (session-start memory recall + skill routing) is
+      // performed inside runAgentTurn so it is covered by the supervisor
+      // lifecycle and the turn's abort signal.
 
       const sharedCallbacks = {
         onAssistantStart: () => {
@@ -3701,6 +3624,27 @@ function App({
             ]);
           }
         },
+        onMemoryRecalled: (count: number) => {
+          setEvents((e) => [
+            ...e,
+            { kind: "memory", key: mkKey(), text: `recalled ${count} memory${count === 1 ? "" : "ies"} about this repo` },
+          ]);
+        },
+        onSkillsSelected: (result: SemanticSkillRoutingResult) => {
+          setSkillsActive(result.sectionCount);
+        },
+        onMetaBanner: (info: { intentTier: string; skillsActive: number; memoryRecalled: boolean }) => {
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "meta",
+              key: mkKey(),
+              intentTier: info.intentTier as "light" | "medium" | "heavy",
+              skillsActive: info.skillsActive,
+              memoryRecalled: info.memoryRecalled,
+            },
+          ]);
+        },
       };
 
       const cleanupTurn = () => {
@@ -3735,6 +3679,9 @@ function App({
         );
       };
 
+      // Clear the one-shot session-start recall so it is not reused.
+      sessionStartRecallRef.current = null;
+
       supervisorRef.current.startTurn(
         {
           accountId: cfg.accountId,
@@ -3761,6 +3708,20 @@ function App({
           cloudDeviceId: cloudDeviceId ?? initialCloudDeviceId,
           onIterationEnd,
           intentClassification: classification,
+          sessionStartRecall: sessionStartRecallRef.current ?? undefined,
+          skillsDb: getMemoryDb() ?? undefined,
+          skillRoutingConfig: {
+            accountId: cfg.accountId,
+            apiToken: cfg.apiToken,
+            embeddingModel: cfg.memoryEmbeddingModel,
+            gateway: gatewayFromConfig(cfg),
+            cloudMode: cfg.cloudMode,
+            cloudToken: cloudToken ?? initialCloudToken,
+            cloudDeviceId: cloudDeviceId ?? initialCloudDeviceId,
+            maxSkillTokens: CONTEXT_LIMIT - 10_000,
+          },
+          mode: modeRef.current,
+          cacheStable: cacheStableRef.current,
           onFileChange: (path, content) => {
             if (content) {
               lspManagerRef.current.notifyChange(path, content);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3373,12 +3373,6 @@ function App({
         }
       }
 
-      // Ensure session-start memory recall has settled before the first turn
-      if (sessionStartRecallRef.current) {
-        await sessionStartRecallRef.current;
-        sessionStartRecallRef.current = null;
-      }
-
       if (opts?.queuedKey) {
         setEvents((evts) =>
           evts.map((e) =>

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -246,6 +246,18 @@ export function updateAccessedAt(db: Database.Database, ids: string[]): void {
   updateMany(ids);
 }
 
+/** Escape a raw query string for safe use in FTS5 MATCH.
+ *  Splits on whitespace, quotes each token, and adds a prefix wildcard.
+ *  This prevents syntax errors from special characters like /, -, etc.
+ */
+function escapeFts5(query: string): string {
+  return query
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .map((t) => `"${t.replace(/"/g, '""')}"*`)
+    .join(" ");
+}
+
 export function searchMemoriesFts(
   db: Database.Database,
   query: string,
@@ -254,7 +266,7 @@ export function searchMemoriesFts(
   agentRole?: string
 ): Array<{ memory: Memory; rank: number }> {
   const conditions: string[] = ["memories_fts MATCH ?", "m.forgotten = 0", "m.superseded_by IS NULL", "m.category != 'task'"];
-  const params: (string | number)[] = [`${query}*`];
+  const params: (string | number)[] = [escapeFts5(query)];
 
   if (repoPath) {
     conditions.push("m.repo_path = ?");


### PR DESCRIPTION
Previously, session-start memory recall and semantic skill selection were performed in `app.tsx`'s `processMessage()` before `supervisor.startTurn()` was called. This blocked the UI for 1-2 seconds on the first message: the user message did not appear and Escape could not interrupt because `busyRef` and `activeScopeRef` were not yet set.

This change moves all pre-turn async work into `runAgentTurn` so it is fully covered by the `TurnSupervisor` lifecycle and the turn's `AbortSignal`:

- `TurnSupervisor` gains a `'preparing'` phase that covers memory + skill work.
- `runAgentTurn` awaits session-start recall and skill selection at its start, racing both against the abort signal so Escape kills them immediately.
- Recalled memories and selected skills are injected into messages before the first LLM call, exactly as before, but now without blocking the UI thread.
- `app.tsx` shows the user message and sets busy immediately, then delegates pre-turn work to the supervisor.

Fixes the trust issue where users could not regain control during the first message of a session when memory was enabled.

**Testing:**
- `npm run typecheck` passes
- All 385 tests pass

Co-authored-by: kimiflare <kimiflare@proton.me>