### PR TITLE
refactor(ui): extract usePermissionController hook from app.tsx (M4.1)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,7 +20,7 @@ import {
   deserializeArtifactStore,
   type SessionState,
 } from "./agent/session-state.js";
-import { ToolExecutor, ALL_TOOLS, type PermissionDecision } from "./tools/executor.js";
+import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ToolSpec } from "./tools/registry.js";
 import { getShellCommand } from "./tools/bash.js";
 import { McpManager } from "./mcp/manager.js";
@@ -36,6 +36,7 @@ import type { CloudCredentials } from "./cloud/auth.js";
 import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
+import { usePermissionController } from "./ui/use-permission-controller.js";
 import { LimitModal, type LimitDecision, type LoopDecision } from "./ui/limit-modal.js";
 import { ResumePicker } from "./ui/resume-picker.js";
 import { CheckpointPicker } from "./ui/checkpoint-picker.js";
@@ -64,7 +65,7 @@ import { deployForTui } from "./remote/deploy.js";
 import { authGitHubForTui } from "./remote/tui-auth.js";
 import { RemoteDashboard, RemoteSessionDetail } from "./ui/remote-dashboard.js";
 import { InboxModal } from "./ui/inbox-modal.js";
-import { nextMode, type Mode, isBlockedInPlanMode, isReadOnlyBash } from "./mode.js";
+import { nextMode, type Mode } from "./mode.js";
 import { classifyIntent } from "./intent/classify.js";
 import {
   selectSkills,
@@ -424,12 +425,6 @@ function trackRecentFile(ref: React.MutableRefObject<Map<string, number>>, path:
   }
 }
 
-interface PendingPermission {
-  tool: ToolSpec;
-  args: Record<string, unknown>;
-  resolve: (d: PermissionDecision) => void;
-}
-
 const CONTEXT_LIMIT = 262_000;
 const AUTO_COMPACT_SUGGEST_PCT = 0.8;
 const MAX_EVENTS = 500;
