### PR TITLE
perf(routing): parallelize pre-turn memory recall + skill routing

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -211,6 +211,19 @@ const MAX_PROMPT_TOKENS = 240_000;
  *  ~10k chars ≈ 2,500 tokens — generous but prevents runaway growth. */
 const MAX_TOOL_CONTENT_CHARS = 10_000;
 
+function extractLastUserText(messages: ChatMessage[]): string {
+  const lastUser = [...messages].reverse().find((m) => m.role === "user");
+  if (!lastUser) return "";
+  if (typeof lastUser.content === "string") return lastUser.content;
+  if (Array.isArray(lastUser.content)) {
+    return lastUser.content
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join(" ");
+  }
+  return "";
+}
+
 function raceWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   return Promise.race([
     promise,
@@ -230,101 +243,103 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const max = opts.maxToolIterations ?? 50;
   const codeMode = opts.codeMode ?? false;
 
-  // --- Pre-turn async work (memory recall + skill routing) ---
+  // --- Pre-turn async work (memory recall + skill routing, in parallel) ---
   let memoryRecalledCount = 0;
   let skillResult: SemanticSkillRoutingResult | undefined;
 
-  if (opts.sessionStartRecall) {
-    try {
-      const results = await raceWithSignal(opts.sessionStartRecall, opts.signal);
-      if (results.length > 0 && opts.memoryManager) {
-        const text = await raceWithSignal(
-          opts.memoryManager.synthesizeRecalled(results, opts.signal),
-          opts.signal,
-        );
-        memoryRecalledCount = results.length;
-        // Insert after existing system messages, before any user messages
-        const lastSystemIdx = opts.messages.findLastIndex((m) => m.role === "system");
-        const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : opts.messages.length;
-        opts.messages.splice(insertIdx, 0, { role: "system", content: text });
-        opts.callbacks.onMemoryRecalled?.(results.length);
-      }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
-      // Non-fatal: session works fine without recalled memories
+  const lastUserPrompt = extractLastUserText(opts.messages);
+
+  // Light + trivially short prompts skip skill routing entirely. These almost
+  // never benefit from injected skills and the embeddings round-trip dominates
+  // their wall-clock time. Threshold is conservative — anything substantive
+  // crosses 40 chars quickly.
+  const skipSkillRouting =
+    opts.intentClassification?.tier === "light" &&
+    lastUserPrompt.length < 40;
+
+  const recallPromise: Promise<{ text: string; count: number } | null> =
+    opts.sessionStartRecall && opts.memoryManager
+      ? (async () => {
+          const results = await opts.sessionStartRecall!;
+          if (results.length === 0 || !opts.memoryManager) return null;
+          const text = await opts.memoryManager.synthesizeRecalled(results, opts.signal);
+          return { text, count: results.length };
+        })()
+      : Promise.resolve(null);
+
+  const skillsPromise: Promise<SemanticSkillRoutingResult | undefined> =
+    opts.skillsDb && opts.skillRoutingConfig && opts.intentClassification && lastUserPrompt && !skipSkillRouting
+      ? selectSkills(
+          {
+            prompt: lastUserPrompt,
+            tier: opts.intentClassification.tier,
+            maxSkillTokens: opts.skillRoutingConfig.maxSkillTokens ?? 250_000 - 10_000,
+          },
+          {
+            db: opts.skillsDb,
+            accountId: opts.skillRoutingConfig.accountId,
+            apiToken: opts.skillRoutingConfig.apiToken,
+            embeddingModel: opts.skillRoutingConfig.embeddingModel,
+            gateway: opts.skillRoutingConfig.gateway,
+            cloudMode: opts.skillRoutingConfig.cloudMode,
+            cloudToken: opts.skillRoutingConfig.cloudToken,
+            cloudDeviceId: opts.skillRoutingConfig.cloudDeviceId,
+          },
+        )
+      : Promise.resolve(undefined);
+
+  const [recallSettled, skillsSettled] = await Promise.allSettled([
+    raceWithSignal(recallPromise, opts.signal),
+    raceWithSignal(skillsPromise, opts.signal),
+  ]);
+
+  // Propagate abort; swallow other failures (both paths are non-fatal).
+  for (const settled of [recallSettled, skillsSettled]) {
+    if (
+      settled.status === "rejected" &&
+      settled.reason instanceof DOMException &&
+      settled.reason.name === "AbortError"
+    ) {
+      throw settled.reason;
     }
   }
 
-  if (opts.signal.aborted) {
-    throw new DOMException("aborted", "AbortError");
+  if (recallSettled.status === "fulfilled" && recallSettled.value) {
+    const { text, count } = recallSettled.value;
+    const lastSystemIdx = opts.messages.findLastIndex((m) => m.role === "system");
+    const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : opts.messages.length;
+    opts.messages.splice(insertIdx, 0, { role: "system", content: text });
+    memoryRecalledCount = count;
+    opts.callbacks.onMemoryRecalled?.(count);
   }
 
-  if (opts.skillsDb && opts.skillRoutingConfig && opts.intentClassification) {
-    try {
-      const lastUserMsg = [...opts.messages].reverse().find((m) => m.role === "user");
-      const prompt =
-        typeof lastUserMsg?.content === "string"
-          ? lastUserMsg.content
-          : Array.isArray(lastUserMsg?.content)
-            ? lastUserMsg.content
-                .filter((p): p is { type: "text"; text: string } => p.type === "text")
-                .map((p) => p.text)
-                .join(" ")
-            : "";
-      if (prompt) {
-        skillResult = await raceWithSignal(
-          selectSkills(
-            {
-              prompt,
-              tier: opts.intentClassification.tier,
-              maxSkillTokens: opts.skillRoutingConfig.maxSkillTokens ?? 250_000 - 10_000,
-            },
-            {
-              db: opts.skillsDb,
-              accountId: opts.skillRoutingConfig.accountId,
-              apiToken: opts.skillRoutingConfig.apiToken,
-              embeddingModel: opts.skillRoutingConfig.embeddingModel,
-              gateway: opts.skillRoutingConfig.gateway,
-              cloudMode: opts.skillRoutingConfig.cloudMode,
-              cloudToken: opts.skillRoutingConfig.cloudToken,
-              cloudDeviceId: opts.skillRoutingConfig.cloudDeviceId,
-            },
-          ),
-          opts.signal,
-        );
-        opts.callbacks.onSkillsSelected?.(skillResult);
+  if (skillsSettled.status === "fulfilled" && skillsSettled.value) {
+    skillResult = skillsSettled.value;
+    opts.callbacks.onSkillsSelected?.(skillResult);
 
-        // Rebuild system prompt with skill context
-        const allTools = opts.tools;
-        if (opts.cacheStable) {
-          // Index 1 = session prefix (index 0 = static prefix)
-          opts.messages[1] = {
-            role: "system",
-            content: buildSessionPrefix({
-              cwd: opts.cwd,
-              tools: allTools,
-              model: opts.model,
-              mode: opts.mode,
-              skillContext: skillResult.skillContext,
-            }),
-          };
-        } else {
-          // Index 0 = single system prompt
-          opts.messages[0] = {
-            role: "system",
-            content: buildSystemPrompt({
-              cwd: opts.cwd,
-              tools: allTools,
-              model: opts.model,
-              mode: opts.mode,
-              skillContext: skillResult.skillContext,
-            }),
-          };
-        }
-      }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
-      // Non-fatal: skills are optional
+    const allTools = opts.tools;
+    if (opts.cacheStable) {
+      opts.messages[1] = {
+        role: "system",
+        content: buildSessionPrefix({
+          cwd: opts.cwd,
+          tools: allTools,
+          model: opts.model,
+          mode: opts.mode,
+          skillContext: skillResult.skillContext,
+        }),
+      };
+    } else {
+      opts.messages[0] = {
+        role: "system",
+        content: buildSystemPrompt({
+          cwd: opts.cwd,
+          tools: allTools,
+          model: opts.model,
+          mode: opts.mode,
+          skillContext: skillResult.skillContext,
+        }),
+      };
     }
   }
 

--- a/src/skills/db.ts
+++ b/src/skills/db.ts
@@ -95,6 +95,13 @@ export function deleteOrphanedSkills(db: Database.Database, existingPaths: strin
   return Number(result.changes);
 }
 
+export function hasAnySections(db: Database.Database): boolean {
+  const row = db
+    .prepare("SELECT 1 FROM skill_sections LIMIT 1")
+    .get() as { 1: number } | undefined;
+  return row !== undefined;
+}
+
 export function listAllSectionRows(
   db: Database.Database
 ): Array<{

--- a/src/skills/search.ts
+++ b/src/skills/search.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { AiGatewayOptions } from "../agent/client.js";
 import { fetchEmbeddings, cosineSimilarity } from "../memory/embeddings.js";
-import { listAllSectionRows, rowToSectionResult } from "./db.js";
+import { hasAnySections, listAllSectionRows, rowToSectionResult } from "./db.js";
 import type { SectionResult } from "./types.js";
 
 export interface SearchOpts {
@@ -23,6 +23,8 @@ export async function searchSections(
   db: Database.Database,
   opts: SearchOpts
 ): Promise<SectionResult[]> {
+  if (!hasAnySections(db)) return [];
+
   const embeddings = await fetchEmbeddings({
     accountId: opts.accountId,
     apiToken: opts.apiToken,


### PR DESCRIPTION
## Summary

Three low-risk latency wins in the adaptive-routing pre-turn path. No model-cost change, no behavior change for substantive prompts.

- **Parallelize memory recall + skill routing.** Today `runAgentTurn` runs session-start recall to completion before kicking off the skill-routing embedding round-trip. Both are I/O-bound on the same gateway and mutate independent slots of `opts.messages`, so `Promise.allSettled` is safe. Aborts still propagate; other failures stay non-fatal as before.
- **Short-circuit skill routing on light + trivially short prompts** (`tier === \"light\" && prompt.length < 40`). These almost never benefit from injected skills and the embedding round-trip dominates their wall-clock cost. Threshold is conservative — anything substantive crosses 40 chars quickly.
- **Bail out of `searchSections` before the embeddings call when the skill_sections table is empty.** New `hasAnySections()` helper avoids a network round-trip on fresh installs or disabled-skills setups.

## Test plan
- [x] `npm test` — 454/454 pass
- [x] `npx tsc --noEmit` clean
- [ ] Spot-check: light/short turn ("ok", "thanks") in a real session — confirm no skill embedding call fires (cost-debug.jsonl)
- [ ] Spot-check: heavy/long turn — confirm skills still injected and recall + skills overlap in wall-clock time

🤖 Generated with [Claude Code](https://claude.com/claude-code)