### PR TITLE
feat(agent): per-call SSE idle timeout with post-first-byte tightening

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -96,7 +96,7 @@ throw at the loop boundary is a worse UX than a compaction prompt.
 **Fix:** at the cap, try one round of message compaction (drop oldest
 tool results, keep their artifacts) before throwing.
 
-### RF-7 — SSE idle timeout is global (S)
+### RF-7 — SSE idle timeout is global (S) — ✅ shipped (OP-4)
 
 `src/agent/client.ts:254`, default 60_000 ms.
 
@@ -106,6 +106,11 @@ first-byte.
 
 **Fix:** expose `idleTimeoutMs` on the call options. Bonus: once the first
 data byte arrives, drop the idle timeout to 30 s — the model is alive.
+
+**Status:** `idleTimeoutMs` and `postFirstByteIdleTimeoutMs` are now
+plumbed through `AgentTurnOpts` → `RunKimiOpts` → `readSSE`. Defaults
+are 60s pre-first-byte, 30s post-first-byte. Callers can override per
+turn (long embedding/image turns can bump the pre-first-byte budget).
 
 ### RF-8 — Retry backoff has weak jitter (S) — ✅ shipped (M1.1)
 
@@ -345,7 +350,7 @@ Tracked as M1.0 in the development roadmap.
 - **OP-1.** Full-jitter retry backoff (fix for RF-8).
 - **OP-2.** Size-aware artifact eviction (fix for RF-9).
 - **OP-3.** `onTruncation` callback + TUI hint (fix for RF-12).
