### PR TITLE
fix(feedback-worker): stop microphone stream leaks after recording

### DIFF
--- a/feedback-worker/src/index.ts
+++ b/feedback-worker/src/index.ts
@@ -377,8 +377,9 @@ async function htmlPage(session: string, version: string, pageUrl: string): Prom
 
   async function listMics() {
     try {
-      await navigator.mediaDevices.getUserMedia({ audio: true });
+      const tempStream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const devices = await navigator.mediaDevices.enumerateDevices();
+      tempStream.getTracks().forEach(t => t.stop());
       micDevices = devices.filter(d => d.kind === 'audioinput');
       const select = $('mic-select');
       select.innerHTML = '';
@@ -426,7 +427,7 @@ async function htmlPage(session: string, version: string, pageUrl: string): Prom
   function stopRecording() {
     if (!mediaRecorder || mediaRecorder.state === 'inactive') return;
     mediaRecorder.stop();
-    if (stream) { stream.getTracks().forEach(t => t.stop()); }
+    if (stream) { stream.getTracks().forEach(t => t.stop()); stream = null; }
     stopTimer();
     isRecording = false;
     if (meterRaf) { cancelAnimationFrame(meterRaf); meterRaf = null; }
@@ -476,6 +477,7 @@ async function htmlPage(session: string, version: string, pageUrl: string): Prom
     chunks = [];
     mediaRecorder.ondataavailable = e => { if (e.data.size > 0) chunks.push(e.data); };
     mediaRecorder.onstop = () => {
+      if (stream) { stream.getTracks().forEach(t => t.stop()); stream = null; }
       const type = mime || 'audio/webm';
       audioBlob = new Blob(chunks, { type });
       if (audioBlob.size === 0) {


### PR DESCRIPTION
Fixes the issue where the browser tab continued showing the mic as active (orange indicator on iOS) even after the user finished recording and sent feedback.

Changes:
- listMics() now stops the temporary getUserMedia stream after enumerating devices
- stopRecording() nulls out the stream reference after stopping tracks
- mediaRecorder.onstop defensively cleans up the stream as a backup