### PR TITLE
feat(mcp): per-call timeout for tool invocations

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -316,7 +316,7 @@ interface Cfg {
   coauthor?: boolean;
   coauthorName?: string;
   coauthorEmail?: string;
-  mcpServers?: Record<string, { type: "local" | "remote"; command?: string[]; url?: string; env?: Record<string, string>; headers?: Record<string, string>; enabled?: boolean }>;
+  mcpServers?: Record<string, { type: "local" | "remote"; command?: string[]; url?: string; env?: Record<string, string>; headers?: Record<string, string>; enabled?: boolean; timeoutMs?: number }>;
   cacheStablePrompts?: boolean;
   compiledContext?: boolean;
   imageHistoryTurns?: number;
@@ -1238,9 +1238,13 @@ function App({
       if (server.enabled === false) continue;
       try {
         if (server.type === "local" && server.command && server.command.length > 0) {
-          await manager.addLocalServer(name, server.command, server.env);
+          await manager.addLocalServer(name, server.command, server.env, {
+            timeoutMs: server.timeoutMs,
+          });
         } else if (server.type === "remote" && server.url) {
-          await manager.addRemoteServer(name, server.url, server.headers);
+          await manager.addRemoteServer(name, server.url, server.headers, {
+            timeoutMs: server.timeoutMs,
+          });
         } else {
           setEvents((e) => [
             ...e,

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ export interface McpServerConfig {
   env?: Record<string, string>;
   headers?: Record<string, string>;
   enabled?: boolean;
+  /** Per-call timeout in milliseconds for tool invocations on this server. Default: 60000. */
+  timeoutMs?: number;
 }
 
 export interface LspServerConfig {

--- a/src/mcp/adapter.test.ts
+++ b/src/mcp/adapter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { mcpToolToSpec, withTimeout } from "./adapter.js";
+
+describe("withTimeout", () => {
+  it("resolves when the inner promise resolves before the deadline", async () => {
+    const result = await withTimeout(Promise.resolve(42), 100, "test");
+    assert.strictEqual(result, 42);
+  });
+
+  it("rejects with a labeled error when the deadline elapses first", async () => {
+    const slow = new Promise((resolve) => setTimeout(resolve, 200));
+    await assert.rejects(
+      () => withTimeout(slow, 20, "slow op"),
+      /slow op timed out after 20ms/,
+    );
+  });
+
+  it("passes the inner promise through unchanged when ms <= 0", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 0, "test");
+    assert.strictEqual(result, "ok");
+  });
+});
+
+function makeFakeClient(callTool: (req: unknown) => Promise<unknown>): Client {
+  return { callTool } as unknown as Client;
+}
+
+describe("mcpToolToSpec timeout", () => {
+  const tool = {
+    name: "do_thing",
+    description: "Does a thing",
+    inputSchema: { type: "object" as const, properties: {} },
+  };
+
+  it("times out a hung MCP call with a recognizable error", async () => {
+    const client = makeFakeClient(() => new Promise(() => {}));
+    const { spec } = mcpToolToSpec("myserver", tool, client, { timeoutMs: 25 });
+    await assert.rejects(
+      () => spec.run({}, { cwd: "/", signal: new AbortController().signal }),
+      /MCP request 'myserver\/do_thing' timed out after 25ms/,
+    );
+  });
+
+  it("returns text content when the call resolves in time", async () => {
+    const client = makeFakeClient(async () => ({
+      content: [{ type: "text", text: "hello" }],
+    }));
+    const { spec } = mcpToolToSpec("s", tool, client, { timeoutMs: 1000 });
+    const out = await spec.run({}, { cwd: "/", signal: new AbortController().signal });
+    assert.strictEqual(out, "hello");
+  });
+});

--- a/src/mcp/adapter.ts
+++ b/src/mcp/adapter.ts
@@ -7,6 +7,25 @@ export interface McpToolEntry {
   serverName: string;
 }
 
+export const DEFAULT_MCP_TIMEOUT_MS = 60_000;
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  if (!Number.isFinite(ms) || ms <= 0) return promise;
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  }) as Promise<T>;
+}
+
 export function mcpToolToSpec(
   serverName: string,
   mcpTool: {
@@ -19,9 +38,11 @@ export function mcpToolToSpec(
     };
   },
   client: Client,
+  options?: { timeoutMs?: number },
 ): McpToolEntry {
   const prefix = `mcp_${sanitizeName(serverName)}_`;
   const prefixedName = `${prefix}${sanitizeName(mcpTool.name)}`;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_MCP_TIMEOUT_MS;
 
   const spec: ToolSpec = {
     name: prefixedName,
@@ -30,10 +51,14 @@ export function mcpToolToSpec(
     needsPermission: true,
     render: () => ({ title: `${prefixedName}` }),
     async run(args) {
-      const result = await client.callTool({
-        name: mcpTool.name,
-        arguments: args as Record<string, unknown>,
-      });
+      const result = await withTimeout(
+        client.callTool({
+          name: mcpTool.name,
+          arguments: args as Record<string, unknown>,
+        }),
+        timeoutMs,
+        `MCP request '${serverName}/${mcpTool.name}'`,
+      );
 
       // Handle both standard and compatibility result shapes
       if ("content" in result && Array.isArray(result.content)) {

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -19,7 +19,12 @@ interface ActiveConnection {
 export class McpManager {
   private connections = new Map<string, ActiveConnection>();
 
-  async addLocalServer(name: string, command: string[], env?: Record<string, string>): Promise<void> {
+  async addLocalServer(
+    name: string,
+    command: string[],
+    env?: Record<string, string>,
+    options?: { timeoutMs?: number },
+  ): Promise<void> {
     if (this.connections.has(name)) {
       await this.removeServer(name);
     }
@@ -35,12 +40,17 @@ export class McpManager {
     await client.connect(transport);
 
     const listResult = await client.listTools();
-    const tools = listResult.tools.map((t) => mcpToolToSpec(name, t, client));
+    const tools = listResult.tools.map((t) => mcpToolToSpec(name, t, client, options));
 
     this.connections.set(name, { client, transport, tools });
   }
 
-  async addRemoteServer(name: string, url: string, headers?: Record<string, string>): Promise<void> {
+  async addRemoteServer(
+    name: string,
+    url: string,
+    headers?: Record<string, string>,
+    options?: { timeoutMs?: number },
+  ): Promise<void> {
     if (this.connections.has(name)) {
       await this.removeServer(name);
     }
@@ -53,7 +63,7 @@ export class McpManager {
     await client.connect(transport);
 
     const listResult = await client.listTools();
-    const tools = listResult.tools.map((t) => mcpToolToSpec(name, t, client));
+    const tools = listResult.tools.map((t) => mcpToolToSpec(name, t, client, options));
 
     this.connections.set(name, { client, transport, tools });
   }


### PR DESCRIPTION
## Summary

- Wraps `client.callTool` with a configurable timeout (default 60s) so a hung MCP server no longer blocks the agent turn until session-level abort.
- Adds `McpServerConfig.timeoutMs` and threads it through `McpManager.{addLocalServer,addRemoteServer}` → `mcpToolToSpec`.
- Local `withTimeout(promise, ms, label)` helper inside `src/mcp/adapter.ts` — kept local until a second caller appears.

Addresses **OP-15 (MCP half)** / **RF-16** from `docs/architecture/agent-loop-findings.md`. Companion PR for the LSP half (and OP-16 auto-restart) is filed separately.

## Test plan

- [x] `npx tsx --test src/mcp/adapter.test.ts` — 5 new tests pass (timeout fires with labeled error, resolves when fast, ms<=0 passes through, prefixed name still works).
- [x] Full suite `npm test` — 397 tests pass.
- [ ] Manual: point a local MCP server at a `sleep 120` script, set `timeoutMs: 5000` in config, invoke its tool, confirm the loop recovers with a timeout error in ≤ 6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)