### PR TITLE
fix(loop): wrap onKimiMdStale/onWarning fires in memory-extraction IIFE

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -915,7 +915,18 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
                       const recent = events.filter((t) => t >= cutoff);
                       driftEvents.set(sid, recent);
                       if (recent.length >= DRIFT_THRESHOLD) {
-                        opts.callbacks.onKimiMdStale?.();
+                        // Wrapped defensively: a throwing callback inside
+                        // this fire-and-forget IIFE would become an
+                        // unhandled rejection (process-fatal under Node's
+                        // default --unhandled-rejections=throw).
+                        try {
+                          opts.callbacks.onKimiMdStale?.();
+                        } catch (cbErr) {
+                          logger.debug("memory:onKimiMdStale_threw", {
+                            sessionId: opts.sessionId,
+                            error: cbErr instanceof Error ? cbErr.message : String(cbErr),
+                          });
+                        }
                         driftEvents.set(sid, []);
                       }
                     }
@@ -938,10 +949,19 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
                   });
                   // Only emit the user-visible warning on the first failure
                   // per session — repeated errors stay in the counter.
+                  // Wrapped defensively for the same reason as the
+                  // onKimiMdStale fire above.
                   if (next === 1) {
-                    opts.callbacks.onWarning?.(
-                      `[memory] auto-extraction failed (${msg}). Subsequent failures will be counted silently; check /memory health.`,
-                    );
+                    try {
+                      opts.callbacks.onWarning?.(
+                        `[memory] auto-extraction failed (${msg}). Subsequent failures will be counted silently; check /memory health.`,
+                      );
+                    } catch (cbErr) {
+                      logger.debug("memory:onWarning_threw", {
+                        sessionId: opts.sessionId,
+                        error: cbErr instanceof Error ? cbErr.message : String(cbErr),
+                      });
+                    }
                   }
                 }
               })();


### PR DESCRIPTION
## Summary

Follow-up to the merged OP-7 (#434) and OP-8 (#435).

Both PRs landed callback fires (\`onKimiMdStale\` and \`onWarning\`) inside the fire-and-forget memory-extraction IIFE in \`loop.ts\`. **A throwing consumer callback there became an unhandled promise rejection** — process-fatal under Node's default \`--unhandled-rejections=throw\`. This wraps both sites in \`try/catch\` and routes the consumer error to \`logger.debug\` so the loop keeps running.

The TUI's current handlers don't throw in practice, but the exposure was real and grew when OP-7 added the new \`onWarning\` call inside the catch handler.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npx tsx --test src/agent/loop.test.ts\` — 2 pass
- [ ] Manual: inject a callback that throws and confirm the loop continues (debug log emitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)