### PR TITLE
fix(agent): enforce budget exhaustion on pure-text turns

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -71,7 +71,7 @@ hashing.
 **Fix:** allow each `ToolSpec` to declare a `signatureKey(args)` projector
 that strips known nonce fields. Default falls back to current behavior.
 
-### RF-5 — Budget exhaustion only triggers when tools were called (S)
+### RF-5 — Budget exhaustion only triggers when tools were called (S) — ✅ shipped (OP-9)
 
 `src/agent/loop.ts:530–574`. The condition is
 `cumulativePromptTokens >= maxInputTokens && toolCalls.length > 0`.
@@ -82,6 +82,11 @@ practice agents do sometimes emit long pure-text turns past the cap.
 **Fix:** evaluate budget on every iteration end; let the no-tools case
 short-circuit straight to `BudgetExhaustedError` instead of an extra
 synthesis turn.
+
+**Status:** Removed `toolCalls.length > 0` from the budget condition.
+Pure-text turns past the cap now flip `budgetExhausted`, and the
+existing no-tools branch (which throws `BudgetExhaustedError` when the
+flag is set) short-circuits without an extra synthesis turn.
 
 ### RF-6 — `MAX_PROMPT_TOKENS = 240_000` hard error (S)
 
@@ -352,7 +357,7 @@ Tracked as M1.0 in the development roadmap.
 - **OP-7.** Memory extraction error counter + `/memory health` surface
   (fix for RF-1).
 - **OP-8.** Sliding-window drift detection (fix for RF-2).
-- **OP-9.** Zero-tool-call budget check (fix for RF-5).
+- **OP-9.** Zero-tool-call budget check (fix for RF-5). ✅ shipped
 - **OP-10.** Re-emit isolated-vm fallback warning per session
   (fix for RF-19).
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -539,12 +539,15 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     if (lastUsage) {
       opts.callbacks.onUsageFinal?.(lastUsage, gatewayMeta);
       cumulativePromptTokens += lastUsage.prompt_tokens;
+      // Flip the budget flag regardless of whether this turn produced tool
+      // calls — a long pure-text turn past the cap should still trip the
+      // limit. The no-tools branch below short-circuits to BudgetExhaustedError
+      // instead of an extra synthesis turn. (RF-5 / OP-9.)
       if (
         !budgetExhausted &&
         opts.maxInputTokens !== undefined &&
         opts.maxInputTokens > 0 &&
-        cumulativePromptTokens >= opts.maxInputTokens &&
-        toolCalls.length > 0
+        cumulativePromptTokens >= opts.maxInputTokens
       ) {
         budgetExhausted = true;
       }


### PR DESCRIPTION
## Summary

- Drops the \`toolCalls.length > 0\` clause from the budget-exhaustion condition.
- A long pure-text turn past \`maxInputTokens\` now flips \`budgetExhausted\` and the existing no-tools branch short-circuits to \`BudgetExhaustedError\` instead of letting one more synthesis turn slip through.

Fixes RF-5 / OP-9.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npx tsx --test src/agent/loop.test.ts\` — 2 pass
- [ ] Manual: synthetic turn that emits long pure text past the cap — confirm BudgetExhaustedError

🤖 Generated with [Claude Code](https://claude.com/claude-code)