### PR TITLE
refactor(ui): extract useTurnController hook from app.tsx (M4.5)

### DIFF
--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,7 +15,24 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
-- **M4.4** — `SessionManager` extracted from `app.tsx` — *(this PR)*.
+- **M4.5** — `TurnController` extracted from `app.tsx` — *(this PR)*.
+  Hook in `src/ui/use-turn-controller.ts` owns the turn-lifecycle
+  state: `busy` / `busyRef`, `supervisorRef`, `isAbortingRef`,
+  `lastEscapeAtRef`, the four status-pill fields (`turnPhase`,
+  `turnStartedAt`, `currentToolName`, `lastActivityAt`),
+  `showReasoning`, `turnCounterRef`, and the task-tracking trio
+  (`tasks` + `tasksRef`, `tasksStartedAt`, `tasksStartTokens`).
+  Operations: `beginTurn()`, `endTurn()`, `clearTaskTracking()`,
+  `toggleReasoning()`, `markAborting()`. Folded three duplicated
+  `beginTurn` blocks, three `endTurn` blocks, and three task-reset
+  blocks into single-line calls. Other-controller cleanups (permission
+  ref, limit/loop refs, pending tool calls) stay at the call sites —
+  they belong to M4.1 / M4.3 / M4.4 territory. `app.tsx` 3,954 →
+  3,917 LOC; the headline number is small because the hook also adds
+  149 LOC of consolidated state declarations, but the structural win
+  is real (turn lifecycle now has one owner instead of being smeared
+  across 10 useState/useRef calls and three duplicated finally blocks).
+- **M4.4** — `SessionManager` extracted from `app.tsx` — merged in #448.
   Pulled load/resume/checkpoint/save state and handlers into
   `src/ui/use-session-manager.ts`. The hook owns the three identity
   refs (`sessionIdRef`, `sessionCreatedAtRef`, `sessionTitleRef`) and
@@ -327,8 +344,12 @@ that touches UI assumes M4 is making steady progress.
   save/resume/checkpoint handlers. `extractFirstUserText()` extracted
   as a pure helper for the session-id seed text. `app.tsx` shrank
   4,093 → 3,954 LOC.
-- **M4.5** — `refactor(ui): extract TurnController`
-  - Supervisor wiring, status pills, reasoning view.
+- ✅ **M4.5** — `refactor(ui): extract TurnController`
+  *(merged in this PR)*. Hook in `src/ui/use-turn-controller.ts` owns
+  busy / supervisor / phase / status / reasoning / task-tracking state
+  plus `beginTurn` / `endTurn` / `clearTaskTracking` helpers. Three
+  duplicated lifecycle blocks folded to one-line calls. `app.tsx`
+  shrank 3,954 → 3,917 LOC.
 - **M4.6** — `refactor(ui): extract InputController`
   - The 200+ line `useInput` handler split by mode (normal /
     picker / modal).

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Text, useApp, useInput, render } from "ink";
 
 import { runAgentTurn, AgentLoopError } from "./agent/loop.js";
-import { TurnSupervisor } from "./agent/supervisor.js";
 import type { AiGatewayOptions, GatewayMeta } from "./agent/client.js";
 import { buildSystemPrompt, buildSystemMessages, buildSessionPrefix } from "./agent/system-prompt.js";
 import { summarizeMessagesViaLlm } from "./agent/llm-summarize.js";
@@ -108,6 +107,7 @@ import { usePickerController } from "./ui/use-picker-controller.js";
 import { useModalHost } from "./ui/use-modal-host.js";
 import { ModalHost, ModalOverlay } from "./ui/modal-host.js";
 import { useSessionManager } from "./ui/use-session-manager.js";
