### PR TITLE
refactor(ui): extract useSessionManager hook from app.tsx (M4.4)

### DIFF
--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,7 +15,20 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
-- **M4.3** — `ModalHost` extracted from `app.tsx` — *(this PR)*.
+- **M4.4** — `SessionManager` extracted from `app.tsx` — *(this PR)*.
+  Pulled load/resume/checkpoint/save state and handlers into
+  `src/ui/use-session-manager.ts`. The hook owns the three identity
+  refs (`sessionIdRef`, `sessionCreatedAtRef`, `sessionTitleRef`) and
+  returns them so the ~20 call sites elsewhere in `app.tsx` keep
+  working unchanged. The picker JSX (resume + checkpoint) stays inline
+  — 20 LOC of declarative JSX not worth its own component. Pure
+  refactor; resume-flow side effects (history, usage, gateway meta,
+  memory recall) all preserved. New `resetSession()` helper folds the
+  three null-assignments at the start of the `/clear` path into one
+  call. Extracted `extractFirstUserText()` as a pure helper for the
+  session-id seed text and added 7 unit tests. `app.tsx` 4,093 →
+  3,954 LOC.
+- **M4.3** — `ModalHost` extracted from `app.tsx` — merged in #443.
   Lifted ten modal families (limit, loop, command wizard / picker /
   delete / list, LSP wizard, theme picker, remote dashboard, inbox)
   into `src/ui/use-modal-host.ts` (state owner) and
@@ -308,8 +321,12 @@ that touches UI assumes M4 is making steady progress.
   `app.tsx` shrank 4,153 → 4,038 LOC. Pure refactor; two pre-existing
   modal-set asymmetries (picker close-on-modal vs. Esc modal-open
   check) preserved verbatim and flagged inline for the M9.10 audit.
-- **M4.4** — `refactor(ui): extract SessionManager`
-  - Load, resume, checkpoint, save logic into one module.
+- ✅ **M4.4** — `refactor(ui): extract SessionManager`
+  *(merged in this PR)*. Hook in `src/ui/use-session-manager.ts` owns
+  the three identity refs plus picker state and the
+  save/resume/checkpoint handlers. `extractFirstUserText()` extracted
+  as a pure helper for the session-id seed text. `app.tsx` shrank
+  4,093 → 3,954 LOC.
 - **M4.5** — `refactor(ui): extract TurnController`
   - Supervisor wiring, status pills, reasoning view.
 - **M4.6** — `refactor(ui): extract InputController`

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,7 +16,6 @@ import {
   ArtifactStore,
   formatRecalledArtifacts,
   serializeArtifactStore,
-  deserializeArtifactStore,
   type SessionState,
 } from "./agent/session-state.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
