### PR TITLE
docs(architecture): agent loop reference, findings, competitor analysis, and roadmap

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -1,0 +1,366 @@
+# Agent loop — red flags and opportunities
+
+Companion to [`agent-loop.md`](./agent-loop.md). Everything here is grounded
+in the code as it exists on the branch that introduced this document; line
+numbers will drift, but the underlying patterns are stable enough that a
+quick `rg` should re-locate any item.
+
+Each entry: short title, code reference, why it matters, suggested effort
+(**S** = ≤ 1 day, **M** = a few days, **L** = a week or more of focused
+work).
+
+> Context for prioritization: ~14k weekly NPM downloads and 145+ GitHub
+> stars at time of writing. We are past the "personal toy" phase — the
+> long tail of users notices roughness that wouldn't matter at 100 DL/wk.
+
+---
+
+## Red flags
+
+### RF-1 — Fire-and-forget memory extraction swallows errors (S → M)
+
+`src/agent/loop.ts:752–810`, error swallowed at `:806`.
+
+Memory extraction after each tool result is intentionally async and
+non-blocking, but the error path is a bare swallow with no logging, no
+counter, and no retry. If extraction is failing systemically (bad embedding
+endpoint, DB lock, schema mismatch), we never know. Visibility comes only
+from "memory recall is empty."
+
+**Fix:** route extraction errors through `onWarning` (already in the
+callback surface) at debug level; add a per-session error counter exposed
+in `/cost` or a `/memory health` subcommand.
+
+### RF-2 — Drift accumulator decays as fast as it fires (S)
+
+`DRIFT_THRESHOLD = 5` at `src/agent/loop.ts:138`, decay −1 per turn at turn
+end (~`loop.ts:825`).
+
+The `onKimiMdStale()` signal is meant to nudge users to refresh `KIMI.md`
+once a session has drifted. With a 5-event threshold and a 1-per-turn
+decay, it almost never fires on long sessions — the accumulator hovers
+near zero. The result is a feature that exists in code but rarely surfaces
+in the UI.
+
+**Fix:** either drop the decay to 0.5/turn (rounded fractional accumulator)
+or change the trigger to a sliding window (e.g., 3 high-signal memories
+in 10 turns).
+
+### RF-3 — Web-fetch spiral guardrail is per-turn only (S)
+
+`src/agent/loop.ts:609–666`.
+
+The `MAX_WEB_FETCH_PER_TURN = 5` and `WEB_FETCH_DOMAIN_THRESHOLD = 2`
+counters reset every turn. An agent that splits a research spiral across
+three turns can re-fetch the same domain ~15 times. Cheap to abuse.
+
+**Fix:** lift `totalWebFetches` and `domainCounts` to session state. Add a
+soft session cap (e.g., 25 fetches before a "synthesize what you have"
+nudge).
+
+### RF-4 — Anti-loop signature is sensitive to nonces (M)
+
+`src/agent/loop.ts:584–607`, signature = `name + stableStringify(args)`.
+
+If a tool's args contain a timestamp, request ID, or any non-deterministic
+field, two semantically identical calls produce different signatures and
+the guardrail never fires. Affects bash with `--date=now`, MCP tools that
+pass correlation IDs, any tool that mints a UUID internally before
+hashing.
+
+**Fix:** allow each `ToolSpec` to declare a `signatureKey(args)` projector
+that strips known nonce fields. Default falls back to current behavior.
+
+### RF-5 — Budget exhaustion only triggers when tools were called (S)
+
+`src/agent/loop.ts:530–574`. The condition is
+`cumulativePromptTokens >= maxInputTokens && toolCalls.length > 0`.
+
+A turn that ends with zero tool calls bypasses budget enforcement. In
+practice agents do sometimes emit long pure-text turns past the cap.
+
+**Fix:** evaluate budget on every iteration end; let the no-tools case
+short-circuit straight to `BudgetExhaustedError` instead of an extra
+synthesis turn.
+
+### RF-6 — `MAX_PROMPT_TOKENS = 240_000` hard error (S)
+
+`src/agent/loop.ts:157, 455–459`. Throws if the local estimate exceeds the
+cap.
+
+The estimator's accuracy isn't independently verified anywhere in the
+repo. If the estimate is conservative we throw early; if it's permissive
+we still hit the 256k Kimi context limit at the API. Either way, a hard
+throw at the loop boundary is a worse UX than a compaction prompt.
+
+**Fix:** at the cap, try one round of message compaction (drop oldest
+tool results, keep their artifacts) before throwing.
+
+### RF-7 — SSE idle timeout is global (S)
+
+`src/agent/client.ts:254`, default 60_000 ms.
+
+Cold Workers AI inferences on first-token-after-tool-use can exceed 60 s
+under load. There is no per-call override and no exponential extend on
+first-byte.
+
+**Fix:** expose `idleTimeoutMs` on the call options. Bonus: once the first
+data byte arrives, drop the idle timeout to 30 s — the model is alive.
+
+### RF-8 — Retry backoff has weak jitter (S)
+
+`src/agent/client.ts:116`, `500 * 2^attempt + random(0..250)`.
+
+Under a thundering herd (e.g., a Cloudflare incident affecting Workers
+AI), all clients retry on nearly identical schedules. The ±250 ms jitter
+window is too narrow at the larger waits.
+
+**Fix:** full-jitter backoff: `random(0, 500 * 2^attempt)`.
+
+### RF-9 — Artifact eviction is age-only (S)
+
+`src/agent/session-state.ts:82–88`.
+
+LRU-by-timestamp ignores artifact size. Evicting one 200 KB artifact
+frees more headroom than evicting five 5 KB ones, but the policy will
+prefer the latter.
+
+**Fix:** size-weighted LRU: pick the oldest item whose size would
+materially relieve pressure (e.g., evict the largest among the oldest
+quartile).
+
+### RF-10 — In-place mutation of `opts.messages` during skill rebuild (M)
+
+`src/agent/loop.ts:248–272`.
+
+The system message is mutated in place. If skill selection partially
+succeeds and a downstream step fails, the messages array is left in a
+hybrid state. Hard to reason about during error recovery and during
+checkpoint capture.
+
+**Fix:** snapshot messages, build the new system message into a local,
+swap atomically. Guarantees the array is always in one of two known
+states.
+
+### RF-11 — Code-mode API cache key ignores parameter schemas (S)
+
+`src/agent/loop.ts:293–328`. Cache key is `stableStringify(opts.tools)`,
+which includes tool names but is otherwise a simple identity hash.
+
+If a tool's parameter schema changes mid-session (e.g., user enables a new
+LSP capability that widens the rename payload), the cached generated API
+is stale. Code-mode-generated TS still compiles, but the runtime args may
+mismatch.
+
+**Fix:** include each tool's parameter schema digest in the cache key.
+
+### RF-12 — Tool output truncation is silent to the UI (S)
+
+`src/agent/loop.ts:704–708, 736–740`.
+
+The truncation banner (`[truncated: N chars omitted]`) appears in the
+model-facing message but nothing surfaces to the user. They cannot tell
+that important grep matches or bash output disappeared without
+re-running. The artifact store has the raw bytes — the UI just doesn't
+know.
+
+**Fix:** emit a `onTruncation(tool, rawBytes, reducedBytes, artifactId)`
+callback; render an inline hint in the TUI ("output truncated — use
+`expand artifact <id>` to view full").
+
+### RF-13 — Sync FS tools don't honor `ctx.signal` (M)
+
+`src/tools/read.ts`, `write.ts`, `edit.ts`, `glob.ts`, `grep.ts`.
+
+`AbortScope` propagates correctly to bash and the network tools, but the
+file-system tools never check `ctx.signal`. A grep over a large monorepo
+or a recursive glob can block Ctrl+C for many seconds. The user
+experience is "the TUI is frozen."
+
+**Fix:** in grep, check `signal.aborted` between batches. In glob, wire
+fast-glob's `signal` option (already supported upstream). In read on
+large files, switch to a streaming read that checks the signal between
+chunks. Edit and write are usually fast enough that a check-at-start is
+sufficient.
+
+### RF-14 — `src/app.tsx` is a 4,393-line god component (L)
+
+Single `App()` function with ~60 hooks managing session, pickers,
+modals, permissions, checkpoints, remote, theming, tasks, reasoning view,
+input handling, and slash commands. Every change touches risk for every
+other feature. Tests can only smoke-test the whole tree.
+
+**Fix:** progressive extraction. Start with the isolated pieces (already
+co-located but inlined):
+
+1. `PermissionController` — modal + decision threading.
+2. `PickerController` — file/mention/slash pickers share an underlying
+   state machine.
+3. `ModalHost` — limit, loop, command, LSP, theme, remote, inbox modals.
+4. `SessionManager` — load, resume, checkpoint, save.
+5. `TurnController` — supervisor wiring + status pills + reasoning view.
+6. `AppRoot` — what remains.
+
+After each extraction, the diff against `app.tsx` should shrink and the
+new module should ship with its own tests. Track this as a quarter-long
+effort, not a single PR.
+
+### RF-15 — LSP `restartAttempts` is dead state (S)
+
+`src/lsp/manager.ts`. The field exists but is never incremented. There is
+no auto-restart for crashed language servers; the session just shows the
+server as "crashed" and stops offering its tools.
+
+**Fix:** on `exit` with non-zero code, requeue start with exponential
+backoff up to N attempts (e.g., 3). Surface attempts in `/lsp status`.
+
+### RF-16 — MCP and LSP tool calls have no per-call timeout (M)
+
+`src/mcp/manager.ts`, `src/lsp/manager.ts`.
+
+A hung MCP server (slow upstream API, stuck stdio) blocks the agent turn
+indefinitely. The session-level abort can still fire, but the loop sits
+waiting on the tool call result until then.
+
+**Fix:** per-tool `timeoutMs` (default 30–60 s for MCP, 10 s for most LSP
+operations). Surface as a `ToolError` so the loop can recover the turn.
+
+### RF-17 — Resume after reducer-config change can misread artifacts (M)
+
+`src/agent/session-state.ts` + `src/tools/reducer.ts`.
+
+Artifact contents include reduction hints (e.g., grep "first 50 lines /
+3 matches per file"). Upgrading the reducer config changes the semantics
+of that hint but the artifact text doesn't carry the version. A resumed
+session may show stale framing.
+
+**Fix:** stamp each artifact with `{ reducerName, reducerVersion }`. On
+resume, if the version doesn't match, either re-reduce from raw (if
+present) or annotate the artifact as "reduced under an older config."
+
+### RF-18 — Bash co-author injection builds shell strings via regex (M)
+
+`src/tools/bash.ts`, `injectCoauthor()` (~lines 103–142 in the version
+this doc was written against).
+
+Forty lines of regex matching plus string assembly to add a `Co-authored-by:`
+trailer. The shell-escape story for the name and email is not obvious.
+If the inputs ever come from a user-controlled source without prior
+sanitization, this is a footgun.
+
+**Fix:** assemble the trailer with parameter-style escaping (or a known-
+good escape helper) rather than template strings; add a unit test with
+adversarial inputs (`"`, `$`, `;`, backticks).
+
+### RF-19 — `isolated-vm` → `node:vm` fallback warning fires once per process (S)
+
+`src/code-mode/sandbox.ts`, `fallbackWarningShown` flag.
+
+When the sandbox quietly downgrades from isolate to `node:vm`, the
+warning is printed once per process. New sessions in the same process
+(common when embedded via SDK) never see it. Users may not realize
+they're outside a true sandbox.
+
+**Fix:** track per session, not per process. Re-emit on each session
+start that uses code mode.
+
+---
+
+## Opportunities
+
+### Quick wins (S — pick most of these up in a week)
+
+- **OP-1.** Full-jitter retry backoff (fix for RF-8).
+- **OP-2.** Size-aware artifact eviction (fix for RF-9).
+- **OP-3.** `onTruncation` callback + TUI hint (fix for RF-12).
+- **OP-4.** Per-call SSE idle timeout knob (fix for RF-7).
+- **OP-5.** `signal.aborted` checks inside grep/glob/read inner loops
+  (fix for RF-13, first half).
+- **OP-6.** Cross-turn `webFetchHistory` (fix for RF-3).
+- **OP-7.** Memory extraction error counter + `/memory health` surface
+  (fix for RF-1).
+- **OP-8.** Sliding-window drift detection (fix for RF-2).
+- **OP-9.** Zero-tool-call budget check (fix for RF-5).
+- **OP-10.** Re-emit isolated-vm fallback warning per session
+  (fix for RF-19).
+
+### Medium investments (M)
+
+- **OP-11.** Pluggable reducer registry. Replace the switch-on-name in
+  `reducer.ts` with `registerReducer(toolName, fn)`. Lets MCP and skill-
+  defined tools bring their own reductions. Pairs with RF-12.
+- **OP-12.** Structured `ToolError { code, message, recoverable,
+  suggestion }`. Today tool errors are strings shoved into the result
+  content. A typed envelope unblocks reliable retry policies, lets the UI
+  render "try X" hints, and lets the loop decide whether to back off vs.
+  fail.
+- **OP-13.** Permission decision returns `{ decision, cached }`. Today
+  the loop cannot tell whether a permission was one-time or session-wide
+  (the callback returns just the decision, the executor decides the
+  caching separately). Pairs with the security audit story.
+- **OP-14.** Artifact reducer-version stamp (fix for RF-17).
+- **OP-15.** Per-call timeouts for MCP and LSP (fix for RF-16).
+- **OP-16.** LSP auto-restart with exponential backoff (fix for RF-15).
+- **OP-17.** Code-mode API freeze per turn. Generate the API once at turn
+  start, hash it, and ensure all `execute_code` calls in the turn see the
+  same snapshot. Eliminates RF-11.
+- **OP-18.** Capture top-level async rejections in the sandbox via
+  `.catch()` around the wrapper IIFE. Today rejected promises silently
+  vanish.
+
+### Bigger bets (L — quarter-scale)
+
+- **OP-19.** Break up `app.tsx` (RF-14). This is the single largest
+  velocity unlock. Until this happens, every UI change carries
+  disproportionate review and regression risk. Sequence it as six
+  extractions over a quarter, each shipping behind a no-op refactor PR.
+- **OP-20.** Structured JSON telemetry. Emit `{ timestamp, level, module,
+  event, fields }` to `~/.config/kimiflare/logs/` and optionally to a
+  user-configured Datadog / Honeycomb / OpenTelemetry collector. Per-tool
+  timing, retry attempts, truncation deltas, memory recall hit-rate,
+  budget headroom — all queryable. Today this kind of analysis requires
+  parsing session JSONs after the fact.
+- **OP-21.** Delta-encoded session checkpoints with zstd. Today each
+  checkpoint is a full snapshot; 1,000-turn sessions are unwieldy. Delta
+  + compression should bring typical sessions to a few hundred KB and
+  unlock much longer sessions without checkpoint storms.
+- **OP-22.** Circuit breaker for MCP servers. After N consecutive
+  failures from a single server, disable its tools for a cool-off and
+  notify the user. Today a flaky MCP server poisons every turn until the
+  user manually disables it.
+- **OP-23.** Quotas / budgets per tool (e.g., max bash calls per turn,
+  max bytes written per session). Complements the existing token budget
+  and the web-fetch guardrail.
+- **OP-24.** Cross-turn loop detection. Today the loop signature window
+  is per-turn (`recentToolCalls`). Lifting it to session state catches
+  the "same investigation, three turns running" pattern that current
+  guardrails miss.
+- **OP-25.** Multi-label cost attribution. The current classifier picks
+  one category per turn. Tagging tokens into a category mix (e.g., 60 %
+  feature, 40 % docs) matches reality better and improves the `/cost`
+  report.
+
+---
+
+## Suggested ordering
+
+A pragmatic next-quarter plan, balanced for risk and impact:
+
+1. **Sprint 1 (week 1):** OP-1 through OP-10 — the quick wins. Each is a
+   small, well-bounded PR.
+2. **Sprint 2 (week 2–3):** OP-12 (structured `ToolError`) and OP-13
+   (permission decision shape). These unblock cleaner code in subsequent
+   sprints.
+3. **Sprint 3 (week 4–5):** OP-15, OP-16 (timeouts + LSP auto-restart),
+   plus the RF-13 second half (proper streaming read).
+4. **Background, parallelizable:** start OP-19 (`app.tsx` breakup). Aim
+   for one extraction every two weeks.
+5. **Sprint 6 (week 8+):** OP-20 (structured telemetry). After this
+   ships, the rest of the roadmap becomes data-driven.
+6. **Stretch goals:** OP-21 (session checkpoint compression), OP-24
+   (cross-turn loop detection). Both require schema or protocol changes;
+   schedule alongside a release-please minor.
+
+This roadmap leaves untouched: protocol-level changes (e.g., a Kimi v2 API
+migration), GPU-side improvements (embedding model choice), and the
+remote/Cloud product line. Those belong in separate documents.

--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -1,0 +1,430 @@
+# Agent loop architecture
+
+A code-grounded reference for how a KimiFlare turn actually executes. Every
+non-trivial claim cites `file:line` against the source on the branch this
+document lives in — when in doubt, read the line.
+
+Scope: the spine from CLI entry to tool execution, plus the subsystems that
+plug into it. UI internals and the cost-attribution CLI are covered only where
+they intersect the loop. Findings (red flags, opportunities) live in the
+companion doc [`agent-loop-findings.md`](./agent-loop-findings.md).
+
+## The spine
+
+```
+src/index.tsx (Commander)
+        │
+        ▼
+src/app.tsx ─── TurnSupervisor ─── runAgentTurn() ── runKimi() ── Workers AI
+   (Ink TUI)    (supervisor.ts)    (loop.ts)         (client.ts)
+        │              │                │
+        │              │                ├── tools/executor.run() ── tools/*
+        │              │                │       │
+        │              │                │       └── reducer + artifact store
+        │              │                │
+        │              │                ├── memory recall / extraction (memory/)
+        │              │                ├── skill routing (skills/)
+        │              │                ├── code-mode sandbox (code-mode/)
+        │              │                └── guardrails (loop / web fetch)
+        │              │
+        │              └── phase events → UI
+        │
+        └── pickers, modals, permission prompts, checkpoints
+```
+
+A turn is a single call to `runAgentTurn(opts)`. Inside, the loop iterates
+streaming-LLM → tool-execution up to 50 times until the assistant emits a
+turn with zero tool calls (normal end), the budget is exhausted, every tool
+is blocked, or the abort signal fires.
+
+## 1. Entry — `src/index.tsx` (430 LOC)
+
+Commander dispatch. Three top-level modes:
+
+- **Interactive** (default): renders the Ink TUI from `app.tsx`.
+- **Print** (`-p, --print`): one-shot prompt, prints assistant text, exits.
+- **RPC** (`--mode rpc`): JSONL-over-stdio server, delegated to `sdk/rpc.ts`.
+
+Subcommands (memory, sessions, skills, cost, lsp, mcp, etc.) live in their own
+files imported here.
+
+Exit codes:
+
+| Code | Meaning                              | Where                                     |
+| ---: | ------------------------------------ | ----------------------------------------- |
+|    0 | Normal exit                          | —                                         |
+|    1 | Unhandled error                      | top-level catches                         |
+|    2 | Missing config                       | startup checks                            |
+|   42 | `BudgetExhaustedError`               | `src/index.tsx:392–393`                   |
+|   43 | `AgentLoopError` (all tools blocked) | `src/index.tsx:397–398`                   |
+
+Both error classes are exported from `src/agent/loop.ts:120,127` and thrown
+from inside the loop (see §5).
+
+## 2. TUI root — `src/app.tsx` (4,393 LOC)
+
+Single React/Ink `App()` component. State surface includes session, event
+log, input buffer, usage counters, permission decisions, pickers (file, slash,
+mention), modals (limit, loop, command, LSP, theme, remote, inbox),
+checkpoints, task list, reasoning view, themes, skill state, memory-recall
+banner, intent tier, git branch.
+
+The relevant wiring for the agent loop:
+
+- Owns a `TurnSupervisor` instance and forwards user input to it.
+- Renders the 22-callback surface exposed by `runAgentTurn` — see §5.
+- Renders `AgentLoopError` as a dedicated modal (`app.tsx:2119`).
+
+Depth on this file lives in the findings doc; it is the largest single source
+file in the repo and the prime refactor target.
+
+## 3. Supervisor — `src/agent/supervisor.ts` (82 LOC)
+
+A thin decoupler, not a controller. Responsibilities:
+
+- Enforce **single in-flight turn**: `startTurn()` rejects if `currentTurn`
+  is non-null (`supervisor.ts:39–41`).
+- Track a coarse phase: `idle | preparing | streaming | executing |
+  compacting | error` (used by the UI for status pills).
+- Provide a soft `killTurn()` that flips a flag; actual cancellation flows
+  through the `AbortSignal` the caller passes in.
+
+It does **no** pre-turn setup itself. Memory recall and skill routing live
+inside `runAgentTurn`, not here.
+
+## 4. Workers AI client — `src/agent/client.ts` (446 LOC)
+
+The async generator `runKimi(opts)` is what `loop.ts` actually consumes.
+
+### Endpoint routing (`client.ts:199–237`)
+
+Three deployment modes, branched on config:
+
+- **Cloud**: `https://api.kimiflare.com/v1/chat` (proxied; usage reported back
+  to `…/v1/usage/report` at `client.ts:165–182`, fire-and-forget).
+- **AI Gateway**: Cloudflare AI Gateway URL with cache headers.
+- **Direct**: Cloudflare account AI endpoint.
+
+Model ID is validated by regex (`client.ts:194`); must match
+`@namespace/name[/version]`.
+
+### Retry policy (`client.ts:54, 90–116`)
+
+- `MAX_ATTEMPTS = 5` (`client.ts:54`).
+- Retryable on Cloudflare error `3040` (capacity), HTTP 429, HTTP 5xx, and the
+  string "Internal server error" (`client.ts:61–67`).
+- Backoff: `500 * 2^attempt + random(0..250)` ms (`client.ts:116`).
+- Kill-switch is detected via `detectKillSwitch()` (`client.ts:110`).
+
+### Non-SSE response handling (`client.ts:128–139`)
+
+If the response `Content-Type` is not `text/event-stream`, the body is parsed
+as JSON and matched against two error envelopes:
+
+- Cloudflare: `{ success: false, errors: [{ code, message }] }`
+- OpenAI-style: `{ object: "error", message, code }`
+
+Mapped to humanized error messages around lines 403–431.
+
+### SSE consumption (`client.ts:256–343`)
+
+Driven by `readSSE(body, signal, idleTimeoutMs)` (default `60_000` ms,
+`client.ts:254`). Event types yielded back to the loop:
+
+- `gateway_meta` — cache status, log id (from response headers).
+- `reasoning` / `text` — content deltas.
+- `tool_call_start` / `tool_call_args` / `tool_call_complete` — tool-call
+  lifecycle, accumulated by index into a map (`client.ts:261`) and emitted in
+  order at stream end (`client.ts:332–341`).
+- `usage` — prompt/completion tokens.
+- `done` — finish reason + final usage.
+
+## 5. Turn loop — `src/agent/loop.ts` (896 LOC)
+
+The centerpiece. `runAgentTurn(opts)` is a flat function with a single
+`while(true)` driving turns, not a state machine.
+
+### Hard-coded constants (verified)
+
+| Constant                       | Value     | Where                  |
+| ------------------------------ | --------- | ---------------------- |
+| `DRIFT_THRESHOLD`              | `5`       | `loop.ts:138`          |
+| `MAX_PROMPT_TOKENS`            | `240_000` | `loop.ts:157`          |
+| `MAX_TOOL_CONTENT_CHARS`       | `10_000`  | `loop.ts:161`          |
+| `LOOP_WINDOW`                  | `8`       | `loop.ts:338`          |
+| `LOOP_THRESHOLD`               | `2`       | `loop.ts:339`          |
+| `MAX_WEB_FETCH_PER_TURN`       | `5`       | `loop.ts:343`          |
+| `WEB_FETCH_DOMAIN_THRESHOLD`   | `2`       | `loop.ts:344`          |
+| Tool-iteration cap (default)   | `50`      | `loop.ts:179` (overrideable) |
+
+### Pre-turn setup (`loop.ts:186–288`)
+
+In order:
+
+1. **Session-start memory recall** — awaits `opts.sessionStartRecall`
+   (`loop.ts:188`), races against the abort signal, injects results as a
+   system message after the last system message (`loop.ts:196–198`).
+2. **Skill routing** — `selectSkills()` (`loop.ts:224–243`) chooses skill
+   sections; the system prompt is rebuilt in place at `loop.ts:248–272`
+   depending on the `cacheStable` flag.
+3. **Reasoning history stripping** — if `KIMIFLARE_STRIP_REASONING=1`,
+   removes reasoning blocks from prior assistant messages; otherwise a
+   "shadow strip" measures hypothetical savings (`loop.ts:419–447`).
+4. **Token estimate** — `estimatePromptTokens()`; hard error if the result
+   exceeds `MAX_PROMPT_TOKENS` (`loop.ts:455–459`).
+
+Memory recall, skill selection, and prompt rebuild all swallow non-abort
+errors so a pre-turn hiccup never blocks the turn.
+
+### Streaming phase (`loop.ts:463–524`)
+
+Iterates `runKimi()` events, accumulating reasoning, text, and tool calls.
+Tool calls are validated as they finalize (`loop.ts:507`). `lastUsage` is
+captured for budget accounting.
+
+### Tool execution phase (`loop.ts:580–816`)
+
+For each tool call:
+
+- **Anti-loop guardrail** (`loop.ts:584–607`). A signature
+  (`name + stableStringify(args)`) is pushed into a rolling window of size
+  `LOOP_WINDOW = 8`. If the same signature appears `LOOP_THRESHOLD = 2`
+  times already (i.e., this is the 3rd identical call), the call is blocked
+  and a warning is returned in place of execution.
+- **Web-fetch spiral guardrail** (`loop.ts:609–666`). Two thresholds:
+  - Total fetches per turn ≥ `MAX_WEB_FETCH_PER_TURN = 5` → block.
+  - 3rd fetch to the same domain → block.
+- **Code-mode branch** (`loop.ts:668–725`). If the tool is `execute_code`,
+  the generated TypeScript runs in the sandbox via `runInSandbox()`;
+  internal tool calls executed from the sandbox come back through the same
+  executor. Output is truncated at `MAX_TOOL_CONTENT_CHARS = 10_000`
+  (`loop.ts:704–708`).
+- **Normal dispatch** (`loop.ts:727–815`). Calls `opts.executor.run()`,
+  truncates the resulting `content` to the same 10k cap (`loop.ts:736–740`),
+  then fires async memory extraction without awaiting it
+  (`loop.ts:752–810`). Memory extraction errors are swallowed
+  (`loop.ts:806`). Real-time drift detection increments a per-session
+  accumulator on high-signal memories; at `DRIFT_THRESHOLD = 5` the
+  `onKimiMdStale()` callback fires (`loop.ts:795–802`).
+
+### Budget accounting (`loop.ts:530–574`)
+
+After each iteration, `cumulativePromptTokens += lastUsage.prompt_tokens`.
+If the cumulative count exceeds `opts.maxInputTokens` **and** the iteration
+made tool calls, `budgetExhausted = true` is set for the **next** iteration,
+which injects a synthesis system message and forces one final no-tools turn.
+If the next turn still has tool calls, `BudgetExhaustedError` is thrown
+(`loop.ts:574`).
+
+### Termination paths
+
+| Condition                                       | Where                  |
+| ------------------------------------------------ | ---------------------- |
+| Zero tool calls in the assistant message         | `loop.ts:561–578` — normal return |
+| Budget exhausted and synthesis turn also had tools | `loop.ts:574`, also `:854` |
+| Tool-iteration cap (default 50) reached          | `loop.ts:354–397` — calls `onToolLimitReached()`; `continueOnLimit` resets `iter` |
+| Every tool in the turn was blocked               | `loop.ts:818–884` — `onLoopDetected()` returns `continue`, `synthesize`, or `stop`; otherwise throws `AgentLoopError` (`loop.ts:883`) |
+| `signal.aborted`                                 | checked at `loop.ts:207, 280, 526, 582, 834` |
+
+### State mutated across iterations
+
+- `opts.messages` — appended with assistant message, tool results, and
+  injected system messages. Caller sees post-turn state via the same array.
+- `recentToolCalls` — rolling window of length ≤ `LOOP_WINDOW`.
+- `driftAccumulator` (keyed per session) — incremented on high-signal
+  memories, decayed by 1 per turn at turn end.
+- `cumulativePromptTokens` — monotonically increases; underlies budget
+  enforcement.
+
+### Callback surface
+
+`runAgentTurn` accepts roughly 22 optional callbacks. The most relevant ones
+(grep `loop.ts` for the full list):
+
+`onAssistantStart`, `onReasoningDelta`, `onTextDelta`, `onToolCallFinalized`,
+`onToolResult`, `onWarning`, `askPermission`, `onToolLimitReached`,
+`onLoopDetected`, `onKimiMdStale`, `onMemoryRecalled`, `onSkillsSelected`,
+`onMetaBanner`, …
+
+These are the boundary between the loop and the UI (or any embedder via the
+SDK).
+
+## 6. Tools layer — `src/tools/`
+
+### Executor — `executor.ts` (238 LOC)
+
+- Tools are stored by name in a Map (`executor.ts:66–75`). `expand_artifact`
+  is registered dynamically (`executor.ts:74`).
+- Argument parsing: `JSON.parse` the tool-call args string; structured failure
+  string on error (`executor.ts:114–122`).
+- Permission gating (`executor.ts:125–139`): if a tool has `needsPermission`
+  and is not in the session-scoped `sessionAllowed` set, the `askPermission`
+  callback is consulted. Decisions: `allow` (one-time), `allow_session`
+  (cached for the remainder of the session), `deny`. The permission key is
+  the tool name, except bash uses the first token (e.g., `bash:git`,
+  `executor.ts:204–209`).
+- Output handling (`executor.ts:160–180`): for `git diff/show/log -p` and
+  `git stash show -p`, raw output is archived as an artifact and returned
+  unreduced (the bash reducer would mangle diff context); see
+  `isDiffCommand()` (`executor.ts:217–226`). Every other tool goes through
+  `reduceToolOutput()` (`executor.ts:175–180`).
+- Tool errors return a failed `ToolResult` rather than throwing
+  (`executor.ts:191–200`).
+
+### Registry — `registry.ts` (71 LOC)
+
+Canonical `ALL_TOOLS` list (in order): read, write, edit, bash, glob, grep,
+web_fetch, web_search, github_pr, github_issue, github_code, browser_fetch,
+tasks_set, memory_remember, memory_recall, memory_forget. `toOpenAIToolDefs()`
+(`registry.ts:37–46`) projects each spec into the OpenAI function-schema
+format the model expects.
+
+### Reducer — `reducer.ts` (635 LOC)
+
+Per-tool tuned reductions:
+
+- grep: 50 lines, 3 matches/file.
+- read: 60-line outline.
+- bash: 40 lines, error-block focus.
+- web tools: 2–4 KB.
+- default: 10 KB cap.
+
+Raw output is always archived to the artifact store; reductions are
+lossless under `expand_artifact`. The reducer dispatches via a single switch
+on tool name — adding a new tool requires editing this file.
+
+## 7. Session state & resume
+
+### In-memory artifact store — `src/agent/session-state.ts` (222 LOC)
+
+Bounded by `maxArtifacts = 200` and `maxTotalChars = 500_000`
+(`session-state.ts:76–77`). Eviction policy is LRU-by-timestamp
+(`session-state.ts:82–88`); eviction happens **before** insert so insert
+always succeeds. No persistence at this layer — artifacts are serialized as
+part of the session file by `src/sdk/sessions.ts`.
+
+### Session file — `src/sdk/sessions.ts`
+
+Persisted JSON: `id, cwd, model, createdAt, messages, sessionState,
+artifactStore, checkpoints`. Resume reads the full file. Checkpoint resume
+truncates `messages` to the chosen turn index. Path defaults to
+`~/.local/share/kimiflare/sessions/<id>.json`.
+
+## 8. Abort propagation — `src/util/abort-scope.ts` (84 LOC)
+
+Parent/child scope tree. `abort()` walks children recursively
+(`abort-scope.ts:42–54`). `detach()` removes a child from its parent
+(`abort-scope.ts:77–83`) so a child can outlive its parent.
+
+Threading is session → turn → tool. Bash, web-fetch, web-search, github, and
+browser tools honor `ctx.signal`. Read, write, edit, glob, and grep do **not**
+— see findings.
+
+## 9. Permission modes
+
+Set globally for the session, read by `executor.ts`:
+
+- **plan** — strict read-only allowlist (read, glob, grep, web search,
+  GitHub read-only, browser fetch). Writes, edits, mutating bash, MCP, and
+  LSP renames are blocked.
+- **edit** — default. Mutating tools prompt per call (with `allow_session`
+  caching).
+- **auto** — approve everything.
+
+## 10. Subsystems that plug in
+
+### Memory — `src/memory/` (~1.8K LOC)
+
+SQLite with WAL journaling; FTS5 virtual table; per-row BLOB embeddings.
+Default embedding model `@cf/baai/bge-base-en-v1.5` (768-dim) via Workers AI.
+
+Recall (`memory/retrieval.ts`) is a 5-channel RRF fusion: topic-key 0.35,
+FTS 0.20, vector 0.20, exact 0.15, raw-message 0.10. Vector candidates are
+filtered by recency (`maxAgeDays`, default 90) and capped at 2000 rows.
+Hypothesis queries can be LLM-synthesized to boost recall.
+
+Extraction (`memory/extractors.ts`) is mostly deterministic — `package_json`,
+`tsconfig`, `entry_point`, with an optional LLM-backed `edit_event`
+extractor. Invoked fire-and-forget from `loop.ts:752–810` after each tool
+call.
+
+Default DB path: `~/.local/share/kimiflare/memory.db`.
+
+### LSP — `src/lsp/` (~1.1K LOC across multiple files)
+
+`LspManager` spawns a server per `(id, rootUri)` tuple. `LspConnection`
+wraps the stdio/SSE transport; `LspClient` handles JSON-RPC and diagnostics.
+`src/tools/lsp.ts` (`makeLspTools`) exposes hover, definition, references,
+symbols, rename, codeAction, etc. as `ToolSpec`s. Servers are auto-picked by
+`resolveClientForPath` using rootUri prefix match.
+
+### MCP — `src/mcp/manager.ts` (95 LOC) + `adapter.ts` (64 LOC)
+
+`@modelcontextprotocol/sdk` client. Two transports — `StdioClientTransport`
+and `SSEClientTransport`. `mcpToolToSpec` (in `adapter.ts`) prefixes names as
+`mcp_<server>_<tool>` and adapts the result envelope. `getAllTools()`
+returns a flat `ToolSpec[]` merged into the executor at session init.
+
+### Code mode — `src/code-mode/sandbox.ts` (331 LOC) + `api-generator.ts`
+
+`runInSandbox()` prefers `isolated-vm` (true isolate, separate context, 30 s
+timeout, 128 MB memory limit) and falls back to `node:vm` if `isolated-vm`
+fails to load. TypeScript is transpiled via the installed `typescript`
+package when available, with a regex `stripTypescript` fallback. The
+exposed surface to user code is the generated tool API; no file, network, or
+`child_process` access is bound into the sandbox globals. A fallback warning
+is emitted once per process when `node:vm` is used.
+
+### Skills — `src/skills/`
+
+`router.ts` (56 LOC) runs `searchSections()` (embedding similarity over
+skill section text) and `buildSkillContext()` (tier-bounded token packing:
+`light=2k`, `medium=8k`, `heavy=24k`). Selected sections are injected into
+the system prompt by `loop.ts` during prompt assembly. Skills live in
+`~/.config/kimiflare/skills` (global) and `.kimiflare/skills` (project), as
+markdown files with YAML frontmatter.
+
+### Cost attribution — `src/cost-attribution/`
+
+`heuristic.ts` (209 LOC) is a deterministic regex classifier over tool name
++ args + file extensions. When confidence falls below 0.6
+(`classify-from-session.ts`), an LLM fallback is consulted. Output is
+appended to `history.jsonl` (append-only; all-time totals derived from it).
+
+### SDK — `src/sdk/session.ts` (555 LOC) + `rpc.ts` (183 LOC)
+
+`createAgentSession(opts)` is the public Node API. It composes memory, LSP,
+the executor, and the system prompt, and returns a session handle.
+
+`rpc.ts` is a JSONL-over-stdio server. Commands: `prompt`, `steer`,
+`follow_up`, `abort`, `get_state`, `get_messages`,
+`set_permission_decision`, `close`. Each command produces an event stream
+written back on stdout.
+
+## 11. Verification
+
+To re-validate this document against the code:
+
+```sh
+# LOC claims
+wc -l src/agent/loop.ts src/agent/supervisor.ts src/agent/client.ts \
+      src/agent/session-state.ts src/tools/executor.ts \
+      src/tools/registry.ts src/tools/reducer.ts \
+      src/util/abort-scope.ts src/index.tsx src/app.tsx \
+      src/mcp/manager.ts src/mcp/adapter.ts src/code-mode/sandbox.ts
+
+# Constants
+rg -n 'MAX_PROMPT_TOKENS|MAX_TOOL_CONTENT_CHARS|LOOP_WINDOW|LOOP_THRESHOLD|MAX_WEB_FETCH_PER_TURN|WEB_FETCH_DOMAIN_THRESHOLD|DRIFT_THRESHOLD|MAX_ATTEMPTS' \
+   src/agent/loop.ts src/agent/client.ts
+
+# Exit codes
+rg -n 'code 42|code 43|BudgetExhaustedError|AgentLoopError' src/
+
+# Sanity-build (no edits made by this doc, so this just guards against drift)
+npm run typecheck
+```
+
+Spot-check at least 10 random `file:line` citations after any large
+refactor of the agent loop; the line ranges in this document are tied to
+the source as of the commit that introduced it and will drift if not
+maintained.

--- a/docs/architecture/competitor-analysis.md
+++ b/docs/architecture/competitor-analysis.md
@@ -1,0 +1,312 @@
+# Competitor analysis: Claude Code
+
+Companion to [`agent-loop.md`](./agent-loop.md) and
+[`agent-loop-findings.md`](./agent-loop-findings.md). Frames KimiFlare's
+agent-loop architecture against Anthropic's Claude Code — the most
+directly comparable terminal coding agent — and identifies the features
+worth borrowing.
+
+This is not a feature checklist. The goal is to surface architectural
+patterns that compound: things where Claude Code's design choices unlock
+downstream capabilities KimiFlare currently can't reach without
+significant rework.
+
+> This document is written from the perspective of an analyst who has
+> read both products' code (Claude Code from the outside as a daily
+> driver; KimiFlare from the inside). Confidence varies — Claude Code
+> internals are partly inferred from observable behavior and public
+> docs.
+
+## What Claude Code does that KimiFlare doesn't (in priority order)
+
+### 1. Subagents with context isolation — **biggest single gap**
+
+Claude Code's `Task` / `Agent` tool spawns specialized sub-agents
+(`Explore` for read-only search, `Plan` for design, `general-purpose`
+for multi-step research, plus user-defined ones). Each runs with:
+
+- Its own tool allowlist (Explore is read-only by construction).
+- Its own context window (parent doesn't see the sub-agent's tool
+  output, only the final report).
+- Optionally its own git worktree (`isolation: "worktree"`) — a
+  temporary branch that auto-cleans if no changes are made.
+- Parallel execution — multiple subagents in a single tool-call batch
+  run concurrently.
+
+**Why it matters.** For tasks like "explore this 4k-LOC file and report
+back" the parent agent stays at a small context size while the
+subagent burns through file reads. KimiFlare's single-loop architecture
+forces all that exploration into the user-visible context, eating the
+budget and slowing every subsequent turn.
+
+**KimiFlare today:** strictly single-threaded loop, single context, no
+delegation primitive.
+
+**Build cost:** L. Requires context isolation in the loop, callback
+marshalling between parent and child contexts, parallel orchestration
+in the supervisor, and a worktree manager. Pairs naturally with the
+`app.tsx` breakup (parent/child UI states).
+
+**Counter-argument:** Code mode (`src/code-mode/`) is KimiFlare's stab
+at a different solution to the same problem — batch many tool calls
+into one model turn. Worth deciding whether subagents and code mode
+coexist or one supersedes the other. My read: they solve different
+problems. Code mode is for known-shape multi-tool sequences;
+subagents are for open-ended delegated exploration.
+
+### 2. Hooks — user-configured shell commands at lifecycle events
+
+Claude Code reads `~/.claude/settings.json` (and project-local
+overrides) for hook definitions: `PreToolUse`, `PostToolUse`, `Stop`,
+`UserPromptSubmit`, `PreCompact`, etc. Each fires a shell command with
+JSON context on stdin; the command can block the action or annotate
+the result.
+
+Real-world uses observed in the wild:
+
+- Pre-commit linters as `PostToolUse` for `edit`.
+- Secret scanners as `PreToolUse` for `write`.
+- Slack/notification on `Stop`.
+- Project-specific permission policies via `PreToolUse` shell scripts.
+
+**KimiFlare today:** 22 internal callbacks in the loop, no user-
+visible hook surface.
+
+**Build cost:** M. The internal callback machinery already exists —
+the work is in defining a stable JSON schema for hook context,
+shelling out safely, and documenting the surface. Project-local
+overrides need a discovery rule (probably `.kimiflare/settings.json`).
+
+### 3. Pattern-based permissions
+
+Claude Code permission entries are patterns, not booleans:
+`"Bash(npm test:*)"`, `"Bash(git diff:*)"`, `"WebFetch(domain:github.com)"`,
+`"Read(./src/**)"`. Allow / deny / ask tiers with deny winning over
+allow.
+
+**Why it matters.** Today KimiFlare users facing repeated permission
+prompts have two choices: approve one-by-one (fatiguing) or switch to
+`auto` mode (losing safety entirely). Pattern allowlists let power
+users say "allow all bash git commands and npm scripts, ask for
+everything else" in a config file once.
+
+**KimiFlare today:** Permission gating in `executor.ts:125–139` is
+keyed by tool name with a `bash:<first-token>` carve-out. No glob, no
+config-file source.
+
+**Build cost:** S–M. The permission key extractor in
+`executor.ts:204–209` is the right hook point. Extend to read a
+pattern list from settings; match argv against globs. Pair with
+typed `askPermission` return (see OP-13).
+
+### 4. Hierarchical context files
+
+Claude Code reads `CLAUDE.md` from the working directory, walks up
+to parent directories (monorepos), then `~/.claude/CLAUDE.md` for
+user-global, then enterprise policy files. All concatenated into the
+system prompt with provenance.
+
+**KimiFlare today:** `KIMI.md` and `CLAUDE.md` per project, no
+walking, no user-global tier.
+
+**Build cost:** S. Pure pre-turn assembly logic. Pairs with the
+existing `selectSkills()` path in `loop.ts:224–272`.
+
+### 5. User-extensible slash commands
+
+`.claude/commands/<name>.md` files become first-class slash commands.
+Each file declares its allowed tools, optional model override, and
+the prompt body with `$ARGUMENTS` interpolation. Users ship
+`/review`, `/migrate`, `/security-check` without writing TypeScript.
+
+**KimiFlare today:** Skills cover part of this, but conceptually
+skills route into the prompt; commands route into the tool-execution
+plan. Different primitive.
+
+**Build cost:** M. The TUI's existing slash-command machinery (in
+`app.tsx`) is the integration point. Need a command discovery pass,
+arg parsing, and an execution shim.
+
+### 6. Auto-compaction at context limit
+
+When context approaches the model's hard limit, Claude Code summarizes
+older turns into a compact narrative and continues seamlessly. The
+user sees a transient "Compacting…" status. Compacted summaries
+preserve recent tool results verbatim and lossy-summarize older ones.
+
+**KimiFlare today:** `MAX_PROMPT_TOKENS = 240_000` at
+`loop.ts:157` throws `BudgetExhaustedError` with exit code 42. Hard
+wall, not a transition.
+
+**Build cost:** M–L. Needs the summarizer prompt, a cache-friendly
+insertion point (preserve everything before the "last cached point"
+verbatim where possible), and rules for what survives verbatim. The
+artifact store already separates raw from reduced — leverage that.
+
+### 7. Enforced plan mode at the harness layer
+
+In Claude Code, plan mode is enforced by the harness: every mutating
+tool call errors at the boundary, regardless of what the model
+attempts. The model can't write files; it's not a polite request.
+
+**KimiFlare today:** Plan mode is enforced in `executor.ts`. Worth
+auditing whether all paths respect it:
+
+- MCP-injected tools (`mcp/manager.ts`) — do they go through the same
+  gate?
+- LSP rename — explicitly mentioned as blocked, verify.
+- Code-mode sandbox — does it re-enter the executor for each internal
+  call, so plan-mode gating still fires?
+- Skill-provided tools — same question.
+
+**Build cost:** S (audit) + S–M (any gaps found).
+
+### 8. Structured `-p` output
+
+Claude Code supports `--output-format json` and `--output-format
+stream-json` for print mode. Output envelope includes `result`,
+`usage`, `tool_calls`, `exit_code`, and per-event JSON for the stream
+variant.
+
+**KimiFlare today:** Print mode (`src/index.tsx`) emits human-
+readable text only.
+
+**Build cost:** S. A day of work. Critical for CI integrations,
+scripting, and any product surface that wants to embed KimiFlare.
+
+### 9. Background bash with monitoring
+
+Claude Code's `Bash` tool accepts `run_in_background: true` and a
+companion `Monitor` tool tails stdout from background processes. Long
+deploys, long test runs, long builds don't block the agent loop.
+
+**KimiFlare today:** Bash is synchronous, max 10-minute timeout
+(`tools/bash.ts`). A failing 9-minute test run blocks the entire
+loop until it dies.
+
+**Build cost:** M. Needs a background-task table, stdout streaming
+to the artifact store, and notification when a task completes
+between turns. Naturally integrates with the existing artifact
+system.
+
+### 10. Status line, output styles, polish
+
+Configurable status line (git branch, model, tokens remaining).
+"Explanatory" output style for users who want verbose reasoning vs.
+"concise" for power users. Theming.
+
+**KimiFlare today:** Has theming. Status surface is implicit in the
+TUI.
+
+**Build cost:** S each. The kind of polish that signals seriousness.
+
+## What KimiFlare does *better* than Claude Code
+
+Worth protecting and amplifying — not just neutral parity points:
+
+### Memory subsystem
+
+`src/memory/` is substantively richer than Claude Code's memory
+system. SQLite + WAL + FTS5 + BGE embeddings + 5-channel RRF recall
+(topic 0.35 / FTS 0.20 / vector 0.20 / exact 0.15 / raw 0.10).
+Deterministic extractors for `package_json`, `tsconfig`,
+`entry_point`, plus an LLM-backed `edit_event` extractor.
+
+**Implication:** Don't water this down. Lean in — a `/memory health`
+command, recall-hit-rate telemetry, and a "memory inspector" TUI
+would be differentiated features.
+
+### Code mode
+
+The `isolated-vm` TypeScript sandbox at `src/code-mode/` is a novel
+direction. Claude Code doesn't have an analog. For multi-tool turns
+where the sequence is known, executing one TypeScript program with
+inline tool calls is materially faster than streaming each tool call
+through the model.
+
+**Implication:** Decide whether code mode and subagents (gap #1
+above) coexist or compete. If they coexist, document when each is
+preferred.
+
+### Cost attribution
+
+`src/cost-attribution/` classifies token spend per feature. Claude
+Code users have to build this externally. KimiFlare users get
+`/cost` and `history.jsonl` out of the box.
+
+**Implication:** Surface it more aggressively in the TUI. A weekly
+summary at session start. Multi-label classification (OP-25).
+
+### Cloud mode
+
+The Cloudflare Workers AI proxy with usage reporting
+(`client.ts:165–182`) is a clean monetization path Claude Code
+doesn't have a direct analog for.
+
+**Implication:** Architectural leverage. Anything that can be
+metered cleanly here is a future revenue lever.
+
+### LSP integration as tools
+
+`src/lsp/` exposes hover, definitions, references, rename, code
+actions as agent tools. Claude Code reads files and greps; LSP gives
+the agent semantic understanding for free. This is a real edge for
+TypeScript / Rust / Go work.
+
+**Implication:** Fix the auto-restart gap (RF-15) and the per-call
+timeout gap (RF-16) so users actually keep LSP enabled. The
+infrastructure is there; reliability is the missing piece.
+
+## Architectural meta-observation
+
+Claude Code's biggest advantage isn't any one feature. It's that the
+harness-around-the-model is factored into composable pieces:
+
+- Subagents (delegation primitive)
+- Hooks (lifecycle extension)
+- Slash commands (user-defined entry points)
+- Skills (prompt-injection primitive)
+- Permissions (security primitive)
+- Plan mode (enforced gate)
+
+Each piece can be extended by users or by the team independently. A
+new feature usually slots in as a new file in `.claude/commands/` or
+a new hook entry in `settings.json`, not a code change to the
+harness.
+
+KimiFlare has most of the same primitives, but they're more tightly
+coupled inside `loop.ts` and `app.tsx`. Adding a hook surface today
+means editing the loop. Adding subagents means editing the loop *and*
+the TUI. Adding user commands means editing the TUI.
+
+The `app.tsx` breakup (RF-14 / OP-19 in the findings doc) is the
+upstream unblocker. Until it lands, every competitor-parity feature
+becomes more expensive than it should be. This is why the development
+roadmap puts that refactor on the critical path even though it's the
+single largest item.
+
+## Summary scoreboard
+
+| Capability                       | Claude Code | KimiFlare today | Priority to close |
+| -------------------------------- | :---------: | :-------------: | :---------------: |
+| Subagents / delegation           |     ✅      |       ❌        |       **P0**      |
+| Hooks (lifecycle)                |     ✅      |       ❌        |       **P0**      |
+| Pattern-based permissions        |     ✅      |   partial       |       **P1**      |
+| Hierarchical context files       |     ✅      |   partial       |       **P1**      |
+| User slash commands              |     ✅      |   partial (skills) |  **P1**       |
+| Auto-compaction                  |     ✅      |       ❌        |       **P1**      |
+| Enforced plan mode (audit)       |     ✅      |   partial       |       **P2**      |
+| Structured `-p` output           |     ✅      |       ❌        |       **P2**      |
+| Background bash                  |     ✅      |       ❌        |       **P2**      |
+| Status line / output styles      |     ✅      |   partial       |       **P3**      |
+| **Memory (SQLite+RRF)**          |   partial   |       ✅        | *defend*          |
+| **Code mode sandbox**            |     ❌      |       ✅        | *defend*          |
+| **Cost attribution**             |     ❌      |       ✅        | *defend*          |
+| **Cloud monetization path**      |     ❌      |       ✅        | *defend*          |
+| **LSP as agent tools**           |     ❌      |       ✅        | *defend*          |
+
+P0 = critical for closing the gap. P1 = high value, well-scoped.
+P2 = important polish. P3 = nice-to-have.
+
+See [`development-roadmap.md`](./development-roadmap.md) for how
+these slot into milestone-scoped PRs.

