### PR TITLE
feat(memory): add extraction error counter and first-failure warning

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -17,7 +17,7 @@ work).
 
 ## Red flags
 
-### RF-1 — Fire-and-forget memory extraction swallows errors (S → M)
+### RF-1 — Fire-and-forget memory extraction swallows errors (S → M) — ✅ shipped (OP-7)
 
 `src/agent/loop.ts:752–810`, error swallowed at `:806`.
 
@@ -30,6 +30,17 @@ from "memory recall is empty."
 **Fix:** route extraction errors through `onWarning` (already in the
 callback surface) at debug level; add a per-session error counter exposed
 in `/cost` or a `/memory health` subcommand.
+
+**Status:**
+- Errors increment a per-session counter in
+  `memoryExtractionErrorCounts` (module-level Map, same pattern as the
+  drift accumulator).
+- The first error per session also fires `onWarning(…)` with a `[memory]`
+  prefix — subsequent failures stay silent on the UI but still increment
+  the counter, and every error is sent to `logger.debug` with the
+  underlying message.
+- `getMemoryExtractionErrorCount(sessionId)` is exported for the eventual
+  `/memory health` subcommand (TUI work, M4-adjacent).
 
 ### RF-2 — Drift accumulator decays as fast as it fires (S)
 
@@ -350,7 +361,7 @@ Tracked as M1.0 in the development roadmap.
   (fix for RF-13, first half).
 - **OP-6.** Cross-turn `webFetchHistory` (fix for RF-3).
 - **OP-7.** Memory extraction error counter + `/memory health` surface
-  (fix for RF-1).
+  (fix for RF-1). ✅ counter + onWarning shipped; `/memory health` surface deferred to M4
 - **OP-8.** Sliding-window drift detection (fix for RF-2).
 - **OP-9.** Zero-tool-call budget check (fix for RF-5).
 - **OP-10.** Re-emit isolated-vm fallback warning per session

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -137,6 +137,18 @@ const codeModeApiCache = new Map<string, string>();
 const driftAccumulator = new Map<string, number>();
 const DRIFT_THRESHOLD = 5;
 
+/** Per-session count of fire-and-forget memory-extraction errors. Exposed via
+ *  `getMemoryExtractionErrorCount` for a future `/memory health` surface. */
+const memoryExtractionErrorCounts = new Map<string, number>();
+
+export function getMemoryExtractionErrorCount(sessionId: string | undefined): number {
+  return memoryExtractionErrorCounts.get(sessionId ?? "default") ?? 0;
+}
+
+export function _resetMemoryExtractionErrorCountsForTests(): void {
+  memoryExtractionErrorCounts.clear();
+}
+
 function isHighSignalMemory(memory: {
   topicKey: string;
   category: string;
@@ -813,8 +825,29 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
                       }
                     }
                   }
-                } catch {
-                  // Swallow auto-extraction errors so they never break the loop
+                } catch (err) {
+                  // Auto-extraction must never break the turn, but a silent
+                  // swallow hides systemic failures (bad embedding endpoint,
+                  // DB lock, schema mismatch). Track per session and surface
+                  // through onWarning so /memory health (and SDK consumers)
+                  // can see something is wrong.
+                  const sid = opts.sessionId ?? "default";
+                  const next = (memoryExtractionErrorCounts.get(sid) ?? 0) + 1;
+                  memoryExtractionErrorCounts.set(sid, next);
+                  const msg = err instanceof Error ? err.message : String(err);
+                  logger.debug("memory:extract_error", {
+                    sessionId: opts.sessionId,
+                    tool: tc.function.name,
+                    count: next,
+                    error: msg,
+                  });
+                  // Only emit the user-visible warning on the first failure
+                  // per session — repeated errors stay in the counter.
+                  if (next === 1) {
+                    opts.callbacks.onWarning?.(
+                      `[memory] auto-extraction failed (${msg}). Subsequent failures will be counted silently; check /memory health.`,
+                    );
+                  }
                 }
               })();
             }


### PR DESCRIPTION
## Summary

- The fire-and-forget memory extractor in \`loop.ts\` used to swallow every error silently.
- Each failure now increments \`memoryExtractionErrorCounts\` (module Map, session-keyed).
- The first failure per session fires \`onWarning(\"[memory] …\")\`; subsequent failures stay quiet on the UI but still count, and all go to \`logger.debug\`.
- \`getMemoryExtractionErrorCount(sessionId)\` is exported for a future \`/memory health\` surface — that UI work lives in \`app.tsx\` and is deferred to M4.

Fixes RF-1 / OP-7 except for the slash-command surface.

## Test plan
- [x] \`npm run typecheck\`
- [ ] Force an extraction failure (bad embedding URL) and confirm the single warning + the counter increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)