### PR TITLE
fix(tools): respect AbortSignal in grep, glob, and read

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -171,7 +171,7 @@ know.
 callback; render an inline hint in the TUI ("output truncated — use
 `expand artifact <id>` to view full").
 
-### RF-13 — Sync FS tools don't honor `ctx.signal` (M)
+### RF-13 — Sync FS tools don't honor `ctx.signal` (M) — ✅ first half shipped (OP-5)
 
 `src/tools/read.ts`, `write.ts`, `edit.ts`, `glob.ts`, `grep.ts`.
 
@@ -185,6 +185,20 @@ fast-glob's `signal` option (already supported upstream). In read on
 large files, switch to a streaming read that checks the signal between
 chunks. Edit and write are usually fast enough that a check-at-start is
 sufficient.
+
+**Status (first half):**
+- `grep`: ripgrep path now forwards `ctx.signal` to `execFile`. The JS
+  fallback checks `signal.aborted` between every file. Errata on the
+  upstream `signal` claim — fast-glob 3.x doesn't accept an AbortSignal
+  natively, so glob support is via streaming + destroy on abort instead.
+- `glob`: switched to `fg.stream()`; we check `signal.aborted` between
+  yielded entries and destroy the stream on abort, so a recursive walk
+  of a giant monorepo terminates promptly.
+- `read`: checks `signal.aborted` at entry, after stat, and forwards
+  `ctx.signal` to `fs.readFile`.
+
+**Still pending (second half):** streaming read for the >MAX_BYTES case
+and explicit `write`/`edit` check-at-start.
 
 ### RF-14 — `src/app.tsx` is a 4,393-line god component (L)
 
@@ -347,7 +361,7 @@ Tracked as M1.0 in the development roadmap.
 - **OP-3.** `onTruncation` callback + TUI hint (fix for RF-12).
 - **OP-4.** Per-call SSE idle timeout knob (fix for RF-7).
 - **OP-5.** `signal.aborted` checks inside grep/glob/read inner loops
-  (fix for RF-13, first half).
+  (fix for RF-13, first half). ✅ shipped
 - **OP-6.** Cross-turn `webFetchHistory` (fix for RF-3).
 - **OP-7.** Memory extraction error counter + `/memory health` surface
   (fix for RF-1).

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -23,14 +23,36 @@ export const globTool: ToolSpec<Args> = {
   needsPermission: false,
   render: (args) => ({ title: `glob ${args.pattern ?? ""}${args.path ? ` in ${collapsePath(String(args.path), process.cwd())}` : ""}` }),
   async run(args, ctx) {
+    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
     const root = args.path ? resolvePath(ctx.cwd, args.path) : ctx.cwd;
-    const entries = (await fg(args.pattern, {
+    // Stream results so a Ctrl+C during a recursive walk over a large
+    // monorepo can interrupt promptly. fast-glob doesn't expose an
+    // AbortSignal, so we check between yielded entries and destroy the
+    // stream on abort.
+    const stream = fg.stream(args.pattern, {
       cwd: root,
       absolute: true,
       dot: false,
       onlyFiles: false,
       stats: true,
-    })) as unknown as Array<{ path: string; stats?: { mtimeMs: number } }>;
+    }) as NodeJS.ReadableStream & { destroy: (err?: Error) => void };
+    const entries: Array<{ path: string; stats?: { mtimeMs: number } }> = [];
+    const onAbort = () => {
+      try {
+        stream.destroy(new DOMException("aborted", "AbortError"));
+      } catch {
+        /* already destroyed */
+      }
+    };
+    ctx.signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      for await (const entry of stream) {
+        if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
+        entries.push(entry as unknown as { path: string; stats?: { mtimeMs: number } });
+      }
+    } finally {
+      ctx.signal?.removeEventListener("abort", onAbort);
+    }
     entries.sort((a, b) => (b.stats?.mtimeMs ?? 0) - (a.stats?.mtimeMs ?? 0));
     const paths = entries.slice(0, 200).map((e) => e.path);
     return paths.length ? paths.join("\n") : "(no matches)";

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -50,10 +50,11 @@ export const grepTool: ToolSpec<Args> = {
   needsPermission: false,
   render: (args) => ({ title: `grep ${args.pattern ?? ""}${args.glob ? ` (${args.glob})` : ""}` }),
   async run(args, ctx) {
+    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
     const root = args.path ? resolvePath(ctx.cwd, args.path) : ctx.cwd;
     const mode = args.output_mode ?? "content";
-    if (await hasRipgrep()) return runRipgrep(args, root, mode);
-    return runJsFallback(args, root, mode);
+    if (await hasRipgrep()) return runRipgrep(args, root, mode, ctx.signal);
+    return runJsFallback(args, root, mode, ctx.signal);
   },
 };
 
@@ -61,6 +62,7 @@ async function runRipgrep(
   args: Args,
   root: string,
   mode: "content" | "files",
+  signal?: AbortSignal,
 ): Promise<ToolOutput> {
   const rgArgs = ["--no-heading", "--color=never", "--line-number"];
   if (args.case_insensitive) rgArgs.push("-i");
@@ -68,7 +70,7 @@ async function runRipgrep(
   if (mode === "files") rgArgs.push("-l");
   rgArgs.push("--", args.pattern, root);
   try {
-    const { stdout } = await pExecFile("rg", rgArgs, { maxBuffer: 10 * 1024 * 1024 });
+    const { stdout } = await pExecFile("rg", rgArgs, { maxBuffer: 10 * 1024 * 1024, signal });
     const trimmed = stdout.trim();
     if (!trimmed) return { content: "(no matches)", rawBytes: 0, reducedBytes: 0 };
     return {
@@ -87,6 +89,7 @@ async function runJsFallback(
   args: Args,
   root: string,
   mode: "content" | "files",
+  signal?: AbortSignal,
 ): Promise<ToolOutput> {
   const re = new RegExp(args.pattern, args.case_insensitive ? "i" : "");
   const globPattern = args.glob ? `**/${args.glob}` : "**/*";
@@ -98,7 +101,11 @@ async function runJsFallback(
     ignore: ["**/node_modules/**", "**/.git/**", "**/dist/**"],
   });
   const out: string[] = [];
-  for (const file of files.slice(0, 5000)) {
+  for (let fi = 0; fi < Math.min(files.length, 5000); fi++) {
+    // Check abort signal between files — a slow regex over a big monorepo
+    // shouldn't keep running after the user hit Ctrl+C.
+    if (signal?.aborted) throw new DOMException("aborted", "AbortError");
+    const file = files[fi]!;
     try {
       const content = await readFile(file, "utf8");
       if (mode === "files") {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -27,10 +27,13 @@ export const readTool: ToolSpec<Args> = {
   needsPermission: false,
   render: ({ path }) => ({ title: `read ${collapsePath(path, process.cwd())}` }),
   async run(args, ctx) {
+    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
     const abs = resolvePath(ctx.cwd, args.path);
     const st = await stat(abs);
     if (st.size > MAX_BYTES) throw new Error(`file too large: ${st.size} bytes (max ${MAX_BYTES})`);
-    const text = await readFile(abs, "utf8");
+    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
+    const text = await readFile(abs, { encoding: "utf8", signal: ctx.signal });
+    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
     const lines = text.split("\n");
     const start = Math.max(0, (args.offset ?? 1) - 1);
     const end = args.limit ? Math.min(lines.length, start + args.limit) : lines.length;


### PR DESCRIPTION
## Summary

- **grep**: ripgrep path forwards \`ctx.signal\` to \`execFile\`; JS fallback checks \`signal.aborted\` between every file.
- **glob**: switched to \`fg.stream()\` + check signal between yields + destroy the stream on abort. (fast-glob 3.x doesn't natively accept an AbortSignal — corrects the note in the findings doc.)
- **read**: check signal at entry, after stat, and forward \`ctx.signal\` to \`fs.readFile\`.

Result: a recursive grep/glob over a giant tree no longer blocks Ctrl+C for many seconds.

Second half (streaming read for >MAX_BYTES, explicit write/edit check-at-start) still pending.

Fixes RF-13 / OP-5 first half.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npx tsx --test src/tools/*.test.ts\` — 48 pass
- [ ] Manual: trigger a slow grep over a large monorepo and Ctrl+C; confirm prompt unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)