--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -1,0 +1,407 @@
+# Development roadmap
+
+A milestone-scoped plan to act on the findings in
+[`agent-loop-findings.md`](./agent-loop-findings.md) and close the
+gaps in [`competitor-analysis.md`](./competitor-analysis.md).
+
+This document is the source of truth for "what should we build next."
+Each milestone lists PR-sized work items with explicit references to
+the relevant finding (`RF-N`), opportunity (`OP-N`), or competitor
+gap (numbered 1–10 in the competitor doc).
+
+## Guiding principles
+
+1. **Small PRs.** Every item below should land in one PR ≤ 500 LOC of
+   net diff. If an item grows beyond that, split it.
+2. **No silent regressions.** Add or extend a test next to any
+   behavior change. Co-located `*.test.ts` next to source, per CLAUDE.md.
+3. **Ship continuously.** Each milestone is shippable as a minor
+   release. Conventional Commits (`feat(scope):`, `fix(scope):`) so
+   release-please can build the changelog.
+4. **Defer big bets.** The `app.tsx` breakup runs in parallel
+   throughout the quarter, one extraction per fortnight. Don't try to
+   do it in one heroic PR.
+5. **Telemetry before optimization.** Anything that requires "we
+   should make X faster" waits until M5 (structured telemetry)
+   so we measure, not guess.
+
+## Critical path
+
+```
+M0 — Branch hygiene
+        │
+M1 — Quick wins (10 small PRs)         ──┐
+        │                                │
+M2 — Typed errors & permission shape    │  Foundations for
+        │                                │  everything in M3+
+M3 — Reliability: timeouts, restarts   ──┘
+        │
+M4 ── app.tsx breakup (runs in parallel, one extraction per 2 weeks)
+        │
+M5 — Telemetry
+        │
+M6 — Competitor parity wave 1: hooks, hierarchical context, JSON output
+        │
+M7 — Competitor parity wave 2: subagents, auto-compaction
+        │
+M8 — Competitor parity wave 3: user slash commands, background bash
+        │
+M9 — Stretch: checkpoint compression, MCP circuit breaker, multi-label cost
+```
+
+Estimated timeline: **one calendar quarter** for M0–M5, **a second
+quarter** for M6–M9. A team of 1–2 maintainers should target one
+milestone per 1–2 weeks for M1–M3, then heavier work scales out.
+
+---
+
+## M0 — Branch hygiene & docs land *(½ day)*
+
+**Goal:** This roadmap and its sibling docs land on `main`. Nothing
+else.
+
+**PRs:**
+
+- **M0.1** — `docs(architecture): add agent loop reference, findings,
+  competitor analysis, and development roadmap`
+  - Adds `docs/architecture/agent-loop.md`,
+    `agent-loop-findings.md`, `competitor-analysis.md`, and this
+    file.
+  - No code changes.
+
+**Exit criteria:** All four docs merged to `main`.
+
+---
+
+## M1 — Quick wins *(1 week, ~10 PRs)*
+
+**Goal:** Ten small, independent, user-visible improvements. No
+shared dependencies between PRs; ideal for parallel review or
+batching.
+
+**PRs:**
+
+- **M1.1** — `fix(client): full-jitter retry backoff` *(OP-1 / RF-8)*
+  - `src/agent/client.ts:116` → `random(0, 500 * 2^attempt)`.
+  - Unit test: 5 retries don't fall into a sub-300ms window.
+- **M1.2** — `feat(session-state): size-aware artifact eviction`
+  *(OP-2 / RF-9)*
+  - `src/agent/session-state.ts:82–88` — evict largest among oldest
+    quartile.
+  - Test that capacity is reached fewer times under a mixed-size
+    workload.
+- **M1.3** — `feat(loop): onTruncation callback + TUI hint`
+  *(OP-3 / RF-12)*
+  - Add `onTruncation?(tool, rawBytes, reducedBytes, artifactId)` to
+    callback surface at `loop.ts:704–708, 736–740`.
+  - TUI renders inline "output truncated — `expand artifact <id>`".
+- **M1.4** — `feat(client): per-call SSE idle timeout`
+  *(OP-4 / RF-7)*
+  - Expose `idleTimeoutMs` on `runKimi()` options.
+  - Default unchanged. Document in `KIMI.md`.
+- **M1.5** — `fix(tools): signal-aware grep / glob inner loops`
+  *(OP-5 / RF-13, first half)*
+  - `src/tools/grep.ts`: check `signal.aborted` between batches.
+  - `src/tools/glob.ts`: wire `signal` into fast-glob.
+  - Manual test: Ctrl+C during a large-repo grep returns within
+    < 250 ms.
+- **M1.6** — `feat(loop): cross-turn web-fetch tracking`
+  *(OP-6 / RF-3)*
+  - Lift `totalWebFetches` and `domainCounts` from per-turn locals to
+    session state.
+  - Cap at session-level (default 25); soft nudge.
+- **M1.7** — `feat(memory): extraction error counter` *(OP-7 / RF-1)*
+  - Replace bare swallow at `loop.ts:806` with `onWarning` debug
+    emit + counter.
+  - Add `kimiflare memory health` subcommand showing counters.
+- **M1.8** — `fix(loop): sliding-window drift detection`
+  *(OP-8 / RF-2)*
+  - Replace decay-by-1-per-turn with a 10-turn sliding window;
+    trigger at 3 high-signal memories.
+- **M1.9** — `fix(loop): zero-tool-call budget check` *(OP-9 / RF-5)*
+  - `loop.ts:530–574` — drop the `toolCalls.length > 0` guard.
+- **M1.10** — `fix(code-mode): per-session fallback warning`
+  *(OP-10 / RF-19)*
+  - `src/code-mode/sandbox.ts` — track warning state per session,
+    not per process.
+
+**Exit criteria:** All 10 PRs merged; one minor release cut by
+release-please.
+
+---
+
+## M2 — Typed errors & permission shape *(1–2 weeks, 2 PRs)*
+
+**Goal:** Foundation work that unblocks reliable retries, UI
+suggestion hints, and pattern permissions. Each is one focused PR
+that touches many call sites — review carefully.
+
+**PRs:**
+
+- **M2.1** — `refactor(tools): introduce structured ToolError`
+  *(OP-12)*
+  - New type: `ToolError { code, message, recoverable, suggestion? }`.
+  - All tools return `ToolResult { content?, error?, … }`.
+  - Loop checks `recoverable` to decide retry vs. fail-fast.
+  - Migration of all 15 core tools + MCP / LSP adapters.
+  - **High risk:** broad surface change. Land behind a feature flag
+    in the loop (`opts.useTypedErrors`) for one release if needed.
+- **M2.2** — `refactor(executor): typed askPermission return`
+  *(OP-13)*
+  - `askPermission` now returns `{ decision, scope: "once" | "session"
+    | "pattern" }`.
+  - Caller can prepare for pattern allowlists in M6.
+
+**Exit criteria:** Both PRs merged. All existing tools migrated. No
+test regressions.
+
+---
+
+## M3 — Reliability: timeouts, restarts, streaming reads *(1–2 weeks, 4 PRs)*
+
+**Goal:** Close the "hangs and silent failures" class of issues.
+
+**PRs:**
+
+- **M3.1** — `feat(mcp): per-call timeouts` *(OP-15 / RF-16)*
+  - Default 60 s per tool invocation; configurable per server.
+  - On timeout, return `ToolError { code: "TIMEOUT", recoverable: true }`.
+- **M3.2** — `feat(lsp): per-call timeouts` *(OP-15 / RF-16)*
+  - Default 10 s. Faster fallback than MCP because LSP ops are
+    usually local.
+- **M3.3** — `feat(lsp): auto-restart with backoff` *(OP-16 / RF-15)*
+  - Increment `restartAttempts` on exit. Backoff: 1s, 4s, 16s, then
+    surface failure.
+  - Show attempt state in `/lsp status`.
+- **M3.4** — `feat(tools): streaming read for large files`
+  *(RF-13, second half)*
+  - Stream-read past, say, 1 MB. Check `signal` between chunks.
+
+**Exit criteria:** Hung MCP server scenario from RF-16 verified
+fixed by a regression test (mock server that never responds).
+
+---
+
+## M4 — `app.tsx` breakup *(runs in background through Q1, ~6 PRs)*
+
+**Goal:** Reduce `src/app.tsx` from 4,393 LOC to < 1,000 LOC by
+extracting six concerns, one per fortnight, each as a pure refactor
+PR.
+
+This is the **single largest velocity unlock**. Every PR in M6–M8
+that touches UI assumes M4 is making steady progress.
+
+**PRs (in suggested order, but most are independent):**
+
+- **M4.1** — `refactor(ui): extract PermissionController`
+  - Modal + decision threading + `sessionAllowed` set lift to a
+    standalone hook + component.
+- **M4.2** — `refactor(ui): extract PickerController`
+  - File picker, mention picker, slash picker share a state machine.
+- **M4.3** — `refactor(ui): extract ModalHost`
+  - Limit, loop, command, LSP, theme, remote, inbox modals routed
+    through one host.
+- **M4.4** — `refactor(ui): extract SessionManager`
+  - Load, resume, checkpoint, save logic into one module.
+- **M4.5** — `refactor(ui): extract TurnController`
+  - Supervisor wiring, status pills, reasoning view.
+- **M4.6** — `refactor(ui): extract InputController`
+  - The 200+ line `useInput` handler split by mode (normal /
+    picker / modal).
+
+**Definition of done per PR:** No behavior change, no new tests
+fail, `app.tsx` shrinks by ≥ 300 LOC.
+
+**Exit criteria:** `wc -l src/app.tsx` returns < 1000.
+
+---
+
+## M5 — Structured telemetry *(1 week, 2 PRs)*
+
+**Goal:** After this lands, the rest of the roadmap becomes data-
+driven.
+
+**PRs:**
+
+- **M5.1** — `feat(telemetry): structured JSON logs`
+  *(OP-20)*
+  - Emit `{ timestamp, level, module, event, fields }` to
+    `~/.config/kimiflare/logs/<date>.jsonl`.
+  - All existing `console.log` / `console.warn` migrated.
+  - Log rotation policy (7 days, as the existing constant suggests
+    was intended).
+- **M5.2** — `feat(telemetry): optional OTel export`
+  *(OP-20)*
+  - `KIMIFLARE_OTEL_ENDPOINT` env var → emit OTLP. No-op if unset.
+
+**Exit criteria:** `cat ~/.config/kimiflare/logs/*.jsonl | jq` can
+answer "what's the per-tool p95 latency this week" without writing
+new code.
+
+---
+
+## M6 — Competitor parity wave 1 *(2 weeks, 4 PRs)*
+
+**Goal:** Close the cheapest competitor gaps. Each PR is a feature,
+not a refactor.
+
+**PRs:**
+
+- **M6.1** — `feat(hooks): user-configured lifecycle hooks`
+  *(Competitor #2)*
+  - Read `~/.config/kimiflare/settings.json` and
+    `.kimiflare/settings.json`.
+  - Events: `PreToolUse`, `PostToolUse`, `UserPromptSubmit`,
+    `Stop`, `PreCompact`.
+  - Shell out with JSON on stdin; collect exit code + stdout.
+  - **Depends on M2.1** (typed errors so hook failures classify
+    properly).
+- **M6.2** — `feat(permissions): pattern-based allowlists`
+  *(Competitor #3)*
+  - Patterns in `settings.json`: `"Bash(npm test:*)"`,
+    `"Read(./src/**)"`, etc.
+  - Match argv against globs in `executor.ts` permission gating.
+  - Deny wins over allow.
+  - **Depends on M2.2** (permission decision shape).
+- **M6.3** — `feat(context): hierarchical CLAUDE.md / KIMI.md`
+  *(Competitor #4)*
+  - Walk cwd → parents → `~/.config/kimiflare/CLAUDE.md`.
+  - Concatenate with provenance comments.
+- **M6.4** — `feat(cli): --output-format json for print mode`
+  *(Competitor #8)*
+  - `{ result, usage, tool_calls, exit_code }` envelope.
+  - Also `--output-format stream-json` for per-event JSON lines.
+
+**Exit criteria:** Closing one issue from each of the four gap
+categories. Document in `KIMI.md`.
+
+---
+
+## M7 — Competitor parity wave 2: subagents & auto-compaction *(3–4 weeks, 4 PRs)*
+
+**Goal:** The two largest competitor gaps. Both touch the loop
+deeply. **Depends on M4 being substantially complete** — both need
+clean UI surfaces.
+
+**PRs:**
+
+- **M7.1** — `feat(supervisor): subagent primitive`
+  *(Competitor #1)*
+  - `Agent` tool with `subagent_type` parameter (`general`,
+    `explore`, `plan` to start).
+  - Each subagent gets its own context, tool allowlist, and
+    callback surface.
+  - Parent sees only the final report.
+- **M7.2** — `feat(supervisor): parallel subagent execution`
+  - Multiple `Agent` tool calls in one batch run concurrently.
+- **M7.3** — `feat(supervisor): worktree isolation`
+  - `isolation: "worktree"` option creates a temp git worktree per
+    subagent. Auto-cleanup if no changes.
+- **M7.4** — `feat(loop): auto-compaction at MAX_PROMPT_TOKENS`
+  *(Competitor #6 / RF-6)*
+  - At cap, summarize older turns into a compact narrative.
+  - Preserve last N tool results verbatim.
+  - Fall back to `BudgetExhaustedError` only if compaction fails.
+
+**Exit criteria:** Multi-agent task ("explore X, plan Y, review Z")
+completes in one session with parent context staying small.
+1000-turn synthetic session does not throw `BudgetExhaustedError`.
+
+---
+
+## M8 — Competitor parity wave 3 *(2 weeks, 3 PRs)*
+
+**PRs:**
+
+- **M8.1** — `feat(commands): user-extensible slash commands`
+  *(Competitor #5)*
+  - `.kimiflare/commands/<name>.md` with frontmatter (`allowed_tools`,
+    `model_override`) and `$ARGUMENTS` interpolation.
+- **M8.2** — `feat(tools): background bash with Monitor`
+  *(Competitor #9)*
+  - `run_in_background: true` returns a task ID.
+  - `Monitor` tool tails stdout. Notification when task completes.
+- **M8.3** — `feat(ui): status line, output styles`
+  *(Competitor #10)*
+  - Configurable status line (branch, model, tokens-remaining).
+  - "Explanatory" vs "concise" output style.
+
+**Exit criteria:** All P0–P3 competitor gaps closed. KimiFlare's
+public capability matrix matches or exceeds Claude Code's on terminal
+coding-agent fundamentals.
+
+---
+
+## M9 — Stretch *(open-ended)*
+
+Items here are valuable but not on the critical path. Pick up as
+capacity allows.
+
+- **M9.1** — `feat(session): delta-encoded checkpoints with zstd`
+  *(OP-21)*
+- **M9.2** — `feat(mcp): circuit breaker per server` *(OP-22)*
+- **M9.3** — `feat(loop): per-tool quotas` *(OP-23)*
+- **M9.4** — `feat(loop): cross-turn loop detection` *(OP-24)*
+- **M9.5** — `feat(cost-attribution): multi-label classification`
+  *(OP-25)*
+- **M9.6** — `feat(code-mode): freeze API per turn` *(OP-17)*
+- **M9.7** — `feat(code-mode): catch async rejections in sandbox`
+  *(OP-18)*
+- **M9.8** — `feat(tools): pluggable reducer registry` *(OP-11)*
+- **M9.9** — `feat(session-state): artifact reducer-version stamp`
+  *(OP-14 / RF-17)*
+- **M9.10** — `audit: plan mode enforcement across subsystems`
+  *(Competitor #7)*
+- **M9.11** — `security: bash co-author injection escape audit`
+  *(RF-18)*
+- **M9.12** — `refactor(loop): atomic system message rebuild`
+  *(RF-10)*
+- **M9.13** — `fix(code-mode): cache key includes parameter schemas`
+  *(RF-11)*
+
+---
+
+## Risk register
+
+Per-milestone risks worth tracking:
+
+| Milestone | Risk                                                                       | Mitigation                                                                 |
+| --------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| M1        | One of the small PRs subtly changes behavior in a way tests don't catch.   | Co-locate a test with each PR. Cut a 0.x.y release after every 3–4 PRs.    |
+| M2        | `ToolError` migration breaks an MCP adapter no maintainer tests.           | Feature-flag for one release; defer flag removal until field reports clean. |
+| M3        | LSP auto-restart loops forever on a server that crashes on init.           | Cap restart attempts; surface failure clearly in `/lsp status`.            |
+| M4        | UI extractions accidentally change keybinding semantics.                   | Manual smoke tests per extraction. Keep a checklist of every keybinding.   |
+| M5        | Telemetry blows up disk usage.                                             | Rotation policy from day one. Default cap 100 MB; warn at 80 MB.           |
+| M6        | Pattern permissions create a false sense of security with malformed globs. | Strict glob parser; reject ambiguous patterns at load time with a clear error. |
+| M7        | Subagent context isolation has a leak (parent sees child's tool output).   | Tests that explicitly assert parent context size doesn't grow with child tool calls. |
+| M8        | Background bash leaks processes on session exit.                           | Process group tracking; SIGTERM all on session end with 5s SIGKILL fallback. |
+
+---
+
+## Tracking & accountability
+
+- This document is the canonical roadmap. PR descriptions should
+  reference the milestone tag (e.g., `Closes M1.3`).
+- Milestones are tracked as GitHub milestones with the same names.
+- Each PR's body includes a checkbox for "exit criteria for this
+  milestone item satisfied" — the merging maintainer ticks it.
+- At the end of each milestone, the maintainer updates this file
+  with a short retrospective (1 paragraph): what shipped, what
+  slipped, lessons learned.
+- Release-please automatically tags releases per Conventional
+  Commit history; no manual version bumps.
+
+---
+
+## What this roadmap does *not* cover
+
+- **Kimi model upgrades** — out of scope; tracked separately.
+- **The remote / Cloud product line** (`remote/worker/`,
+  `remote/agent/`) — those have their own deploy story and
+  shouldn't block the main CLI roadmap.
+- **GPU-side improvements** (embedding model choice, code mode
+  performance) — measure after M5 lands; act when there's data.
+- **Marketing & onboarding** — separate workstream.
+
+Anything not on this list and not in M9 should get a discussion and
+a finding entry before it consumes engineering time.


### PR DESCRIPTION
## Summary

Adds four code-grounded documents under `docs/architecture/`:

- **`agent-loop.md`** — deep dive into the turn loop with `file:line` citations throughout. Covers CLI entry, TUI, supervisor, loop, Workers AI client, tools layer, session state, abort propagation, permission modes, and plug-in subsystems (memory, LSP, MCP, code-mode, skills, cost-attribution, SDK).
- **`agent-loop-findings.md`** — 19 red flags and 25 opportunities, each with code refs and S/M/L effort sizing. Notable items: silent memory-extraction errors (RF-1), sync FS tools ignoring `AbortSignal` (RF-13), the 4,393-line `app.tsx` god component (RF-14), LSP `restartAttempts` dead state (RF-15), per-turn-only web-fetch guardrails (RF-3).
- **`competitor-analysis.md`** — KimiFlare vs Claude Code scoreboard. P0 gaps to close: subagents with context isolation, lifecycle hooks. P1: pattern permissions, hierarchical CLAUDE.md, user slash commands, auto-compaction. Also identifies capabilities to defend: memory (SQLite+RRF), code mode sandbox, cost attribution, cloud monetization, LSP as agent tools.
- **`development-roadmap.md`** — milestone-scoped plan M0–M9 fusing findings + competitor gaps into PR-sized work items. Critical path: M1 quick wins → M2 typed errors → M3 reliability → M4 `app.tsx` breakup (in parallel through Q1) → M5 telemetry → M6/M7/M8 competitor parity waves.

No code changes in this PR.

## Test plan

- [ ] Spot-check 10 random `file:line` citations in `agent-loop.md` resolve to the described code on this branch.
- [ ] Confirm constants (`MAX_PROMPT_TOKENS`, `LOOP_WINDOW`, `MAX_WEB_FETCH_PER_TURN`, `DRIFT_THRESHOLD`, `MAX_TOOL_CONTENT_CHARS`, `MAX_ATTEMPTS`) match values cited.
- [ ] Markdown renders cleanly on GitHub (ASCII diagram in `agent-loop.md`).
- [ ] No code changes, so no `npm run typecheck` / tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)