### PR TITLE
feat(ai-gateway): make Cloudflare AI Gateway the default backend

### DIFF
--- a/KIMI.md
+++ b/KIMI.md
@@ -210,8 +210,8 @@ node --inspect-brk bin/kimiflare.mjs
 7. Optional: memory extraction, cost tracking, compaction, skill injection.
 
 ### External Integrations
-- **Cloudflare Workers AI** — primary LLM backend (Kimi-K2.6).
-- **Cloudflare AI Gateway** — caching, rate limiting, observability.
+- **Cloudflare AI Gateway** — the spine. All Workers AI traffic is routed through the user's own Gateway by default: this gives us per-request logs, caching, and authoritative cost attribution via `cf-aig-metadata` tagging (`feature`, `sessionId`, `turnIdx`). Gateway logs are the source of truth for `/cost`; local heuristics are demoted to a brief fallback used only until logs catch up. Emergency opt-out: `KIMIFLARE_DISABLE_AI_GATEWAY=1`.
+- **Cloudflare Workers AI** — LLM backend (Kimi-K2.6). Reached via the Gateway in normal operation; direct path remains in code as fallback only.
 - **KimiFlare Cloud** — optional proxy mode with device auth.
 - **MCP Servers** — external tools via Model Context Protocol.
 - **LSP Servers** — language servers for code intelligence.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ npx kimiflare
 
 Requires Node.js ≥ 20.
 