-- **OP-4.** Per-call SSE idle timeout knob (fix for RF-7).
+- **OP-4.** Per-call SSE idle timeout knob (fix for RF-7). ✅ shipped
 - **OP-5.** `signal.aborted` checks inside grep/glob/read inner loops
   (fix for RF-13, first half).
 - **OP-6.** Cross-turn `webFetchHistory` (fix for RF-3).

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -33,6 +33,9 @@ export interface RunKimiOpts {
   requestId?: string;
   /** Abort the stream if no data arrives for this many milliseconds. Default 60000. */
   idleTimeoutMs?: number;
+  /** Once the first byte arrives, tighten the idle timeout to this value.
+   *  Default 30000 — a live stream stalling mid-flight should surface fast. */
+  postFirstByteIdleTimeoutMs?: number;
 }
 
 export interface AiGatewayOptions {
@@ -155,7 +158,7 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
 
     let lastUsage: Usage | null = null;
     logger.debug("runKimi:stream_start", { requestId });
-    for await (const ev of parseStream(res.body, opts.signal, opts.idleTimeoutMs)) {
+    for await (const ev of parseStream(res.body, opts.signal, opts.idleTimeoutMs, opts.postFirstByteIdleTimeoutMs)) {
       if (ev.type === "usage") lastUsage = ev.usage;
       yield ev;
     }
@@ -252,18 +255,19 @@ function readGatewayMeta(headers: Headers): GatewayMeta | null {
 }
 
 const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+const DEFAULT_POST_FIRST_BYTE_IDLE_TIMEOUT_MS = 30_000;
 
 async function* parseStream(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
   idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
+  postFirstByteIdleTimeoutMs = DEFAULT_POST_FIRST_BYTE_IDLE_TIMEOUT_MS,
 ): AsyncGenerator<KimiEvent, void, void> {
   const toolCalls = new Map<number, { id: string; name: string; args: string }>();
   let lastUsage: Usage | null = null;
   let finishReason: string | null = null;
-  let lastDataAt = Date.now();
 
-  for await (const dataStr of readSSE(body, signal, idleTimeoutMs)) {
+  for await (const dataStr of readSSE(body, signal, idleTimeoutMs, postFirstByteIdleTimeoutMs)) {
     if (dataStr === "[DONE]") break;
     let chunk: StreamChunk | null = null;
     try {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -115,6 +115,13 @@ export interface AgentTurnOpts {
   mode?: Mode;
   /** Whether to use cache-stable prompt assembly (dual system messages). */
   cacheStable?: boolean;
+  /** Abort the API stream if no data arrives for this many milliseconds. Default 60000.
+   *  Cold Workers AI calls after tool use can exceed the default — bump this for
+   *  long-running embeddings / image-heavy turns. */
+  idleTimeoutMs?: number;
+  /** Once the first byte arrives, tighten the idle timeout to this value.
+   *  Default 30000 — a live stream stalling mid-flight should surface fast. */
+  postFirstByteIdleTimeoutMs?: number;
 }
 
 export class BudgetExhaustedError extends Error {
@@ -486,7 +493,8 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       cloudMode: opts.cloudMode,
       cloudToken: opts.cloudToken,
       cloudDeviceId: opts.cloudDeviceId,
-      idleTimeoutMs: 60_000,
+      idleTimeoutMs: opts.idleTimeoutMs ?? 60_000,
+      postFirstByteIdleTimeoutMs: opts.postFirstByteIdleTimeoutMs,
     });
 
     let gotFirstChunk = false;

--- a/src/util/sse.ts
+++ b/src/util/sse.ts
@@ -12,11 +12,13 @@ export async function* readSSE(
   stream: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
   idleTimeoutMs?: number,
+  postFirstByteIdleTimeoutMs?: number,
 ): AsyncGenerator<string, void, void> {
   const reader = stream.getReader();
   const decoder = new TextDecoder("utf-8");
   let buffer = "";
   let lastDataAt = Date.now();
+  let gotFirstByte = false;
 
   const onAbort = () => {
     reader.cancel(new DOMException("aborted", "AbortError")).catch(() => {
@@ -42,16 +44,23 @@ export async function* readSSE(
   try {
     while (true) {
       if (signal?.aborted) throw new DOMException("aborted", "AbortError");
-      if (idleTimeoutMs !== undefined && Date.now() - lastDataAt > idleTimeoutMs) {
-        logger.warn("sse:idle_timeout", { idleTimeoutMs });
+      // After the first byte we know the model is alive; tighten the idle
+      // budget so a stalled mid-stream surfaces sooner.
+      const activeIdleTimeoutMs =
+        gotFirstByte && postFirstByteIdleTimeoutMs !== undefined
+          ? postFirstByteIdleTimeoutMs
+          : idleTimeoutMs;
+      if (activeIdleTimeoutMs !== undefined && Date.now() - lastDataAt > activeIdleTimeoutMs) {
+        logger.warn("sse:idle_timeout", { idleTimeoutMs: activeIdleTimeoutMs, gotFirstByte });
         throw new DOMException(
-          `kimiflare: stream idle for ${idleTimeoutMs}ms — no data received from API`,
+          `kimiflare: stream idle for ${activeIdleTimeoutMs}ms — no data received from API`,
           "TimeoutError",
         );
       }
       const { done, value } = await abortRace(reader.read());
       if (done) break;
       lastDataAt = Date.now();
+      gotFirstByte = true;
       buffer += decoder.decode(value, { stream: true });
       buffer = buffer.replace(/\r\n/g, "\n");
 


### PR DESCRIPTION
## Summary

- \`idleTimeoutMs\` is now per-turn (was hardcoded 60s in the loop).
- New \`postFirstByteIdleTimeoutMs\` (default **30s**) — once we know the model is alive, a stalled mid-stream surfaces fast.
- Plumbed through \`AgentTurnOpts\` → \`RunKimiOpts\` → \`readSSE\`.

Fixes RF-7 / OP-4.

## Test plan
- [x] \`npm run typecheck\`
- [ ] Inject an artificial mid-stream stall and verify it errors after 30s
- [ ] Long cold call (image turn) — bump \`idleTimeoutMs\` and confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)