### PR TITLE
refactor(ui): extract ModalHost from app.tsx (M4.3)

### DIFF
--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,7 +15,23 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
-- **M4.2** — `PickerController` extracted from `app.tsx` — *(this PR)*.
+- **M4.3** — `ModalHost` extracted from `app.tsx` — *(this PR)*.
+  Lifted ten modal families (limit, loop, command wizard / picker /
+  delete / list, LSP wizard, theme picker, remote dashboard, inbox)
+  into `src/ui/use-modal-host.ts` (state owner) and
+  `src/ui/modal-host.tsx` (renderer; fullscreen `<ModalHost>` and
+  inline `<ModalOverlay>`). The hook destructures with the original
+  state-variable names, so the 49 setter call sites elsewhere in
+  `app.tsx` did not need to change. `app.tsx` shrank 4,153 → 4,038 LOC.
+  Pure refactor. Two pre-existing keybinding asymmetries spotted in
+  the picker close-on-modal check and the Esc-handler modal-open
+  check (each excludes a different subset of modals); both preserved
+  verbatim and flagged inline for the eventual M9.10 audit. Resolver
+  refs (`limitResolveRef`, `loopResolveRef`) still live in `app.tsx`
+  because the agent loop's abort path reads them — `<ModalOverlay>`
+  gets `onLimitResolved` / `onLoopResolved` callbacks to clear them.
+- **M4.2** — `PickerController` extracted from `app.tsx` — merged in
+  #432.
   Pulled the file-mention `@`, slash-command `/` state machine into
   `src/ui/use-picker-controller.ts` (~320 LOC) with a pure
   `decidePickerTransition()` core and 32 unit tests (helpers +
@@ -283,9 +299,15 @@ that touches UI assumes M4 is making steady progress.
   `decidePickerTransition()` core and 32 unit tests. `app.tsx` shrank
   4,355 → 4,153 LOC. Pure refactor; the two pickers share state and
   lifted cleanly with no call-site asymmetries to preserve.
-- **M4.3** — `refactor(ui): extract ModalHost`
-  - Limit, loop, command, LSP, theme, remote, inbox modals routed
-    through one host.
+- ✅ **M4.3** — `refactor(ui): extract ModalHost`
+  *(merged in this PR)*. State owner in
+  `src/ui/use-modal-host.ts`, renderer in `src/ui/modal-host.tsx`
+  (`<ModalHost>` for the 8 fullscreen modals, `<ModalOverlay>` for
+  the 2 resolver overlays). Hook destructures with the original
+  state-variable names so existing setter call sites don't churn.
+  `app.tsx` shrank 4,153 → 4,038 LOC. Pure refactor; two pre-existing
+  modal-set asymmetries (picker close-on-modal vs. Esc modal-open
+  check) preserved verbatim and flagged inline for the M9.10 audit.
 - **M4.4** — `refactor(ui): extract SessionManager`
   - Load, resume, checkpoint, save logic into one module.
 - **M4.5** — `refactor(ui): extract TurnController`

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Text, useApp, useInput, render } from "ink";
-import SelectInput from "ink-select-input";
 
 import { runAgentTurn, AgentLoopError } from "./agent/loop.js";
 import { TurnSupervisor } from "./agent/supervisor.js";
@@ -37,7 +36,7 @@ import { ChatView, type ChatEvent } from "./ui/chat.js";
 import { StatusBar } from "./ui/status.js";
 import { PermissionModal } from "./ui/permission.js";
 import { usePermissionController } from "./ui/use-permission-controller.js";
-import { LimitModal, type LimitDecision, type LoopDecision } from "./ui/limit-modal.js";
+import type { LimitDecision, LoopDecision } from "./ui/limit-modal.js";
 import { ResumePicker } from "./ui/resume-picker.js";
 import { CheckpointPicker } from "./ui/checkpoint-picker.js";
 import { TaskList } from "./ui/task-list.js";
@@ -63,8 +62,6 @@ import { startRemoteSession, streamRemoteProgress } from "./remote/worker-client
 import { saveRemoteSession, type RemoteSession } from "./remote/session-store.js";
 import { deployForTui } from "./remote/deploy.js";
 import { authGitHubForTui } from "./remote/tui-auth.js";
