### PR TITLE
refactor(ui): extract usePickerController hook from app.tsx (M4.2)

### DIFF
--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,6 +15,15 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
+- **M4.2** — `PickerController` extracted from `app.tsx` — *(this PR)*.
+  Pulled the file-mention `@`, slash-command `/` state machine into
+  `src/ui/use-picker-controller.ts` (~320 LOC) with a pure
+  `decidePickerTransition()` core and 32 unit tests (helpers +
+  transition table). `app.tsx` shrank 4,355 → 4,153 LOC. Pure refactor —
+  observable behavior preserved (open/close triggers, sticky-cancel,
+  selected-index clamping, modal-takeover close, lazy file loading on
+  first `@`, recents-first sort). No call-site asymmetries spotted; the
+  two existing pickers shared the underlying state and lifted cleanly.
 - **M1.0** — Ctrl+C no longer freezes the session — *(this PR)*.
   Single-line fix: pass `exitOnCtrlC: false` to Ink's `render()` in
   `src/app.tsx`. The real root cause was Ink's built-in Ctrl+C
@@ -268,8 +277,12 @@ that touches UI assumes M4 is making steady progress.
   next extraction: the wiring pattern (hook returns `{ pending,
   askPermission, hasPending, decide, denyPending, clearResolveRef }`)
   works well — reuse it for the other controllers.
-- **M4.2** — `refactor(ui): extract PickerController`
-  - File picker, mention picker, slash picker share a state machine.
+- ✅ **M4.2** — `refactor(ui): extract usePickerController hook`
+  *(merged in this PR)*. Pulled the file-mention `@` and slash-command
+  `/` state machine into `src/ui/use-picker-controller.ts` with a pure
+  `decidePickerTransition()` core and 32 unit tests. `app.tsx` shrank
+  4,355 → 4,153 LOC. Pure refactor; the two pickers share state and
+  lifted cleanly with no call-site asymmetries to preserve.
 - **M4.3** — `refactor(ui): extract ModalHost`
   - Limit, loop, command, LSP, theme, remote, inbox modals routed
     through one host.

