### PR TITLE
feat(tools): streaming read for files over the 2 MB cap (M3.4)

### DIFF
--- a/docs/architecture/agent-loop-findings.md
+++ b/docs/architecture/agent-loop-findings.md
@@ -244,8 +244,12 @@ sufficient.
 - `read`: checks `signal.aborted` at entry, after stat, and forwards
   `ctx.signal` to `fs.readFile`.
 
-**Still pending (second half):** streaming read for the >MAX_BYTES case
-and explicit `write`/`edit` check-at-start.
+**Status (second half):**
+- ✅ `read`: streaming path for files over MAX_BYTES (M3.4). Above the
+  cap, callers must supply `offset`+`limit` and the file is streamed
+  line-by-line with abort-signal checks between chunks; a 50 MB hard
+  ceiling on bytes scanned protects against runaway reads.
+- Still pending: explicit `write`/`edit` check-at-start.
 
 ### RF-14 — `src/app.tsx` is a 4,393-line god component (L)
 

--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,8 +15,19 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
+- **M3.4** — Streaming read for large files *(RF-13 second half)* —
+  *(this PR)*. `src/tools/read.ts` previously refused any file over
+  2 MB outright. Files above the cap now require an explicit
+  `offset`+`limit` slice and stream line-by-line, checking
+  `ctx.signal` between chunks and destroying the underlying read
+  stream on abort. A 50 MB hard ceiling on bytes scanned protects
+  against runaway reads (e.g. `offset: 999_999_999` on a multi-GB
+  log file). Small-file fast path unchanged. Exported
+  `readSliceStreaming` for direct testing; 8 unit tests cover both
+  paths plus the abort + EOF + over-cap-no-slice cases. **M3
+  complete.**
 - **M4.6** — `InputController` helpers extracted from `app.tsx` —
-  *(this PR)*. The Ctrl+C, Esc, and SIGINT abort paths used to be
+  merged in #453. The Ctrl+C, Esc, and SIGINT abort paths used to be
   three nearly-identical ~30-line copies of "deny permission → clear
   limit/loop resolvers → kill turn → save session → clear tasks → exit
   if idle." That logic lives in `src/ui/input-handlers.ts` now as
@@ -307,13 +318,16 @@ test regressions.
   `LspServerStatus`. A `/lsp status` slash command remains to be
   built — deferred because it touches `app.tsx` and would conflict
   with M4 extractions.
-- **M3.4** — `feat(tools): streaming read for large files`
-  *(RF-13, second half)*
-  - Stream-read past, say, 1 MB. Check `signal` between chunks.
+- ✅ **M3.4** — `feat(tools): streaming read for large files`
+  *(RF-13, second half)* — *merged in this PR*. Files over the 2 MB
+  cap now require an explicit `offset`+`limit` slice and stream
+  line-by-line with abort-signal checks between chunks; a 50 MB hard
+  ceiling on bytes scanned protects against runaway reads. Small-file
+  fast path unchanged.
 
 **Exit criteria:** Hung MCP server scenario from RF-16 verified
 fixed by a regression test (mock server that never responds).
-M3.4 remains; M3.1–M3.3 shipped.
+**M3 complete** (M3.1–M3.4 all shipped).
 
 ---
 

