### PR TITLE
docs: strike through Kimiflare Cloud mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 | Mode | How it works | Best for |
 |------|-------------|----------|
 | **BYOK** | Bring your own Cloudflare Account ID + API Token. Traffic goes straight to Workers AI from your account. | Power users who want full control and direct billing. |
-| **Kimiflare Cloud** | Device auth — no API key needed. We proxy requests through our managed endpoint. | Getting started quickly without a Cloudflare account. |
+| ~~**Kimiflare Cloud**~~ | ~~Device auth — no API key needed. We proxy requests through our managed endpoint.~~ | ~~Getting started quickly without a Cloudflare account.~~ |
 
-> 🎁 **Try Kimiflare Cloud free** — sign up and get **5 million tokens** on us until May 14, 2026. Run `kimiflare --cloud` or pick "Cloud (managed)" during onboarding.
+> ~~🎁 **Try Kimiflare Cloud free** — sign up and get **5 million tokens** on us until May 14, 2026. Run `kimiflare --cloud` or pick "Cloud (managed)" during onboarding.~~
 
 ## What to remember
 
@@ -66,7 +66,7 @@ npm install -g kimiflare
 kimiflare
 ```
 
-On first run, an interactive onboarding wizard asks how you want to connect — BYOK or Cloud. That's it.
+On first run, an interactive onboarding wizard asks how you want to connect — BYOK ~~or Cloud~~. That's it.
 
 Or run without installing:
 
@@ -148,7 +148,7 @@ const { session } = await createAgentSession({
 });
 ```
 
-**For zero-credential onboarding**, use KimiFlare Cloud mode. The user authenticates via GitHub device flow and a Cloudflare Worker proxies AI requests. Your app never sees raw Cloudflare credentials — only a GitHub token and `remoteWorkerUrl`.
+~~**For zero-credential onboarding**, use KimiFlare Cloud mode. The user authenticates via GitHub device flow and a Cloudflare Worker proxies AI requests. Your app never sees raw Cloudflare credentials — only a GitHub token and `remoteWorkerUrl`.~~
 
 #### RPC mode (subprocess)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -714,7 +714,7 @@
       Claude Code alternative, on your own Cloudflare account.
     </h1>
     <p class="hero-subtitle fade-in delay-2">
-      An open-source terminal coding agent powered by Kimi K2.6. Run on your own Cloudflare account (BYOK) or try Kimiflare Cloud — no API key needed.
+      An open-source terminal coding agent powered by Kimi K2.6. Run on your own Cloudflare account (BYOK)<s> or try Kimiflare Cloud — no API key needed</s>.
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
@@ -729,7 +729,7 @@
 
     <div class="fade-in delay-3" style="margin-top: 1.5rem; padding: 0.75rem 1rem; background: var(--accent-dim); border: 1px solid var(--accent); border-radius: 8px; max-width: 480px;">
       <p style="font-size: 0.85rem; color: var(--text); margin: 0;">
-        <strong>Try Kimiflare Cloud free</strong> — get <strong>5 million tokens</strong> on us until May 14, 2026. After that, bring your own Cloudflare key.
+        <s><strong>Try Kimiflare Cloud free</strong> — get <strong>5 million tokens</strong> on us until May 14, 2026. After that, bring your own Cloudflare key.</s>
       </p>
     </div>
 
@@ -853,7 +853,7 @@
             <li>Extensible JSON themes with WCAG contrast validation</li>
             <li>KIMI.md drift detection with memory-based staleness</li>
             <li>Fuzzy @ file picker with inline filtering</li>
-            <li>Kimiflare Cloud mode — device auth, no API key</li>
+            <li><s>Kimiflare Cloud mode — device auth, no API key</s></li>
             <li>Context-window guardrails</li>
           </ul>
         </div>
@@ -940,8 +940,8 @@
       </div>
       <div class="feature-item">
         <span class="feature-num">13</span>
-        <h3>Kimiflare Cloud mode</h3>
-        <p>Device auth — no API key needed. Get started in seconds with a managed proxy and real-time token budget tracking. 5 million free tokens until May 14, 2026.</p>
+        <h3><s>Kimiflare Cloud mode</s></h3>
+        <p><s>Device auth — no API key needed. Get started in seconds with a managed proxy and real-time token budget tracking. 5 million free tokens until May 14, 2026.</s></p>
       </div>
       <div class="feature-item">
         <span class="feature-num">14</span>
@@ -1005,11 +1005,11 @@
 <span class="c"># Install</span><br>
 <span class="v">npm</span> install -g kimiflare<br>
 <br>
-<span class="c"># Run — onboarding asks BYOK or Cloud</span><br>
+<span class="c"># Run — onboarding asks BYOK <s>or Cloud</s></span><br>
 <span class="v">kimiflare</span><br>
 <br>
-<span class="c"># Or start in Cloud mode directly</span><br>
-<span class="v">kimiflare</span> --cloud
+<s><span class="c"># Or start in Cloud mode directly</span><br>
+<span class="v">kimiflare</span> --cloud</s>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Kimiflare Cloud was discontinued on 2026-05-13 (Cloudflare credits expired).
- Strike through (rather than remove) all Cloud mentions in `README.md` and `docs/index.html` to preserve historical context.

## Test plan
- [ ] Visual check of rendered README on GitHub
- [ ] Deploy landing page worker and verify strikethrough renders on hero subtitle, free-tokens callout, changelog item, feature card, and install snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)