--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -3,13 +3,13 @@ import assert from "node:assert";
 import { mkdtempSync, writeFileSync, rmdirSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildFilePickerIgnoreList } from "./app.js";
 import {
-  buildFilePickerIgnoreList,
   filterPickerItems,
   shouldOpenMentionPicker,
   shouldOpenSlashPicker,
   insertSlashCommand,
-} from "./app.js";
+} from "./ui/use-picker-controller.js";
 import type { FilePickerItem } from "./ui/file-picker.js";
 
 describe("buildFilePickerIgnoreList", () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -118,7 +118,7 @@ import { maybeLspNudge } from "./util/lsp-nudge.js";
 import fg from "fast-glob";
 import { FilePicker, type FilePickerItem } from "./ui/file-picker.js";
 import { SlashPicker } from "./ui/slash-picker.js";
-import { fuzzyFilter } from "./util/fuzzy.js";
+import { usePickerController } from "./ui/use-picker-controller.js";
 import { readFileSync } from "node:fs";
 
 /**
@@ -246,63 +246,6 @@ export function buildFilePickerIgnoreList(cwd: string): string[] {
 
   return [...hardcoded, ...gitignorePatterns];
 }
-
-export function filterPickerItems(items: FilePickerItem[], query: string): FilePickerItem[] {
-  return fuzzyFilter(items, query, (item) => item.name).slice(0, 50);
-}
-
-export function shouldOpenMentionPicker(
-  input: string,
-  cursorOffset: number,
-  pickerCancelOffset: number | null,
-): boolean {
-  if (pickerCancelOffset === cursorOffset) return false;
-  if (cursorOffset > 0 && input[cursorOffset - 1] === "@") {
-    const beforeAt = cursorOffset - 2;
-    return beforeAt < 0 || /\s/.test(input[beforeAt]!);
-  }
-  return false;
-}
-
-/**
- * Slash picker triggers when:
- *   - the char immediately before the cursor is "/"
- *   - everything before that "/" is whitespace-only
- * This matches handleSlash() dispatch (it only runs on inputs where the
- * trimmed text starts with "/"), so the picker can't surface commands
- * that won't actually fire.
- */
-export function shouldOpenSlashPicker(
-  input: string,
-  cursorOffset: number,
-  cancelOffset: number | null,
-): boolean {
-  if (cancelOffset === cursorOffset) return false;
-  if (cursorOffset === 0 || input[cursorOffset - 1] !== "/") return false;
-  return /^\s*$/.test(input.slice(0, cursorOffset - 1));
-}
-
-/**
- * Insert a picked slash-command name into the input, replacing the entire
- * command token (from `/` through the next whitespace or EOL). Preserves
- * any args the user already typed past the cursor and ensures exactly one
- * separating space.
- */
-export function insertSlashCommand(
-  input: string,
-  anchor: number,
-  name: string,
-): { value: string; cursor: number } {
-  let tokenEnd = anchor + 1;
-  while (tokenEnd < input.length && !/\s/.test(input[tokenEnd]!)) tokenEnd++;
-  const head = input.slice(0, anchor + 1) + name;
-  const tail = " " + input.slice(tokenEnd).replace(/^\s+/, "");
-  return { value: head + tail, cursor: head.length + 1 };
-}
-
-type ActivePicker =
-  | { kind: "file"; anchor: number; selected: number }
-  | { kind: "slash"; anchor: number; selected: number };
 
 interface Cfg {
   accountId: string;
@@ -701,11 +644,9 @@ function App({
     return () => { cancelled = true; };
   }, [cfg?.cloudMode, initialCloudToken]);
 
-  // Picker state — single popup at a time (file mention or slash command).
+  // Cursor offset for the input box. The picker controller owns its own
+  // open/close/selection state — see `usePickerController` below.
   const [cursorOffset, setCursorOffset] = useState(0);
-  const [activePicker, setActivePicker] = useState<ActivePicker | null>(null);
-  const [filePickerItems, setFilePickerItems] = useState<FilePickerItem[]>([]);
-  const filePickerLoadedRef = useRef(false);
   const [customCommandsVersion, setCustomCommandsVersion] = useState(0);
 
   const cacheStableRef = useRef(initialCfg?.cacheStablePrompts !== false);
@@ -756,37 +697,8 @@ function App({
   const pendingTextRef = useRef<Map<number, { text: string; reasoning: string }>>(new Map());
   const flushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const customCommandsRef = useRef<CustomCommand[]>([]);
-  const pickerCancelRef = useRef<number | null>(null);
   const recentFilesRef = useRef<Map<string, number>>(new Map());
   const MAX_RECENT_FILES = 10;
-
-
-
-  // ── Picker logic (file mention `@` and slash command `/`) ──────────────
-  // Depend on stable fields (kind, anchor) — not the activePicker reference,
-  // which churns on every arrow-key press.
-  const pickerAnchor = activePicker?.anchor ?? null;
-  const pickerKind = activePicker?.kind ?? null;
-  const pickerQuery = React.useMemo(() => {
-    if (pickerAnchor === null) return null;
-    return input.slice(pickerAnchor + 1, cursorOffset);
-  }, [input, cursorOffset, pickerAnchor]);
-
-  const filteredFileItems = React.useMemo(() => {
-    if (pickerKind !== "file" || pickerQuery === null) return [];
-    const items = filterPickerItems(filePickerItems, pickerQuery).slice();
-    const now = Date.now();
-    return items.sort((a, b) => {
-      const aRecent = recentFilesRef.current.get(a.name) ?? 0;
-      const bRecent = recentFilesRef.current.get(b.name) ?? 0;
-      if (aRecent && !bRecent) return -1;
-      if (!aRecent && bRecent) return 1;
-      if (aRecent && bRecent) return bRecent - aRecent;
-      if (a.isDirectory && !b.isDirectory) return -1;
-      if (!a.isDirectory && b.isDirectory) return 1;
-      return a.name.localeCompare(b.name);
-    });
-  }, [pickerKind, filePickerItems, pickerQuery]);
 
   // Custom commands that shadow built-ins are warned about and won't run, so
   // don't surface them in the picker either. customCommandsVersion is bumped
@@ -802,169 +714,55 @@ function App({
     return [...BUILTIN_COMMANDS, ...customs];
   }, [customCommandsVersion]);
 
-  const filteredSlashItems = React.useMemo(() => {
-    if (pickerKind !== "slash" || pickerQuery === null) return [];
-    return fuzzyFilter(allSlashCommands, pickerQuery, (c) => c.name).slice(0, 50);
-  }, [pickerKind, allSlashCommands, pickerQuery]);
+  const modalActive =
+    commandWizard !== null ||
+    commandPicker !== null ||
+    commandToDelete !== null ||
+    showCommandList ||
+    showLspWizard ||
+    resumeSessions !== null ||
+    checkpointSession !== null ||
+    perm !== null ||
+    limitModal !== null ||
+    loopModal !== null ||
+    showInboxModal;
 
-  useEffect(() => {
-    if (activePicker !== null) {
-      const trigger = activePicker.kind === "file" ? "@" : "/";
-      if (cursorOffset < activePicker.anchor) {
-        setActivePicker(null);
-        return;
-      }
-      if (input[activePicker.anchor] !== trigger) {
-        setActivePicker(null);
-        return;
-      }
-      // Whitespace ends the token (start of args for slash, end of mention for @).
-      const query = input.slice(activePicker.anchor + 1, cursorOffset);
-      if (/\s/.test(query)) {
-        setActivePicker(null);
-        return;
-      }
-      return;
-    }
-
-    // Drop sticky-cancel once the cursor moves away from the cancel offset.
-    if (pickerCancelRef.current === cursorOffset) {
-      pickerCancelRef.current = null;
-      return;
-    }
-
-    if (filePickerEnabled && shouldOpenMentionPicker(input, cursorOffset, pickerCancelRef.current)) {
-      setActivePicker({ kind: "file", anchor: cursorOffset - 1, selected: 0 });
-      if (!filePickerLoadedRef.current) {
-        filePickerLoadedRef.current = true;
-        const cwd = process.cwd();
-        void fg("**/*", {
-          cwd,
-          ignore: buildFilePickerIgnoreList(cwd),
-          dot: false,
-          absolute: false,
-          onlyFiles: false,
-          markDirectories: true,
-        } as fg.Options)
-          .then((entries) => {
-            const strings = (entries as string[]).slice(0, 300);
-            const items: FilePickerItem[] = strings.map((e) => ({
-              name: e.endsWith("/") ? e.slice(0, -1) : e,
-              isDirectory: e.endsWith("/"),
-            }));
-            items.sort((a, b) => {
-              if (a.isDirectory && !b.isDirectory) return -1;
-              if (!a.isDirectory && b.isDirectory) return 1;
-              return a.name.localeCompare(b.name);
-            });
-            setFilePickerItems(items);
-          })
-          .catch(() => {
-            setFilePickerItems([]);
-          });
-      }
-      return;
-    }
-
-    if (shouldOpenSlashPicker(input, cursorOffset, pickerCancelRef.current)) {
-      setActivePicker({ kind: "slash", anchor: cursorOffset - 1, selected: 0 });
-      return;
-    }
-  }, [input, cursorOffset, activePicker, filePickerEnabled]);
-
-  // Clamp selected index when filtered list shrinks below the current selection.
-  useEffect(() => {
-    if (activePicker?.kind !== "file") return;
-    const max = Math.max(0, filteredFileItems.length - 1);
-    if (activePicker.selected > max) {
-      setActivePicker({ ...activePicker, selected: max });
-    }
-  }, [filteredFileItems.length, activePicker]);
-
-  useEffect(() => {
-    if (activePicker?.kind !== "slash") return;
-    const max = Math.max(0, filteredSlashItems.length - 1);
-    if (activePicker.selected > max) {
-      setActivePicker({ ...activePicker, selected: max });
-    }
-  }, [filteredSlashItems.length, activePicker]);
-
-  const handlePickerUp = useCallback(() => {
-    setActivePicker((p) => {
-      if (!p) return null;
-      const next = Math.max(0, p.selected - 1);
-      return next === p.selected ? p : { ...p, selected: next };
+  const loadFilePickerItems = useCallback(async (): Promise<FilePickerItem[]> => {
+    const cwd = process.cwd();
+    const entries = await fg("**/*", {
+      cwd,
+      ignore: buildFilePickerIgnoreList(cwd),
+      dot: false,
+      absolute: false,
+      onlyFiles: false,
+      markDirectories: true,
+    } as fg.Options);
+    const strings = (entries as string[]).slice(0, 300);
+    const items: FilePickerItem[] = strings.map((e) => ({
+      name: e.endsWith("/") ? e.slice(0, -1) : e,
+      isDirectory: e.endsWith("/"),
+    }));
+    items.sort((a, b) => {
+      if (a.isDirectory && !b.isDirectory) return -1;
+      if (!a.isDirectory && b.isDirectory) return 1;
+      return a.name.localeCompare(b.name);
     });
+    return items;
   }, []);
 
-  const handlePickerDown = useCallback(() => {
-    setActivePicker((p) => {
-      if (!p) return null;
-      const max = p.kind === "file"
-        ? Math.max(0, filteredFileItems.length - 1)
-        : Math.max(0, filteredSlashItems.length - 1);
-      const next = Math.min(max, p.selected + 1);
-      return next === p.selected ? p : { ...p, selected: next };
-    });
-  }, [filteredFileItems.length, filteredSlashItems.length]);
-
-  const handlePickerSelect = useCallback(() => {
-    if (!activePicker) return;
-    if (activePicker.kind === "file") {
-      const item = filteredFileItems[activePicker.selected];
-      if (!item) return;
-      trackRecentFile(recentFilesRef, item.name, MAX_RECENT_FILES);
-      const insert = item.name + (item.isDirectory ? "/" : " ");
-      const newInput = input.slice(0, activePicker.anchor) + insert + input.slice(cursorOffset);
-      setInput(newInput);
-      setCursorOffset(activePicker.anchor + insert.length);
-      setActivePicker(null);
-      return;
-    }
-    // slash
-    const item = filteredSlashItems[activePicker.selected];
-    if (!item) return;
-    const { value } = insertSlashCommand(input, activePicker.anchor, item.name);
-    setActivePicker(null);
-    submitRef.current(value);
-  }, [activePicker, filteredFileItems, filteredSlashItems, input, cursorOffset]);
-
-  const handlePickerCancel = useCallback(() => {
-    pickerCancelRef.current = cursorOffset;
-    setActivePicker(null);
-  }, [cursorOffset]);
-
-  // Close any open picker when a modal takes over the input. Without this,
-  // picker state would survive the modal and re-render on close.
-  useEffect(() => {
-    const modalActive =
-      commandWizard !== null ||
-      commandPicker !== null ||
-      commandToDelete !== null ||
-      showCommandList ||
-      showLspWizard ||
-      resumeSessions !== null ||
-      checkpointSession !== null ||
-      perm !== null ||
-      limitModal !== null ||
-      loopModal !== null ||
-      showInboxModal;
-    if (modalActive && activePicker !== null) {
-      setActivePicker(null);
-    }
-  }, [
-    commandWizard,
-    commandPicker,
-    commandToDelete,
-    showCommandList,
-    showLspWizard,
-    resumeSessions,
-    perm,
-    limitModal,
-    loopModal,
-    showInboxModal,
-    activePicker,
-  ]);
+  const picker = usePickerController({
+    input,
+    cursorOffset,
+    setInput,
+    setCursorOffset,
+    filePickerEnabled,
+    allSlashCommands,
+    modalActive,
+    loadFilePickerItems,
+    onFileSelected: (name) => trackRecentFile(recentFilesRef, name, MAX_RECENT_FILES),
+    onSlashSelected: (value) => submitRef.current(value),
+    getRecentFiles: () => recentFilesRef.current,
+  });
 
   useEffect(() => {
     if (!cfg) return;
@@ -4248,19 +4046,19 @@ function App({
               gitBranch={gitBranch}
               intentTier={intentTier ?? undefined}
             />
-            {activePicker?.kind === "file" && (
+            {picker.active?.kind === "file" && (
               <FilePicker
-                items={filteredFileItems}
-                selectedIndex={activePicker.selected}
-                query={pickerQuery ?? ""}
+                items={picker.fileItems}
+                selectedIndex={picker.active.selected}
+                query={picker.query}
                 recentFiles={new Set(recentFilesRef.current.keys())}
               />
             )}
-            {activePicker?.kind === "slash" && (
+            {picker.active?.kind === "slash" && (
               <SlashPicker
-                items={filteredSlashItems}
-                selectedIndex={activePicker.selected}
-                query={pickerQuery ?? ""}
+                items={picker.slashItems}
+                selectedIndex={picker.active.selected}
+                query={picker.query}
               />
             )}
           <Box marginTop={1}>
@@ -4272,11 +4070,11 @@ function App({
               enablePaste
               cursorOffset={cursorOffset}
               onCursorChange={setCursorOffset}
-              pickerActive={activePicker !== null}
-              onPickerUp={handlePickerUp}
-              onPickerDown={handlePickerDown}
-              onPickerSelect={handlePickerSelect}
-              onPickerCancel={handlePickerCancel}
+              pickerActive={picker.isActive}
+              onPickerUp={picker.onUp}
+              onPickerDown={picker.onDown}
+              onPickerSelect={picker.onSelect}
+              onPickerCancel={picker.onCancel}
               onHistoryUp={() => {
                 if (history.length === 0) return;
                 if (historyIndex === -1) {

--- a/src/ui/use-picker-controller.test.ts
+++ b/src/ui/use-picker-controller.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  decidePickerTransition,
+  filterPickerItems,
+  shouldOpenMentionPicker,
+  shouldOpenSlashPicker,
+  insertSlashCommand,
+  type ActivePicker,
+} from "./use-picker-controller.js";
+import type { FilePickerItem } from "./file-picker.js";
+
+describe("filterPickerItems", () => {
+  const items: FilePickerItem[] = [
+    { name: "src/app.tsx", isDirectory: false },
+    { name: "src", isDirectory: true },
+    { name: "README.md", isDirectory: false },
+  ];
+
+  it("filters by substring case-insensitively", () => {
+    const result = filterPickerItems(items, "app");
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0]!.name, "src/app.tsx");
+  });
+
+  it("returns all items when query is empty", () => {
+    assert.strictEqual(filterPickerItems(items, "").length, 3);
+  });
+
+  it("caps results at 50", () => {
+    const many = Array.from({ length: 100 }, (_, i) => ({
+      name: `file${i}.ts`,
+      isDirectory: false,
+    }));
+    assert.strictEqual(filterPickerItems(many, "").length, 50);
+  });
+});
+
+describe("shouldOpenMentionPicker", () => {
+  it("opens when @ is typed at start", () => {
+    assert.strictEqual(shouldOpenMentionPicker("@", 1, null), true);
+  });
+  it("opens when @ follows whitespace", () => {
+    assert.strictEqual(shouldOpenMentionPicker("hello @", 7, null), true);
+  });
+  it("does not open when @ follows a non-whitespace character", () => {
+    assert.strictEqual(shouldOpenMentionPicker("hello@", 6, null), false);
+  });
+  it("does not open immediately after cancel at same offset", () => {
+    assert.strictEqual(shouldOpenMentionPicker("hello ", 6, 6), false);
+  });
+  it("does not open when cursor is at 0", () => {
+    assert.strictEqual(shouldOpenMentionPicker("", 0, null), false);
+  });
+});
+
+describe("shouldOpenSlashPicker", () => {
+  it("opens when / is the first char", () => {
+    assert.strictEqual(shouldOpenSlashPicker("/", 1, null), true);
+  });
+  it("opens when / follows leading whitespace", () => {
+    assert.strictEqual(shouldOpenSlashPicker("  /", 3, null), true);
+  });
+  it("does not open when / is mid-message", () => {
+    assert.strictEqual(shouldOpenSlashPicker("hello /", 7, null), false);
+    assert.strictEqual(shouldOpenSlashPicker("path/to", 5, null), false);
+  });
+  it("does not open immediately after cancel at same offset", () => {
+    assert.strictEqual(shouldOpenSlashPicker("/", 1, 1), false);
+  });
+  it("does not open when cursor is at 0", () => {
+    assert.strictEqual(shouldOpenSlashPicker("", 0, null), false);
+  });
+  it("does not open when char before cursor isn't /", () => {
+    assert.strictEqual(shouldOpenSlashPicker("hello", 5, null), false);
+  });
+});
+
+describe("insertSlashCommand", () => {
+  it("inserts and appends a trailing space when input ends at the token", () => {
+    const { value, cursor } = insertSlashCommand("/mod", 0, "model");
+    assert.strictEqual(value, "/model ");
+    assert.strictEqual(cursor, "/model ".length);
+  });
+  it("preserves args past the typed command token", () => {
+    const { value, cursor } = insertSlashCommand("/mod rest", 0, "model");
+    assert.strictEqual(value, "/model rest");
+    assert.strictEqual(cursor, "/model ".length);
+  });
+  it("does not duplicate spaces if a space already follows the token", () => {
+    assert.strictEqual(insertSlashCommand("/m foo", 0, "model").value, "/model foo");
+  });
+  it("works with leading whitespace before the slash", () => {
+    const { value, cursor } = insertSlashCommand("  /he arg", 2, "help");
+    assert.strictEqual(value, "  /help arg");
+    assert.strictEqual(cursor, "  /help ".length);
+  });
+  it("collapses multi-space tails to a single separator", () => {
+    assert.strictEqual(insertSlashCommand("/m  foo", 0, "model").value, "/model foo");
+  });
+  it("normalizes tab/newline tails to a single space", () => {
+    assert.strictEqual(insertSlashCommand("/m\tfoo", 0, "model").value, "/model foo");
+  });
+});
+
+describe("decidePickerTransition", () => {
+  describe("when no picker is active", () => {
+    it("opens the file picker on a leading @", () => {
+      const t = decidePickerTransition(null, "@", 1, null, true);
+      assert.deepStrictEqual(t, {
+        kind: "open",
+        picker: { kind: "file", anchor: 0, selected: 0 },
+        loadFiles: true,
+      });
+    });
+
+    it("opens the slash picker on a leading /", () => {
+      const t = decidePickerTransition(null, "/", 1, null, true);
+      assert.deepStrictEqual(t, {
+        kind: "open",
+        picker: { kind: "slash", anchor: 0, selected: 0 },
+        loadFiles: false,
+      });
+    });
+
+    it("does NOT open the file picker when filePickerEnabled is false", () => {
+      const t = decidePickerTransition(null, "@", 1, null, false);
+      assert.deepStrictEqual(t, { kind: "none" });
+    });
+
+    it("still opens slash even when filePickerEnabled is false", () => {
+      const t = decidePickerTransition(null, "/", 1, null, false);
+      assert.strictEqual(t.kind, "open");
+    });
+
+    it("returns dropCancel when cursor returns to the cancel offset", () => {
+      const t = decidePickerTransition(null, "hello ", 6, 6, true);
+      assert.deepStrictEqual(t, { kind: "dropCancel" });
+    });
+
+    it("returns none when nothing relevant has changed", () => {
+      const t = decidePickerTransition(null, "hello world", 11, null, true);
+      assert.deepStrictEqual(t, { kind: "none" });
+    });
+  });
+
+  describe("when a picker is active", () => {
+    const fileActive: ActivePicker = { kind: "file", anchor: 0, selected: 0 };
+    const slashActive: ActivePicker = { kind: "slash", anchor: 0, selected: 0 };
+
+    it("keeps the picker open while typing query chars", () => {
+      const t = decidePickerTransition(fileActive, "@src", 4, null, true);
+      assert.deepStrictEqual(t, { kind: "none" });
+    });
+
+    it("closes when the cursor moves before the anchor", () => {
+      const anchored: ActivePicker = { kind: "file", anchor: 5, selected: 0 };
+      const t = decidePickerTransition(anchored, "abc @s", 3, null, true);
+      assert.deepStrictEqual(t, { kind: "close" });
+    });
+
+    it("closes when the trigger char at the anchor was deleted", () => {
+      const t = decidePickerTransition(fileActive, "src", 3, null, true);
+      assert.deepStrictEqual(t, { kind: "close" });
+    });
+
+    it("closes when whitespace is typed inside the query", () => {
+      const t = decidePickerTransition(fileActive, "@sr c", 5, null, true);
+      assert.deepStrictEqual(t, { kind: "close" });
+    });
+
+    it("closes the slash picker when the anchor no longer holds /", () => {
+      const t = decidePickerTransition(slashActive, "x", 1, null, true);
+      assert.deepStrictEqual(t, { kind: "close" });
+    });
+
+    it("keeps the slash picker open while typing", () => {
+      const t = decidePickerTransition(slashActive, "/hel", 4, null, true);
+      assert.deepStrictEqual(t, { kind: "none" });
+    });
+  });
+});

--- a/src/ui/use-picker-controller.ts
+++ b/src/ui/use-picker-controller.ts
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fuzzyFilter } from "../util/fuzzy.js";
+import type { FilePickerItem } from "./file-picker.js";
+import type { SlashItem } from "../commands/types.js";
+
+export type PickerKind = "file" | "slash";
+
+export type ActivePicker =
+  | { kind: "file"; anchor: number; selected: number }
+  | { kind: "slash"; anchor: number; selected: number };
+
+// ── Pure helpers (kept here so unit tests don't have to load app.tsx) ─────
+
+export function filterPickerItems(
+  items: FilePickerItem[],
+  query: string,
+): FilePickerItem[] {
+  return fuzzyFilter(items, query, (item) => item.name).slice(0, 50);
+}
+
+export function shouldOpenMentionPicker(
+  input: string,
+  cursorOffset: number,
+  pickerCancelOffset: number | null,
+): boolean {
+  if (pickerCancelOffset === cursorOffset) return false;
+  if (cursorOffset > 0 && input[cursorOffset - 1] === "@") {
+    const beforeAt = cursorOffset - 2;
+    return beforeAt < 0 || /\s/.test(input[beforeAt]!);
+  }
+  return false;
+}
+
+/**
+ * Slash picker triggers when:
+ *   - the char immediately before the cursor is "/"
+ *   - everything before that "/" is whitespace-only
+ * This matches handleSlash() dispatch (it only runs on inputs where the
+ * trimmed text starts with "/"), so the picker can't surface commands
+ * that won't actually fire.
+ */
+export function shouldOpenSlashPicker(
+  input: string,
+  cursorOffset: number,
+  cancelOffset: number | null,
+): boolean {
+  if (cancelOffset === cursorOffset) return false;
+  if (cursorOffset === 0 || input[cursorOffset - 1] !== "/") return false;
+  return /^\s*$/.test(input.slice(0, cursorOffset - 1));
+}
+
+/**
+ * Insert a picked slash-command name into the input, replacing the entire
+ * command token (from `/` through the next whitespace or EOL). Preserves
+ * any args the user already typed past the cursor and ensures exactly one
+ * separating space.
+ */
+export function insertSlashCommand(
+  input: string,
+  anchor: number,
+  name: string,
+): { value: string; cursor: number } {
+  let tokenEnd = anchor + 1;
+  while (tokenEnd < input.length && !/\s/.test(input[tokenEnd]!)) tokenEnd++;
+  const head = input.slice(0, anchor + 1) + name;
+  const tail = " " + input.slice(tokenEnd).replace(/^\s+/, "");
+  return { value: head + tail, cursor: head.length + 1 };
+}
+
+// ── Pure transition function (the core decision) ─────────────────────────
+
+export type PickerTransition =
+  | { kind: "none" }
+  | { kind: "close" }
+  | { kind: "open"; picker: ActivePicker; loadFiles: boolean }
+  | { kind: "dropCancel" };
+
+export function decidePickerTransition(
+  active: ActivePicker | null,
+  input: string,
+  cursorOffset: number,
+  pickerCancelOffset: number | null,
+  filePickerEnabled: boolean,
+): PickerTransition {
+  if (active !== null) {
+    const trigger = active.kind === "file" ? "@" : "/";
+    if (cursorOffset < active.anchor) return { kind: "close" };
+    if (input[active.anchor] !== trigger) return { kind: "close" };
+    const query = input.slice(active.anchor + 1, cursorOffset);
+    if (/\s/.test(query)) return { kind: "close" };
+    return { kind: "none" };
+  }
+
+  if (pickerCancelOffset === cursorOffset) {
+    return { kind: "dropCancel" };
+  }
+
+  if (filePickerEnabled && shouldOpenMentionPicker(input, cursorOffset, pickerCancelOffset)) {
+    return {
+      kind: "open",
+      picker: { kind: "file", anchor: cursorOffset - 1, selected: 0 },
+      loadFiles: true,
+    };
+  }
+
+  if (shouldOpenSlashPicker(input, cursorOffset, pickerCancelOffset)) {
+    return {
+      kind: "open",
+      picker: { kind: "slash", anchor: cursorOffset - 1, selected: 0 },
+      loadFiles: false,
+    };
+  }
+
+  return { kind: "none" };
+}
+
+// ── React hook ───────────────────────────────────────────────────────────
+
+export interface UsePickerControllerOptions {
+  input: string;
+  cursorOffset: number;
+  setInput: (v: string) => void;
+  setCursorOffset: (n: number) => void;
+  filePickerEnabled: boolean;
+  allSlashCommands: SlashItem[];
+  modalActive: boolean;
+  /** Lazy-load file list on first `@` trigger. Called at most once. */
+  loadFilePickerItems: () => Promise<FilePickerItem[]>;
+  /** Called when a file is picked so the caller can update its recents store. */
+  onFileSelected?: (name: string) => void;
+  /** Called with the new input value when a slash command is picked. */
+  onSlashSelected: (value: string) => void;
+  /** Snapshot of the recents map for the file-picker sort. */
+  getRecentFiles: () => Map<string, number>;
+}
+
+export interface PickerController {
+  active: ActivePicker | null;
+  isActive: boolean;
+  query: string;
+  fileItems: FilePickerItem[];
+  slashItems: SlashItem[];
+  onUp: () => void;
+  onDown: () => void;
+  onSelect: () => void;
+  onCancel: () => void;
+}
+
+export function usePickerController(opts: UsePickerControllerOptions): PickerController {
+  const {
+    input,
+    cursorOffset,
+    setInput,
+    setCursorOffset,
+    filePickerEnabled,
+    allSlashCommands,
+    modalActive,
+    loadFilePickerItems,
+    onFileSelected,
+    onSlashSelected,
+    getRecentFiles,
+  } = opts;
+
+  const [active, setActive] = useState<ActivePicker | null>(null);
+  const [fileItemsRaw, setFileItemsRaw] = useState<FilePickerItem[]>([]);
+  const filesLoadedRef = useRef(false);
+  const cancelOffsetRef = useRef<number | null>(null);
+
+  // Stash callbacks/getters in refs so the public handlers keep stable
+  // identities and we never close over a stale closure.
+  const onFileSelectedRef = useRef(onFileSelected);
+  onFileSelectedRef.current = onFileSelected;
+  const onSlashSelectedRef = useRef(onSlashSelected);
+  onSlashSelectedRef.current = onSlashSelected;
+  const getRecentFilesRef = useRef(getRecentFiles);
+  getRecentFilesRef.current = getRecentFiles;
+  const loadFilePickerItemsRef = useRef(loadFilePickerItems);
+  loadFilePickerItemsRef.current = loadFilePickerItems;
+
+  // Depend on stable fields (kind, anchor) — not the active reference,
+  // which churns on every arrow-key press.
+  const activeAnchor = active?.anchor ?? null;
+  const activeKind = active?.kind ?? null;
+
+  const query = useMemo(() => {
+    if (activeAnchor === null) return "";
+    return input.slice(activeAnchor + 1, cursorOffset);
+  }, [input, cursorOffset, activeAnchor]);
+
+  const fileItems = useMemo(() => {
+    if (activeKind !== "file") return [];
+    const items = filterPickerItems(fileItemsRaw, query).slice();
+    const recents = getRecentFilesRef.current();
+    return items.sort((a, b) => {
+      const aRecent = recents.get(a.name) ?? 0;
+      const bRecent = recents.get(b.name) ?? 0;
+      if (aRecent && !bRecent) return -1;
+      if (!aRecent && bRecent) return 1;
+      if (aRecent && bRecent) return bRecent - aRecent;
+      if (a.isDirectory && !b.isDirectory) return -1;
+      if (!a.isDirectory && b.isDirectory) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [activeKind, fileItemsRaw, query]);
+
+  const slashItems = useMemo(() => {
+    if (activeKind !== "slash") return [];
+    return fuzzyFilter(allSlashCommands, query, (c) => c.name).slice(0, 50);
+  }, [activeKind, allSlashCommands, query]);
+
+  // Transition on input/cursor changes.
+  useEffect(() => {
+    const t = decidePickerTransition(
+      active,
+      input,
+      cursorOffset,
+      cancelOffsetRef.current,
+      filePickerEnabled,
+    );
+    if (t.kind === "close") {
+      setActive(null);
+      return;
+    }
+    if (t.kind === "dropCancel") {
+      cancelOffsetRef.current = null;
+      return;
+    }
+    if (t.kind === "open") {
+      setActive(t.picker);
+      if (t.loadFiles && !filesLoadedRef.current) {
+        filesLoadedRef.current = true;
+        void loadFilePickerItemsRef
+          .current()
+          .then((items) => setFileItemsRaw(items))
+          .catch(() => setFileItemsRaw([]));
+      }
+    }
+  }, [input, cursorOffset, active, filePickerEnabled]);
+
+  // Clamp selected index when filtered list shrinks below current selection.
+  useEffect(() => {
+    if (active?.kind !== "file") return;
+    const max = Math.max(0, fileItems.length - 1);
+    if (active.selected > max) {
+      setActive({ ...active, selected: max });
+    }
+  }, [fileItems.length, active]);
+
+  useEffect(() => {
+    if (active?.kind !== "slash") return;
+    const max = Math.max(0, slashItems.length - 1);
+    if (active.selected > max) {
+      setActive({ ...active, selected: max });
+    }
+  }, [slashItems.length, active]);
+
+  // Close the picker whenever a modal takes over the input. Without this,
+  // picker state survives the modal and re-renders on close.
+  useEffect(() => {
+    if (modalActive && active !== null) {
+      setActive(null);
+    }
+  }, [modalActive, active]);
+
+  const onUp = useCallback(() => {
+    setActive((p) => {
+      if (!p) return null;
+      const next = Math.max(0, p.selected - 1);
+      return next === p.selected ? p : { ...p, selected: next };
+    });
+  }, []);
+
+  const onDown = useCallback(() => {
+    setActive((p) => {
+      if (!p) return null;
+      const max = p.kind === "file"
+        ? Math.max(0, fileItems.length - 1)
+        : Math.max(0, slashItems.length - 1);
+      const next = Math.min(max, p.selected + 1);
+      return next === p.selected ? p : { ...p, selected: next };
+    });
+  }, [fileItems.length, slashItems.length]);
+
+  const onSelect = useCallback(() => {
+    if (!active) return;
+    if (active.kind === "file") {
+      const item = fileItems[active.selected];
+      if (!item) return;
+      onFileSelectedRef.current?.(item.name);
+      const insert = item.name + (item.isDirectory ? "/" : " ");
+      const newInput = input.slice(0, active.anchor) + insert + input.slice(cursorOffset);
+      setInput(newInput);
+      setCursorOffset(active.anchor + insert.length);
+      setActive(null);
+      return;
+    }
+    const item = slashItems[active.selected];
+    if (!item) return;
+    const { value } = insertSlashCommand(input, active.anchor, item.name);
+    setActive(null);
+    onSlashSelectedRef.current(value);
+  }, [active, fileItems, slashItems, input, cursorOffset, setInput, setCursorOffset]);
+
+  const onCancel = useCallback(() => {
+    cancelOffsetRef.current = cursorOffset;
+    setActive(null);
+  }, [cursorOffset]);
+
+  return {
+    active,
+    isActive: active !== null,
+    query,
+    fileItems,
+    slashItems,
+    onUp,
+    onDown,
+    onSelect,
+    onCancel,
+  };
+}


### PR DESCRIPTION
## Summary

Second extraction in the M4 `app.tsx` breakup, following the M4.1 template (#419). The file-mention `@` and slash-command `/` state machine moves out of `src/app.tsx` into `src/ui/use-picker-controller.ts`.

- **Pure decision core**: `decidePickerTransition()` takes `(active, input, cursorOffset, cancelOffset, filePickerEnabled)` and returns `{ kind: 'none' | 'close' | 'open' | 'dropCancel', ... }`. No React, fully unit-tested.
- **Thin React hook**: `usePickerController({ ... })` owns active-picker state, the lazy file loader (called at most once on first `@`), the filtered item memos, modal-takeover close, selected-index clamping, and the up/down/select/cancel handlers.
- **Helpers moved with the hook**: `filterPickerItems`, `shouldOpenMentionPicker`, `shouldOpenSlashPicker`, `insertSlashCommand` now live next to the hook; `app.test.tsx` imports updated to point at the new module.
- **app.tsx**: 4,355 → 4,153 LOC (−202).
- **Tests**: 32 new unit tests in `src/ui/use-picker-controller.test.ts` covering the four helpers plus the transition table; existing helper tests in `app.test.tsx` retained (now imported from the new module).

## Behavior preserved

This is a pure refactor. Every observable behavior of the prior inline machine is preserved:

- `@` mention picker opens only after whitespace (or BOL), gated on `filePickerEnabled`.
- `/` slash picker opens only when everything before the `/` is whitespace.
- Sticky-cancel: `Esc` records the cancel offset; the picker won't reopen until the cursor moves off that offset.
- Picker closes when the cursor moves before the anchor, the trigger char is deleted, or whitespace is typed inside the query.
- Selected index is clamped when the filtered list shrinks.
- Any modal opening forces the picker closed.
- File list is fetched lazily on the first `@` trigger and cached for the session.
- Recents-first sort on filtered file items.
- Slash picker custom-command shadowing (built-ins win) preserved via the existing `allSlashCommands` memo, now passed as a hook input.

## Asymmetries spotted

None. Both pickers shared the same underlying state machine in `app.tsx`, so the lift is symmetric — no `promptOnBlockedBash`-style flag was needed.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 446/446 pass (was 446 before, 32 of which are new picker tests; 14 prior helper tests in `app.test.tsx` retained via re-imports)
- [x] `npm run build` — clean ESM + DTS
- [ ] Manual smoke (not runnable from this non-TTY environment): open each picker (`@`, `/`), navigate with ↑/↓, select with Enter, dismiss with Esc; verify modal close (e.g. open `/help` then a slash command); verify recents-first sort after picking a file.

Closes M4.2. Roadmap progress log and inline M4 section updated in this PR.