@@ -73,14 +72,9 @@ import {
 import { openMemoryDb, getMemoryDb } from "./memory/db.js";
 import { listAllSkills, createSkill, deleteSkill, setSkillEnabled, findSkillFile } from "./skills/manager.js";
 import {
-  listSessions,
   loadSession,
-  loadSessionFromCheckpoint,
   addCheckpoint,
-  makeSessionId,
-  saveSession,
   generateSessionTitle,
-  type SessionSummary,
   type Checkpoint,
 } from "./sessions.js";
 import { unlink } from "node:fs/promises";
@@ -113,6 +107,7 @@ import { SlashPicker } from "./ui/slash-picker.js";
 import { usePickerController } from "./ui/use-picker-controller.js";
 import { useModalHost } from "./ui/use-modal-host.js";
 import { ModalHost, ModalOverlay } from "./ui/modal-host.js";
+import { useSessionManager } from "./ui/use-session-manager.js";
 import { readFileSync } from "node:fs";
 
 /**
@@ -550,9 +545,6 @@ function App({
   const [effort, setEffort] = useState<ReasoningEffort>(
     initialCfg?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
   );
-  const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
-  const [checkpointSession, setCheckpointSession] = useState<SessionSummary | null>(null);
-  const [checkpointList, setCheckpointList] = useState<Checkpoint[]>([]);
   const [selectedRemoteSession, setSelectedRemoteSession] = useState<RemoteSession | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
@@ -678,9 +670,6 @@ function App({
   const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
   const loopResolveRef = useRef<((d: LoopDecision) => void) | null>(null);
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
-  const sessionIdRef = useRef<string | null>(null);
-  const sessionCreatedAtRef = useRef<string | null>(null);
-  const sessionTitleRef = useRef<string | null>(null);
   const modeRef = useRef<Mode>(mode);
   const effortRef = useRef<ReasoningEffort>(effort);
   const tasksRef = useRef<Task[]>([]);
@@ -705,6 +694,37 @@ function App({
   const sessionStartRecallRef = useRef<Promise<import("./memory/schema.js").HybridResult[]> | null>(null);
   const kimiMdStaleNudgedRef = useRef(false);
   const turnCounterRef = useRef(0);
+
+  const sessionMgr = useSessionManager({
+    cfg,
+    messagesRef,
+    sessionStateRef,
+    artifactStoreRef,
+    compiledContextRef,
+    gatewayMetaRef,
+    memoryManagerRef,
+    setEvents,
+    setHistory,
+    setUsage,
+    setSessionUsage,
+    setGatewayMeta,
+    mkKey,
+  });
+  const {
+    sessionIdRef,
+    sessionCreatedAtRef,
+    sessionTitleRef,
+    resumeSessions, setResumeSessions,
+    checkpointSession, setCheckpointSession,
+    checkpointList,
+    ensureSessionId,
+    saveSessionSafe,
+    openResumePicker,
+    doResumeSession,
+    handleResumePick,
+    handleCheckpointPick,
+    resetSession,
+  } = sessionMgr;
 
   // Batched streaming delta refs to reduce React re-render frequency
   const pendingTextRef = useRef<Map<number, { text: string; reasoning: string }>>(new Map());
@@ -1199,47 +1219,6 @@ function App({
     }
   }, [cfg, initMcp, initLsp]);
 
-  const ensureSessionId = useCallback(() => {
-    if (sessionIdRef.current) return sessionIdRef.current;
-    const firstUser = messagesRef.current.find((m) => m.role === "user");
-    let firstText = "session";
-    if (typeof firstUser?.content === "string") {
-      firstText = firstUser.content;
-    } else if (Array.isArray(firstUser?.content)) {
-      const textPart = firstUser.content.find((p) => p.type === "text");
-      if (textPart?.text) firstText = textPart.text;
-    }
-    sessionIdRef.current = makeSessionId(firstText);
-    return sessionIdRef.current;
-  }, []);
-
-  const saveSessionSafe = useCallback(async () => {
-    if (!cfg) return;
-    ensureSessionId();
-    const now = new Date().toISOString();
-    if (!sessionCreatedAtRef.current) {
-      sessionCreatedAtRef.current = now;
-    }
-    try {
-      await saveSession({
-        id: sessionIdRef.current!,
-        cwd: process.cwd(),
-        model: cfg.model,
-        createdAt: sessionCreatedAtRef.current,
-        updatedAt: now,
-        title: sessionTitleRef.current ?? undefined,
-        messages: messagesRef.current,
-        sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
-        artifactStore: serializeArtifactStore(artifactStoreRef.current),
-      });
-    } catch (e) {
-      setEvents((es) => [
-        ...es,
-        { kind: "error", key: mkKey(), text: `session save failed: ${(e as Error).message}` },
-      ]);
-    }
-  }, [cfg, ensureSessionId]);
-
   /** Mid-turn compaction hook: called between tool-iteration cycles in runAgentTurn.
    *  Prevents context overflow during long exploration sessions. */
   const onIterationEnd = useCallback(
@@ -1639,11 +1618,6 @@ function App({
     }
   }, [cfg, busy, saveSessionSafe]);
 
-  const openResumePicker = useCallback(async () => {
-    const sessions = await listSessions(200, process.cwd());
-    setResumeSessions(sessions);
-  }, []);
-
   const runInit = useCallback(async () => {
     if (!cfg) return;
     if (busy) {
@@ -1976,115 +1950,6 @@ function App({
     [],
   );
 
-  const doResumeSession = useCallback(
-    async (filePath: string, checkpointId?: string) => {
-      try {
-        const file = checkpointId
-          ? (await loadSessionFromCheckpoint(filePath, checkpointId)).file
-          : await loadSession(filePath);
-        messagesRef.current = file.messages;
-        sessionIdRef.current = file.id;
-        sessionCreatedAtRef.current = file.createdAt;
-        if (file.sessionState && compiledContextRef.current) {
-          sessionStateRef.current = file.sessionState;
-        }
-        if (file.artifactStore) {
-          artifactStoreRef.current = deserializeArtifactStore(file.artifactStore);
-        } else {
-          artifactStoreRef.current = new ArtifactStore();
-        }
-        // Recall memories for resumed session so the model has context
-        const manager = memoryManagerRef.current;
-        if (manager) {
-          try {
-            const cwd = process.cwd();
-            const results = await manager.recall({ text: cwd, repoPath: cwd, limit: 5 });
-            if (results.length > 0) {
-              const text = await manager.synthesizeRecalled(results);
-              const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
-              const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
-              messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
-            }
-          } catch {
-            // Non-fatal
-          }
-        }
-
-        const msg = checkpointId
-          ? `resumed session ${file.id} from checkpoint`
-          : `resumed session ${file.id} (${file.messages.filter((m) => m.role !== "system").length} msgs)`;
-        setEvents([{ kind: "info", key: mkKey(), text: msg }]);
-        const userMsgs = file.messages
-          .filter((m) => m.role === "user" && m.content)
-          .map((m) => {
-            if (!m.content) return "";
-            if (typeof m.content === "string") return m.content;
-            const textPart = m.content.find((p) => p.type === "text");
-            return textPart?.text ?? "";
-          })
-          .filter((text) => text.length > 0);
-        if (userMsgs.length > 0) setHistory(userMsgs);
-        setUsage(null);
-        setSessionUsage(null);
-        gatewayMetaRef.current = null;
-        setGatewayMeta(null);
-        void getCostReport(file.id).then((report) => setSessionUsage(report.session));
-      } catch (e) {
-        setEvents((es) => [
-          ...es,
-          { kind: "error", key: mkKey(), text: `failed to load session: ${(e as Error).message}` },
-        ]);
-      }
-    },
-    [],
-  );
-
-  const handleResumePick = useCallback(
-    async (picked: SessionSummary | null) => {
-      setResumeSessions(null);
-      if (!picked) return;
-      if (picked.checkpointCount > 0) {
-        // Load checkpoints and show picker
-        try {
-          const file = await loadSession(picked.filePath);
-          setCheckpointList(file.checkpoints ?? []);
-          setCheckpointSession(picked);
-        } catch (e) {
-          setEvents((es) => [
-            ...es,
-            { kind: "error", key: mkKey(), text: `failed to load checkpoints: ${(e as Error).message}` },
-          ]);
-          await doResumeSession(picked.filePath);
-        }
-        return;
-      }
-      await doResumeSession(picked.filePath);
-    },
-    [doResumeSession],
-  );
-
-  const handleCheckpointPick = useCallback(
-    async (checkpointId: string | null) => {
-      const session = checkpointSession;
-      setCheckpointSession(null);
-      setCheckpointList([]);
-      if (!session || !checkpointId) {
-        // User cancelled or went back — reopen session list
-        if (session) {
-          setResumeSessions(await listSessions(200, process.cwd()));
-        }
-        return;
-      }
-      if (checkpointId === "__start__") {
-        await doResumeSession(session.filePath);
-        return;
-      }
-      await doResumeSession(session.filePath, checkpointId);
-    },
-    [checkpointSession, doResumeSession],
-  );
-
-
   const handleSlash = useCallback(
     (cmd: string): boolean => {
       const raw = cmd.trim();
@@ -2106,11 +1971,7 @@ function App({
         } else {
           messagesRef.current = [messagesRef.current[0]!];
         }
-        sessionIdRef.current = null;
-        sessionCreatedAtRef.current = null;
-        sessionTitleRef.current = null;
-        sessionStateRef.current = emptySessionState();
-        artifactStoreRef.current = new ArtifactStore();
+        resetSession();
         executorRef.current.clearArtifacts();
         if (flushTimeoutRef.current) {
           clearTimeout(flushTimeoutRef.current);

--- a/src/ui/use-session-manager.test.ts
+++ b/src/ui/use-session-manager.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { extractFirstUserText } from "./use-session-manager.js";
+import type { ChatMessage } from "../agent/messages.js";
+
+describe("extractFirstUserText", () => {
+  it("returns 'session' for empty messages", () => {
+    assert.strictEqual(extractFirstUserText([]), "session");
+  });
+
+  it("returns 'session' when there is no user message", () => {
+    const msgs: ChatMessage[] = [
+      { role: "system", content: "you are kimi" },
+      { role: "assistant", content: "hi" },
+    ];
+    assert.strictEqual(extractFirstUserText(msgs), "session");
+  });
+
+  it("returns string content directly", () => {
+    const msgs: ChatMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "fix the bug in auth.ts" },
+    ];
+    assert.strictEqual(extractFirstUserText(msgs), "fix the bug in auth.ts");
+  });
+
+  it("extracts the first text part from an array-shaped user message", () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "image", image_url: { url: "data:..." } } as never,
+          { type: "text", text: "describe this screenshot" },
+        ],
+      },
+    ];
+    assert.strictEqual(extractFirstUserText(msgs), "describe this screenshot");
+  });
+
+  it("falls back to 'session' when array content has no text part", () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "image", image_url: { url: "data:..." } } as never],
+      },
+    ];
+    assert.strictEqual(extractFirstUserText(msgs), "session");
+  });
+
+  it("falls back to 'session' when string content is empty", () => {
+    const msgs: ChatMessage[] = [{ role: "user", content: "" }];
+    assert.strictEqual(extractFirstUserText(msgs), "session");
+  });
+
+  it("uses only the first user message, ignoring later ones", () => {
+    const msgs: ChatMessage[] = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "second" },
+    ];
+    assert.strictEqual(extractFirstUserText(msgs), "first");
+  });
+});