-import { RemoteDashboard, RemoteSessionDetail } from "./ui/remote-dashboard.js";
-import { InboxModal } from "./ui/inbox-modal.js";
 import { nextMode, type Mode } from "./mode.js";
 import { classifyIntent } from "./intent/classify.js";
 import {
@@ -103,13 +100,8 @@ import type { CustomCommand, SlashItem } from "./commands/types.js";
 import { BUILTIN_COMMANDS, BUILTIN_COMMAND_NAMES } from "./commands/builtins.js";
 import { saveCustomCommand, deleteCustomCommand } from "./commands/save.js";
 import type { SaveCustomCommandOptions } from "./commands/save.js";
-import { CommandWizard } from "./ui/command-wizard.js";
 import { buildInitPrompt } from "./init/context-generator.js";
-import { CommandPicker } from "./ui/command-picker.js";
-import { CommandList } from "./ui/command-list.js";
-import { LspWizard } from "./ui/lsp-wizard.js";
 import { ThemeProvider } from "./ui/theme-context.js";
-import { ThemePicker } from "./ui/theme-picker.js";
 import { resolveTheme, themeList, themeNames, DEFAULT_THEME_NAME } from "./ui/theme.js";
 import { loadAndMergeThemes } from "./ui/theme-loader.js";
 import type { Theme } from "./ui/theme.js";
@@ -119,6 +111,8 @@ import fg from "fast-glob";
 import { FilePicker, type FilePickerItem } from "./ui/file-picker.js";
 import { SlashPicker } from "./ui/slash-picker.js";
 import { usePickerController } from "./ui/use-picker-controller.js";
+import { useModalHost } from "./ui/use-modal-host.js";
+import { ModalHost, ModalOverlay } from "./ui/modal-host.js";
 import { readFileSync } from "node:fs";
 
 /**
@@ -516,8 +510,21 @@ function App({
       ]);
     },
   );
-  const [limitModal, setLimitModal] = useState<{ limit: number; resolve: (d: LimitDecision) => void } | null>(null);
-  const [loopModal, setLoopModal] = useState<{ resolve: (d: LoopDecision) => void } | null>(null);
+  const modals = useModalHost();
+  const {
+    limitModal, setLimitModal,
+    loopModal, setLoopModal,
+    commandWizard, setCommandWizard,
+    commandPicker, setCommandPicker,
+    commandToDelete, setCommandToDelete,
+    showCommandList, setShowCommandList,
+    showLspWizard, setShowLspWizard,
+    showThemePicker, setShowThemePicker,
+    showRemoteDashboard, setShowRemoteDashboard,
+    showInboxModal, setShowInboxModal,
+    hasFullscreenModal,
+    hasAnyModal,
+  } = modals;
   const [queue, setQueue] = useState<Array<{ full: string; display: string; key: string }>>([]);
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
@@ -532,14 +539,7 @@ function App({
   const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
   const [checkpointSession, setCheckpointSession] = useState<SessionSummary | null>(null);
   const [checkpointList, setCheckpointList] = useState<Checkpoint[]>([]);
-  const [commandWizard, setCommandWizard] = useState<{ mode: "create" | "edit"; initial?: CustomCommand } | null>(null);
-  const [commandPicker, setCommandPicker] = useState<{ mode: "edit" | "delete" } | null>(null);
-  const [commandToDelete, setCommandToDelete] = useState<CustomCommand | null>(null);
-  const [showCommandList, setShowCommandList] = useState(false);
-  const [showLspWizard, setShowLspWizard] = useState(false);
-  const [showRemoteDashboard, setShowRemoteDashboard] = useState(false);
   const [selectedRemoteSession, setSelectedRemoteSession] = useState<RemoteSession | null>(null);
-  const [showInboxModal, setShowInboxModal] = useState(false);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
   const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
@@ -551,7 +551,6 @@ function App({
   const [hasUpdate, setHasUpdate] = useState(initialUpdateResult?.hasUpdate ?? false);
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
   const [theme, setTheme] = useState<Theme>(resolveTheme(initialCfg?.theme));
-  const [showThemePicker, setShowThemePicker] = useState(false);
   const [originalTheme, setOriginalTheme] = useState<Theme | null>(null);
   const [skillsActive, setSkillsActive] = useState(0);
   const [memoryRecalled, setMemoryRecalled] = useState(false);
@@ -714,6 +713,11 @@ function App({
     return [...BUILTIN_COMMANDS, ...customs];
   }, [customCommandsVersion]);
 
+  // Preserves the pre-refactor asymmetry: the picker close-on-modal check
+  // includes showInboxModal but EXCLUDES showRemoteDashboard and
+  // showThemePicker. Likely an oversight from when those modals were
+  // added later — kept as-is for this pure refactor; revisit when we
+  // audit modal/keybinding semantics.
   const modalActive =
     commandWizard !== null ||
     commandPicker !== null ||
@@ -1356,6 +1360,10 @@ function App({
     }
     if (key.escape) {
       const now = Date.now();
+      // Preserves the pre-refactor asymmetry: this Esc-handler check
+      // EXCLUDES commandPicker, showInboxModal, and showRemoteDashboard
+      // (so Esc still fires the abort-turn path when those are open).
+      // Kept as-is for this pure refactor.
       const modalOpen =
         perm !== null ||
         limitModal !== null ||
@@ -3098,7 +3106,63 @@ function App({
         ]);
       }
     },
-    [reloadCustomCommands, setEvents],
+    [reloadCustomCommands, setEvents, setCommandToDelete],
+  );
+
+  const handleLspSave = useCallback(
+    (
+      servers: NonNullable<Cfg["lspServers"]>,
+      enabled: boolean,
+      scope: "project" | "global",
+    ) => {
+      setCfg((c) => (c ? { ...c, lspEnabled: enabled, lspServers: servers } : c));
+      setLspScope(scope);
+      if (scope === "project") {
+        void saveProjectLspConfig(process.cwd(), { lspEnabled: enabled, lspServers: servers })
+          .then((path) => {
+            setLspProjectPath(path);
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: `LSP config saved to project (${path}). Run /lsp reload to apply.` },
+            ]);
+          })
+          .catch(() => {
+            setEvents((e) => [
+              ...e,
+              { kind: "error", key: mkKey(), text: "Failed to save project LSP config." },
+            ]);
+          });
+      } else if (cfg) {
+        void saveConfig({ ...cfg, lspEnabled: enabled, lspServers: servers }).catch(() => {});
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `LSP config saved to global config. Run /lsp reload to apply.` },
+        ]);
+      }
+      setShowLspWizard(false);
+    },
+    [cfg, setCfg, setEvents, setShowLspWizard],
+  );
+
+  const handleRemoteCancel = useCallback(
+    async (session: RemoteSession) => {
+      try {
+        const { cancelRemoteSession } = await import("./remote/worker-client.js");
+        await cancelRemoteSession(session.workerUrl, session.sessionId);
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `Cancelled session ${session.sessionId}` },
+        ]);
+      } catch (err) {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: `Failed to cancel: ${err instanceof Error ? err.message : String(err)}` },
+        ]);
+      }
+      setSelectedRemoteSession(null);
+      setShowRemoteDashboard(false);
+    },
+    [setEvents, setShowRemoteDashboard],
   );
 
   const processMessage = useCallback(
@@ -3781,187 +3845,26 @@ function App({
     );
   }
 
-  if (showRemoteDashboard) {
+  if (hasFullscreenModal) {
     return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          {selectedRemoteSession ? (
-            <RemoteSessionDetail
-              session={selectedRemoteSession}
-              onBack={() => setSelectedRemoteSession(null)}
-              onCancel={async (session) => {
-                try {
-                  const { cancelRemoteSession } = await import("./remote/worker-client.js");
-                  await cancelRemoteSession(session.workerUrl, session.sessionId);
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "info", key: mkKey(), text: `Cancelled session ${session.sessionId}` },
-                  ]);
-                } catch (err) {
-                  setEvents((e) => [
-                    ...e,
-                    { kind: "error", key: mkKey(), text: `Failed to cancel: ${err instanceof Error ? err.message : String(err)}` },
-                  ]);
-                }
-                setSelectedRemoteSession(null);
-                setShowRemoteDashboard(false);
-              }}
-            />
-          ) : (
-            <RemoteDashboard
-              onSelect={(session) => setSelectedRemoteSession(session)}
-              onCancel={() => setShowRemoteDashboard(false)}
-            />
-          )}
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (showInboxModal) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <InboxModal
-            onDone={() => setShowInboxModal(false)}
-            onOpen={(url) => openBrowser(url)}
-          />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (showLspWizard) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <LspWizard
-            servers={cfg?.lspServers ?? {}}
-            currentScope={lspScope}
-            hasProjectDir={existsSync(join(process.cwd(), ".kimiflare"))}
-            onDone={() => setShowLspWizard(false)}
-            onSave={(servers, enabled, scope) => {
-              setCfg((c) => (c ? { ...c, lspEnabled: enabled, lspServers: servers } : c));
-              setLspScope(scope);
-              if (scope === "project") {
-                void saveProjectLspConfig(process.cwd(), { lspEnabled: enabled, lspServers: servers })
-                  .then((path) => {
-                    setLspProjectPath(path);
-                    setEvents((e) => [
-                      ...e,
-                      { kind: "info", key: mkKey(), text: `LSP config saved to project (${path}). Run /lsp reload to apply.` },
-                    ]);
-                  })
-                  .catch(() => {
-                    setEvents((e) => [
-                      ...e,
-                      { kind: "error", key: mkKey(), text: "Failed to save project LSP config." },
-                    ]);
-                  });
-              } else if (cfg) {
-                void saveConfig({ ...cfg, lspEnabled: enabled, lspServers: servers }).catch(() => {});
-                setEvents((e) => [
-                  ...e,
-                  { kind: "info", key: mkKey(), text: `LSP config saved to global config. Run /lsp reload to apply.` },
-                ]);
-              }
-              setShowLspWizard(false);
-            }}
-          />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (commandWizard) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <CommandWizard
-            mode={commandWizard.mode}
-            initial={commandWizard.initial}
-            existingNames={customCommandsRef.current.map((c) => c.name)}
-            builtinNames={BUILTIN_COMMAND_NAMES}
-            onDone={() => setCommandWizard(null)}
-            onSave={handleCommandSave}
-          />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (commandPicker) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <CommandPicker
-            commands={customCommandsRef.current}
-            title={commandPicker.mode === "edit" ? "Edit custom command" : "Delete custom command"}
-            onPick={(cmd) => {
-              setCommandPicker(null);
-              if (!cmd) return;
-              if (commandPicker.mode === "edit") {
-                setCommandWizard({ mode: "edit", initial: cmd });
-              } else {
-                setCommandToDelete(cmd);
-              }
-            }}
-          />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (commandToDelete) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
-        <Text color={theme.accent} bold>
-          Delete /{commandToDelete.name}?
-        </Text>
-        <Text color={theme.info.color}>
-          {commandToDelete.filepath}
-        </Text>
-        <Box marginTop={1}>
-          <SelectInput
-            items={[
-              { label: "Yes, delete", value: "yes", key: "yes" },
-              { label: "Cancel", value: "cancel", key: "cancel" },
-            ]}
-            onSelect={(item) => {
-              if (item.value === "yes") {
-                void handleCommandDelete(commandToDelete);
-              } else {
-                setCommandToDelete(null);
-              }
-            }}
-          />
-        </Box>
-      </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (showCommandList) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <CommandList
-            commands={customCommandsRef.current}
-            onDone={() => setShowCommandList(false)}
-          />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (showThemePicker) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <ThemePicker themes={themeList()} onPick={handleThemePick} />
-        </Box>
-      </ThemeProvider>
+      <ModalHost
+        modals={modals}
+        theme={theme}
+        customCommands={customCommandsRef.current}
+        builtinNames={BUILTIN_COMMAND_NAMES}
+        onCommandSave={handleCommandSave}
+        onCommandDelete={handleCommandDelete}
+        lspServers={cfg?.lspServers ?? {}}
+        lspScope={lspScope}
+        hasProjectDir={existsSync(join(process.cwd(), ".kimiflare"))}
+        onLspSave={handleLspSave}
+        themes={themeList()}
+        onPickTheme={handleThemePick}
+        selectedRemoteSession={selectedRemoteSession}
+        onSelectRemoteSession={setSelectedRemoteSession}
+        onCancelRemoteSession={handleRemoteCancel}
+        onInboxOpen={openBrowser}
+      />
     );
   }
 
@@ -3984,29 +3887,11 @@ function App({
               submitRef.current(text);
             }}
           />
-        ) : limitModal ? (
-          <LimitModal
-            limit={limitModal.limit}
-            onDecide={(d) => {
-              limitModal.resolve(d);
-              limitResolveRef.current = null;
-              setLimitModal(null);
-            }}
-          />
-        ) : loopModal ? (
-          <LimitModal
-            limit={50}
-            title="Agent stuck in a loop"
-            description="The agent kept calling the same tools with identical arguments. What would you like to do?"
-            items={[
-              { label: "Continue", value: "continue" },
-              { label: "Synthesize", value: "synthesize" },
-            ]}
-            onDecide={(d) => {
-              loopModal.resolve(d);
-              loopResolveRef.current = null;
-              setLoopModal(null);
-            }}
+        ) : limitModal || loopModal ? (
+          <ModalOverlay
+            modals={modals}
+            onLimitResolved={() => { limitResolveRef.current = null; }}
+            onLoopResolved={() => { loopResolveRef.current = null; }}
           />
         ) : (
           <Box flexDirection="column" marginTop={1}>

--- a/src/ui/modal-host.tsx
+++ b/src/ui/modal-host.tsx
@@ -1,0 +1,286 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import { ThemeProvider } from "./theme-context.js";
+import { LimitModal } from "./limit-modal.js";
+import { CommandWizard } from "./command-wizard.js";
+import { CommandPicker } from "./command-picker.js";
+import { CommandList } from "./command-list.js";
+import { LspWizard } from "./lsp-wizard.js";
+import { ThemePicker } from "./theme-picker.js";
+import { RemoteDashboard, RemoteSessionDetail } from "./remote-dashboard.js";
+import { InboxModal } from "./inbox-modal.js";
+import type { Theme } from "./theme.js";
+import type { ModalHostController } from "./use-modal-host.js";
+import type { CustomCommand } from "../commands/types.js";
+import type { SaveCustomCommandOptions } from "../commands/save.js";
+import type { RemoteSession } from "../remote/session-store.js";
+
+interface LspServersConfig {
+  [key: string]: {
+    command: string[];
+    env?: Record<string, string>;
+    enabled?: boolean;
+    rootPatterns?: string[];
+  };
+}
+
+export interface ModalHostProps {
+  modals: ModalHostController;
+  theme: Theme;
+  // Command modals
+  customCommands: CustomCommand[];
+  builtinNames: Set<string>;
+  onCommandSave: (opts: SaveCustomCommandOptions) => Promise<void> | void;
+  onCommandDelete: (cmd: CustomCommand) => Promise<void> | void;
+  // LSP wizard
+  lspServers: LspServersConfig;
+  lspScope: "project" | "global";
+  hasProjectDir: boolean;
+  onLspSave: (
+    servers: LspServersConfig,
+    enabled: boolean,
+    scope: "project" | "global",
+  ) => void;
+  // Theme picker
+  themes: Theme[];
+  onPickTheme: (theme: Theme | null) => void;
+  // Remote dashboard
+  selectedRemoteSession: RemoteSession | null;
+  onSelectRemoteSession: (s: RemoteSession | null) => void;
+  onCancelRemoteSession: (session: RemoteSession) => void | Promise<void>;
+  // Inbox
+  onInboxOpen: (url: string) => void;
+}
+
+/**
+ * Renders whichever fullscreen modal is currently active, wrapped in the
+ * shared `ThemeProvider`. Returns null when no fullscreen modal is open
+ * — callers should check `modals.hasFullscreenModal` and skip the main
+ * conversation render if true.
+ */
+export function ModalHost(props: ModalHostProps): React.ReactElement | null {
+  const {
+    modals,
+    theme,
+    customCommands,
+    builtinNames,
+    onCommandSave,
+    onCommandDelete,
+    lspServers,
+    lspScope,
+    hasProjectDir,
+    onLspSave,
+    themes,
+    onPickTheme,
+    selectedRemoteSession,
+    onSelectRemoteSession,
+    onCancelRemoteSession,
+    onInboxOpen,
+  } = props;
+
+  if (modals.showRemoteDashboard) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          {selectedRemoteSession ? (
+            <RemoteSessionDetail
+              session={selectedRemoteSession}
+              onBack={() => onSelectRemoteSession(null)}
+              onCancel={(session) => {
+                void onCancelRemoteSession(session);
+              }}
+            />
+          ) : (
+            <RemoteDashboard
+              onSelect={(session) => onSelectRemoteSession(session)}
+              onCancel={() => modals.setShowRemoteDashboard(false)}
+            />
+          )}
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.showInboxModal) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <InboxModal
+            onDone={() => modals.setShowInboxModal(false)}
+            onOpen={onInboxOpen}
+          />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.showLspWizard) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <LspWizard
+            servers={lspServers}
+            currentScope={lspScope}
+            hasProjectDir={hasProjectDir}
+            onDone={() => modals.setShowLspWizard(false)}
+            onSave={onLspSave}
+          />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.commandWizard) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <CommandWizard
+            mode={modals.commandWizard.mode}
+            initial={modals.commandWizard.initial}
+            existingNames={customCommands.map((c) => c.name)}
+            builtinNames={builtinNames}
+            onDone={() => modals.setCommandWizard(null)}
+            onSave={onCommandSave}
+          />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.commandPicker) {
+    const pickerMode = modals.commandPicker.mode;
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <CommandPicker
+            commands={customCommands}
+            title={pickerMode === "edit" ? "Edit custom command" : "Delete custom command"}
+            onPick={(cmd) => {
+              modals.setCommandPicker(null);
+              if (!cmd) return;
+              if (pickerMode === "edit") {
+                modals.setCommandWizard({ mode: "edit", initial: cmd });
+              } else {
+                modals.setCommandToDelete(cmd);
+              }
+            }}
+          />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.commandToDelete) {
+    const cmd = modals.commandToDelete;
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+          <Text color={theme.accent} bold>
+            Delete /{cmd.name}?
+          </Text>
+          <Text color={theme.info.color}>
+            {cmd.filepath}
+          </Text>
+          <Box marginTop={1}>
+            <SelectInput
+              items={[
+                { label: "Yes, delete", value: "yes", key: "yes" },
+                { label: "Cancel", value: "cancel", key: "cancel" },
+              ]}
+              onSelect={(item) => {
+                if (item.value === "yes") {
+                  void onCommandDelete(cmd);
+                } else {
+                  modals.setCommandToDelete(null);
+                }
+              }}
+            />
+          </Box>
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.showCommandList) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <CommandList
+            commands={customCommands}
+            onDone={() => modals.setShowCommandList(false)}
+          />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.showThemePicker) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <ThemePicker themes={themes} onPick={onPickTheme} />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Renders the active resolver-style overlay (limit or loop). Sits inline
+ * inside the main conversation view, gating the input/queue/statusbar
+ * region. Returns null when no overlay is active.
+ */
+export interface ModalOverlayProps {
+  modals: ModalHostController;
+  /**
+   * Called after the limit modal resolves and before the modal is closed.
+   * Used by `app.tsx` to also clear its `limitResolveRef` bookkeeping —
+   * the agent loop reads that ref to fire `"stop"` on Ctrl+C / abort.
+   */
+  onLimitResolved?: () => void;
+  /** Mirror of `onLimitResolved` for the loop modal. */
+  onLoopResolved?: () => void;
+}
+
+export function ModalOverlay({
+  modals,
+  onLimitResolved,
+  onLoopResolved,
+}: ModalOverlayProps): React.ReactElement | null {
+  if (modals.limitModal) {
+    const m = modals.limitModal;
+    return (
+      <LimitModal
+        limit={m.limit}
+        onDecide={(d) => {
+          m.resolve(d);
+          onLimitResolved?.();
+          modals.setLimitModal(null);
+        }}
+      />
+    );
+  }
+  if (modals.loopModal) {
+    const m = modals.loopModal;
+    return (
+      <LimitModal
+        limit={50}
+        title="Agent stuck in a loop"
+        description="The agent kept calling the same tools with identical arguments. What would you like to do?"
+        items={[
+          { label: "Continue", value: "continue" },
+          { label: "Synthesize", value: "synthesize" },
+        ]}
+        onDecide={(d) => {
+          m.resolve(d);
+          onLoopResolved?.();
+          modals.setLoopModal(null);
+        }}
+      />
+    );
+  }
+  return null;
+}

