### PR TITLE
fix(cloud): TUI cloud auth now passes credentials directly and persists cloudMode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,6 +32,7 @@ import { KimiApiError, isCloudQuotaExhaustedError, isKillSwitchError, humanizeCl
 import { AbortScope } from "./util/abort-scope.js";
 import { logger } from "./util/logger.js";
 import { buildReport, sendReport } from "./cloud/report.js";
+import type { CloudCredentials } from "./cloud/auth.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
@@ -3963,13 +3964,13 @@ function App({
       <ThemeProvider theme={theme}>
         <Onboarding
         onCancel={() => exit()}
-        onDone={async (newCfg) => {
+        onDone={async (newCfg, cloudCredentials) => {
           setCfg(newCfg);
           if (newCfg.cloudMode) {
-            const { loadCloudCredentials } = await import("./cloud/auth.js");
-            const creds = await loadCloudCredentials();
+            const creds = cloudCredentials;
             if (creds) {
               setCloudToken(creds.accessToken);
+              setCloudDeviceId(creds.deviceId);
               setEvents((e) => [
                 ...e,
                 { kind: "info", key: mkKey(), text: "configuration saved — welcome to kimiflare! (cloud mode)" },

--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -212,6 +212,7 @@ export async function loadCloudCredentials(): Promise<CloudCredentials | null> {
 
 export async function saveCloudCredentials(creds: CloudCredentials): Promise<void> {
   const p = cloudCredPath();
+  await mkdir(join(p, ".."), { recursive: true });
   await writeFile(p, JSON.stringify(creds, null, 2), "utf8");
   if (creds.deviceId) {
     await persistDeviceId(creds.deviceId).catch(() => { /* ignore */ });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { loadConfig, DEFAULT_MODEL } from "./config.js";
+import { loadConfig, saveConfig, DEFAULT_MODEL } from "./config.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
 import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
 import { KimiApiError, isKillSwitchError, humanizeCloudflareError } from "./util/errors.js";
@@ -111,6 +111,15 @@ program
             }
           });
           console.log(`Authenticated! Token expires at ${new Date(creds.expiresAt * 1000).toISOString()}`);
+
+          // Also enable cloud mode in config so the user doesn't need --cloud on every run
+          const existing = await loadConfig();
+          await saveConfig({
+            accountId: "",
+            apiToken: "",
+            model: existing?.model ?? DEFAULT_MODEL,
+            cloudMode: true,
+          });
 
           // Fetch usage info
           const { fetchCloudUsage } = await import("./cloud/auth.js");

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -24,7 +24,7 @@ import { isKillSwitchError } from "../util/errors.js";
 const execAsync = promisify(exec);
 
 interface Props {
-  onDone: (cfg: { accountId: string; apiToken: string; model: string; cloudMode?: boolean }) => void;
+  onDone: (cfg: { accountId: string; apiToken: string; model: string; cloudMode?: boolean }, cloudCredentials?: CloudCredentials) => void;
   onCancel?: () => void;
 }
 
@@ -178,7 +178,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
     try {
       const path = await saveConfig(cfg);
       setSavedPath(path);
-      onDone(cfg);
+      onDone(cfg, cloudAuth.creds);
     } catch (e) {
       setSavedPath(`error: ${(e as Error).message}`);
     }


### PR DESCRIPTION
## Problem

When logging in via TUI onboarding (selecting "Cloud (managed)"), users would get authentication errors on their first message:
- "Authentication required. Please check your API token or run `kimiflare auth cloud` if using cloud mode."
- "Authentication failed. Check that your Cloudflare API token has the 'Workers AI' permission."

However, running `kimiflare auth cloud` from CLI worked fine.

## Root Cause

1. **TUI onboarding** saved credentials to disk but never passed them to the parent `App` component. `App` tried to reload them from disk via `loadCloudCredentials()`, which could fail or race, leaving `cloudToken` undefined.
2. Even when credentials loaded, `App` only set `cloudToken` state — not `cloudDeviceId`. API requests went out without the `X-Device-ID` header.
3. `saveCloudCredentials` didn't mkdir the config directory defensively.
4. `kimiflare auth cloud` didn't write `cloudMode: true` to config, so users still needed `--cloud` on every run.

## Changes

- **`src/ui/onboarding.tsx`**: `onDone` prop now accepts optional `CloudCredentials`; passes them directly from successful auth.
- **`src/app.tsx`**: `onDone` handler receives credentials and sets both `cloudToken` and `cloudDeviceId` state immediately.
- **`src/cloud/auth.ts`**: `saveCloudCredentials` now mkdirs the config directory.
- **`src/index.tsx`**: `auth cloud` now also persists `cloudMode: true` to config.

## Testing

- `npm run typecheck` passes
- `npm test` passes (385/385)

Co-authored-by: kimiflare <kimiflare@proton.me>