--- a/src/tools/read.test.ts
+++ b/src/tools/read.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readTool, readSliceStreaming } from "./read.js";
+import type { ToolContext } from "./registry.js";
+
+let dir: string;
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "read-tool-test-"));
+});
+after(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function ctx(overrides: Partial<ToolContext> = {}): ToolContext {
+  return { cwd: dir, ...overrides };
+}
+
+describe("readTool — small files (fast path)", () => {
+  it("reads a small file in full", async () => {
+    const p = join(dir, "small.txt");
+    writeFileSync(p, "alpha\nbeta\ngamma\n");
+    const out = await readTool.run({ path: "small.txt" }, ctx());
+    assert.ok(typeof out === "string");
+    assert.match(out as string, /^ ?1\talpha\n ?2\tbeta\n ?3\tgamma\n ?4\t$/);
+  });
+
+  it("slices small files with offset+limit", async () => {
+    const p = join(dir, "ten.txt");
+    writeFileSync(p, Array.from({ length: 10 }, (_, i) => `line${i + 1}`).join("\n"));
+    const out = (await readTool.run({ path: "ten.txt", offset: 4, limit: 3 }, ctx())) as string;
+    const lines = out.split("\n");
+    assert.strictEqual(lines.length, 3);
+    assert.match(lines[0]!, /4\tline4/);
+    assert.match(lines[2]!, /6\tline6/);
+  });
+});
+
+describe("readTool — large files (streaming path)", () => {
+  /** 3 MB of "line N\n" content — comfortably over the 2 MB cap. */
+  const makeBigFile = (name: string): string => {
+    const p = join(dir, name);
+    const chunks: string[] = [];
+    let bytes = 0;
+    let n = 0;
+    while (bytes < 3 * 1024 * 1024) {
+      n += 1;
+      const line = `line${n}\n`;
+      chunks.push(line);
+      bytes += line.length;
+    }
+    writeFileSync(p, chunks.join(""));
+    return p;
+  };
+
+  it("rejects an unbounded read on a file over the cap", async () => {
+    makeBigFile("big-unbounded.txt");
+    await assert.rejects(
+      readTool.run({ path: "big-unbounded.txt" }, ctx()),
+      /file too large: .* bytes \(max .* for full read; supply offset\+limit/,
+    );
+  });
+
+  it("rejects with offset only (no limit)", async () => {
+    makeBigFile("big-no-limit.txt");
+    await assert.rejects(
+      readTool.run({ path: "big-no-limit.txt", offset: 100 }, ctx()),
+      /supply offset\+limit/,
+    );
+  });
+
+  it("streams a small slice from a big file", async () => {
+    makeBigFile("big-slice.txt");
+    const out = (await readTool.run(
+      { path: "big-slice.txt", offset: 50, limit: 3 },
+      ctx(),
+    )) as string;
+    const lines = out.split("\n");
+    assert.strictEqual(lines.length, 3);
+    assert.match(lines[0]!, /50\tline50/);
+    assert.match(lines[1]!, /51\tline51/);
+    assert.match(lines[2]!, /52\tline52/);
+  });
+
+  it("returns fewer lines than requested when the slice runs past EOF", async () => {
+    // 5 lines total, ask for 100 starting at line 3
+    const p = join(dir, "short.txt");
+    writeFileSync(p, "a\nb\nc\nd\ne\n");
+    // Force the streaming path by also writing a separate big file? No —
+    // the streaming function is exported, test it directly.
+    const lines = await readSliceStreaming(p, 3, 100);
+    assert.deepStrictEqual(lines, ["c", "d", "e"]);
+  });
+
+  it("respects an already-aborted signal before opening the file", async () => {
+    makeBigFile("big-aborted.txt");
+    const c = new AbortController();
+    c.abort();
+    await assert.rejects(
+      readTool.run({ path: "big-aborted.txt", offset: 100, limit: 5 }, ctx({ signal: c.signal })),
+      (err: Error) => err.name === "AbortError",
+    );
+  });
+
+  it("aborts mid-stream when the signal fires", async () => {
+    // Big file with a slice deep into it so the stream has time to react.
+    const p = join(dir, "big-mid-abort.txt");
+    const chunks: string[] = [];
+    for (let i = 1; i <= 200_000; i++) chunks.push(`line${i}\n`);
+    writeFileSync(p, chunks.join(""));
+    const c = new AbortController();
+    // Fire abort on the next tick so the read has actually started.
+    setTimeout(() => c.abort(), 0);
+    await assert.rejects(
+      readSliceStreaming(p, 199_000, 100, c.signal),
+      (err: Error) => err.name === "AbortError",
+    );
+  });
+});

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1,8 +1,23 @@
 import { readFile, stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
 import type { ToolSpec } from "./registry.js";
 import { resolvePath, collapsePath } from "../util/paths.js";
 
+/**
+ * Fast-path size cap. Files at or below this size are read into memory
+ * in a single `fs.readFile` call. Files above it require an explicit
+ * `offset` + `limit` slice and stream line-by-line, checking the abort
+ * signal between chunks (RF-13 second half).
+ */
 const MAX_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Hard ceiling on bytes scanned while seeking a streaming slice. Guards
+ * against runaway reads — e.g. asking for `offset: 999_999_999` on a
+ * 5 GB log file. Hit this and the read fails fast.
+ */
+const MAX_STREAM_BYTES = 50 * 1024 * 1024;
 
 interface Args {
   path: string;
@@ -10,10 +25,70 @@ interface Args {
   limit?: number;
 }
 
+function aborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+function abortError(): DOMException {
+  return new DOMException("aborted", "AbortError");
+}
+
+/**
+ * Stream a slice [offset, offset+limit) of `abs` line by line. Both
+ * `offset` and `limit` are 1-indexed line numbers, matching the rest of
+ * the tool. Throws if the abort signal fires mid-stream or if more than
+ * `MAX_STREAM_BYTES` are consumed before reaching the slice.
+ */
+export async function readSliceStreaming(
+  abs: string,
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  if (aborted(signal)) throw abortError();
+  const rs = createReadStream(abs, { encoding: "utf8" });
+  const onAbort = () => rs.destroy(abortError());
+  signal?.addEventListener("abort", onAbort);
+  try {
+    const rl = createInterface({ input: rs, crlfDelay: Infinity });
+    const startLine = Math.max(1, offset);
+    const endLine = startLine + Math.max(0, limit) - 1;
+    const collected: string[] = [];
+    let lineNum = 0;
+    let bytesScanned = 0;
+    for await (const line of rl) {
+      if (aborted(signal)) throw abortError();
+      lineNum += 1;
+      bytesScanned += Buffer.byteLength(line, "utf8") + 1; // +1 for the LF
+      if (bytesScanned > MAX_STREAM_BYTES) {
+        throw new Error(
+          `file too large to stream: exceeded ${MAX_STREAM_BYTES} bytes while seeking slice at line ${startLine}`,
+        );
+      }
+      if (lineNum >= startLine && lineNum <= endLine) {
+        collected.push(line);
+      }
+      if (lineNum >= endLine) break;
+    }
+    return collected;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    rs.destroy();
+  }
+}
+
+function formatLines(lines: string[], startLine: number): string {
+  const endLine = startLine + lines.length - 1;
+  const width = String(endLine).length;
+  return lines
+    .map((l, i) => `${String(startLine + i).padStart(width, " ")}\t${l}`)
+    .join("\n");
+}
+
 export const readTool: ToolSpec<Args> = {
   name: "read",
   description:
-    "Read a text file from the local filesystem. Supports optional line offset/limit. Refuses files larger than 2MB. Returns contents with 1-indexed line numbers prefixed, cat -n style. When reading a full file without offset/limit, the output is reduced to a compact outline (imports, exports, signatures, preview) by default; use expand_artifact to retrieve the full content or specify offset/limit for a targeted slice.",
+    "Read a text file from the local filesystem. Supports optional line offset/limit. Files up to 2MB are read in a single pass; larger files require an explicit offset+limit slice and are streamed line by line (cancellable mid-stream). Returns contents with 1-indexed line numbers prefixed, cat -n style. When reading a full file without offset/limit, the output is reduced to a compact outline (imports, exports, signatures, preview) by default; use expand_artifact to retrieve the full content or specify offset/limit for a targeted slice.",
   parameters: {
     type: "object",
     properties: {
@@ -27,13 +102,27 @@ export const readTool: ToolSpec<Args> = {
   needsPermission: false,
   render: ({ path }) => ({ title: `read ${collapsePath(path, process.cwd())}` }),
   async run(args, ctx) {
-    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
+    if (aborted(ctx.signal)) throw abortError();
     const abs = resolvePath(ctx.cwd, args.path);
     const st = await stat(abs);
-    if (st.size > MAX_BYTES) throw new Error(`file too large: ${st.size} bytes (max ${MAX_BYTES})`);
-    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
+    if (aborted(ctx.signal)) throw abortError();
+
+    if (st.size > MAX_BYTES) {
+      // Large file: require an explicit slice and stream it. Refusing
+      // unbounded full reads protects the model context from a 5MB log
+      // file blowing the prompt budget.
+      if (args.offset === undefined || args.limit === undefined) {
+        throw new Error(
+          `file too large: ${st.size} bytes (max ${MAX_BYTES} for full read; supply offset+limit to stream a slice)`,
+        );
+      }
+      const lines = await readSliceStreaming(abs, args.offset, args.limit, ctx.signal);
+      return formatLines(lines, args.offset);
+    }
+
+    // Fast path: small file, read it all at once.
     const text = await readFile(abs, { encoding: "utf8", signal: ctx.signal });
-    if (ctx.signal?.aborted) throw new DOMException("aborted", "AbortError");
+    if (aborted(ctx.signal)) throw abortError();
     const lines = text.split("\n");
     const start = Math.max(0, (args.offset ?? 1) - 1);
     const end = args.limit ? Math.min(lines.length, start + args.limit) : lines.length;


### PR DESCRIPTION
## Summary

Closes the second half of **RF-13** (sync FS tools don't honor \`ctx.signal\`) — the read tool. With this PR the M3 reliability milestone is complete.

## What changed

\`src/tools/read.ts\` previously refused any file larger than \`MAX_BYTES\` (2 MB) outright with:

\`\`\`
file too large: 5242880 bytes (max 2097152)
\`\`\`

That's hostile to a real use case — sliced reads of large log files. It also meant a Ctrl+C during a slow read couldn't propagate (the entire \`readFile\` happens in one shot).

**New behavior:**

- **Below 2 MB**: unchanged. Single \`fs.readFile\` fast path.
- **Above 2 MB**: callers must supply both \`offset\` and \`limit\`. The file is then streamed line-by-line via \`fs.createReadStream\` + \`readline.createInterface\`, checking \`ctx.signal\` between iterations and destroying the underlying stream on abort.
- **50 MB hard ceiling** on bytes scanned while seeking a slice — protects against runaway reads like \`offset: 999_999_999\` on a multi-GB log file.

The error message for over-cap unbounded reads now points the model at the new path:

\`\`\`
file too large: 5242880 bytes (max 2097152 for full read; supply offset+limit to stream a slice)
\`\`\`

## Why protect the context

The 2 MB cap on full reads stays because read output goes straight into the LLM message stream. A 5 MB unbounded read would blow the prompt budget. The cap is now a "you must slice" guard, not a "you can't have this file" guard.

## New API surface

- \`readSliceStreaming(abs, offset, limit, signal?)\` is exported so it can be unit-tested directly without going through the tool's ToolContext.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 481/481 pass (8 new \`src/tools/read.test.ts\`)
- [x] \`npm run build\` — clean ESM + DTS
- [x] New tests cover:
  - small-file fast path (full + sliced)
  - large-file rejection without offset+limit
  - large-file rejection with offset but no limit
  - large-file slice returns the right lines
  - slice past EOF returns fewer lines (no error)
  - already-aborted signal rejects immediately
  - mid-stream abort fires within a tick
- [ ] Manual smoke (not runnable from this non-TTY environment): \`/clear\`, then ask the model to read a slice from a large log file (e.g. \`read path: foo.log offset: 1000 limit: 50\`); Ctrl+C during a slow streaming slice should cancel within a tick.

## Docs

Roadmap Progress log entry added; M3 marked complete. RF-13 status block in \`agent-loop-findings.md\` updated to reflect the new streaming path (\`write\`/\`edit\` check-at-start remains as future work).