### PR TITLE
feat(agent): add onTruncation callback for tool output truncation

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -183,7 +183,7 @@ mismatch.
 
 **Fix:** include each tool's parameter schema digest in the cache key.
 
-### RF-12 — Tool output truncation is silent to the UI (S)
+### RF-12 — Tool output truncation is silent to the UI (S) — ✅ shipped (OP-3, callback only)
 
 `src/agent/loop.ts:704–708, 736–740`.
 
@@ -196,6 +196,13 @@ know.
 **Fix:** emit a `onTruncation(tool, rawBytes, reducedBytes, artifactId)`
 callback; render an inline hint in the TUI ("output truncated — use
 `expand artifact <id>` to view full").
+
+**Status:** `AgentCallbacks.onTruncation({ tool, toolCallId, rawBytes,
+reducedBytes, artifactId? })` is now fired from both truncation sites
+(regular executor path and code-mode sandbox path). The TUI hint
+itself ("output truncated — use `expand_artifact <id>` to view full")
+is **not yet wired** because that lives in `app.tsx`, which is
+reserved for the M4 breakup; SDK consumers can subscribe today.
 
 ### RF-13 — Sync FS tools don't honor `ctx.signal` (M) — ✅ first half shipped (OP-5)
 
@@ -384,7 +391,7 @@ Tracked as M1.0 in the development roadmap.
 
 - **OP-1.** Full-jitter retry backoff (fix for RF-8).
 - **OP-2.** Size-aware artifact eviction (fix for RF-9). ✅ shipped
-- **OP-3.** `onTruncation` callback + TUI hint (fix for RF-12).
+- **OP-3.** `onTruncation` callback + TUI hint (fix for RF-12). ✅ callback shipped; TUI hint deferred to M4
 - **OP-4.** Per-call SSE idle timeout knob (fix for RF-7). ✅ shipped
 - **OP-5.** `signal.aborted` checks inside grep/glob/read inner loops
   (fix for RF-13, first half). ✅ shipped

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -37,6 +37,9 @@ export interface AgentCallbacks {
   onTasks?: (tasks: Task[]) => void;
   /** Called once per session when the sandbox falls back to node:vm. */
   onWarning?: (message: string) => void;
+  /** Called when a tool's content was truncated before being shown to the model.
+   *  `artifactId`, when present, points at the full raw bytes in the artifact store. */
+  onTruncation?: (info: { tool: string; toolCallId: string; rawBytes: number; reducedBytes: number; artifactId?: string }) => void;
   askPermission: PermissionAsker;
   /** Called when the tool-call iteration limit is reached. Return "continue" to
    *  reset the counter and keep going, or "stop" to end the turn immediately. */
@@ -736,9 +739,16 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           ? `Error: ${sandboxResult.error}\n\nOutput:\n${sandboxResult.output}`
           : sandboxResult.output;
         if (resultContent.length > MAX_TOOL_CONTENT_CHARS) {
+          const rawBytes = resultContent.length;
           resultContent =
             resultContent.slice(0, MAX_TOOL_CONTENT_CHARS) +
-            `\n\n[truncated: ${resultContent.length - MAX_TOOL_CONTENT_CHARS} chars omitted]`;
+            `\n\n[truncated: ${rawBytes - MAX_TOOL_CONTENT_CHARS} chars omitted]`;
+          opts.callbacks.onTruncation?.({
+            tool: "execute_code",
+            toolCallId: tc.id,
+            rawBytes,
+            reducedBytes: resultContent.length,
+          });
         }
 
         const result: ToolResult = {
@@ -768,9 +778,17 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         );
         let content = result.content;
         if (content.length > MAX_TOOL_CONTENT_CHARS) {
+          const rawBytes = content.length;
           content =
             content.slice(0, MAX_TOOL_CONTENT_CHARS) +
-            `\n\n[truncated: ${content.length - MAX_TOOL_CONTENT_CHARS} chars omitted]`;
+            `\n\n[truncated: ${rawBytes - MAX_TOOL_CONTENT_CHARS} chars omitted]`;
+          opts.callbacks.onTruncation?.({
+            tool: tc.function.name,
+            toolCallId: tc.id,
+            rawBytes,
+            reducedBytes: content.length,
+            artifactId: result.artifactId,
+          });
         }
         logger.debug("turn:tool_end", { sessionId: opts.sessionId, tool: tc.function.name, toolCallId: tc.id, ok: result.ok });
         toolResults.push(result);


### PR DESCRIPTION
## Summary

- Adds \`AgentCallbacks.onTruncation\` — fired whenever tool output is truncated before the model sees it.
- Covers both truncation sites in \`loop.ts\` (executor path and code-mode sandbox path).
- The TUI inline hint described in RF-12 is **not** in this PR — it lives in \`app.tsx\`, which is reserved for the M4 breakup. SDK consumers can subscribe today.

Partially fixes RF-12 / OP-3.

## Test plan
- [x] \`npm run typecheck\`
- [ ] SDK consumer subscribes to \`onTruncation\` and observes a fire
- [ ] M4 follow-up: render \"output truncated — use \`expand_artifact <id>\`\" hint in the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)