### PR TITLE
feat(agent): sliding-window drift detection for KIMI.md staleness

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -42,7 +42,7 @@ in `/cost` or a `/memory health` subcommand.
 - `getMemoryExtractionErrorCount(sessionId)` is exported for the eventual
   `/memory health` subcommand (TUI work, M4-adjacent).
 
-### RF-2 — Drift accumulator decays as fast as it fires (S)
+### RF-2 — Drift accumulator decays as fast as it fires (S) — ✅ shipped (OP-8)
 
 `DRIFT_THRESHOLD = 5` at `src/agent/loop.ts:138`, decay −1 per turn at turn
 end (~`loop.ts:825`).
@@ -56,6 +56,12 @@ in the UI.
 **Fix:** either drop the decay to 0.5/turn (rounded fractional accumulator)
 or change the trigger to a sliding window (e.g., 3 high-signal memories
 in 10 turns).
+
+**Status:** Replaced the counter-with-decay with a sliding window —
+`driftEvents` is a `Map<sessionId, number[]>` of turn indices, and
+`onKimiMdStale` fires when **≥ 3 high-signal memories land within 10
+turns**. After firing, the window is cleared so we don't re-nudge on
+every subsequent turn. The end-of-turn decay block is gone.
 
 ### RF-3 — Web-fetch spiral guardrail is per-turn only (S)
 
@@ -388,10 +394,10 @@ Tracked as M1.0 in the development roadmap.
 - **OP-4.** Per-call SSE idle timeout knob (fix for RF-7). ✅ shipped
 - **OP-5.** `signal.aborted` checks inside grep/glob/read inner loops
   (fix for RF-13, first half). ✅ shipped
-- **OP-6.** Cross-turn `webFetchHistory` (fix for RF-3).
+- **OP-6.** Cross-turn `webFetchHistory` (fix for RF-3). ✅ shipped
 - **OP-7.** Memory extraction error counter + `/memory health` surface
   (fix for RF-1). ✅ counter + onWarning shipped; `/memory health` surface deferred to M4
-- **OP-8.** Sliding-window drift detection (fix for RF-2).
+- **OP-8.** Sliding-window drift detection (fix for RF-2). ✅ shipped
 - **OP-9.** Zero-tool-call budget check (fix for RF-5). ✅ shipped
 - **OP-10.** Re-emit isolated-vm fallback warning per session
   (fix for RF-19).

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -140,9 +140,17 @@ export class AgentLoopError extends Error {
 
 const codeModeApiCache = new Map<string, string>();
 
-/** Per-session accumulator for high-signal memories that may indicate KIMI.md drift. */
-const driftAccumulator = new Map<string, number>();
-const DRIFT_THRESHOLD = 5;
+/** Per-session sliding window of turn indices where a high-signal memory landed.
+ *  We fire `onKimiMdStale` when >=DRIFT_THRESHOLD events fall inside
+ *  DRIFT_WINDOW recent turns. Replaces the older count-with-decay scheme
+ *  which almost never fired on long sessions (RF-2 / OP-8). */
+const driftEvents = new Map<string, number[]>();
+const DRIFT_WINDOW = 10;
+const DRIFT_THRESHOLD = 3;
+
+export function _resetDriftEventsForTests(): void {
+  driftEvents.clear();
+}
 
 /** Per-session count of fire-and-forget memory-extraction errors. Exposed via
  *  `getMemoryExtractionErrorCount` for a future `/memory health` surface. */
@@ -801,6 +809,10 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
           const llmOpts = opts.memoryManager.getExtractionLlmOpts();
 
+          // Capture turn at IIFE creation so the sliding-window drift
+          // detector below is anchored to when the memory was extracted,
+          // not whatever value `turn` has when the await chain settles.
+          const turnAtMemoryCommit = turn;
           for (const extractor of EXTRACTORS) {
             if (extractor.match(tc.function.name, filePath)) {
               void (async () => {
@@ -825,14 +837,21 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
                       memory.topicKey,
                     );
 
-                    // Real-time drift detection (Trigger B)
+                    // Real-time drift detection — sliding window:
+                    // fire `onKimiMdStale` when >=DRIFT_THRESHOLD high-signal
+                    // memories land within DRIFT_WINDOW turns. Clustered
+                    // changes = drift; spread-out changes = incremental work
+                    // and aren't worth nagging about. (RF-2 / OP-8.)
                     if (isHighSignalMemory(memory)) {
                       const sid = opts.sessionId ?? "default";
-                      const current = (driftAccumulator.get(sid) ?? 0) + 1;
-                      driftAccumulator.set(sid, current);
-                      if (current >= DRIFT_THRESHOLD) {
+                      const events = driftEvents.get(sid) ?? [];
+                      events.push(turnAtMemoryCommit);
+                      const cutoff = turnAtMemoryCommit - DRIFT_WINDOW + 1;
+                      const recent = events.filter((t) => t >= cutoff);
+                      driftEvents.set(sid, recent);
+                      if (recent.length >= DRIFT_THRESHOLD) {
                         opts.callbacks.onKimiMdStale?.();
-                        driftAccumulator.set(sid, 0);
+                        driftEvents.set(sid, []);
                       }
                     }
                   }
@@ -874,14 +893,8 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
       loopExhausted = true;
     }
 
-    // Decay drift accumulator at end of turn (clustered changes = drift,
-    // spread-out changes = incremental and not worth nagging)
-    if (opts.sessionId) {
-      const current = driftAccumulator.get(opts.sessionId) ?? 0;
-      if (current > 0) {
-        driftAccumulator.set(opts.sessionId, Math.max(0, current - 1));
-      }
-    }
+    // (Drift accumulator decay was removed in OP-8 — drift detection is
+    // now a sliding window over recent turns, not a decaying counter.)
 
     // Allow external compaction / state management between iterations
     if (opts.onIterationEnd) {


### PR DESCRIPTION
## Summary

- Replaces the counter-with-decay drift signal (threshold 5, decay -1/turn) with a sliding window.
- \`onKimiMdStale\` now fires when **≥ 3 high-signal memories land within 10 turns**.
- \`driftEvents\` is a \`Map<sessionId, number[]>\` of turn indices. After firing, the window clears so we don't re-nudge on every turn after.
- End-of-turn decay block removed.
- \`turn\` captured before the async IIFE so the entry is anchored to extraction time, not when the await chain settles.

Fixes RF-2 / OP-8.

## Test plan
- [x] \`npm run typecheck\`
- [ ] Manual: drive 3 high-signal extractions in a row, confirm onKimiMdStale fires; then drive sparse extractions and confirm it stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)