--- a/src/ui/use-modal-host.test.ts
+++ b/src/ui/use-modal-host.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { computeModalFlags, EMPTY_MODAL_STATE } from "./use-modal-host.js";
+
+describe("computeModalFlags", () => {
+  it("returns all-false for an empty state", () => {
+    const f = computeModalFlags(EMPTY_MODAL_STATE);
+    assert.deepStrictEqual(f, {
+      hasFullscreenModal: false,
+      hasOverlayModal: false,
+      hasAnyModal: false,
+    });
+  });
+
+  it("flags limit overlay only", () => {
+    const f = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      limitModal: { limit: 50, resolve: () => {} },
+    });
+    assert.strictEqual(f.hasOverlayModal, true);
+    assert.strictEqual(f.hasFullscreenModal, false);
+    assert.strictEqual(f.hasAnyModal, true);
+  });
+
+  it("flags loop overlay only", () => {
+    const f = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      loopModal: { resolve: () => {} },
+    });
+    assert.strictEqual(f.hasOverlayModal, true);
+    assert.strictEqual(f.hasFullscreenModal, false);
+  });
+
+  it("flags command wizard as fullscreen", () => {
+    const f = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      commandWizard: { mode: "create" },
+    });
+    assert.strictEqual(f.hasFullscreenModal, true);
+    assert.strictEqual(f.hasOverlayModal, false);
+    assert.strictEqual(f.hasAnyModal, true);
+  });
+
+  it("flags each boolean fullscreen modal", () => {
+    for (const key of [
+      "showCommandList",
+      "showLspWizard",
+      "showThemePicker",
+      "showRemoteDashboard",
+      "showInboxModal",
+    ] as const) {
+      const f = computeModalFlags({ ...EMPTY_MODAL_STATE, [key]: true });
+      assert.strictEqual(f.hasFullscreenModal, true, `${key} should be fullscreen`);
+      assert.strictEqual(f.hasOverlayModal, false, `${key} should not be overlay`);
+    }
+  });
+
+  it("flags command picker / command-to-delete as fullscreen", () => {
+    const f1 = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      commandPicker: { mode: "delete" },
+    });
+    assert.strictEqual(f1.hasFullscreenModal, true);
+
+    const f2 = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      commandToDelete: {
+        name: "foo",
+        template: "",
+        source: "project",
+        filepath: "/tmp/foo.md",
+      },
+    });
+    assert.strictEqual(f2.hasFullscreenModal, true);
+  });
+
+  it("combines flags when both overlay and fullscreen are open", () => {
+    const f = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      limitModal: { limit: 50, resolve: () => {} },
+      showLspWizard: true,
+    });
+    assert.deepStrictEqual(f, {
+      hasFullscreenModal: true,
+      hasOverlayModal: true,
+      hasAnyModal: true,
+    });
+  });
+});

