### PR TITLE
feat(lsp): per-request timeout knob + auto-restart on crash

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,10 @@ export interface LspServerConfig {
   env?: Record<string, string>;
   enabled?: boolean;
   rootPatterns?: string[];
+  /** Per-request timeout in milliseconds for LSP calls. Default: 10000. */
+  timeoutMs?: number;
+  /** Max auto-restart attempts after a crash. Default: 3. Set 0 to disable. */
+  maxRestartAttempts?: number;
 }
 
 export interface KimiConfig {

--- a/src/lsp/manager.test.ts
+++ b/src/lsp/manager.test.ts
@@ -1,0 +1,167 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { EventEmitter } from "node:events";
+import { LspManager, DEFAULT_LSP_MAX_RESTART_ATTEMPTS } from "./manager.js";
+import type { LspServerConfig } from "../config.js";
+import type { LspConnection } from "./connection.js";
+import type { LspClient } from "./client.js";
+
+class FakeConnection extends EventEmitter {
+  startCalls = 0;
+  killed = false;
+  constructor(public timeoutMs: number) {
+    super();
+  }
+  async start(_command: string[], _env?: Record<string, string>): Promise<void> {
+    this.startCalls += 1;
+  }
+  kill(): void {
+    this.killed = true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  request(_method: string, _params?: unknown, _signal?: AbortSignal): Promise<any> {
+    return Promise.resolve(null);
+  }
+  notify(_method: string, _params?: unknown): void {}
+  child = { pid: 1234 };
+}
+
+class FakeClient {
+  initialized = 0;
+  capabilities: Record<string, unknown> = {};
+  async initialize(): Promise<void> {
+    this.initialized += 1;
+  }
+  async shutdown(): Promise<void> {}
+  didChange(_path: string, _content: string): void {}
+  getCapabilities(): Record<string, unknown> {
+    return this.capabilities;
+  }
+}
+
+function buildManager(opts: { failInitializeUntilAttempt?: number } = {}) {
+  let attempt = 0;
+  const connections: FakeConnection[] = [];
+  const clients: FakeClient[] = [];
+  const restarts: Array<{ attempt: number; delayMs: number }> = [];
+  let gaveUp: { attempts: number; reason: string } | undefined;
+
+  const manager = new LspManager({
+    sleep: () => Promise.resolve(),
+    connectionFactory: (timeoutMs) => {
+      const c = new FakeConnection(timeoutMs);
+      connections.push(c);
+      return c as unknown as LspConnection;
+    },
+    clientFactory: () => {
+      const client = new FakeClient();
+      clients.push(client);
+      if (opts.failInitializeUntilAttempt !== undefined) {
+        const myAttempt = attempt;
+        attempt += 1;
+        if (myAttempt < opts.failInitializeUntilAttempt) {
+          client.initialize = async () => {
+            throw new Error(`forced failure on attempt ${myAttempt}`);
+          };
+        }
+      }
+      return client as unknown as LspClient;
+    },
+    onRestart: (info) => restarts.push({ attempt: info.attempt, delayMs: info.delayMs }),
+    onRestartGaveUp: (info) => {
+      gaveUp = { attempts: info.attempts, reason: info.reason };
+    },
+  });
+  return {
+    manager,
+    connections,
+    clients,
+    restarts,
+    getGaveUp: () => gaveUp,
+  };
+}
+
+const cfg: LspServerConfig = { command: ["fake-lsp"], timeoutMs: 1234 };
+const rootPath = "/tmp/proj";
+
+describe("LspManager — timeout threading", () => {
+  it("passes config.timeoutMs into the LspConnection", async () => {
+    const { manager, connections } = buildManager();
+    await manager.startServer("ts", cfg, rootPath);
+    assert.strictEqual(connections[0]?.timeoutMs, 1234);
+  });
+
+  it("uses the default when timeoutMs is unset", async () => {
+    const { manager, connections } = buildManager();
+    await manager.startServer("ts", { command: ["fake-lsp"] }, rootPath);
+    assert.strictEqual(connections[0]?.timeoutMs, 10_000);
+  });
+});
+
+describe("LspManager — auto-restart on exit", () => {
+  it("does not restart on clean exit (code=0)", async () => {
+    const { manager, connections, restarts } = buildManager();
+    await manager.startServer("ts", cfg, rootPath);
+    connections[0]!.emit("exit", 0, null);
+    await new Promise((r) => setTimeout(r, 5));
+    assert.strictEqual(restarts.length, 0);
+    const status = manager.listActive()[0]!;
+    assert.strictEqual(status.state, "crashed");
+    assert.strictEqual(status.restartAttempts, 0);
+  });
+
+  it("restarts on non-zero exit and increments attempts", async () => {
+    const { manager, connections, restarts } = buildManager();
+    await manager.startServer("ts", cfg, rootPath);
+    connections[0]!.emit("exit", 1, null);
+    await new Promise((r) => setTimeout(r, 5));
+    assert.strictEqual(restarts.length, 1);
+    assert.strictEqual(restarts[0]!.attempt, 1);
+    const status = manager.listActive()[0]!;
+    assert.strictEqual(status.state, "running");
+    assert.strictEqual(status.restartAttempts, 1);
+    assert.strictEqual(connections.length, 2);
+  });
+
+  it("gives up after maxRestartAttempts consecutive failures", async () => {
+    const max = DEFAULT_LSP_MAX_RESTART_ATTEMPTS;
+    const { manager, connections, restarts, getGaveUp } = buildManager();
+    await manager.startServer("ts", cfg, rootPath);
+    for (let i = 0; i < max + 1; i++) {
+      const latest = connections[connections.length - 1]!;
+      latest.emit("exit", 1, null);
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    assert.strictEqual(restarts.length, max);
+    const status = manager.listActive()[0]!;
+    assert.strictEqual(status.state, "crashed");
+    assert.strictEqual(status.restartAttempts, max);
+    const gaveUp = getGaveUp();
+    assert.ok(gaveUp, "should have called onRestartGaveUp");
+    assert.strictEqual(gaveUp!.attempts, max);
+  });
+
+  it("respects maxRestartAttempts=0 to disable auto-restart", async () => {
+    const { manager, connections, restarts, getGaveUp } = buildManager();
+    await manager.startServer(
+      "ts",
+      { command: ["fake-lsp"], maxRestartAttempts: 0 },
+      rootPath,
+    );
+    connections[0]!.emit("exit", 1, null);
+    await new Promise((r) => setTimeout(r, 5));
+    assert.strictEqual(restarts.length, 0);
+    const gaveUp = getGaveUp();
+    assert.ok(gaveUp);
+    assert.strictEqual(manager.listActive()[0]!.state, "crashed");
+  });
+
+  it("does not restart after explicit stopServer", async () => {
+    const { manager, connections, restarts } = buildManager();
+    await manager.startServer("ts", cfg, rootPath);
+    await manager.stopServer("ts", rootPath);
+    connections[0]!.emit("exit", 1, null);
+    await new Promise((r) => setTimeout(r, 5));
+    assert.strictEqual(restarts.length, 0);
+  });
+});

--- a/src/lsp/manager.ts
+++ b/src/lsp/manager.ts
@@ -3,8 +3,14 @@ import { LspClient } from "./client.js";
 import { toUri } from "./protocol.js";
 import type { LspServerConfig } from "../config.js";
 
+export const DEFAULT_LSP_TIMEOUT_MS = 10_000;
+export const DEFAULT_LSP_MAX_RESTART_ATTEMPTS = 3;
+const RESTART_BASE_DELAY_MS = 500;
+const RESTART_MAX_DELAY_MS = 10_000;
+
 interface ActiveServer {
   id: string;
+  rootPath: string;
   rootUri: string;
   config: LspServerConfig;
   connection: LspConnection;
@@ -12,6 +18,7 @@ interface ActiveServer {
   state: "starting" | "running" | "crashed";
   restartAttempts: number;
   pid?: number;
+  stopping?: boolean;
 }
 
 export interface LspServerStatus {
@@ -20,14 +27,43 @@ export interface LspServerStatus {
   state: "starting" | "running" | "crashed";
   pid?: number;
   toolCount: number;
+  restartAttempts: number;
+}
+
+export interface LspManagerHooks {
+  /** Sleep for the given number of ms. Overridable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Called when an unexpected exit triggers (or fails to trigger) a restart. */
+  onRestart?: (info: { id: string; rootPath: string; attempt: number; delayMs: number }) => void;
+  onRestartGaveUp?: (info: { id: string; rootPath: string; attempts: number; reason: string }) => void;
+  /** Connection factory override for tests. */
+  connectionFactory?: (timeoutMs: number) => LspConnection;
+  /** Client factory override for tests. */
+  clientFactory?: (connection: LspConnection, rootUri: string) => LspClient;
 }
 
 export class LspManager {
   private servers = new Map<string, ActiveServer>();
-  private readonly maxRestartAttempts = 3;
+  private readonly hooks: LspManagerHooks;
+
+  constructor(hooks: LspManagerHooks = {}) {
+    this.hooks = hooks;
+  }
 
   private key(id: string, rootUri: string): string {
     return `${id}::${rootUri}`;
+  }
+
+  private makeConnection(timeoutMs: number): LspConnection {
+    return this.hooks.connectionFactory
+      ? this.hooks.connectionFactory(timeoutMs)
+      : new LspConnection(timeoutMs);
+  }
+
+  private makeClient(connection: LspConnection, rootUri: string): LspClient {
+    return this.hooks.clientFactory
+      ? this.hooks.clientFactory(connection, rootUri)
+      : new LspClient(connection, rootUri);
   }
 
   async startServer(id: string, config: LspServerConfig, rootPath: string): Promise<void> {
@@ -38,17 +74,21 @@ export class LspManager {
       await this.stopServer(id, rootPath);
     }
 
-    const connection = new LspConnection();
+    const timeoutMs = config.timeoutMs ?? DEFAULT_LSP_TIMEOUT_MS;
+    const connection = this.makeConnection(timeoutMs);
     const server: ActiveServer = {
       id,
+      rootPath,
       rootUri,
       config,
       connection,
-      client: new LspClient(connection, rootUri),
+      client: this.makeClient(connection, rootUri),
       state: "starting",
       restartAttempts: 0,
     };
     this.servers.set(k, server);
+
+    this.wireExitHandler(server);
 
     try {
       await connection.start(config.command, config.env);
@@ -61,12 +101,72 @@ export class LspManager {
     }
   }
 
+  private wireExitHandler(server: ActiveServer): void {
+    server.connection.once("exit", (code: number | null, _signal: NodeJS.Signals | null) => {
+      if (server.stopping) return;
+      if (code === 0) {
+        server.state = "crashed";
+        return;
+      }
+      this.scheduleRestart(server, `exit code=${code}`);
+    });
+  }
+
+  private scheduleRestart(server: ActiveServer, reason: string): void {
+    const k = this.key(server.id, server.rootUri);
+    if (this.servers.get(k) !== server) return;
+
+    const maxAttempts = server.config.maxRestartAttempts ?? DEFAULT_LSP_MAX_RESTART_ATTEMPTS;
+    if (maxAttempts <= 0 || server.restartAttempts >= maxAttempts) {
+      server.state = "crashed";
+      this.hooks.onRestartGaveUp?.({
+        id: server.id,
+        rootPath: server.rootPath,
+        attempts: server.restartAttempts,
+        reason,
+      });
+      return;
+    }
+
+    server.restartAttempts += 1;
+    server.state = "starting";
+    const exp = RESTART_BASE_DELAY_MS * 2 ** (server.restartAttempts - 1);
+    const cap = Math.min(exp, RESTART_MAX_DELAY_MS);
+    const delayMs = Math.floor(Math.random() * cap);
+
+    this.hooks.onRestart?.({
+      id: server.id,
+      rootPath: server.rootPath,
+      attempt: server.restartAttempts,
+      delayMs,
+    });
+
+    const sleep = this.hooks.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+    void sleep(delayMs).then(async () => {
+      if (this.servers.get(k) !== server) return;
+      try {
+        const timeoutMs = server.config.timeoutMs ?? DEFAULT_LSP_TIMEOUT_MS;
+        const nextConnection = this.makeConnection(timeoutMs);
+        server.connection = nextConnection;
+        server.client = this.makeClient(nextConnection, server.rootUri);
+        this.wireExitHandler(server);
+        await nextConnection.start(server.config.command, server.config.env);
+        server.pid = nextConnection["child"]?.pid;
+        await server.client.initialize();
+        server.state = "running";
+      } catch (e) {
+        this.scheduleRestart(server, `restart failed: ${(e as Error).message}`);
+      }
+    });
+  }
+
   async stopServer(id: string, rootPath: string): Promise<void> {
     const rootUri = toUri(rootPath);
     const k = this.key(id, rootUri);
     const server = this.servers.get(k);
     if (!server) return;
 
+    server.stopping = true;
     this.servers.delete(k);
     try {
       await server.client.shutdown();
@@ -78,6 +178,7 @@ export class LspManager {
 
   async stopAll(): Promise<void> {
     for (const [k, server] of this.servers) {
+      server.stopping = true;
       try {
         await server.client.shutdown();
       } catch {
@@ -135,6 +236,7 @@ export class LspManager {
         state: server.state,
         pid: server.pid,
         toolCount: this.estimateToolCount(server.client.getCapabilities()),
+        restartAttempts: server.restartAttempts,
       });
     }
     return out;


### PR DESCRIPTION
## Summary

- Threads `LspServerConfig.timeoutMs` into `LspConnection` (default 10s — same as the previous hardcoded value, now configurable per-server).
- Subscribes to the connection's `exit` event in `LspManager` and auto-restarts crashed servers with **full-jitter exponential backoff** (`500ms * 2^attempt`, capped at 10s) up to `maxRestartAttempts` (default 3, set 0 to disable).
- Clean exits (`code === 0`) and explicit `stopServer` / `stopAll` do **not** trigger restarts.
- Surfaces `restartAttempts` on `LspServerStatus` so callers can see how often a server has been resurrected.
- Adds `LspManagerHooks` test seam (sleep, restart callbacks, connection/client factories) — kept internal, no production-facing behavior change.

Addresses **OP-15 (LSP half)** and **OP-16** / **RF-15**, **RF-16** from `docs/architecture/agent-loop-findings.md`. Companion to #421 (MCP half).

## Test plan

- [x] `npx tsx --test src/lsp/manager.test.ts` — 7 new tests pass:
  - timeoutMs threads through; default applies when unset
  - clean exit (code=0) does not restart, leaves state `crashed`
  - non-zero exit restarts and increments attempts
  - gives up after `maxRestartAttempts` consecutive failures
  - `maxRestartAttempts: 0` disables auto-restart
  - exit after explicit `stopServer` does not restart
- [x] Full suite `npm test` — 397 tests pass.
- [ ] Manual: start a session with an LSP server, `kill -9` the server process, verify `listActive()` shows `state: running, restartAttempts: 1`; kill three times rapidly, verify state ends `crashed` and stays there.

## Notes

- Zero overlap with `src/app.tsx` (the OP-19 god-component breakup is the parallel quarter-long track — this PR was deliberately scoped to avoid conflict).
- `/lsp status` slash command (mentioned in RF-15) is deferred — that would touch `app.tsx`. The `restartAttempts` field on `LspServerStatus` makes adding that command later trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)