### PR TITLE
feat(observability): log prompt preview + preTurnMs, surface routing in AI Gateway

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -244,10 +244,12 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const codeMode = opts.codeMode ?? false;
 
   // --- Pre-turn async work (memory recall + skill routing, in parallel) ---
+  const preTurnStart = performance.now();
   let memoryRecalledCount = 0;
   let skillResult: SemanticSkillRoutingResult | undefined;
 
   const lastUserPrompt = extractLastUserText(opts.messages);
+  const userPromptPreview = lastUserPrompt.slice(0, 200);
 
   // Light + trivially short prompts skip skill routing entirely. These almost
   // never benefit from injected skills and the embeddings round-trip dominates
@@ -346,6 +348,8 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   if (opts.signal.aborted) {
     throw new DOMException("aborted", "AbortError");
   }
+
+  const preTurnMs = Math.round(performance.now() - preTurnStart);
 
   opts.callbacks.onMetaBanner?.({
     intentTier: opts.intentClassification?.tier ?? "medium",
@@ -529,6 +533,10 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     }
 
     logger.debug("turn:api_request", { sessionId: opts.sessionId, messageCount: apiMessages.length });
+    // Cloudflare AI Gateway caps cf-aig-metadata at 5 keys. Keep the most
+    // queryable signals: feature + sessionId for tracing, tier/cm/skl for
+    // routing analysis from the dashboard. turnIdx is dropped here (still
+    // available in cost-debug.jsonl).
     const turnGateway = opts.gateway
       ? {
           ...opts.gateway,
@@ -536,7 +544,9 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
             ...(opts.gateway.metadata ?? {}),
             feature: "chat",
             ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
-            turnIdx: turn,
+            tier: opts.intentClassification?.tier ?? "medium",
+            cm: codeMode ? "1" : "0",
+            skl: String(skillResult?.sectionCount ?? 0),
           },
         }
       : undefined;
@@ -652,6 +662,13 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           toolResults,
           usage: lastUsage,
           shadowStrip: shadowStripMetrics,
+          durationMs: Math.round(performance.now() - turnStart),
+          intentClassification: opts.intentClassification,
+          codeMode: opts.codeMode,
+          selectedSkills: opts.selectedSkills,
+          userPromptPreview,
+          preTurnMs,
+          memoryRecalled: memoryRecalledCount > 0,
         });
       }
       if (budgetExhausted) {
@@ -1015,6 +1032,9 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
         intentClassification: opts.intentClassification,
         codeMode: opts.codeMode,
         selectedSkills: opts.selectedSkills,
+        userPromptPreview,
+        preTurnMs,
+        memoryRecalled: memoryRecalledCount > 0,
       });
     }
 

--- a/src/cost-debug.ts
+++ b/src/cost-debug.ts
@@ -69,6 +69,12 @@ export interface CostDebugEntry {
   intentClassification?: IntentClassification; // NEW: what we predicted
   codeMode?: boolean; // NEW: was Code Mode enabled this turn
   selectedSkills?: string[]; // NEW: skill names injected this turn
+  /** First 200 chars of the last user message in this turn — for quickly grepping logs. */
+  userPromptPreview?: string;
+  /** Wall-clock ms spent on pre-turn setup (memory recall + skill routing) before the first model call. */
+  preTurnMs?: number;
+  /** True if at least one memory was recalled and injected this turn. */
+  memoryRecalled?: boolean;
 }
 
 function debugDir(): string {
@@ -165,6 +171,9 @@ export interface TurnDebugContext {
   codeMode?: boolean;
   /** Skills injected into this turn */
   selectedSkills?: { name: string; body: string }[];
+  userPromptPreview?: string;
+  preTurnMs?: number;
+  memoryRecalled?: boolean;
 }
 
 /** Serialize the prompt prefix (all leading system messages) for comparison. */
@@ -274,6 +283,9 @@ export async function logTurnDebug(ctx: TurnDebugContext): Promise<void> {
     intentClassification: ctx.intentClassification,
     codeMode: ctx.codeMode,
     selectedSkills: ctx.selectedSkills?.map((s) => s.name),
+    userPromptPreview: ctx.userPromptPreview,
+    preTurnMs: ctx.preTurnMs,
+    memoryRecalled: ctx.memoryRecalled,
   });
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #449. That PR's squash-merge only picked up the parallelization commit; this commit (originally \`8f0876c\` on the same branch) never reached main. Re-applying it now via cherry-pick onto fresh main — clean apply, no conflicts with the M4.4/M4.5 refactors that landed in between.

**Two files, ~34 lines:**

1. \`src/cost-debug.ts\` — extends \`CostDebugEntry\` and \`TurnDebugContext\` with three optional fields:
   - \`userPromptPreview\` (first 200 chars of the last user message — so you can grep cost-debug.jsonl without cross-referencing transcripts)
   - \`preTurnMs\` (wall-clock spent on memory recall + skill routing before the first model call — the metric #449's parallelization is meant to move)
   - \`memoryRecalled\` (boolean for at-a-glance filtering)

2. \`src/agent/loop.ts\` — captures \`preTurnStart\`/\`preTurnMs\`, builds \`userPromptPreview\` from the last user message, threads all three into both \`logTurnDebug\` call sites, and extends \`cf-aig-metadata\` so the AI Gateway dashboard surfaces routing decisions per request:
   - \`tier\` (light/medium/heavy)
   - \`cm\` (\"0\"/\"1\" — code-mode)
   - \`skl\` (skill count as string)

Cloudflare AI Gateway caps \`cf-aig-metadata\` at 5 keys, so \`turnIdx\` was dropped to make room. It remains queryable via cost-debug.jsonl.

## Verification

Already verified end-to-end on the original branch by hitting the AI Gateway logs REST API after a print-mode turn — the new fields landed exactly as expected:

\`\`\`json
\"metadata\": {
  \"cm\": \"1\",
  \"feature\": \"chat\",
  \"skl\": \"0\",
  \"tier\": \"medium\"
}
\`\`\`

## Test plan
- [x] \`npm test\` — 461/461 pass
- [x] \`npx tsc --noEmit\` clean
- [x] Live verification against AI Gateway logs API (see above)
- [ ] After merge: confirm the Metadata panel in Cloudflare AI Gateway dashboard surfaces tier/cm/skl on new log rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)