+import { useTurnController } from "./ui/use-turn-controller.js";
 import { readFileSync } from "node:fs";
 
 /**
@@ -479,7 +479,6 @@ function App({
     [],
   );
   const [input, setInput] = useState("");
-  const [busy, setBusy] = useState(false);
   const [usage, setUsage] = useState<Usage | null>(null);
   const [sessionUsage, setSessionUsage] = useState<DailyUsage | null>(null);
 
@@ -498,7 +497,22 @@ function App({
   }, []);
   const [gatewayMeta, setGatewayMeta] = useState<GatewayMeta | null>(null);
   const [cloudBudget, setCloudBudget] = useState<{ remaining: number; limit: number } | null>(null);
-  const [showReasoning, setShowReasoning] = useState(false);
+  const turn = useTurnController();
+  const {
+    busy, busyRef,
+    isAbortingRef, lastEscapeAtRef,
+    supervisorRef,
+    turnPhase, setTurnPhase,
+    turnStartedAt,
+    currentToolName, setCurrentToolName,
+    lastActivityAt, setLastActivityAt,
+    turnCounterRef,
+    showReasoning,
+    tasks, setTasks, tasksRef,
+    tasksStartedAt, setTasksStartedAt,
+    tasksStartTokens, setTasksStartTokens,
+    beginTurn, endTurn, clearTaskTracking,
+  } = turn;
   const {
     pending: perm,
     askPermission: askForPermission,
@@ -546,13 +560,6 @@ function App({
     initialCfg?.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
   );
   const [selectedRemoteSession, setSelectedRemoteSession] = useState<RemoteSession | null>(null);
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
-  const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
-  const [turnStartedAt, setTurnStartedAt] = useState<number | null>(null);
-  const [turnPhase, setTurnPhase] = useState<import("./ui/status.js").TurnPhase>("waiting");
-  const [currentToolName, setCurrentToolName] = useState<string | null>(null);
-  const [lastActivityAt, setLastActivityAt] = useState<number | null>(null);
   const [verbose, setVerbose] = useState(false);
   const [hasUpdate, setHasUpdate] = useState(initialUpdateResult?.hasUpdate ?? false);
   const [latestVersion, setLatestVersion] = useState<string | null>(initialUpdateResult?.latestVersion ?? null);
@@ -662,9 +669,6 @@ function App({
   const activeAsstIdRef = useRef<number | null>(null);
   const sessionScopeRef = useRef<AbortScope>(new AbortScope());
   const activeScopeRef = useRef<AbortScope | null>(null);
-  const supervisorRef = useRef<TurnSupervisor>(new TurnSupervisor());
-  const isAbortingRef = useRef(false);
-  const lastEscapeAtRef = useRef(0);
   /** Holds the latest Ctrl+C interrupt logic so the SIGINT handler can delegate to it. */
   const sigintHandlerRef = useRef<(() => void) | null>(null);
   const limitResolveRef = useRef<((d: LimitDecision) => void) | null>(null);
