### PR TITLE
feat(usage): gateway latency, per-feature cost, cache-hit ratio

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -89,7 +89,7 @@ import {
 import { unlink } from "node:fs/promises";
 import { execSync } from "node:child_process";
 import { encodeImageFile, isImagePath, type EncodedImage } from "./util/image.js";
-import { recordUsage, getCostReport, formatCostReport, formatGatewaySection, getSessionGatewayLogs, usageEvents } from "./usage-tracker.js";
+import { recordUsage, getCostReport, formatCostReport, formatGatewaySection, formatFeatureBreakdown, getSessionGatewayLogs, usageEvents } from "./usage-tracker.js";
 import type { GatewayUsageLookup, DailyUsage } from "./usage-tracker.js";
 import { MemoryManager } from "./memory/manager.js";
 import { RETENTION } from "./storage-limits.js";
@@ -2160,6 +2160,28 @@ function App({
               const logs = sid ? await getSessionGatewayLogs(sid).catch(() => []) : [];
               const gwSection = formatGatewaySection(report, cfg.accountId, cfg.aiGatewayId, logs);
               if (gwSection) lines.push("", gwSection);
+
+              // Pull per-feature cost from the Gateway logs API (1-hour cache),
+              // and surface drift status alongside the local total.
+              try {
+                const { reconcileWithCloudflare } = await import("./cost-attribution/reconcile.js");
+                const today = new Date().toISOString().slice(0, 10);
+                const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+                  .toISOString()
+                  .slice(0, 10);
+                const recon = await reconcileWithCloudflare({
+                  localCost: report.month.cost,
+                  accountId: cfg.accountId,
+                  apiToken: cfg.apiToken,
+                  gatewayId: cfg.aiGatewayId,
+                  startDate: sevenDaysAgo,
+                  endDate: today,
+                });
+                const breakdown = formatFeatureBreakdown(recon.featureBreakdown);
+                if (breakdown) lines.push("", breakdown);
+              } catch {
+                /* best-effort; /cost still renders without the breakdown */
+              }
             }
             if (cfg?.costAttribution) {
               const { getCategoryReportText } = await import("./cost-attribution/tui-report.js");
@@ -2238,6 +2260,25 @@ function App({
             lines.push(`collect-logs: ${cfg.aiGatewayCollectLogPayload ?? false}`);
             const meta = cfg.aiGatewayMetadata;
             lines.push(`metadata: ${meta && Object.keys(meta).length > 0 ? JSON.stringify(meta) : "none"}`);
+            // Tack on the live cache-hit ratio for the current session — derived
+            // from the cf-aig-cache-status headers we've collected so far.
+            const sid = sessionIdRef.current;
+            if (sid) {
+              void getCostReport(sid).then((report) => {
+                const req = report.session.gatewayRequests ?? 0;
+                if (req === 0) return;
+                const cached = report.session.gatewayCachedRequests ?? 0;
+                const pct = ((cached / req) * 100).toFixed(1);
+                setEvents((e) => [
+                  ...e,
+                  {
+                    kind: "info",
+                    key: mkKey(),
+                    text: `cache hits (session): ${cached}/${req} (${pct}%)`,
+                  },
+                ]);
+              }).catch(() => {});
+            }
           } else {
             lines.push("gateway: off (direct Workers AI)");
           }

--- a/src/cost-attribution/reconcile.ts
+++ b/src/cost-attribution/reconcile.ts
@@ -153,6 +153,7 @@ export async function reconcileWithCloudflare(opts: ReconcileOptions): Promise<R
       cloudflareCost,
       driftPct: Math.round(driftPct * 1000) / 10,
       message: `Reconciled ${logs.length} Gateway log entries`,
+      featureBreakdown: aggregateByFeature(logs),
     };
     cache.set(key, { result, expires: Date.now() + 60 * 60 * 1000 });
     return result;

--- a/src/cost-attribution/types.ts
+++ b/src/cost-attribution/types.ts
@@ -87,6 +87,9 @@ export interface ReconciliationResult {
   cloudflareCost?: number;
   driftPct?: number;
   message?: string;
+  /** Per-feature cost breakdown derived from the `metadata.feature` tag on
+   *  Gateway logs. Only populated when the reconcile call succeeded. */
+  featureBreakdown?: Array<{ feature: string; cost: number; requests: number }>;
 }
 
 export interface CostAttributionReport {

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -155,6 +155,9 @@ export function buildRightParts(
     } else {
       parts.push(`${prefix}${sessionUsage.cost.toFixed(2)}`);
     }
+    if (typeof sessionUsage.lastTurnMs === "number") {
+      parts.push(formatDuration(sessionUsage.lastTurnMs));
+    }
   } else {
     const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
     const cost = calculateCost(usage.prompt_tokens, usage.completion_tokens, cached);
@@ -184,6 +187,11 @@ function formatTokens(n: number): string {
 export function formatGatewayCacheStatus(gatewayMeta?: GatewayMeta | null): string | null {
   const status = gatewayMeta?.cacheStatus?.trim();
   return status ? `AI Gateway · cache ${status.toLowerCase()}` : null;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 function formatElapsed(ms: number): string {

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -35,6 +35,10 @@ export interface DailyUsage {
   /** True iff this is a session-scoped DailyUsage with at least one turn whose
    *  Gateway cost has not yet been confirmed. Always undefined for day/month/all-time. */
   reconcilePending?: boolean;
+  /** Most recently confirmed turn duration in ms, sourced from the Gateway log.
+   *  Only set on the session-scoped DailyUsage when at least one turn has been
+   *  reconciled with a duration field. */
+  lastTurnMs?: number;
 }
 
 /** A single agent turn's cost record. `estimatedCost` is the local-pricing
@@ -445,6 +449,7 @@ export async function getCostReport(sessionId?: string): Promise<CostReport> {
         gatewayCachedRequests: rawSession.gatewayCachedRequests,
         gatewayCost: rawSession.gatewayCost,
         reconcilePending: hasPendingReconcile(rawSession),
+        lastTurnMs: latestConfirmedDurationMs(rawSession),
       }
     : { date, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cost: 0 };
 
@@ -498,6 +503,15 @@ function hasPendingReconcile(session: SessionUsage): boolean {
   return session.turns.some(
     (t) => t.logId && t.confirmedCost === undefined && !t.reconcileFailed,
   );
+}
+
+function latestConfirmedDurationMs(session: SessionUsage): number | undefined {
+  if (!session.turns) return undefined;
+  for (let i = session.turns.length - 1; i >= 0; i--) {
+    const ms = session.turns[i]?.durationMs;
+    if (typeof ms === "number") return ms;
+  }
+  return undefined;
 }
 
 /** Fetch the GatewayUsageSnapshot array recorded against a session, for /cost rendering. */
@@ -554,6 +568,22 @@ export function formatGatewaySection(
   lines.push(
     `  dashboard:  https://dash.cloudflare.com/${accountId}/ai/ai-gateway/gateways/${gatewayId}`,
   );
+  return lines.join("\n");
+}
+
+/** Render the per-feature cost breakdown — one row per metadata.feature tag
+ *  observed in the Gateway logs. Skips trivial breakdowns (1 unknown row). */
+export function formatFeatureBreakdown(
+  breakdown: Array<{ feature: string; cost: number; requests: number }> | undefined,
+): string {
+  if (!breakdown || breakdown.length === 0) return "";
+  if (breakdown.length === 1 && breakdown[0]!.feature === "unknown") return "";
+  const lines = ["─── By feature (Gateway-confirmed) ───"];
+  for (const row of breakdown) {
+    lines.push(
+      `  ${row.feature.padEnd(20)} $${row.cost.toFixed(4)}  (${row.requests} req)`,
+    );
+  }
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## Summary

- **Latency in the status bar** — the most-recent confirmed turn's `durationMs` (from the Gateway log) renders next to cost as `1.2s` (or `420ms` for sub-second turns). New `lastTurnMs` field on the session-scoped `DailyUsage`, populated by `getCostReport`. Only appears once a turn has been reconciled — no estimate.
- **Per-feature breakdown in /cost** — `reconcileWithCloudflare` already computed `aggregateByFeature` internally and threw it away. It's now exposed via `ReconciliationResult.featureBreakdown` and rendered as a \"By feature (Gateway-confirmed)\" section under /cost. Trivial \"unknown only\" breakdowns are skipped. The reconcile call is cached for 1 hour, so repeat /cost invocations don't re-hit the Cloudflare logs API.
- **Cache-hit ratio in /gateway status** — derived from the `gatewayCachedRequests / gatewayRequests` counters we already accumulate from `cf-aig-cache-status` headers per turn. Appears as `cache hits (session): 7/12 (58.3%)`.

Part 2 of the AI Gateway data plan.

## Test plan

- [x] `npm test` — 447 pass (no test changes needed; new code is additive)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Manual: run a few turns, status bar shows `$0.0X · 1.2s` after reconcile lands
- [ ] Manual: run `/cost` with a Gateway configured and metadata tagging — confirm \"By feature\" section appears
- [ ] Manual: run `/gateway status` — confirm cache-hit ratio line is appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)