### PR TITLE
fix(app): bail SIGINT handler when useInput already aborting (M1.0)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1614,7 +1614,18 @@ function App({
   // Keep the SIGINT handler in sync with the latest state/refs so that when
   // the terminal sends a real SIGINT (bypassing Ink raw mode) we can still
   // interrupt the turn or exit gracefully.
+  //
+  // A terminal Ctrl+C delivers BOTH the raw byte (captured by Ink's useInput)
+  // AND the SIGINT signal. Without the guard below, both handlers fire on
+  // every Ctrl+C: useInput aborts the turn (setting isAbortingRef.current to
+  // true), then SIGINT falls through to its fall-through exit() branch and
+  // tears Ink down mid-cleanup — leaving the TUI in an in-between state
+  // where typed characters print but Enter doesn't submit. See RF-20.
   sigintHandlerRef.current = () => {
+    if (isAbortingRef.current) {
+      logger.info("sigint:handler:already-aborting");
+      return;
+    }
     logger.info("sigint:handler", {
       busy: busyRef.current,
       hasActiveScope: activeScopeRef.current !== null,


### PR DESCRIPTION
## Summary

Closes the long-standing **"Ctrl+C freezes the session"** bug ([RF-20](https://github.com/sinameraji/kimiflare/blob/main/docs/architecture/agent-loop-findings.md#rf-20)). User-flagged urgent; tracked as M1.0 in the development roadmap.

### Root cause (recap)

A terminal Ctrl+C delivers **both** the raw byte (captured by Ink's \`useInput\`) **and** the SIGINT signal (caught by \`process.on(\"SIGINT\")\`). Before this change both handlers fired on every Ctrl+C:

1. \`useInput\` fires first, sets \`isAbortingRef.current = true\`, kills the supervisor, aborts the scope. The reset of \`isAborting\` back to \`false\` lives in the turn's \`finally\` block, which has not run yet.
2. A microtask later the SIGINT handler fires. It sees \`isAborting === true\` so its primary \`if\` branch is false. It falls through to \`else if (!hadPerm && !hadLimit)\` — both of which \`useInput\` already drained — and calls \`exit()\` while Ink's render tree is mid-cleanup.

Visible symptom: typed characters still print to the screen but Enter doesn't submit.

### The fix

One-line guard at the top of \`sigintHandlerRef.current\`:

\`\`\`ts
if (isAbortingRef.current) {
  logger.info(\"sigint:handler:already-aborting\");
  return;
}
\`\`\`

The fallback case (raw mode disabled, \`useInput\` doesn't fire) still works: in that path \`isAborting\` is \`false\` at SIGINT-handler-invocation time so the guard is a no-op and the existing abort dance runs normally.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 408/408 pass
- [x] \`npm run build\` — succeeds
- [ ] Manual verification in \`npm run dev\` (the only meaningful test for this bug):
  - [ ] Start a busy turn (ask Kimi a research question that uses bash/grep)
  - [ ] Press **Ctrl+C** while busy → should see \`(interrupted)\` and the prompt should return to a clean, usable state
  - [ ] Type a follow-up message and press Enter → should submit normally (this is the regression check; pre-fix it would NOT submit)
  - [ ] Press **Ctrl+C** again on an idle prompt → should exit the app cleanly (no half-dead state)
  - [ ] **Escape** during a busy turn still works exactly as before

### Why no automated test

A proper regression test would need to simulate Ink's \`useInput\` firing concurrently with \`process.emit(\"SIGINT\")\`. That requires either \`ink-testing-library\` (not in deps) or further extraction of the SIGINT handler from \`app.tsx\` into a pure, testable shape. Both belong with M4-track refactor work; adding either inside this fix would balloon the PR. The manual verification above covers the regression; the fix itself is one line of well-understood guard.

Closes M1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)