--- a/src/ui/use-session-manager.ts
+++ b/src/ui/use-session-manager.ts
@@ -1,0 +1,281 @@
+import React, { useCallback, useRef, useState } from "react";
+import {
+  listSessions,
+  loadSession,
+  loadSessionFromCheckpoint,
+  makeSessionId,
+  saveSession,
+  type Checkpoint,
+  type SessionSummary,
+} from "../sessions.js";
+import {
+  ArtifactStore,
+  deserializeArtifactStore,
+  emptySessionState,
+  serializeArtifactStore,
+  type SessionState,
+} from "../agent/session-state.js";
+import type { ChatMessage, Usage } from "../agent/messages.js";
+import type { GatewayMeta } from "../agent/client.js";
+import type { MemoryManager } from "../memory/manager.js";
+import { getCostReport } from "../usage-tracker.js";
+import type { DailyUsage } from "../usage-tracker.js";
+import type { ChatEvent } from "./chat.js";
+
+/**
+ * Pull the first chunk of user text out of a message list — used to
+ * derive a stable session id on the first turn. Returns `"session"` if
+ * no user message has any text content, mirroring the pre-extraction
+ * fallback in `app.tsx`.
+ */
+export function extractFirstUserText(messages: ChatMessage[]): string {
+  const firstUser = messages.find((m) => m.role === "user");
+  if (!firstUser) return "session";
+  if (typeof firstUser.content === "string") {
+    return firstUser.content || "session";
+  }
+  if (Array.isArray(firstUser.content)) {
+    const textPart = firstUser.content.find((p) => p.type === "text");
+    if (textPart?.text) return textPart.text;
+  }
+  return "session";
+}
+
+export interface SessionManagerDeps {
+  /** Model name + other config needed at save time. Null while booting. */
+  cfg: { model: string } | null;
+  // Refs the hook needs to read/write at save and resume time. These
+  // belong to the wider app (the agent loop mutates them too), so they're
+  // injected rather than owned.
+  messagesRef: React.MutableRefObject<ChatMessage[]>;
+  sessionStateRef: React.MutableRefObject<SessionState>;
+  artifactStoreRef: React.MutableRefObject<ArtifactStore>;
+  compiledContextRef: React.MutableRefObject<boolean>;
+  gatewayMetaRef: React.MutableRefObject<GatewayMeta | null>;
+  memoryManagerRef: React.MutableRefObject<MemoryManager | null>;
+  // State setters the resume flow needs to reach into.
+  setEvents: React.Dispatch<React.SetStateAction<ChatEvent[]>>;
+  setHistory: (h: string[]) => void;
+  setUsage: (u: Usage | null) => void;
+  setSessionUsage: (s: DailyUsage | null) => void;
+  setGatewayMeta: (g: GatewayMeta | null) => void;
+  /** Stable key generator for event-list items. */
+  mkKey: () => string;
+}
+
+export interface SessionManager {
+  // Identity refs (kept here, but returned so other code can keep
+  // calling `sessionIdRef.current` unchanged).
+  sessionIdRef: React.MutableRefObject<string | null>;
+  sessionCreatedAtRef: React.MutableRefObject<string | null>;
+  sessionTitleRef: React.MutableRefObject<string | null>;
+
+  // Picker state (powers the resume + checkpoint modals).
+  resumeSessions: SessionSummary[] | null;
+  setResumeSessions: (s: SessionSummary[] | null) => void;
+  checkpointSession: SessionSummary | null;
+  setCheckpointSession: (s: SessionSummary | null) => void;
+  checkpointList: Checkpoint[];
+  setCheckpointList: (c: Checkpoint[]) => void;
+  hasPickerOpen: boolean;
+
+  // Operations.
+  ensureSessionId: () => string;
+  saveSessionSafe: () => Promise<void>;
+  openResumePicker: () => Promise<void>;
+  doResumeSession: (filePath: string, checkpointId?: string) => Promise<void>;
+  handleResumePick: (picked: SessionSummary | null) => Promise<void>;
+  handleCheckpointPick: (checkpointId: string | null) => Promise<void>;
+  /** Clears the identity refs. Used by /clear. */
+  resetSession: () => void;
+}
+
+export function useSessionManager(deps: SessionManagerDeps): SessionManager {
+  const sessionIdRef = useRef<string | null>(null);
+  const sessionCreatedAtRef = useRef<string | null>(null);
+  const sessionTitleRef = useRef<string | null>(null);
+
+  const [resumeSessions, setResumeSessions] = useState<SessionSummary[] | null>(null);
+  const [checkpointSession, setCheckpointSession] = useState<SessionSummary | null>(null);
+  const [checkpointList, setCheckpointList] = useState<Checkpoint[]>([]);
+
+  // Stash deps in a ref so the public callbacks keep stable identities.
+  // Same pattern as M4.1's PermissionController and M4.2's PickerController.
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+
+  const ensureSessionId = useCallback(() => {
+    if (sessionIdRef.current) return sessionIdRef.current;
+    const text = extractFirstUserText(depsRef.current.messagesRef.current);
+    sessionIdRef.current = makeSessionId(text);
+    return sessionIdRef.current;
+  }, []);
+
+  const saveSessionSafe = useCallback(async () => {
+    const d = depsRef.current;
+    if (!d.cfg) return;
+    ensureSessionId();
+    const now = new Date().toISOString();
+    if (!sessionCreatedAtRef.current) {
+      sessionCreatedAtRef.current = now;
+    }
+    try {
+      await saveSession({
+        id: sessionIdRef.current!,
+        cwd: process.cwd(),
+        model: d.cfg.model,
+        createdAt: sessionCreatedAtRef.current,
+        updatedAt: now,
+        title: sessionTitleRef.current ?? undefined,
+        messages: d.messagesRef.current,
+        sessionState: d.compiledContextRef.current ? d.sessionStateRef.current : undefined,
+        artifactStore: serializeArtifactStore(d.artifactStoreRef.current),
+      });
+    } catch (e) {
+      d.setEvents((es) => [
+        ...es,
+        { kind: "error", key: d.mkKey(), text: `session save failed: ${(e as Error).message}` },
+      ]);
+    }
+  }, [ensureSessionId]);
+
+  const openResumePicker = useCallback(async () => {
+    const sessions = await listSessions(200, process.cwd());
+    setResumeSessions(sessions);
+  }, []);
+
+  const doResumeSession = useCallback(
+    async (filePath: string, checkpointId?: string) => {
+      const d = depsRef.current;
+      try {
+        const file = checkpointId
+          ? (await loadSessionFromCheckpoint(filePath, checkpointId)).file
+          : await loadSession(filePath);
+        d.messagesRef.current = file.messages;
+        sessionIdRef.current = file.id;
+        sessionCreatedAtRef.current = file.createdAt;
+        if (file.sessionState && d.compiledContextRef.current) {
+          d.sessionStateRef.current = file.sessionState;
+        }
+        if (file.artifactStore) {
+          d.artifactStoreRef.current = deserializeArtifactStore(file.artifactStore);
+        } else {
+          d.artifactStoreRef.current = new ArtifactStore();
+        }
+        // Recall memories for the resumed session so the model has context.
+        const manager = d.memoryManagerRef.current;
+        if (manager) {
+          try {
+            const cwd = process.cwd();
+            const results = await manager.recall({ text: cwd, repoPath: cwd, limit: 5 });
+            if (results.length > 0) {
+              const text = await manager.synthesizeRecalled(results);
+              const lastSystemIdx = d.messagesRef.current.findLastIndex((m) => m.role === "system");
+              const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : d.messagesRef.current.length;
+              d.messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
+            }
+          } catch {
+            // Non-fatal
+          }
+        }
+
+        const msg = checkpointId
+          ? `resumed session ${file.id} from checkpoint`
+          : `resumed session ${file.id} (${file.messages.filter((m) => m.role !== "system").length} msgs)`;
+        d.setEvents([{ kind: "info", key: d.mkKey(), text: msg }]);
+        const userMsgs = file.messages
+          .filter((m) => m.role === "user" && m.content)
+          .map((m) => {
+            if (!m.content) return "";
+            if (typeof m.content === "string") return m.content;
+            const textPart = m.content.find((p) => p.type === "text");
+            return textPart?.text ?? "";
+          })
+          .filter((text) => text.length > 0);
+        if (userMsgs.length > 0) d.setHistory(userMsgs);
+        d.setUsage(null);
+        d.setSessionUsage(null);
+        d.gatewayMetaRef.current = null;
+        d.setGatewayMeta(null);
+        void getCostReport(file.id).then((report) => d.setSessionUsage(report.session));
+      } catch (e) {
+        d.setEvents((es) => [
+          ...es,
+          { kind: "error", key: d.mkKey(), text: `failed to load session: ${(e as Error).message}` },
+        ]);
+      }
+    },
+    [],
+  );
+
+  const handleResumePick = useCallback(
+    async (picked: SessionSummary | null) => {
+      setResumeSessions(null);
+      if (!picked) return;
+      if (picked.checkpointCount > 0) {
+        // Load checkpoints and show picker.
+        try {
+          const file = await loadSession(picked.filePath);
+          setCheckpointList(file.checkpoints ?? []);
+          setCheckpointSession(picked);
+        } catch (e) {
+          depsRef.current.setEvents((es) => [
+            ...es,
+            { kind: "error", key: depsRef.current.mkKey(), text: `failed to load checkpoints: ${(e as Error).message}` },
+          ]);
+          await doResumeSession(picked.filePath);
+        }
+        return;
+      }
+      await doResumeSession(picked.filePath);
+    },
+    [doResumeSession],
+  );
+
+  const handleCheckpointPick = useCallback(
+    async (checkpointId: string | null) => {
+      const session = checkpointSession;
+      setCheckpointSession(null);
+      setCheckpointList([]);
+      if (!session || !checkpointId) {
+        // User cancelled or went back — reopen the session list.
+        if (session) {
+          setResumeSessions(await listSessions(200, process.cwd()));
+        }
+        return;
+      }
+      if (checkpointId === "__start__") {
+        await doResumeSession(session.filePath);
+        return;
+      }
+      await doResumeSession(session.filePath, checkpointId);
+    },
+    [checkpointSession, doResumeSession],
+  );
+
+  const resetSession = useCallback(() => {
+    sessionIdRef.current = null;
+    sessionCreatedAtRef.current = null;
+    sessionTitleRef.current = null;
+    const d = depsRef.current;
+    d.sessionStateRef.current = emptySessionState();
+    d.artifactStoreRef.current = new ArtifactStore();
+  }, []);
+
+  return {
+    sessionIdRef,
+    sessionCreatedAtRef,
+    sessionTitleRef,
+    resumeSessions, setResumeSessions,
+    checkpointSession, setCheckpointSession,
+    checkpointList, setCheckpointList,
+    hasPickerOpen: resumeSessions !== null || checkpointSession !== null,
+    ensureSessionId,
+    saveSessionSafe,
+    openResumePicker,
+    doResumeSession,
+    handleResumePick,
+    handleCheckpointPick,
+    resetSession,
+  };
+}