@@ -672,7 +676,6 @@ function App({
   const pendingToolCallsRef = useRef<Map<string, string>>(new Map());
   const modeRef = useRef<Mode>(mode);
   const effortRef = useRef<ReasoningEffort>(effort);
-  const tasksRef = useRef<Task[]>([]);
   const usageRef = useRef<Usage | null>(null);
   const gatewayMetaRef = useRef<GatewayMeta | null>(null);
   const lastApiErrorRef = useRef<{ httpStatus?: number; code?: number; message: string } | null>(null);
@@ -689,11 +692,9 @@ function App({
   const lspManagerRef = useRef(new LspManager());
   const lspToolsRef = useRef<ToolSpec[]>([]);
   const lspInitRef = useRef(false);
-  const busyRef = useRef(busy);
   const memoryManagerRef = useRef<MemoryManager | null>(null);
   const sessionStartRecallRef = useRef<Promise<import("./memory/schema.js").HybridResult[]> | null>(null);
   const kimiMdStaleNudgedRef = useRef(false);
-  const turnCounterRef = useRef(0);
 
   const sessionMgr = useSessionManager({
     cfg,
@@ -1341,10 +1342,7 @@ function App({
         // Save session so interrupted turn is not lost
         void saveSessionSafe();
         // Clear task list immediately so it doesn't keep spinning
-        setTasks([]);
-        setTasksStartedAt(null);
-        setTasksStartTokens(0);
-        tasksRef.current = [];
+        clearTaskTracking();
       } else if (!hadPerm && !hadLimit && !hadLoop) {
         logger.info("input:ctrl+c:exiting");
         void lspManagerRef.current.stopAll().finally(() => exit());
@@ -1391,15 +1389,12 @@ function App({
         }
         pendingToolCallsRef.current.clear();
         // Clear task list immediately so it doesn't keep spinning
-        setTasks([]);
-        setTasksStartedAt(null);
-        setTasksStartTokens(0);
-        tasksRef.current = [];
+        clearTaskTracking();
         return;
       }
     }
     if (key.ctrl && inputChar === "r") {
-      setShowReasoning((s) => !s);
+      turn.toggleReasoning();
       return;
     }
     if (key.shift && key.tab) {
@@ -1443,10 +1438,7 @@ function App({
       activeScopeRef.current.abort("user_stopped");
       setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "(interrupted)" }]);
       void saveSessionSafe();
-      setTasks([]);
-      setTasksStartedAt(null);
-      setTasksStartTokens(0);
-      tasksRef.current = [];
+      clearTaskTracking();
     } else if (!hadPerm && !hadLimit) {
       logger.info("sigint:handler:exiting");
       void lspManagerRef.current.stopAll().finally(() => exit());
@@ -1527,9 +1519,7 @@ function App({
       setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't compact while model is running" }]);
       return;
     }
-    setBusy(true);
-    busyRef.current = true;
-    setTurnStartedAt(Date.now());
+    beginTurn();
     const turnScope = sessionScopeRef.current.createChild();
     activeScopeRef.current = turnScope;
     try {
@@ -1604,14 +1594,8 @@ function App({
       }
     } finally {
       logger.info("runCompact:finally");
-      setBusy(false);
-      busyRef.current = false;
-      setTurnStartedAt(null);
-      setTurnPhase("waiting");
-      setCurrentToolName(null);
-      setLastActivityAt(null);
+      endTurn();
       activeScopeRef.current = null;
-      isAbortingRef.current = false;
       clearPermissionResolveRef();
       limitResolveRef.current = null;
       pendingToolCallsRef.current.clear();
@@ -1629,9 +1613,7 @@ function App({
 
     setEvents((e) => [...e, { kind: "user", key: mkKey(), text: isRefresh ? `/init (refreshing ${targetFilename})` : "/init" }]);
     messagesRef.current.push({ role: "user", content: sanitizeString(prompt) });
-    setBusy(true);
-    busyRef.current = true;
-    setTurnStartedAt(Date.now());
+    beginTurn();
     const turnScope = sessionScopeRef.current.createChild();
     activeScopeRef.current = turnScope;
 
@@ -1915,15 +1897,9 @@ function App({
       setCodeMode(false);
       const asstId = activeAsstIdRef.current;
       if (asstId !== null) updateAssistant(asstId, () => ({ streaming: false }));
-      setBusy(false);
-      busyRef.current = false;
-      setTurnStartedAt(null);
-      setTurnPhase("waiting");
-      setCurrentToolName(null);
-      setLastActivityAt(null);
+      endTurn();
       activeAsstIdRef.current = null;
       activeScopeRef.current = null;
-      isAbortingRef.current = false;
       clearPermissionResolveRef();
       limitResolveRef.current = null;
       loopResolveRef.current = null;
@@ -1987,15 +1963,13 @@ function App({
         setSessionUsage(null);
         gatewayMetaRef.current = null;
         setGatewayMeta(null);
-        setTasks([]);
-        setTasksStartedAt(null);
-        setTasksStartTokens(0);
+        clearTaskTracking();
         compactSuggestedRef.current = false;
         updateNudgedRef.current = false;
         return true;
       }
       if (c === "/reasoning") {
-        setShowReasoning((s) => {
+        turn.setShowReasoning((s) => {
           const next = !s;
           setEvents((e) => [
             ...e,
@@ -3208,11 +3182,9 @@ function App({
         ]);
       }
 
-      setBusy(true);
-      busyRef.current = true;
+      beginTurn();
       gatewayMetaRef.current = null;
       setGatewayMeta(null);
-      setTurnStartedAt(Date.now());
 
       const classification = classifyIntent(trimmed);
       setIntentTier(classification.tier);
@@ -3408,15 +3380,9 @@ function App({
         setCodeMode(false);
         const asstId = activeAsstIdRef.current;
         if (asstId !== null) updateAssistant(asstId, () => ({ streaming: false }));
-        setBusy(false);
-        busyRef.current = false;
-        setTurnStartedAt(null);
-        setTurnPhase("waiting");
-        setCurrentToolName(null);
-        setLastActivityAt(null);
+        endTurn();
         activeAsstIdRef.current = null;
         activeScopeRef.current = null;
-        isAbortingRef.current = false;
         clearPermissionResolveRef();
         limitResolveRef.current = null;
         loopResolveRef.current = null;
@@ -3424,10 +3390,7 @@ function App({
         pendingToolCallsRef.current.clear();
 
         // Clear task list so it doesn't linger into the next turn
-        setTasks([]);
-        setTasksStartedAt(null);
-        setTasksStartTokens(0);
-        tasksRef.current = [];
+        clearTaskTracking();
 
         // Mark any still-running tools as interrupted
         setEvents((evts) =>

--- a/src/ui/use-turn-controller.ts
+++ b/src/ui/use-turn-controller.ts
@@ -1,0 +1,149 @@
+import React, { useCallback, useRef, useState } from "react";
+import { TurnSupervisor } from "../agent/supervisor.js";
+import type { TurnPhase } from "./status.js";
+import type { Task } from "../tools/registry.js";
+
+export interface TurnController {
+  // ── Lifecycle state ────────────────────────────────────────────────
+  /** True while a model turn is in flight. */
+  busy: boolean;
+  setBusy: (b: boolean) => void;
+  /** Synchronous mirror of `busy` for hot paths (input handler, agent
+   *  callbacks) that need to read it without waiting for a re-render. */
+  busyRef: React.MutableRefObject<boolean>;
+
+  /** Guard against double-aborts when Ctrl+C / Esc fire while abort is
+   *  already in progress. */
+  isAbortingRef: React.MutableRefObject<boolean>;
+  /** Esc debounce (used by the input handler to require two quick
+   *  presses for certain paths). */
+  lastEscapeAtRef: React.MutableRefObject<number>;
+
+  /** The TurnSupervisor instance that owns per-turn phase tracking. */
+  supervisorRef: React.MutableRefObject<TurnSupervisor>;
+
+  /** Coarse phase for the status pill ("generating" / "executing" / "waiting"). */
+  turnPhase: TurnPhase;
+  setTurnPhase: (p: TurnPhase) => void;
+
+  /** Timestamp the current turn started, or null between turns. Drives
+   *  the elapsed-time display in the status bar. */
+  turnStartedAt: number | null;
+  setTurnStartedAt: (n: number | null) => void;
+
+  /** Name of the currently-executing tool, surfaced in the status pill. */
+  currentToolName: string | null;
+  setCurrentToolName: (n: string | null) => void;
+
+  /** Wall-clock of the last streamed delta / tool result. Used by the
+   *  status pill to detect stalls. */
+  lastActivityAt: number | null;
+  setLastActivityAt: (n: number | null) => void;
+
+  /** Counter that ticks once per completed turn — used by the periodic
+   *  hooks (memory housekeeping, etc.) that fire every N turns. */
+  turnCounterRef: React.MutableRefObject<number>;
+
+  // ── Reasoning view ─────────────────────────────────────────────────
+  showReasoning: boolean;
+  setShowReasoning: (b: boolean | ((prev: boolean) => boolean)) => void;
+  toggleReasoning: () => void;
+
+  // ── Task tracking (the agent's todo list during a turn) ────────────
+  tasks: Task[];
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>;
+  tasksRef: React.MutableRefObject<Task[]>;
+  tasksStartedAt: number | null;
+  setTasksStartedAt: (n: number | null) => void;
+  tasksStartTokens: number;
+  setTasksStartTokens: (n: number) => void;
+
+  // ── Operations ─────────────────────────────────────────────────────
+  /** Flip into the "model is running" state. Sets busy=true, mirrors
+   *  to the ref, stamps turnStartedAt=now. */
+  beginTurn: () => void;
+
+  /** Tear down per-turn lifecycle state. Clears busy / busyRef / phase
+   *  / current tool / activity / abort flag / turnStartedAt. Does NOT
+   *  touch refs owned by other controllers (permission, limit/loop,
+   *  pending tool calls); the caller orchestrates those. */
+  endTurn: () => void;
+
+  /** Wipe the task-list state (tasks, startedAt, startTokens). Called
+   *  on abort and at turn end so the list doesn't linger. */
+  clearTaskTracking: () => void;
+
+  /** Mark abort-in-progress and ask the supervisor to kill the turn.
+   *  Returns true on the first call within a turn, false on re-entry. */
+  markAborting: () => boolean;
+}
+
+export function useTurnController(): TurnController {
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  const isAbortingRef = useRef(false);
+  const lastEscapeAtRef = useRef(0);
+  const supervisorRef = useRef<TurnSupervisor>(new TurnSupervisor());
+
+  const [turnPhase, setTurnPhase] = useState<TurnPhase>("waiting");
+  const [turnStartedAt, setTurnStartedAt] = useState<number | null>(null);
+  const [currentToolName, setCurrentToolName] = useState<string | null>(null);
+  const [lastActivityAt, setLastActivityAt] = useState<number | null>(null);
+  const turnCounterRef = useRef(0);
+
+  const [showReasoning, setShowReasoning] = useState(false);
+  const toggleReasoning = useCallback(() => {
+    setShowReasoning((s) => !s);
+  }, []);
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const tasksRef = useRef<Task[]>([]);
+  const [tasksStartedAt, setTasksStartedAt] = useState<number | null>(null);
+  const [tasksStartTokens, setTasksStartTokens] = useState<number>(0);
+
+  const beginTurn = useCallback(() => {
+    setBusy(true);
+    busyRef.current = true;
+    setTurnStartedAt(Date.now());
+  }, []);
+
+  const endTurn = useCallback(() => {
+    setBusy(false);
+    busyRef.current = false;
+    setTurnStartedAt(null);
+    setTurnPhase("waiting");
+    setCurrentToolName(null);
+    setLastActivityAt(null);
+    isAbortingRef.current = false;
+  }, []);
+
+  const clearTaskTracking = useCallback(() => {
+    setTasks([]);
+    setTasksStartedAt(null);
+    setTasksStartTokens(0);
+    tasksRef.current = [];
+  }, []);
+
+  const markAborting = useCallback((): boolean => {
+    if (isAbortingRef.current) return false;
+    isAbortingRef.current = true;
+    supervisorRef.current.killTurn();
+    return true;
+  }, []);
+
+  return {
+    busy, setBusy, busyRef,
+    isAbortingRef, lastEscapeAtRef,
+    supervisorRef,
+    turnPhase, setTurnPhase,
+    turnStartedAt, setTurnStartedAt,
+    currentToolName, setCurrentToolName,
+    lastActivityAt, setLastActivityAt,
+    turnCounterRef,
+    showReasoning, setShowReasoning, toggleReasoning,
+    tasks, setTasks, tasksRef,
+    tasksStartedAt, setTasksStartedAt,
+    tasksStartTokens, setTasksStartTokens,
+    beginTurn, endTurn, clearTaskTracking, markAborting,
+  };
+}


### PR DESCRIPTION
## Summary

Fifth extraction in the M4 \`app.tsx\` breakup, following M4.1 (#419), M4.2 (#432), M4.3 (#443), and M4.4 (#448). The turn-lifecycle state moves out of \`app.tsx\` into a focused hook.

**New module:** \`src/ui/use-turn-controller.ts\` owns:

- **Lifecycle:** \`busy\` / \`busyRef\` (with the sync ref-mirror so hot paths can read it), \`supervisorRef\`, \`isAbortingRef\`, \`lastEscapeAtRef\`.
- **Status pill:** \`turnPhase\`, \`turnStartedAt\`, \`currentToolName\`, \`lastActivityAt\`.
- **Reasoning view:** \`showReasoning\` + \`toggleReasoning()\` (folds the Ctrl+R toggle and /reasoning command).
- **Misc:** \`turnCounterRef\` (the every-N-turns periodic hook counter).
- **Task tracking:** \`tasks\` + \`tasksRef\`, \`tasksStartedAt\`, \`tasksStartTokens\`.

Operations:
- \`beginTurn()\` — sets busy true, mirrors to ref, stamps \`turnStartedAt\`.
- \`endTurn()\` — clears busy / phase / status-pill fields / \`isAborting\`.
- \`clearTaskTracking()\` — wipes all task-related state in one call.
- \`markAborting()\` — guards re-entry + asks the supervisor to kill the current turn.

## app.tsx changes

- 10 inline \`useState\` / \`useRef\` declarations → 1 \`useTurnController()\` destructure.
- **Three** duplicated \`beginTurn\` blocks (4 lines each) → \`beginTurn()\`.
- **Three** duplicated \`endTurn\` blocks (6 lines each, in two different indentation contexts) → \`endTurn()\`.
- **Three** duplicated task-reset blocks (4 lines each) → \`clearTaskTracking()\`.
- /reasoning command and Ctrl+R handler both route through \`turn.toggleReasoning()\` / \`turn.setShowReasoning\`.
- Stale \`TurnSupervisor\` import dropped.

## Behavior preserved

Pure refactor; no observable behavior change. Other-controller cleanups (permission ref, limit/loop resolver refs, pending tool-calls map, active scope) **stay at the call sites** — they belong to M4.1 / M4.3 / M4.4 / future M4.6 territory, not turn lifecycle. The three lifecycle blocks that this PR consolidates are exactly the turn-state subset, not the broader cleanup soup.

## On the LOC headline

**\`app.tsx\` 3,954 → 3,917 (−37)** is the smallest shrink so far in the M4 series. The reason: the hook adds 149 LOC of state declarations + operation bodies, and only the lifecycle-block folding hits net-negative on the main file. The structural win is real (turn lifecycle now has one owner instead of being smeared across 10 useState/useRef calls and three duplicated finally blocks) but the LOC headline understates it.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 461/461 pass
- [x] \`npm run build\` — clean ESM + DTS
- [ ] Manual smoke (not runnable from this non-TTY environment): send a message and watch the status pill cycle through generating → executing → waiting; Ctrl+R toggles reasoning; \`/reasoning\` does the same; Ctrl+C and Esc during a turn both clear the task list and reset the status pill; \`/clear\` resets task tracking; a tool error fires endTurn cleanly.

Closes M4.5. Roadmap Progress log and inline M4 section updated.