@@ -556,7 +551,26 @@ function App({
   const [gatewayMeta, setGatewayMeta] = useState<GatewayMeta | null>(null);
   const [cloudBudget, setCloudBudget] = useState<{ remaining: number; limit: number } | null>(null);
   const [showReasoning, setShowReasoning] = useState(false);
-  const [perm, setPerm] = useState<PendingPermission | null>(null);
+  const {
+    pending: perm,
+    askPermission: askForPermission,
+    hasPending: hasPendingPermission,
+    decide: decidePermission,
+    denyPending: denyPendingPermission,
+    clearResolveRef: clearPermissionResolveRef,
+  } = usePermissionController(
+    () => modeRef.current,
+    (toolName) => {
+      setEvents((e) => [
+        ...e,
+        {
+          kind: "info",
+          key: mkKey(),
+          text: `plan mode blocked ${toolName}; exit plan mode to execute`,
+        },
+      ]);
+    },
+  );
   const [limitModal, setLimitModal] = useState<{ limit: number; resolve: (d: LimitDecision) => void } | null>(null);
   const [loopModal, setLoopModal] = useState<{ resolve: (d: LoopDecision) => void } | null>(null);
   const [queue, setQueue] = useState<Array<{ full: string; display: string; key: string }>>([]);
@@ -705,7 +719,6 @@ function App({
   const lastEscapeAtRef = useRef(0);
   /** Holds the latest Ctrl+C interrupt logic so the SIGINT handler can delegate to it. */
   const sigintHandlerRef = useRef<(() => void) | null>(null);
-  const permResolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
   const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
   const loopResolveRef = useRef<((d: LoopDecision) => void) | null>(null);
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
@@ -1498,17 +1511,12 @@ function App({
         busy: busyRef.current,
         hasActiveScope: activeScopeRef.current !== null,
         isAborting: isAbortingRef.current,
-        hasPerm: permResolveRef.current !== null,
+        hasPerm: hasPendingPermission(),
         hasLimit: limitResolveRef.current !== null,
       });
-      const hadPerm = permResolveRef.current !== null;
+      const hadPerm = denyPendingPermission();
       const hadLimit = limitResolveRef.current !== null;
       const hadLoop = loopResolveRef.current !== null;
-      if (hadPerm) {
-        permResolveRef.current!("deny");
-        permResolveRef.current = null;
-        setPerm(null);
-      }
       if (hadLimit) {
         limitResolveRef.current!("stop");
         limitResolveRef.current = null;
@@ -1559,11 +1567,7 @@ function App({
         lastEscapeAtRef.current = now;
         isAbortingRef.current = true;
         supervisorRef.current.killTurn();
-        if (permResolveRef.current) {
-          permResolveRef.current("deny");
-          permResolveRef.current = null;
-          setPerm(null);
-        }
+        denyPendingPermission();
         if (limitResolveRef.current) {
           limitResolveRef.current("stop");
           limitResolveRef.current = null;
@@ -1611,18 +1615,13 @@ function App({
       busy: busyRef.current,
       hasActiveScope: activeScopeRef.current !== null,
       isAborting: isAbortingRef.current,
-      hasPerm: permResolveRef.current !== null,
+      hasPerm: hasPendingPermission(),
       hasLimit: limitResolveRef.current !== null,
       hasLoop: loopResolveRef.current !== null,
     });
-    const hadPerm = permResolveRef.current !== null;
+    const hadPerm = denyPendingPermission();
     const hadLimit = limitResolveRef.current !== null;
     const hadLoop = loopResolveRef.current !== null;
-    if (hadPerm) {
-      permResolveRef.current!("deny");
-      permResolveRef.current = null;
-      setPerm(null);
-    }
     if (hadLimit) {
       limitResolveRef.current!("stop");
       limitResolveRef.current = null;
@@ -1808,7 +1807,7 @@ function App({
       setLastActivityAt(null);
       activeScopeRef.current = null;
       isAbortingRef.current = false;
-      permResolveRef.current = null;
+      clearPermissionResolveRef();
       limitResolveRef.current = null;
       pendingToolCallsRef.current.clear();
     }
@@ -1993,37 +1992,7 @@ function App({
             }
           },
           onGatewayMeta: updateGatewayMeta,
-          askPermission: (req) =>
-            new Promise<PermissionDecision>((resolve) => {
-              if (modeRef.current === "auto") {
-                resolve("allow");
-                return;
-              }
-              if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
-                if (req.tool.name === "bash" && typeof req.args.command === "string" && isReadOnlyBash(req.args.command)) {
-                  resolve("allow");
-                  return;
-                }
-                if (req.tool.name === "bash") {
-                  // Non-whitelisted bash in plan mode: ask for temporary permission
-                  permResolveRef.current = resolve;
-                  setPerm({ tool: req.tool, args: req.args, resolve });
-                  return;
-                }
-                setEvents((e) => [
-                  ...e,
-                  {
-                    kind: "info",
-                    key: mkKey(),
-                    text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
-                  },
-                ]);
-                resolve("deny");
-                return;
-              }
-              permResolveRef.current = resolve;
-              setPerm({ tool: req.tool, args: req.args, resolve });
-            }),
+          askPermission: (req) => askForPermission(req, { promptOnBlockedBash: true }),
           onKimiMdStale: () => {
             if (!kimiMdStaleNudgedRef.current) {
               kimiMdStaleNudgedRef.current = true;
@@ -2155,7 +2124,7 @@ function App({
       activeAsstIdRef.current = null;
       activeScopeRef.current = null;
       isAbortingRef.current = false;
-      permResolveRef.current = null;
+      clearPermissionResolveRef();
       limitResolveRef.current = null;
       loopResolveRef.current = null;
       setLoopModal(null);
@@ -3600,31 +3569,7 @@ function App({
             setTasksStartTokens(0);
           }
         },
-        askPermission: (req: import("./tools/executor.js").PermissionRequest) =>
-          new Promise<PermissionDecision>((resolve) => {
-            if (modeRef.current === "auto") {
-              resolve("allow");
-              return;
-            }
-            if (modeRef.current === "plan" && isBlockedInPlanMode(req.tool.name)) {
-              if (req.tool.name === "bash" && typeof req.args.command === "string" && isReadOnlyBash(req.args.command)) {
-                resolve("allow");
-                return;
-              }
-              setEvents((e) => [
-                ...e,
-                {
-                  kind: "info",
-                  key: mkKey(),
-                  text: `plan mode blocked ${req.tool.name}; exit plan mode to execute`,
-                },
-              ]);
-              resolve("deny");
-              return;
-            }
-            permResolveRef.current = resolve;
-            setPerm({ tool: req.tool, args: req.args, resolve });
-          }),
+        askPermission: askForPermission,
         onToolLimitReached: () =>
           new Promise<LimitDecision>((resolve) => {
             limitResolveRef.current = resolve;
@@ -3682,7 +3627,7 @@ function App({
         activeAsstIdRef.current = null;
         activeScopeRef.current = null;
         isAbortingRef.current = false;
-        permResolveRef.current = null;
+        clearPermissionResolveRef();
         limitResolveRef.current = null;
         loopResolveRef.current = null;
         setLoopModal(null);
@@ -4224,11 +4169,7 @@ function App({
           <PermissionModal
             tool={perm.tool}
             args={perm.args}
-            onDecide={(d) => {
-              perm.resolve(d);
-              permResolveRef.current = null;
-              setPerm(null);
-            }}
+            onDecide={decidePermission}
             onFeedback={(text) => {
               submitRef.current(text);
             }}

--- a/src/ui/use-permission-controller.test.ts
+++ b/src/ui/use-permission-controller.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { decidePermission } from "./use-permission-controller.js";
+import type { PermissionRequest } from "../tools/executor.js";
+
+function req(toolName: string, args: Record<string, unknown> = {}): PermissionRequest {
+  return {
+    tool: { name: toolName } as PermissionRequest["tool"],
+    args,
+    sessionKey: toolName,
+  };
+}
+
+describe("decidePermission", () => {
+  describe("auto mode", () => {
+    it("resolves any tool with allow", () => {
+      assert.deepStrictEqual(decidePermission(req("bash", { command: "rm -rf /" }), "auto"), {
+        kind: "resolve",
+        decision: "allow",
+      });
+      assert.deepStrictEqual(decidePermission(req("write"), "auto"), {
+        kind: "resolve",
+        decision: "allow",
+      });
+    });
+  });
+
+  describe("plan mode", () => {
+    it("prompts for non-blocked tools (e.g. read)", () => {
+      assert.deepStrictEqual(decidePermission(req("read"), "plan"), { kind: "prompt" });
+    });
+
+    it("auto-allows read-only bash without prompting", () => {
+      assert.deepStrictEqual(decidePermission(req("bash", { command: "git status" }), "plan"), {
+        kind: "resolve",
+        decision: "allow",
+      });
+    });
+
+    it("blocks mutating bash by default", () => {
+      assert.deepStrictEqual(decidePermission(req("bash", { command: "rm -rf node_modules" }), "plan"), {
+        kind: "plan_blocked",
+        toolName: "bash",
+      });
+    });
+
+    it("prompts for mutating bash when promptOnBlockedBash is true", () => {
+      assert.deepStrictEqual(
+        decidePermission(req("bash", { command: "npm install" }), "plan", {
+          promptOnBlockedBash: true,
+        }),
+        { kind: "prompt" },
+      );
+    });
+
+    it("does NOT escape-hatch non-bash blocked tools even with promptOnBlockedBash", () => {
+      assert.deepStrictEqual(
+        decidePermission(req("write"), "plan", { promptOnBlockedBash: true }),
+        { kind: "plan_blocked", toolName: "write" },
+      );
+    });
+
+    it("blocks write and edit", () => {
+      assert.deepStrictEqual(decidePermission(req("write"), "plan"), {
+        kind: "plan_blocked",
+        toolName: "write",
+      });
+      assert.deepStrictEqual(decidePermission(req("edit"), "plan"), {
+        kind: "plan_blocked",
+        toolName: "edit",
+      });
+    });
+
+    it("blocks MCP tools", () => {
+      assert.deepStrictEqual(decidePermission(req("mcp_github_create_issue"), "plan"), {
+        kind: "plan_blocked",
+        toolName: "mcp_github_create_issue",
+      });
+    });
+  });
+
+  describe("edit mode", () => {
+    it("prompts for mutating tools", () => {
+      assert.deepStrictEqual(decidePermission(req("bash", { command: "npm install" }), "edit"), {
+        kind: "prompt",
+      });
+      assert.deepStrictEqual(decidePermission(req("write"), "edit"), { kind: "prompt" });
+    });
+
+    it("also prompts for read-only tools (the executor decides per spec.needsPermission)", () => {
+      assert.deepStrictEqual(decidePermission(req("read"), "edit"), { kind: "prompt" });
+    });
+
+    it("ignores promptOnBlockedBash (irrelevant outside plan mode)", () => {
+      assert.deepStrictEqual(
+        decidePermission(req("bash", { command: "npm test" }), "edit", {
+          promptOnBlockedBash: true,
+        }),
+        { kind: "prompt" },
+      );
+    });
+  });
+});

--- a/src/ui/use-permission-controller.ts
+++ b/src/ui/use-permission-controller.ts
@@ -1,0 +1,139 @@
+import { useCallback, useRef, useState } from "react";
+import type {
+  PermissionDecision,
+  PermissionRequest,
+} from "../tools/executor.js";
+import { isBlockedInPlanMode, isReadOnlyBash, type Mode } from "../mode.js";
+
+export interface PendingPermission {
+  tool: PermissionRequest["tool"];
+  args: Record<string, unknown>;
+  resolve: (decision: PermissionDecision) => void;
+}
+
+export type PermissionOutcome =
+  | { kind: "resolve"; decision: PermissionDecision }
+  | { kind: "prompt" }
+  | { kind: "plan_blocked"; toolName: string };
+
+export interface DecidePermissionOptions {
+  /**
+   * When the active mode is "plan" and the requested tool is blocked, the
+   * default is to emit a "plan mode blocked" event and deny. If this flag
+   * is true and the blocked tool is `bash`, prompt the user instead. This
+   * preserves the pre-refactor asymmetry between the init-turn and
+   * main-turn call sites in `app.tsx` (the init-turn path allowed
+   * one-shot bash prompts while in plan mode; the main-turn path did
+   * not).
+   */
+  promptOnBlockedBash?: boolean;
+}
+
+export function decidePermission(
+  req: PermissionRequest,
+  mode: Mode,
+  opts: DecidePermissionOptions = {},
+): PermissionOutcome {
+  if (mode === "auto") return { kind: "resolve", decision: "allow" };
+  if (mode === "plan" && isBlockedInPlanMode(req.tool.name)) {
+    if (
+      req.tool.name === "bash" &&
+      typeof req.args.command === "string" &&
+      isReadOnlyBash(req.args.command)
+    ) {
+      return { kind: "resolve", decision: "allow" };
+    }
+    if (req.tool.name === "bash" && opts.promptOnBlockedBash) {
+      return { kind: "prompt" };
+    }
+    return { kind: "plan_blocked", toolName: req.tool.name };
+  }
+  return { kind: "prompt" };
+}
+
+export interface PermissionController {
+  pending: PendingPermission | null;
+  askPermission: (
+    req: PermissionRequest,
+    opts?: DecidePermissionOptions,
+  ) => Promise<PermissionDecision>;
+  /**
+   * Synchronously check whether a permission promise is awaiting a
+   * decision. Reads from the resolver ref so it stays correct between
+   * the moment a promise was created and the corresponding state
+   * update flushes.
+   */
+  hasPending: () => boolean;
+  /** Resolve the pending permission with a user-chosen decision. */
+  decide: (decision: PermissionDecision) => void;
+  /**
+   * Synchronously deny any pending permission. Used by Ctrl+C and Escape
+   * to unblock the agent loop while tearing down the modal. Returns true
+   * if there was a pending permission.
+   */
+  denyPending: () => boolean;
+  /**
+   * Defensive clear used at turn-end cleanup. Does NOT resolve any
+   * pending promise — only clears the internal resolver ref so a stale
+   * resolver does not get triggered later.
+   */
+  clearResolveRef: () => void;
+}
+
+export function usePermissionController(
+  getMode: () => Mode,
+  onPlanModeBlocked: (toolName: string) => void,
+): PermissionController {
+  const [pending, setPending] = useState<PendingPermission | null>(null);
+  const resolveRef = useRef<((d: PermissionDecision) => void) | null>(null);
+  // Latest getter / callback are stashed in refs so the public methods
+  // (askPermission especially) keep stable identities across renders.
+  const getModeRef = useRef(getMode);
+  getModeRef.current = getMode;
+  const onPlanModeBlockedRef = useRef(onPlanModeBlocked);
+  onPlanModeBlockedRef.current = onPlanModeBlocked;
+
+  const askPermission = useCallback<PermissionController["askPermission"]>(
+    (req, askOpts) =>
+      new Promise<PermissionDecision>((resolve) => {
+        const outcome = decidePermission(req, getModeRef.current(), askOpts);
+        if (outcome.kind === "resolve") {
+          resolve(outcome.decision);
+          return;
+        }
+        if (outcome.kind === "plan_blocked") {
+          onPlanModeBlockedRef.current(outcome.toolName);
+          resolve("deny");
+          return;
+        }
+        // outcome.kind === "prompt"
+        resolveRef.current = resolve;
+        setPending({ tool: req.tool, args: req.args, resolve });
+      }),
+    [],
+  );
+
+  const hasPending = useCallback(() => resolveRef.current !== null, []);
+
+  const decide = useCallback((decision: PermissionDecision) => {
+    const pendingResolve = resolveRef.current;
+    resolveRef.current = null;
+    setPending(null);
+    pendingResolve?.(decision);
+  }, []);
+
+  const denyPending = useCallback(() => {
+    const pendingResolve = resolveRef.current;
+    if (pendingResolve === null) return false;
+    resolveRef.current = null;
+    setPending(null);
+    pendingResolve("deny");
+    return true;
+  }, []);
+
+  const clearResolveRef = useCallback(() => {
+    resolveRef.current = null;
+  }, []);
+
+  return { pending, askPermission, hasPending, decide, denyPending, clearResolveRef };
+}


### PR DESCRIPTION
First extraction of the **`app.tsx` breakup** (M4 in [`development-roadmap.md`](https://github.com/sinameraji/kimiflare/blob/main/docs/architecture/development-roadmap.md)). M4.1 specifically — `PermissionController`.

## Summary

- New file `src/ui/use-permission-controller.ts` (139 LOC) wraps the permission-prompt state machine:
  - `PendingPermission` state + the pending-resolver ref
  - Both `askPermission` promise-builders that were inlined at the `runAgentTurn` config sites
  - `denyPending()` for the synchronous Ctrl+C / Escape / SIGINT deny paths
  - `clearResolveRef()` for turn-end defensive cleanup
  - `hasPending()` for the diagnostic logs that peek at pending-permission state
- Pure decision logic extracted as `decidePermission()` and unit-tested without React (11 cases).
- `app.tsx` loses 59 net lines (4,393 → 4,334) and stops directly managing `permResolveRef`, the two duplicated `askPermission` bodies, and the modal-state plumbing.

### Behaviour preservation

The pre-refactor code had two near-identical `askPermission` bodies. They differed only in whether a plan-mode-blocked `bash` call falls through to a prompt — the init-turn path (around old line 1996) did; the main-turn path (around old line 3603) did not. This is preserved via a new `DecidePermissionOptions.promptOnBlockedBash` flag. **This PR is a pure refactor and does not change behaviour.**

I'd love a second opinion on whether that asymmetry was intentional. The comment in the old code (\"Non-whitelisted bash in plan mode: ask for temporary permission\") suggests yes, but it's worth flagging.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 396/396 pass (11 new in `use-permission-controller.test.ts`)
- [x] `npm run build` — succeeds
- [ ] Manual smoke test in `npm run dev`:
  - [ ] In `edit` mode, a `bash` call surfaces the permission modal and accepts/rejects correctly
  - [ ] In `auto` mode, no modal appears
  - [ ] In `plan` mode, `write` / `edit` are denied with the inline event log
  - [ ] In `plan` mode, a read-only bash command (`git status`) auto-allows
  - [ ] In `plan` mode, a mutating bash command from the init-turn path prompts (escape hatch)
  - [ ] Ctrl+C during a permission prompt resolves with deny and unblocks the loop
  - [ ] Escape during a permission prompt does the same

Closes M4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)