### PR TITLE
feat(agent): size-weighted artifact eviction in ArtifactStore

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -120,7 +120,7 @@ window is too narrow at the larger waits.
 **Status:** Applied to both retry sites (network-error branch and
 API-error branch including rate-limit handling) in `src/agent/client.ts`.
 
-### RF-9 — Artifact eviction is age-only (S)
+### RF-9 — Artifact eviction is age-only (S) — ✅ shipped (OP-2)
 
 `src/agent/session-state.ts:82–88`.
 
@@ -131,6 +131,11 @@ prefer the latter.
 **Fix:** size-weighted LRU: pick the oldest item whose size would
 materially relieve pressure (e.g., evict the largest among the oldest
 quartile).
+
+**Status:** When the char cap is exceeded, `ArtifactStore.add()` now
+calls `evictSizeWeighted()` — sort by ts, slice the oldest quartile,
+drop the largest in that window. Count-cap eviction stays age-only
+(sizes don't matter when the count is the constraint).
 
 ### RF-10 — In-place mutation of `opts.messages` during skill rebuild (M)
 
@@ -343,7 +348,7 @@ Tracked as M1.0 in the development roadmap.
 ### Quick wins (S — pick most of these up in a week)
 
 - **OP-1.** Full-jitter retry backoff (fix for RF-8).
-- **OP-2.** Size-aware artifact eviction (fix for RF-9).
+- **OP-2.** Size-aware artifact eviction (fix for RF-9). ✅ shipped
 - **OP-3.** `onTruncation` callback + TUI hint (fix for RF-12).
 - **OP-4.** Per-call SSE idle timeout knob (fix for RF-7).
 - **OP-5.** `signal.aborted` checks inside grep/glob/read inner loops

--- a/src/agent/session-state.ts
+++ b/src/agent/session-state.ts
@@ -78,11 +78,12 @@ export class ArtifactStore {
   }
 
   add(a: Artifact): void {
-    // Enforce total char cap by evicting oldest artifacts first
+    // Enforce total char cap with size-weighted LRU: from the oldest quartile,
+    // evict the largest artifact first. One 200KB eviction beats five 5KB ones.
     while (this.totalChars() + a.raw.length > this.maxTotalChars && this.artifacts.size > 0) {
-      this.evictOldest();
+      this.evictSizeWeighted();
     }
-    // Enforce count cap
+    // Enforce count cap (age-only is fine here — sizes don't matter for count)
     while (this.artifacts.size >= this.maxArtifacts) {
       this.evictOldest();
     }
@@ -128,6 +129,22 @@ export class ArtifactStore {
       if (!oldest || a.ts < oldest.ts) oldest = a;
     }
     if (oldest) this.artifacts.delete(oldest.id);
+  }
+
+  /** Evict the largest artifact among the oldest quartile (by timestamp).
+   *  Bounded by the oldest quartile so we never evict freshly-added artifacts;
+   *  size-weighted within that window so one big artifact gets dropped instead
+   *  of many small ones. */
+  private evictSizeWeighted(): void {
+    const sorted = [...this.artifacts.values()].sort((a, b) => (a.ts < b.ts ? -1 : 1));
+    if (sorted.length === 0) return;
+    const quartile = Math.max(1, Math.ceil(sorted.length / 4));
+    const candidates = sorted.slice(0, quartile);
+    let pick: Artifact = candidates[0]!;
+    for (const a of candidates) {
+      if (a.raw.length > pick.raw.length) pick = a;
+    }
+    this.artifacts.delete(pick.id);
   }
 }
 


### PR DESCRIPTION
## Summary

- `ArtifactStore.add()` previously evicted strictly the oldest artifact when over the char cap. That preferred dropping many small artifacts when one big one would free the same headroom.
- Now: when the char cap is exceeded, pick the largest artifact within the oldest quartile and drop it. Count-cap eviction stays age-only.

Fixes RF-9 / OP-2 from \`docs/architecture/agent-loop-findings.md\`.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npx tsx --test src/agent/session-state.test.ts\` — 17 pass
- [ ] Manual sanity check with a long session that exercises eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)