### PR TITLE
feat(ui): add 'Synthesize' option to loop detection modal

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -42,8 +42,9 @@ export interface AgentCallbacks {
    *  reset the counter and keep going, or "stop" to end the turn immediately. */
   onToolLimitReached?: () => Promise<"continue" | "stop">;
   /** Called when the agent is detected repeating identical tool calls (loop). Return "continue" to
-   *  reset the guardrail and keep going, or "stop" to end the turn immediately. */
-  onLoopDetected?: () => Promise<"continue" | "stop">;
+   *  reset the guardrail and keep going, "synthesize" to ask the agent to conclude without tools,
+   *  or "stop" to end the turn immediately. */
+  onLoopDetected?: () => Promise<"continue" | "stop" | "synthesize">;
   /** Called when accumulated high-signal memories suggest KIMI.md may be stale. */
   onKimiMdStale?: () => void;
   /** Called when session-start memory recall succeeds and memories are injected. */
@@ -865,9 +866,19 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           loopExhausted = false;
           recentToolCalls.length = 0;
           continue;
-        } else {
-          return;
         }
+        if (decision === "synthesize") {
+          opts.messages.push({
+            role: "system",
+            content:
+              "You were stuck calling the same tools with identical arguments. " +
+              "Please synthesize and conclude your findings so far. Do not call any more tools.",
+          });
+          loopExhausted = false;
+          recentToolCalls.length = 0;
+          continue;
+        }
+        return;
       }
       throw new AgentLoopError();
     }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -36,7 +36,7 @@ import type { CloudCredentials } from "./cloud/auth.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
-import { LimitModal, type LimitDecision } from "./ui/limit-modal.js";
+import { LimitModal, type LimitDecision, type LoopDecision } from "./ui/limit-modal.js";
 import { ResumePicker } from "./ui/resume-picker.js";
 import { CheckpointPicker } from "./ui/checkpoint-picker.js";
 import { TaskList } from "./ui/task-list.js";
@@ -556,7 +556,7 @@ function App({
   const [showReasoning, setShowReasoning] = useState(false);
   const [perm, setPerm] = useState<PendingPermission | null>(null);
   const [limitModal, setLimitModal] = useState<{ limit: number; resolve: (d: LimitDecision) => void } | null>(null);
-  const [loopModal, setLoopModal] = useState<{ resolve: (d: LimitDecision) => void } | null>(null);
+  const [loopModal, setLoopModal] = useState<{ resolve: (d: LoopDecision) => void } | null>(null);
   const [queue, setQueue] = useState<Array<{ full: string; display: string; key: string }>>([]);
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
@@ -704,7 +704,7 @@ function App({
   const sigintHandlerRef = useRef<(() => void) | null>(null);
   const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
   const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
-  const loopResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
+  const loopResolveRef = useRef<((d: LoopDecision) => void) | null>(null);
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
   const sessionIdRef = useRef<string | null>(null);
   const sessionCreatedAtRef = useRef<string | null>(null);
@@ -3605,7 +3605,7 @@ function App({
             setLimitModal({ limit: 50, resolve });
           }),
         onLoopDetected: () =>
-          new Promise<LimitDecision>((resolve) => {
+          new Promise<LoopDecision>((resolve) => {
             loopResolveRef.current = resolve;
             setLoopModal({ resolve });
           }),
@@ -4225,6 +4225,10 @@ function App({
             limit={50}
             title="Agent stuck in a loop"
             description="The agent kept calling the same tools with identical arguments. What would you like to do?"
+            items={[
+              { label: "Continue", value: "continue" },
+              { label: "Synthesize", value: "synthesize" },
+            ]}
             onDecide={(d) => {
               loopModal.resolve(d);
               loopResolveRef.current = null;

--- a/src/ui/limit-modal.tsx
+++ b/src/ui/limit-modal.tsx
@@ -4,20 +4,23 @@ import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 
 export type LimitDecision = "continue" | "stop";
+export type LoopDecision = "continue" | "stop" | "synthesize";
 
-interface Props {
+interface Props<T extends string = LimitDecision> {
   limit: number;
-  onDecide: (decision: LimitDecision) => void;
+  onDecide: (decision: T) => void;
   title?: string;
   description?: string;
+  items?: Array<{ label: string; value: T }>;
 }
 
-export function LimitModal({ limit, onDecide, title, description }: Props) {
+export function LimitModal<T extends string = LimitDecision>({ limit, onDecide, title, description, items }: Props<T>) {
   const theme = useTheme();
-  const items = [
-    { label: "Continue", value: "continue" as const },
-    { label: "Stop", value: "stop" as const },
+  const defaultItems = [
+    { label: "Continue", value: "continue" as T },
+    { label: "Stop", value: "stop" as T },
   ];
+  const selectItems = items ?? defaultItems;
 
   return (
     <Box flexDirection="column" borderStyle="round" borderColor={theme.error} paddingX={1}>
@@ -29,7 +32,7 @@ export function LimitModal({ limit, onDecide, title, description }: Props) {
       </Text>
       <Box marginTop={1}>
         <SelectInput
-          items={items}
+          items={selectItems}
           onSelect={(item) => onDecide(item.value)}
         />
       </Box>


### PR DESCRIPTION
When the agent is stuck calling the same tools with identical arguments, the modal now offers two choices:

- **Continue** — reset the guardrail and keep going (existing behavior)
- **Synthesize** — ask the agent to conclude its findings without calling any more tools

The tool-call limit modal retains its original Continue/Stop choices. This is fully backward compatible.

### Changes
- `LimitModal` now accepts an optional `items` prop for custom choice lists
- New `LoopDecision` type (`continue | stop | synthesize`) separate from `LimitDecision`
- Agent loop handles `synthesize` by injecting a system message asking the agent to wrap up

Co-authored-by: kimiflare <kimiflare@proton.me>