### PR DESCRIPTION
## Summary

Fourth extraction in the M4 \`app.tsx\` breakup, following M4.1 (#419), M4.2 (#432), and M4.3 (#443). Pulls session lifecycle (load / resume / checkpoint / save) out of \`app.tsx\` into a single focused hook.

**New module:** \`src/ui/use-session-manager.ts\` owns:

- Three identity refs: \`sessionIdRef\`, \`sessionCreatedAtRef\`, \`sessionTitleRef\`. The hook returns them so the ~20 read/write sites elsewhere in \`app.tsx\` (cost reports, save paths, remote-session propagation, title generation, /clear) can keep using \`sessionIdRef.current\` unchanged.
- Picker state: \`resumeSessions\`, \`checkpointSession\`, \`checkpointList\`.
- Handlers: \`ensureSessionId\`, \`saveSessionSafe\`, \`openResumePicker\`, \`doResumeSession\`, \`handleResumePick\`, \`handleCheckpointPick\`, plus a new \`resetSession()\` helper folded into the /clear handler.
- A pure \`extractFirstUserText()\` helper used by \`ensureSessionId\` to seed the session id from the first user message — 7 unit tests cover its edge cases (empty content array, image-only messages, multiple user messages).

**app.tsx changes:**

- 3 identity \`useRef\` declarations + 3 picker \`useState\` declarations → 1 \`useSessionManager()\` destructure.
- ~140 LOC of handler bodies (\`ensureSessionId\`, \`saveSessionSafe\`, \`openResumePicker\`, \`doResumeSession\`, \`handleResumePick\`, \`handleCheckpointPick\`) removed.
- /clear handler: 3 ref-null assignments + 2 state-reset lines → 1 \`resetSession()\` call.
- Picker JSX (resume + checkpoint, ~20 LOC) stays inline — too small to justify its own component.
- Pruned unused imports (\`listSessions\`, \`loadSessionFromCheckpoint\`, \`makeSessionId\`, \`saveSession\`, \`SessionSummary\`, \`deserializeArtifactStore\`).

**LOC**: \`app.tsx\` 4,093 → **3,954** (−139).

## Behavior preserved

Pure refactor; no observable behavior change. All resume-flow side effects preserved verbatim: history population from past user messages, usage/sessionUsage/gatewayMeta reset, memory recall + system-message injection, async cost-report kickoff. The identity refs are still mutated by the agent loop and read by 20+ external sites — returning them from the hook (instead of moving the consumers) keeps the diff small and the surgery local.

## What's NOT in this PR (intentional)

- The agent-loop's reads of \`sessionIdRef.current\` (e.g. for category-cost reports, remote-session propagation, mid-turn save calls) stay in \`app.tsx\`. They're scattered across the file and tightly coupled to the loop. Moving them is M4.5 (TurnController) work, not session work.
- \`pruneSessions\` startup-effect stays inline — it's a one-shot effect tied to \`cfg\` boot, not session lifecycle.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 461/461 pass (7 new tests for \`extractFirstUserText\`)
- [x] \`npm run build\` — clean ESM + DTS
- [ ] Manual smoke (not runnable from this non-TTY environment): start a session, send a few messages, \`/save\`, \`/resume\` (cancel + pick), pick a session with checkpoints (verify checkpoint picker opens, picks resume correctly), \`/clear\`, verify session ID resets and a fresh save lands at a new path.

Closes M4.4. Roadmap Progress log and inline M4 section updated.