+### AI Gateway (default)
+
+KimiFlare now routes Workers AI requests through your own **Cloudflare AI Gateway**. This unlocks:
+
+- Per-request payload logs in the Cloudflare dashboard
+- Response caching (set TTL with `/gateway cache-ttl <seconds>`)
+- Authoritative cost via the Gateway logs API, replacing local cost heuristics
+- Auto-tagging of every request with `feature` / `sessionId` / `turnIdx` metadata
+
+The onboarding wizard creates or picks an AI Gateway for you. Your Cloudflare API token needs these permissions:
+
+- `Workers AI:Read`
+- `AI Gateway:Read` (to list gateways)
+- `AI Gateway:Edit` (to create gateways)
+
+Edit your token at: https://dash.cloudflare.com/profile/api-tokens
+
+Once configured, run `/cost` in the TUI to see a Gateway section with cache hit ratio and direct dashboard links to each request log.
+
+For emergencies, set `KIMIFLARE_DISABLE_AI_GATEWAY=1` to fall back to the direct Workers AI path.
+
 ### One-shot mode
 
 ```sh

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -460,6 +460,17 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     }
 
     logger.debug("turn:api_request", { sessionId: opts.sessionId, messageCount: apiMessages.length });
+    const turnGateway = opts.gateway
+      ? {
+          ...opts.gateway,
+          metadata: {
+            ...(opts.gateway.metadata ?? {}),
+            feature: "chat",
+            ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
+            turnIdx: turn,
+          },
+        }
+      : undefined;
     const events = runKimi({
       accountId: opts.accountId,
       apiToken: opts.apiToken,
@@ -471,7 +482,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       maxCompletionTokens: opts.maxCompletionTokens,
       reasoningEffort: opts.reasoningEffort,
       sessionId: opts.sessionId,
-      gateway: opts.gateway,
+      gateway: turnGateway,
       cloudMode: opts.cloudMode,
       cloudToken: opts.cloudToken,
       cloudDeviceId: opts.cloudDeviceId,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -88,7 +88,7 @@ import {
 import { unlink } from "node:fs/promises";
 import { execSync } from "node:child_process";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
-import { recordUsage, getCostReport, formatCostReport } from "./usage-tracker.js";
+import { recordUsage, getCostReport, formatCostReport, formatGatewaySection, getSessionGatewayLogs } from "./usage-tracker.js";
 import type { GatewayUsageLookup, DailyUsage } from "./usage-tracker.js";
 import { MemoryManager } from "./memory/manager.js";
 import { RETENTION } from "./storage-limits.js";
@@ -347,6 +347,7 @@ interface Cfg {
 }
 
 function gatewayFromConfig(cfg: Cfg): AiGatewayOptions | undefined {
+  if (process.env.KIMIFLARE_DISABLE_AI_GATEWAY === "1") return undefined;
   if (!cfg.aiGatewayId) return undefined;
   return {
     id: cfg.aiGatewayId,
@@ -361,6 +362,7 @@ function gatewayUsageLookupFromConfig(
   cfg: Cfg,
   meta: GatewayMeta | null,
 ): GatewayUsageLookup | undefined {
+  if (process.env.KIMIFLARE_DISABLE_AI_GATEWAY === "1") return undefined;
   if (!cfg.aiGatewayId || !meta) return undefined;
   return {
     accountId: cfg.accountId,
@@ -2368,6 +2370,12 @@ function App({
         void getCostReport(sessionIdRef.current ?? undefined)
           .then(async (report) => {
             const lines = [formatCostReport(report)];
+            if (cfg?.aiGatewayId && process.env.KIMIFLARE_DISABLE_AI_GATEWAY !== "1") {
+              const sid = sessionIdRef.current;
+              const logs = sid ? await getSessionGatewayLogs(sid).catch(() => []) : [];
+              const gwSection = formatGatewaySection(report, cfg.accountId, cfg.aiGatewayId, logs);
+              if (gwSection) lines.push("", gwSection);
+            }
             if (cfg?.costAttribution) {
               const { getCategoryReportText } = await import("./cost-attribution/tui-report.js");
               const catReport = await getCategoryReportText(sessionIdRef.current ?? undefined);

--- a/src/cloud/ai-gateway-api.test.ts
+++ b/src/cloud/ai-gateway-api.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { listGateways, createGateway, AiGatewayError } from "./ai-gateway-api.js";
+
+describe("ai-gateway-api", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let nextResponse: { status: number; body: unknown } = { status: 200, body: { result: [] } };
+  let lastRequest: Request | null = null;
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      lastRequest = new Request(input, init);
+      return new Response(JSON.stringify(nextResponse.body), {
+        status: nextResponse.status,
+        headers: { "content-type": "application/json" },
+      });
+    };
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("listGateways returns the result array", async () => {
+    nextResponse = {
+      status: 200,
+      body: { result: [{ id: "gw-1" }, { id: "gw-2" }] },
+    };
+    const result = await listGateways("acct", "token");
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0]!.id, "gw-1");
+    assert.match(lastRequest!.url, /\/accounts\/acct\/ai-gateway\/gateways$/);
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer token");
+  });
+
+  it("listGateways throws AiGatewayError with kind=forbidden on 403", async () => {
+    nextResponse = {
+      status: 403,
+      body: { errors: [{ message: "Missing AI Gateway:Read scope" }] },
+    };
+    await assert.rejects(
+      () => listGateways("acct", "token"),
+      (err: unknown) => {
+        assert.ok(err instanceof AiGatewayError);
+        assert.strictEqual(err.detail.kind, "forbidden");
+        return true;
+      },
+    );
+  });
+
+  it("createGateway POSTs with cache_ttl=0 and collect_logs=true", async () => {
+    nextResponse = {
+      status: 200,
+      body: { result: { id: "kimiflare", cache_ttl: 0, collect_logs: true } },
+    };
+    const gw = await createGateway("acct", "token", "kimiflare");
+    assert.strictEqual(gw.id, "kimiflare");
+    assert.strictEqual(lastRequest!.method, "POST");
+    const body = JSON.parse(await lastRequest!.text()) as Record<string, unknown>;
+    assert.strictEqual(body.id, "kimiflare");
+    assert.strictEqual(body.cache_ttl, 0);
+    assert.strictEqual(body.collect_logs, true);
+  });
+});

--- a/src/cloud/ai-gateway-api.ts
+++ b/src/cloud/ai-gateway-api.ts
@@ -1,0 +1,151 @@
+import { getUserAgent } from "../util/version.js";
+
+export interface Gateway {
+  id: string;
+  cache_ttl?: number;
+  collect_logs?: boolean;
+  created_at?: string;
+  modified_at?: string;
+}
+
+export type GatewayApiError =
+  | { kind: "forbidden"; message: string }
+  | { kind: "not_found"; message: string }
+  | { kind: "network"; message: string }
+  | { kind: "other"; status: number; message: string };
+
+export class AiGatewayError extends Error {
+  constructor(public readonly detail: GatewayApiError) {
+    super(detail.message);
+    this.name = "AiGatewayError";
+  }
+}
+
+function baseUrl(accountId: string): string {
+  return `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai-gateway/gateways`;
+}
+
+function authHeaders(apiToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiToken}`,
+    "Content-Type": "application/json",
+    "User-Agent": getUserAgent(),
+  };
+}
+
+async function parseCloudflareError(res: Response): Promise<GatewayApiError> {
+  let text = "";
+  try {
+    text = await res.text();
+  } catch {
+    /* ignore */
+  }
+  let message = `HTTP ${res.status}`;
+  try {
+    const parsed = JSON.parse(text) as {
+      errors?: Array<{ message?: string; code?: number }>;
+    };
+    if (parsed.errors?.length) {
+      message = parsed.errors.map((e) => e.message).filter(Boolean).join("; ") || message;
+    }
+  } catch {
+    if (text) message = text.slice(0, 200);
+  }
+  if (res.status === 403 || res.status === 401) {
+    return { kind: "forbidden", message };
+  }
+  if (res.status === 404) {
+    return { kind: "not_found", message };
+  }
+  return { kind: "other", status: res.status, message };
+}
+
+async function doFetch(url: string, init: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (e) {
+    throw new AiGatewayError({
+      kind: "network",
+      message: e instanceof Error ? e.message : String(e),
+    });
+  }
+}
+
+export async function listGateways(
+  accountId: string,
+  apiToken: string,
+): Promise<Gateway[]> {
+  const res = await doFetch(baseUrl(accountId), {
+    method: "GET",
+    headers: authHeaders(apiToken),
+  });
+  if (!res.ok) {
+    throw new AiGatewayError(await parseCloudflareError(res));
+  }
+  const json = (await res.json()) as { result?: Gateway[] };
+  return Array.isArray(json.result) ? json.result : [];
+}
+
+export async function createGateway(
+  accountId: string,
+  apiToken: string,
+  id: string,
+): Promise<Gateway> {
+  const res = await doFetch(baseUrl(accountId), {
+    method: "POST",
+    headers: authHeaders(apiToken),
+    body: JSON.stringify({
+      id,
+      cache_invalidate_on_update: false,
+      cache_ttl: 0,
+      collect_logs: true,
+      rate_limiting_interval: 0,
+      rate_limiting_limit: 0,
+      rate_limiting_technique: "fixed",
+    }),
+  });
+  if (!res.ok) {
+    throw new AiGatewayError(await parseCloudflareError(res));
+  }
+  const json = (await res.json()) as { result?: Gateway };
+  if (!json.result) {
+    throw new AiGatewayError({
+      kind: "other",
+      status: res.status,
+      message: "Cloudflare returned no gateway result",
+    });
+  }
+  return json.result;
+}
+
+/**
+ * Validate that the gateway is reachable for a Workers AI request. We send a
+ * minimal request to a known-cheap embeddings model and treat any 2xx/4xx
+ * response from Cloudflare as proof that routing works; only network errors
+ * and 5xx are surfaced as probe failures.
+ */
+export async function probeGateway(
+  accountId: string,
+  apiToken: string,
+  gatewayId: string,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const url = `https://gateway.ai.cloudflare.com/v1/${encodeURIComponent(accountId)}/${encodeURIComponent(gatewayId)}/workers-ai/@cf/baai/bge-base-en-v1.5`;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+        "User-Agent": getUserAgent(),
+        "cf-aig-skip-cache": "true",
+      },
+      body: JSON.stringify({ text: ["kimiflare probe"] }),
+    });
+    if (res.status >= 500) {
+      return { ok: false, message: `Gateway returned HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -150,6 +150,16 @@ function readGatewayMetadataEnv(): Record<string, string | number | boolean> | u
   }
 }
 
+function warnIfBlankGatewayId(value: string | undefined, source: string): void {
+  if (value === undefined) return;
+  if (value.trim().length === 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `kimiflare: ${source} aiGatewayId is set but empty — gateway routing will be skipped.`,
+    );
+  }
+}
+
 export async function loadConfig(): Promise<KimiConfig | null> {
   const envAccount = process.env.CLOUDFLARE_ACCOUNT_ID ?? process.env.CF_ACCOUNT_ID;
   const envToken = process.env.CLOUDFLARE_API_TOKEN ?? process.env.CF_API_TOKEN;
@@ -157,6 +167,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envEffort = readReasoningEffortEnv();
   const envCoauthor = readCoauthorEnv();
   const envAiGatewayId = process.env.KIMIFLARE_AI_GATEWAY_ID;
+  warnIfBlankGatewayId(envAiGatewayId, "env");
   const envAiGatewayCacheTtl = readNumberEnv("KIMIFLARE_AI_GATEWAY_CACHE_TTL");
   const envAiGatewaySkipCache = readBooleanEnv("KIMIFLARE_AI_GATEWAY_SKIP_CACHE");
   const envAiGatewayCollectLogPayload = readBooleanEnv(
@@ -274,6 +285,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       };
     }
     if (parsed.accountId && parsed.apiToken) {
+      warnIfBlankGatewayId(parsed.aiGatewayId, "config");
       return {
         accountId: envAccount ?? parsed.accountId,
         apiToken: envToken ?? parsed.apiToken,

--- a/src/cost-attribution/reconcile.test.ts
+++ b/src/cost-attribution/reconcile.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { aggregateByFeature } from "./reconcile.js";
+
+describe("aggregateByFeature", () => {
+  it("groups logs by metadata.feature and sums cost", () => {
+    const out = aggregateByFeature([
+      { cost: 0.01, metadata: { feature: "chat" } },
+      { cost: 0.02, metadata: { feature: "chat" } },
+      { cost: 0.005, metadata: { feature: "embedding" } },
+      { cost: 0.001, metadata: null },
+    ]);
+    const chat = out.find((e) => e.feature === "chat");
+    const embedding = out.find((e) => e.feature === "embedding");
+    const unknown = out.find((e) => e.feature === "unknown");
+    assert.ok(chat);
+    assert.strictEqual(chat!.cost, 0.03);
+    assert.strictEqual(chat!.requests, 2);
+    assert.ok(embedding);
+    assert.strictEqual(embedding!.requests, 1);
+    assert.ok(unknown);
+    assert.strictEqual(unknown!.requests, 1);
+  });
+
+  it("parses metadata when stored as a JSON string", () => {
+    const out = aggregateByFeature([
+      { cost: 0.05, metadata: JSON.stringify({ feature: "tool" }) },
+    ]);
+    assert.strictEqual(out[0]!.feature, "tool");
+  });
+});

--- a/src/cost-attribution/reconcile.ts
+++ b/src/cost-attribution/reconcile.ts
@@ -1,16 +1,18 @@
 /**
- * Cloudflare reconciliation: compare local cost sum to gateway ground truth.
+ * Cloudflare AI Gateway reconciliation: bulk-fetch /ai-gateway logs in the
+ * given date range and treat the gateway's cost as ground truth.
  */
 
 import type { ReconciliationResult } from "./types.js";
+import { getUserAgent } from "../util/version.js";
 
 export interface ReconcileOptions {
   localCost: number;
   accountId?: string;
   apiToken?: string;
   gatewayId?: string;
-  startDate: string;
-  endDate: string;
+  startDate: string; // YYYY-MM-DD inclusive
+  endDate: string;   // YYYY-MM-DD inclusive
 }
 
 // In-memory cache for 1 hour
@@ -20,9 +22,106 @@ function cacheKey(opts: ReconcileOptions): string {
   return `${opts.gatewayId ?? "none"}:${opts.startDate}:${opts.endDate}`;
 }
 
+interface GatewayLog {
+  id?: string;
+  cost?: number;
+  cached?: boolean;
+  metadata?: Record<string, unknown> | string | null;
+  created_at?: string;
+}
+
+function toIsoStartOfDay(date: string): string {
+  return `${date}T00:00:00Z`;
+}
+
+function toIsoEndOfDay(date: string): string {
+  return `${date}T23:59:59Z`;
+}
+
+export async function fetchGatewayLogs(
+  accountId: string,
+  apiToken: string,
+  gatewayId: string,
+  startDate: string,
+  endDate: string,
+  pageLimit = 10,
+): Promise<GatewayLog[]> {
+  const base = `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/ai-gateway/gateways/${encodeURIComponent(gatewayId)}/logs`;
+  const headers = {
+    Authorization: `Bearer ${apiToken}`,
+    "User-Agent": getUserAgent(),
+  };
+  const out: GatewayLog[] = [];
+  let cursor: string | undefined;
+  for (let i = 0; i < pageLimit; i++) {
+    const params = new URLSearchParams({
+      per_page: "500",
+      start_date: toIsoStartOfDay(startDate),
+      end_date: toIsoEndOfDay(endDate),
+      order_by: "created_at",
+      order_by_direction: "desc",
+    });
+    if (cursor) params.set("cursor", cursor);
+    const res = await fetch(`${base}?${params.toString()}`, { headers });
+    if (!res.ok) {
+      throw new Error(`gateway logs HTTP ${res.status}`);
+    }
+    const json = (await res.json()) as {
+      result?: GatewayLog[];
+      result_info?: { cursor?: string; total_pages?: number };
+    };
+    const page = Array.isArray(json.result) ? json.result : [];
+    out.push(...page);
+    cursor = json.result_info?.cursor;
+    if (!cursor || page.length === 0) break;
+  }
+  return out;
+}
+
+export interface FeatureBreakdown {
+  feature: string;
+  cost: number;
+  requests: number;
+}
+
+export function aggregateByFeature(logs: GatewayLog[]): FeatureBreakdown[] {
+  const map = new Map<string, FeatureBreakdown>();
+  for (const log of logs) {
+    let feature = "unknown";
+    const m = log.metadata;
+    if (m && typeof m === "object" && !Array.isArray(m)) {
+      const f = (m as Record<string, unknown>).feature;
+      if (typeof f === "string") feature = f;
+    } else if (typeof m === "string") {
+      try {
+        const parsed = JSON.parse(m) as Record<string, unknown>;
+        if (typeof parsed.feature === "string") feature = parsed.feature;
+      } catch {
+        /* ignore */
+      }
+    }
+    const entry = map.get(feature) ?? { feature, cost: 0, requests: 0 };
+    entry.cost += typeof log.cost === "number" ? log.cost : 0;
+    entry.requests += 1;
+    map.set(feature, entry);
+  }
+  return Array.from(map.values()).sort((a, b) => b.cost - a.cost);
+}
+
 export async function reconcileWithCloudflare(opts: ReconcileOptions): Promise<ReconciliationResult> {
   if (!opts.accountId || !opts.apiToken) {
-    return { status: "local-only", localCost: opts.localCost, message: "Missing Cloudflare credentials" };
+    return {
+      status: "local-only",
+      localCost: opts.localCost,
+      message: "Missing Cloudflare credentials",
+    };
+  }
+  if (!opts.gatewayId) {
+    return {
+      status: "local-only",
+      localCost: opts.localCost,
+      message: "No AI Gateway configured",
+    };
   }
 
   const key = cacheKey(opts);
@@ -32,14 +131,29 @@ export async function reconcileWithCloudflare(opts: ReconcileOptions): Promise<R
   }
 
   try {
-    // TODO: implement GraphQL Analytics fetch when gateway API is available
-    // For now, return local-only to avoid blocking the report
+    const logs = await fetchGatewayLogs(
+      opts.accountId,
+      opts.apiToken,
+      opts.gatewayId,
+      opts.startDate,
+      opts.endDate,
+    );
+    const cloudflareCost = logs.reduce(
+      (sum, log) => sum + (typeof log.cost === "number" ? log.cost : 0),
+      0,
+    );
+    const driftPct =
+      cloudflareCost > 0
+        ? Math.abs(opts.localCost - cloudflareCost) / cloudflareCost
+        : 0;
+    const status: ReconciliationResult["status"] = driftPct < 0.02 ? "verified" : "drift";
     const result: ReconciliationResult = {
-      status: "local-only",
+      status,
       localCost: opts.localCost,
-      message: "Cloudflare reconciliation not yet implemented",
+      cloudflareCost,
+      driftPct: Math.round(driftPct * 1000) / 10,
+      message: `Reconciled ${logs.length} Gateway log entries`,
     };
-
     cache.set(key, { result, expires: Date.now() + 60 * 60 * 1000 });
     return result;
   } catch (err) {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -74,10 +74,19 @@ export async function fetchEmbeddings(opts: EmbedOpts): Promise<Float32Array[]> 
       : `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${model}`;
     headers.Authorization = `Bearer ${opts.apiToken}`;
 
-    if (opts.gateway?.metadata) {
-      for (const [k, v] of Object.entries(opts.gateway.metadata)) {
-        headers[`cf-aig-metadata-${k}`] = String(v);
-      }
+    if (opts.gateway) {
+      const merged: Record<string, string | number | boolean> = {
+        ...(opts.gateway.metadata ?? {}),
+        feature: "embedding",
+      };
+      const entries = Object.entries(merged).slice(0, 5);
+      headers["cf-aig-metadata"] = JSON.stringify(Object.fromEntries(entries));
+    }
+    if (opts.gateway?.cacheTtl !== undefined) {
+      headers["cf-aig-cache-ttl"] = String(opts.gateway.cacheTtl);
+    }
+    if (opts.gateway?.skipCache !== undefined) {
+      headers["cf-aig-skip-cache"] = String(opts.gateway.skipCache);
     }
   }
 

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -1,15 +1,32 @@
-import React, { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import { CustomTextInput } from "./text-input.js";
 import { saveConfig, DEFAULT_MODEL } from "../config.js";
 import { useTheme } from "./theme-context.js";
+import {
+  listGateways,
+  createGateway,
+  probeGateway,
+  AiGatewayError,
+  type Gateway,
+} from "../cloud/ai-gateway-api.js";
 
 interface Props {
-  onDone: (cfg: { accountId: string; apiToken: string; model: string }) => void;
+  onDone: (cfg: { accountId: string; apiToken: string; model: string; aiGatewayId?: string }) => void;
   onCancel?: () => void;
 }
 
-type Step = "accountId" | "apiToken" | "model" | "confirm";
+type Step =
+  | "accountId"
+  | "apiToken"
+  | "gatewayLoading"
+  | "gatewayPick"
+  | "gatewayCreate"
+  | "gatewayScopeError"
+  | "gatewayManual"
+  | "gatewayProbing"
+  | "model"
+  | "confirm";
 
 export function Onboarding({ onDone, onCancel }: Props) {
   const theme = useTheme();
@@ -19,7 +36,14 @@ export function Onboarding({ onDone, onCancel }: Props) {
   const [model, setModel] = useState(DEFAULT_MODEL);
   const [savedPath, setSavedPath] = useState<string | null>(null);
 
-  // ─── Keyboard Handling ─────────────────────────────────────────────────────
+  const [gateways, setGateways] = useState<Gateway[]>([]);
+  const [gatewayPickIdx, setGatewayPickIdx] = useState(0);
+  const [aiGatewayId, setAiGatewayId] = useState<string>("");
+  const [gatewayNewName, setGatewayNewName] = useState("kimiflare");
+  const [gatewayManualId, setGatewayManualId] = useState("");
+  const [gatewayError, setGatewayError] = useState<string | null>(null);
+  const [gatewayProbeMsg, setGatewayProbeMsg] = useState<string | null>(null);
+
   useInput(
     useCallback(
       (_input, key) => {
@@ -31,7 +55,74 @@ export function Onboarding({ onDone, onCancel }: Props) {
     ),
   );
 
-  // ─── Handlers ──────────────────────────────────────────────────────────────
+  // Arrow-key navigation on the picker.
+  useInput(
+    (_input, key) => {
+      if (step !== "gatewayPick") return;
+      const total = gateways.length + 1; // +1 for create
+      if (key.upArrow) {
+        setGatewayPickIdx((i) => (i - 1 + total) % total);
+      } else if (key.downArrow) {
+        setGatewayPickIdx((i) => (i + 1) % total);
+      } else if (key.return) {
+        if (gatewayPickIdx === gateways.length) {
+          setStep("gatewayCreate");
+        } else {
+          const picked = gateways[gatewayPickIdx];
+          if (picked) {
+            setAiGatewayId(picked.id);
+            void runProbe(picked.id);
+          }
+        }
+      }
+    },
+  );
+
+  // Kick off gateway listing when entering the loading step.
+  useEffect(() => {
+    if (step !== "gatewayLoading") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await listGateways(accountId, apiToken);
+        if (cancelled) return;
+        if (list.length === 0) {
+          setStep("gatewayCreate");
+        } else {
+          setGateways(list);
+          setGatewayPickIdx(0);
+          setStep("gatewayPick");
+        }
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof AiGatewayError && e.detail.kind === "forbidden") {
+          setGatewayError(e.detail.message);
+          setStep("gatewayScopeError");
+        } else {
+          setGatewayError(e instanceof Error ? e.message : String(e));
+          setStep("gatewayScopeError");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [step, accountId, apiToken]);
+
+  const runProbe = async (gid: string) => {
+    setGatewayProbeMsg(null);
+    setStep("gatewayProbing");
+    const result = await probeGateway(accountId, apiToken, gid);
+    if (result.ok) {
+      setAiGatewayId(gid);
+      setStep("model");
+    } else {
+      setGatewayProbeMsg(result.message);
+      setGatewayError(result.message);
+      setStep("gatewayScopeError");
+    }
+  };
+
   const handleAccountIdSubmit = (value: string) => {
     const trimmed = value.trim();
     if (!trimmed) return;
@@ -43,7 +134,30 @@ export function Onboarding({ onDone, onCancel }: Props) {
     const trimmed = value.trim();
     if (!trimmed) return;
     setApiToken(trimmed);
-    setStep("model");
+    setStep("gatewayLoading");
+  };
+
+  const handleGatewayCreateSubmit = async (value: string) => {
+    const name = (value.trim() || "kimiflare").toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+    setGatewayError(null);
+    try {
+      const gw = await createGateway(accountId, apiToken, name);
+      await runProbe(gw.id);
+    } catch (e) {
+      if (e instanceof AiGatewayError && e.detail.kind === "forbidden") {
+        setGatewayError(e.detail.message);
+        setStep("gatewayScopeError");
+      } else {
+        setGatewayError(e instanceof Error ? e.message : String(e));
+        setStep("gatewayScopeError");
+      }
+    }
+  };
+
+  const handleManualGatewaySubmit = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    void runProbe(trimmed);
   };
 
   const handleModelSubmit = (value: string) => {
@@ -53,7 +167,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
   };
 
   const handleConfirm = async () => {
-    const cfg = { accountId, apiToken, model };
+    const cfg = { accountId, apiToken, model, aiGatewayId: aiGatewayId || undefined };
     try {
       const path = await saveConfig(cfg);
       setSavedPath(path);
@@ -63,12 +177,11 @@ export function Onboarding({ onDone, onCancel }: Props) {
     }
   };
 
-  // ─── Step Count ────────────────────────────────────────────────────────────
-  const steps = ["accountId", "apiToken", "model", "confirm"] as const;
-  const stepIndex = steps.indexOf(step) + 1;
-  const totalSteps = steps.length;
+  // Step numbering: keep simple linear count for visible steps.
+  const visibleSteps: Step[] = ["accountId", "apiToken", "gatewayLoading", "model", "confirm"];
+  const stepIndex = Math.max(1, visibleSteps.indexOf(step) === -1 ? 3 : visibleSteps.indexOf(step) + 1);
+  const totalSteps = visibleSteps.length;
 
-  // ─── Render ────────────────────────────────────────────────────────────────
   return (
     <Box flexDirection="column" paddingY={1}>
       <Box marginBottom={1}>
@@ -103,6 +216,9 @@ export function Onboarding({ onDone, onCancel }: Props) {
             <Text color={theme.info.color}>
               Create one at https://dash.cloudflare.com/profile/api-tokens
             </Text>
+            <Text color={theme.info.color}>
+              Required permissions: Workers AI:Read, AI Gateway:Read, AI Gateway:Edit
+            </Text>
             <Box marginTop={1}>
               <Text color={theme.palette.primary}>› </Text>
               <CustomTextInput
@@ -115,10 +231,97 @@ export function Onboarding({ onDone, onCancel }: Props) {
           </>
         )}
 
+        {step === "gatewayLoading" && (
+          <Text color={theme.info.color}>Looking up your AI Gateways…</Text>
+        )}
+
+        {step === "gatewayPick" && (
+          <>
+            <Text>Pick an AI Gateway to route requests through</Text>
+            <Text color={theme.info.color}>
+              Use ↑/↓ to navigate, Enter to select.
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              {gateways.map((gw, i) => (
+                <Text key={gw.id} color={i === gatewayPickIdx ? theme.palette.primary : undefined}>
+                  {i === gatewayPickIdx ? "› " : "  "}
+                  {gw.id}
+                </Text>
+              ))}
+              <Text color={gatewayPickIdx === gateways.length ? theme.palette.primary : undefined}>
+                {gatewayPickIdx === gateways.length ? "› " : "  "}
+                + Create new…
+              </Text>
+            </Box>
+          </>
+        )}
+
+        {step === "gatewayCreate" && (
+          <>
+            <Text>Name for your new AI Gateway</Text>
+            <Text color={theme.info.color}>
+              Lowercase letters, numbers, _ and - only. Default: kimiflare
+            </Text>
+            <Box marginTop={1}>
+              <Text color={theme.palette.primary}>› </Text>
+              <CustomTextInput
+                value={gatewayNewName}
+                onChange={setGatewayNewName}
+                onSubmit={handleGatewayCreateSubmit}
+              />
+            </Box>
+          </>
+        )}
+
+        {step === "gatewayProbing" && (
+          <Text color={theme.info.color}>Verifying gateway routing…</Text>
+        )}
+
+        {step === "gatewayScopeError" && (
+          <>
+            <Text color={theme.palette.error ?? "red"}>
+              Couldn't reach AI Gateway: {gatewayError ?? "permission denied"}
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              <Text>Your API token likely lacks the required scopes.</Text>
+              <Text color={theme.info.color}>Required permissions:</Text>
+              <Text color={theme.info.color}>  • AI Gateway:Read  (to list gateways)</Text>
+              <Text color={theme.info.color}>  • AI Gateway:Edit  (to create one)</Text>
+              <Text color={theme.info.color}>  • Workers AI:Read  (to run models)</Text>
+              <Text>
+                Edit your token at: https://dash.cloudflare.com/profile/api-tokens
+              </Text>
+            </Box>
+            <Text>{" "}</Text>
+            <Text>Press Enter to retry, or type a Gateway ID manually below.</Text>
+            <Box marginTop={1}>
+              <Text color={theme.palette.primary}>retry › </Text>
+              <CustomTextInput
+                value=""
+                onChange={() => {}}
+                onSubmit={() => setStep("gatewayLoading")}
+              />
+            </Box>
+            <Box marginTop={1}>
+              <Text color={theme.palette.primary}>manual › </Text>
+              <CustomTextInput
+                value={gatewayManualId}
+                onChange={setGatewayManualId}
+                onSubmit={handleManualGatewaySubmit}
+              />
+            </Box>
+          </>
+        )}
+
         {step === "model" && (
           <>
             <Text>Model ID (press Enter for default)</Text>
             <Text color={theme.info.color}>default: {DEFAULT_MODEL}</Text>
+            {aiGatewayId && (
+              <Text color={theme.palette.success}>
+                Gateway: {aiGatewayId} ✓
+              </Text>
+            )}
             <Box marginTop={1}>
               <Text color={theme.palette.primary}>› </Text>
               <CustomTextInput
@@ -144,8 +347,16 @@ export function Onboarding({ onDone, onCancel }: Props) {
               <Text color={theme.info.color}>Account ID: {accountId}</Text>
               <Text color={theme.info.color}>API Token: {"•".repeat(apiToken.length)}</Text>
               <Text color={theme.info.color}>Model: {model}</Text>
+              {aiGatewayId && (
+                <Text color={theme.info.color}>AI Gateway: {aiGatewayId}</Text>
+              )}
             </Box>
             <Text>Press Enter to confirm, or Ctrl+C to cancel</Text>
+            {aiGatewayId && (
+              <Text color={theme.info.color}>
+                Tip: enable response caching with `/gateway cache-ttl 60` to cut costs on repeated prompts.
+              </Text>
+            )}
             <Box marginTop={1}>
               <Text color={theme.palette.primary}>› </Text>
               <CustomTextInput
@@ -155,6 +366,10 @@ export function Onboarding({ onDone, onCancel }: Props) {
               />
             </Box>
           </>
+        )}
+
+        {gatewayProbeMsg && step !== "gatewayProbing" && step !== "gatewayScopeError" && (
+          <Text color={theme.palette.error ?? "red"}>Probe failed: {gatewayProbeMsg}</Text>
         )}
 
         {savedPath && (

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -346,6 +346,13 @@ export async function getCostReport(sessionId?: string): Promise<CostReport> {
   return { session, today: todayUsage, month: monthUsage, allTime };
 }
 
+/** Fetch the GatewayUsageSnapshot array recorded against a session, for /cost rendering. */
+export async function getSessionGatewayLogs(sessionId: string): Promise<GatewayUsageSnapshot[]> {
+  const log = await loadLog();
+  const session = log.sessions.find((s) => s.id === sessionId);
+  return session?.gatewayLogs ?? [];
+}
+
 function fmtTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
@@ -357,6 +364,43 @@ function fmtGateway(u: DailyUsage): string {
   const cached = u.gatewayCachedRequests ? `, ${u.gatewayCachedRequests} cached` : "";
   const cost = u.gatewayCost ? `, gateway $${u.gatewayCost.toFixed(4)}` : "";
   return `  gateway: ${u.gatewayRequests} req${cached}${cost}`;
+}
+
+/** Render the AI Gateway section of /cost — cache hit ratio, recent log IDs,
+ *  and a dashboard link. Returns empty string when no Gateway activity. */
+export function formatGatewaySection(
+  report: CostReport,
+  accountId: string,
+  gatewayId: string,
+  recentLogs: GatewayUsageSnapshot[] = [],
+): string {
+  const session = report.session;
+  const today = report.today;
+  if (!session.gatewayRequests && !today.gatewayRequests) return "";
+  const lines: string[] = ["─── AI Gateway ───"];
+  const fmtRatio = (u: DailyUsage) => {
+    const req = u.gatewayRequests ?? 0;
+    if (!req) return "n/a";
+    const cached = u.gatewayCachedRequests ?? 0;
+    const pct = (cached / req) * 100;
+    return `${cached}/${req} (${pct.toFixed(1)}%)`;
+  };
+  lines.push(`  cache hit ratio  session: ${fmtRatio(session)}   today: ${fmtRatio(today)}`);
+  const logs = recentLogs.slice(-5).reverse();
+  if (logs.length > 0) {
+    lines.push("  recent requests:");
+    for (const log of logs) {
+      const id = log.logId ?? log.eventId ?? "?";
+      const cache = log.cacheStatus ? ` [${log.cacheStatus}]` : "";
+      lines.push(
+        `    ${id}${cache}  https://dash.cloudflare.com/${accountId}/ai/ai-gateway/gateways/${gatewayId}/logs/${id}`,
+      );
+    }
+  }
+  lines.push(
+    `  dashboard:  https://dash.cloudflare.com/${accountId}/ai/ai-gateway/gateways/${gatewayId}`,
+  );
+  return lines.join("\n");
 }
 
 export function formatCostReport(report: CostReport): string {


### PR DESCRIPTION
## Summary

Routes all Workers AI traffic through the user's own Cloudflare AI Gateway by default, unlocking per-request logs, response caching, and authoritative cost attribution via `cf-aig-metadata` tagging.

- **Onboarding** (`src/ui/onboarding.tsx`): arrow-key picker for existing gateways with an inline "+ Create new…" option; scope-error screen lists required permissions (`AI Gateway:Read`, `AI Gateway:Edit`, `Workers AI:Read`) and deep-links to the token edit page; supports manual gateway-ID paste as a fallback.
- **New `src/cloud/ai-gateway-api.ts`**: typed `listGateways` / `createGateway` / `probeGateway` helpers with structured `AiGatewayError` (`forbidden | not_found | network | other`).
- **Per-request metadata** (`src/agent/loop.ts`, `src/memory/embeddings.ts`): every API call is now tagged with `{ feature, sessionId, turnIdx }`. Chat turns get `feature: "chat"`, embeddings get `feature: "embedding"`. Embeddings header was fixed from the buggy per-key `cf-aig-metadata-{k}` format to a single JSON `cf-aig-metadata` header matching `client.ts`.
- **/cost Gateway section** (`src/usage-tracker.ts`, `src/app.tsx`): cache hit ratio (session + today), 5 most recent log IDs with clickable Cloudflare dashboard URLs, and a dashboard root link.
- **Reconciliation** (`src/cost-attribution/reconcile.ts`): replaced the `TODO` stub with a real Gateway logs API fetcher (`fetchGatewayLogs`) and an `aggregateByFeature` helper. Sum-of-cost from Gateway logs is now the ground-truth value compared against local pricing.
- **Emergency opt-out**: `KIMIFLARE_DISABLE_AI_GATEWAY=1` falls back to the direct Workers AI path (kept in code, undocumented in README).
- **Validation**: warns at config load when `aiGatewayId` is set but empty/whitespace.

The local heuristic classifier in `src/cost-attribution/` was intentionally **not** deleted in this PR — it remains as a fallback while the Gateway-driven path bakes in. A follow-up can remove it once we observe `feature` arriving reliably in the Gateway logs.

## Test plan

- [x] `npm test` — 390/390 pass
- [x] `npx tsc --noEmit` — no new errors introduced
- [ ] Fresh install: `rm -rf ~/.config/kimiflare ~/.local/share/kimiflare && npm run dev` — confirm Gateway picker appears
- [ ] Scope-missing path: use a token without `AI Gateway:*` — confirm scope-error screen + deep link
- [ ] Create path: pick "Create new", confirm Gateway appears in Cloudflare dashboard, probe passes
- [ ] Run a chat turn → Cloudflare dashboard → AI Gateway → Logs: confirm `cf-aig-metadata` contains `feature`, `sessionId`, `turnIdx`
- [ ] Run `/cost` — confirm Gateway section renders with cache ratio + dashboard link
- [ ] `KIMIFLARE_DISABLE_AI_GATEWAY=1` — confirm direct Workers AI path still works