--- a/src/ui/use-modal-host.ts
+++ b/src/ui/use-modal-host.ts
@@ -1,0 +1,176 @@
+import { useMemo, useState } from "react";
+import type { LimitDecision, LoopDecision } from "./limit-modal.js";
+import type { CustomCommand } from "../commands/types.js";
+
+export interface LimitModalState {
+  limit: number;
+  resolve: (d: LimitDecision) => void;
+}
+
+export interface LoopModalState {
+  resolve: (d: LoopDecision) => void;
+}
+
+export interface CommandWizardState {
+  mode: "create" | "edit";
+  initial?: CustomCommand;
+}
+
+export interface CommandPickerState {
+  mode: "edit" | "delete";
+}
+
+export interface ModalHostController {
+  // Resolver-style overlays (replace input/queue/statusbar).
+  limitModal: LimitModalState | null;
+  setLimitModal: (v: LimitModalState | null) => void;
+  loopModal: LoopModalState | null;
+  setLoopModal: (v: LoopModalState | null) => void;
+
+  // Fullscreen modals (replace the whole conversation view).
+  commandWizard: CommandWizardState | null;
+  setCommandWizard: (v: CommandWizardState | null) => void;
+  commandPicker: CommandPickerState | null;
+  setCommandPicker: (v: CommandPickerState | null) => void;
+  commandToDelete: CustomCommand | null;
+  setCommandToDelete: (v: CustomCommand | null) => void;
+  showCommandList: boolean;
+  setShowCommandList: (v: boolean) => void;
+  showLspWizard: boolean;
+  setShowLspWizard: (v: boolean) => void;
+  showThemePicker: boolean;
+  setShowThemePicker: (v: boolean) => void;
+  showRemoteDashboard: boolean;
+  setShowRemoteDashboard: (v: boolean) => void;
+  showInboxModal: boolean;
+  setShowInboxModal: (v: boolean) => void;
+
+  /** Any fullscreen modal is active (would trigger an early return). */
+  hasFullscreenModal: boolean;
+  /** Either resolver overlay is active. */
+  hasOverlayModal: boolean;
+  /** Any modal of any kind is active (use to gate input / pickers). */
+  hasAnyModal: boolean;
+}
+
+/**
+ * Lifts the M4.3 modal state out of `app.tsx`. Owns the seven modal
+ * families listed in the roadmap (limit, loop, command*, LSP, theme,
+ * remote, inbox) plus the derived activity flags.
+ *
+ * Note on what is NOT here:
+ *   - `perm` (permission modal) lives in `usePermissionController` (M4.1).
+ *   - `resumeSessions` / `checkpointSession` are session-state and will
+ *     move with `SessionManager` (M4.4).
+ *
+ * The hook returns everything destructured so call sites can keep their
+ * original names (`setLimitModal`, `commandWizard`, …) and no rename
+ * sweep is required — only the JSX renderer changes.
+ */
+export function useModalHost(): ModalHostController {
+  const [limitModal, setLimitModal] = useState<LimitModalState | null>(null);
+  const [loopModal, setLoopModal] = useState<LoopModalState | null>(null);
+  const [commandWizard, setCommandWizard] = useState<CommandWizardState | null>(null);
+  const [commandPicker, setCommandPicker] = useState<CommandPickerState | null>(null);
+  const [commandToDelete, setCommandToDelete] = useState<CustomCommand | null>(null);
+  const [showCommandList, setShowCommandList] = useState(false);
+  const [showLspWizard, setShowLspWizard] = useState(false);
+  const [showThemePicker, setShowThemePicker] = useState(false);
+  const [showRemoteDashboard, setShowRemoteDashboard] = useState(false);
+  const [showInboxModal, setShowInboxModal] = useState(false);
+
+  const flags = useMemo(() => {
+    const hasFullscreenModal =
+      commandWizard !== null ||
+      commandPicker !== null ||
+      commandToDelete !== null ||
+      showCommandList ||
+      showLspWizard ||
+      showThemePicker ||
+      showRemoteDashboard ||
+      showInboxModal;
+    const hasOverlayModal = limitModal !== null || loopModal !== null;
+    return {
+      hasFullscreenModal,
+      hasOverlayModal,
+      hasAnyModal: hasFullscreenModal || hasOverlayModal,
+    };
+  }, [
+    commandWizard,
+    commandPicker,
+    commandToDelete,
+    showCommandList,
+    showLspWizard,
+    showThemePicker,
+    showRemoteDashboard,
+    showInboxModal,
+    limitModal,
+    loopModal,
+  ]);
+
+  return {
+    limitModal, setLimitModal,
+    loopModal, setLoopModal,
+    commandWizard, setCommandWizard,
+    commandPicker, setCommandPicker,
+    commandToDelete, setCommandToDelete,
+    showCommandList, setShowCommandList,
+    showLspWizard, setShowLspWizard,
+    showThemePicker, setShowThemePicker,
+    showRemoteDashboard, setShowRemoteDashboard,
+    showInboxModal, setShowInboxModal,
+    ...flags,
+  };
+}
+
+// ── Pure helpers (handy for tests + downstream consumers) ────────────────
+
+export interface ModalFlagsInput {
+  limitModal: LimitModalState | null;
+  loopModal: LoopModalState | null;
+  commandWizard: CommandWizardState | null;
+  commandPicker: CommandPickerState | null;
+  commandToDelete: CustomCommand | null;
+  showCommandList: boolean;
+  showLspWizard: boolean;
+  showThemePicker: boolean;
+  showRemoteDashboard: boolean;
+  showInboxModal: boolean;
+}
+
+export interface ModalFlags {
+  hasFullscreenModal: boolean;
+  hasOverlayModal: boolean;
+  hasAnyModal: boolean;
+}
+
+export function computeModalFlags(s: ModalFlagsInput): ModalFlags {
+  const hasFullscreenModal =
+    s.commandWizard !== null ||
+    s.commandPicker !== null ||
+    s.commandToDelete !== null ||
+    s.showCommandList ||
+    s.showLspWizard ||
+    s.showThemePicker ||
+    s.showRemoteDashboard ||
+    s.showInboxModal;
+  const hasOverlayModal = s.limitModal !== null || s.loopModal !== null;
+  return {
+    hasFullscreenModal,
+    hasOverlayModal,
+    hasAnyModal: hasFullscreenModal || hasOverlayModal,
+  };
+}
+
+export const EMPTY_MODAL_STATE: ModalFlagsInput = {
+  limitModal: null,
+  loopModal: null,
+  commandWizard: null,
+  commandPicker: null,
+  commandToDelete: null,
+  showCommandList: false,
+  showLspWizard: false,
+  showThemePicker: false,
+  showRemoteDashboard: false,
+  showInboxModal: false,
+};


### PR DESCRIPTION
## Summary

Third extraction in the M4 \`app.tsx\` breakup, following M4.1 (#419) and M4.2 (#432). Ten modal families move out of \`app.tsx\` into two new modules.

**New files:**

- \`src/ui/use-modal-host.ts\` — state owner. Returns a controller that destructures with the original state-variable names (\`limitModal\`, \`commandWizard\`, \`showLspWizard\`, etc.), so the **49 setter call sites elsewhere in app.tsx did not need to change**. Also exports \`computeModalFlags\` (pure function for unit tests) and a \`EMPTY_MODAL_STATE\` sentinel.
- \`src/ui/modal-host.tsx\` — renderer.
  - \`<ModalHost>\` handles the **8 fullscreen modals** (command wizard, command picker, command-to-delete confirm, command list, LSP wizard, theme picker, remote dashboard, inbox) via the existing early-return pattern.
  - \`<ModalOverlay>\` handles the **2 resolver overlays** (limit, loop) rendered inline above the input area.

**app.tsx changes:**

- 10 state declarations → 1 \`useModalHost()\` destructure.
- 8 fullscreen early-return blocks (~190 LOC of JSX) → 1 \`if (hasFullscreenModal) return <ModalHost ... />;\`.
- Limit/loop ternary branch → 1 \`<ModalOverlay>\`.
- Inline LSP-wizard \`onSave\` and remote-dashboard \`onCancel\` callbacks extracted to named \`useCallback\`s (\`handleLspSave\`, \`handleRemoteCancel\`).
- Stale imports pruned (\`SelectInput\`, \`LimitModal\`, \`RemoteDashboard\`, \`InboxModal\`, \`CommandWizard\`, \`CommandPicker\`, \`CommandList\`, \`LspWizard\`, \`ThemePicker\`).

**LOC**: \`app.tsx\` 4,153 → **4,038** (−115).

## Behavior preserved

Pure refactor — every observable behavior is preserved. The hook destructures with original names to avoid a rename sweep, and each early-return block became a prop-driven branch inside \`<ModalHost>\` with the same callbacks.

The \`limitResolveRef\` / \`loopResolveRef\` bookkeeping (read by the agent loop's abort path) still lives in \`app.tsx\`. \`<ModalOverlay>\` receives \`onLimitResolved\` / \`onLoopResolved\` callbacks that clear those refs — preserving the exact same sequence of resolve → ref-clear → setModal(null) as before.

## Asymmetries spotted (and preserved)

Two pre-existing modal-set asymmetries surfaced when I tried to consolidate the \`modalActive\` / \`modalOpen\` checks. Preserved verbatim, with inline comments flagging them for the eventual M9.10 audit:

1. **Picker close-on-modal check** (\`modalActive\` in \`app.tsx\`) — includes \`showInboxModal\` but EXCLUDES \`showRemoteDashboard\` and \`showThemePicker\`. Likely an oversight from when those modals were added later; means the picker stays open if the user opens the remote dashboard or theme picker.
2. **Esc-handler open check** (\`modalOpen\` in the \`useInput\` handler) — EXCLUDES \`commandPicker\`, \`showInboxModal\`, and \`showRemoteDashboard\`. Means Esc still fires the abort-turn path when those are open.

Both inconsistencies pre-date this PR. Folding them into a single \`hasAnyModal\` flag would silently change behavior, so they're kept as-is.

## What's NOT in this PR (intentional)

- \`perm\` (permission modal) — already owned by M4.1's \`usePermissionController\` (#419).
- \`resumeSessions\` / \`checkpointSession\` — belong to M4.4's \`SessionManager\`.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 453/453 pass (7 new tests for \`computeModalFlags\`)
- [x] \`npm run build\` — clean ESM + DTS
- [ ] Manual smoke (not runnable from this non-TTY environment): open each modal — \`/lsp\` wizard, \`/theme\`, \`/commands\` (list/create/edit/delete flows), \`/inbox\`, \`/remote\`, plus the limit and loop overlays (triggered via the agent loop). Verify Esc behavior in each.

Closes M4.3. Roadmap Progress log and inline M4 section updated.