### PR TITLE
refactor(ui): extract slash-command dispatcher from app.tsx

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -113,6 +113,7 @@ import {
   interruptOrExit as runInterruptOrExit,
   type InterruptDeps,
 } from "./ui/input-handlers.js";
+import { dispatchSlashCommand, type SlashContext } from "./ui/slash-commands.js";
 import { readFileSync } from "node:fs";
 
 /**
@@ -241,7 +242,7 @@ export function buildFilePickerIgnoreList(cwd: string): string[] {
   return [...hardcoded, ...gitignorePatterns];
 }
 
-interface Cfg {
+export interface Cfg {
   accountId: string;
   apiToken: string;
   model: string;
@@ -310,15 +311,15 @@ function gatewayUsageLookupFromConfig(
   };
 }
 
-const FEEDBACK_WORKER_URL = "https://hello.kimiflare.com";
+export const FEEDBACK_WORKER_URL = "https://hello.kimiflare.com";
 
-function openBrowser(url: string): void {
+export function openBrowser(url: string): void {
   const cmd = platform() === "darwin" ? "open" : platform() === "win32" ? "start" : "xdg-open";
   const child = spawn(cmd, [url], { detached: true, stdio: "ignore" });
   child.unref();
 }
 
-function detectGitHubRepo(cachedRepo?: string): { owner: string; name: string } | null {
+export function detectGitHubRepo(cachedRepo?: string): { owner: string; name: string } | null {
   if (cachedRepo) {
     const parts = cachedRepo.split("/");
     if (parts.length === 2) return { owner: parts[0]!, name: parts[1]! };
@@ -343,7 +344,7 @@ function detectGitBranch(): string | null {
   }
 }
 
-function formatTokens(n: number): string {
+export function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
@@ -1886,1034 +1887,79 @@ function App({
     [],
   );
 
+  const buildSlashContext = useCallback((): SlashContext => ({
+    exit,
+    busy,
+    mkKey,
+    setEvents,
+    cfg,
+    setCfg,
+    mode,
+    setMode,
+    setShowReasoning: turn.setShowReasoning,
+    setUsage,
+    setSessionUsage,
+    setGatewayMeta,
+    setHasUpdate,
+    setLatestVersion,
+    setShowThemePicker,
+    setShowInboxModal,
+    setShowLspWizard,
+    setShowRemoteDashboard,
+    setShowCommandList,
+    setCommandWizard,
+    setCommandPicker,
+    lspScope,
+    lspProjectPath,
+    resetSession,
+    clearTaskTracking,
+    openResumePicker,
+    runCompact,
+    runInit,
+    initMcp,
+    initLsp,
+    ensureSessionId,
+    lspManagerRef,
+    mcpManagerRef,
+    cacheStableRef,
+    messagesRef,
+    flushTimeoutRef,
+    pendingTextRef,
+    activeAsstIdRef,
+    pendingToolCallsRef,
+    usageRef,
+    turnCounterRef,
+    gatewayMetaRef,
+    executorRef,
+    mcpToolsRef,
+    mcpInitRef,
+    lspToolsRef,
+    lspInitRef,
+    sessionIdRef,
+    compactSuggestedRef,
+    updateNudgedRef,
+    memoryManagerRef,
+    artifactStoreRef,
+    sessionStateRef,
+    compiledContextRef,
+    lastApiErrorRef,
+    activeScopeRef,
+  }), [
+    exit, busy, cfg, mode, lspScope, lspProjectPath,
+    setCfg, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta,
+    setHasUpdate, setLatestVersion, setShowThemePicker, setShowInboxModal,
+    setShowLspWizard, setShowRemoteDashboard, setShowCommandList,
+    setCommandWizard, setCommandPicker,
+    turn.setShowReasoning,
+    resetSession, clearTaskTracking, openResumePicker, runCompact, runInit,
+    initMcp, initLsp, ensureSessionId,
+  ]);
+
   const handleSlash = useCallback(
-    (cmd: string): boolean => {
-      const raw = cmd.trim();
-      const [head, ...rest] = raw.split(/\s+/);
-      const c = (head ?? "").toLowerCase();
-      const arg = rest.join(" ").trim().toLowerCase();
-
-      if (c === "/exit" || c === "/quit") {
-        void lspManagerRef.current.stopAll().finally(() => exit());
-        return true;
-      }
-      if (c === "/clear") {
-        if (busy) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /clear while model is running — press Esc to interrupt first" }]);
-          return true;
-        }
-        if (cacheStableRef.current && messagesRef.current.length >= 2) {
-          messagesRef.current = [messagesRef.current[0]!, messagesRef.current[1]!];
-        } else {
-          messagesRef.current = [messagesRef.current[0]!];
-        }
-        resetSession();
-        executorRef.current.clearArtifacts();
-        if (flushTimeoutRef.current) {
-          clearTimeout(flushTimeoutRef.current);
-          flushTimeoutRef.current = null;
-        }
-        pendingTextRef.current.clear();
-        activeAsstIdRef.current = null;
-        pendingToolCallsRef.current.clear();
-        usageRef.current = null;
-        turnCounterRef.current = 0;
-        setEvents([]);
-        setUsage(null);
-        setSessionUsage(null);
-        gatewayMetaRef.current = null;
-        setGatewayMeta(null);
-        clearTaskTracking();
-        compactSuggestedRef.current = false;
-        updateNudgedRef.current = false;
-        return true;
-      }
-      if (c === "/reasoning") {
-        turn.setShowReasoning((s) => {
-          const next = !s;
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: `reasoning: ${next ? "shown" : "hidden"}` },
-          ]);
-          return next;
-        });
-        return true;
-      }
-      if (c === "/cost") {
-        if (!cfg) return true;
-        if (arg === "on") {
-          const next = { ...cfg, costAttribution: true };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cost attribution enabled" }]);
-          return true;
-        }
-        if (arg === "off") {
-          const next = { ...cfg, costAttribution: false };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cost attribution disabled" }]);
-          return true;
-        }
-        void getCostReport(sessionIdRef.current ?? undefined)
-          .then(async (report) => {
-            const lines = [formatCostReport(report)];
-            if (cfg?.aiGatewayId && process.env.KIMIFLARE_DISABLE_AI_GATEWAY !== "1") {
-              const sid = sessionIdRef.current;
-              const logs = sid ? await getSessionGatewayLogs(sid).catch(() => []) : [];
-              const gwSection = formatGatewaySection(report, cfg.accountId, cfg.aiGatewayId, logs);
-              if (gwSection) lines.push("", gwSection);
-
-              // Pull per-feature cost from the Gateway logs API (1-hour cache),
-              // and surface drift status alongside the local total.
-              try {
-                const { reconcileWithCloudflare } = await import("./cost-attribution/reconcile.js");
-                const today = new Date().toISOString().slice(0, 10);
-                const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-                  .toISOString()
-                  .slice(0, 10);
-                const recon = await reconcileWithCloudflare({
-                  localCost: report.month.cost,
-                  accountId: cfg.accountId,
-                  apiToken: cfg.apiToken,
-                  gatewayId: cfg.aiGatewayId,
-                  startDate: sevenDaysAgo,
-                  endDate: today,
-                });
-                const breakdown = formatFeatureBreakdown(recon.featureBreakdown);
-                if (breakdown) lines.push("", breakdown);
-              } catch {
-                /* best-effort; /cost still renders without the breakdown */
-              }
-            }
-            if (cfg?.costAttribution) {
-              const { getCategoryReportText } = await import("./cost-attribution/tui-report.js");
-              const catReport = await getCategoryReportText(sessionIdRef.current ?? undefined);
-              if (catReport) {
-                lines.push("", "─── Cost by task type ───", catReport);
-              }
-            }
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: lines.join("\n") },
-            ]);
-          })
-          .catch((err) => {
-            setEvents((e) => [
-              ...e,
-              { kind: "error", key: mkKey(), text: `cost report failed: ${(err as Error).message}` },
-            ]);
-          });
-        return true;
-      }
-      if (c === "/shell") {
-        if (!cfg) return true;
-        const valid = ["auto", "bash", "cmd", "powershell"];
-        if (arg === "auto" || arg === "bash" || arg === "cmd" || arg === "powershell") {
-          const next = { ...cfg, shell: arg === "auto" ? undefined : arg };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `shell set to ${arg}` }]);
-          return true;
-        }
-        if (arg) {
-          // Allow absolute paths as custom shells
-          const next = { ...cfg, shell: arg };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `shell set to ${arg}` }]);
-          return true;
-        }
-        const detected = getShellCommand(cfg.shell);
-        setEvents((e) => [
-          ...e,
-          {
-            kind: "info",
-            key: mkKey(),
-            text: `shell: ${cfg.shell ?? "auto"} (${detected.shell} ${detected.args.join(" ")})`,
-          },
-        ]);
-        return true;
-      }
-      if (c === "/model") {
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: `current model: ${cfg?.model ?? "unknown"}` },
-        ]);
-        return true;
-      }
-      if (c === "/gateway") {
-        if (!cfg) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no config loaded" }]);
-          return true;
-        }
-        if (cfg.cloudMode) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "AI Gateway is managed by Kimiflare Cloud" }]);
-          return true;
-        }
-        const sub = rest[0]?.toLowerCase() ?? "";
-        const subArg = rest.slice(1).join(" ").trim();
-
-        if (!sub || sub === "status") {
-          const lines: string[] = [];
-          if (cfg.aiGatewayId) {
-            lines.push(`gateway: ${cfg.aiGatewayId}`);
-            lines.push(`cache-ttl: ${cfg.aiGatewayCacheTtl ?? "default"}`);
-            lines.push(`skip-cache: ${cfg.aiGatewaySkipCache ?? false}`);
-            lines.push(`collect-logs: ${cfg.aiGatewayCollectLogPayload ?? false}`);
-            const meta = cfg.aiGatewayMetadata;
-            lines.push(`metadata: ${meta && Object.keys(meta).length > 0 ? JSON.stringify(meta) : "none"}`);
-            // Tack on the live cache-hit ratio for the current session — derived
-            // from the cf-aig-cache-status headers we've collected so far.
-            const sid = sessionIdRef.current;
-            if (sid) {
-              void getCostReport(sid).then((report) => {
-                const req = report.session.gatewayRequests ?? 0;
-                if (req === 0) return;
-                const cached = report.session.gatewayCachedRequests ?? 0;
-                const pct = ((cached / req) * 100).toFixed(1);
-                setEvents((e) => [
-                  ...e,
-                  {
-                    kind: "info",
-                    key: mkKey(),
-                    text: `cache hits (session): ${cached}/${req} (${pct}%)`,
-                  },
-                ]);
-              }).catch(() => {});
-            }
-          } else {
-            lines.push("gateway: off (direct Workers AI)");
-          }
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
-          return true;
-        }
-
-        if (sub === "off") {
-          const next = { ...cfg, aiGatewayId: undefined };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "gateway disabled — using direct Workers AI" }]);
-          return true;
-        }
-
-        if (sub === "cache-ttl") {
-          const ttl = parseInt(subArg, 10);
-          if (Number.isNaN(ttl) || ttl < 0) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway cache-ttl <seconds>" }]);
-            return true;
-          }
-          const next = { ...cfg, aiGatewayCacheTtl: ttl };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway cache-ttl set to ${ttl}s` }]);
-          return true;
-        }
-
-        if (sub === "skip-cache") {
-          const val = subArg === "true" ? true : subArg === "false" ? false : undefined;
-          if (val === undefined) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway skip-cache true|false" }]);
-            return true;
-          }
-          const next = { ...cfg, aiGatewaySkipCache: val };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway skip-cache set to ${val}` }]);
-          return true;
-        }
-
-        if (sub === "collect-logs") {
-          const val = subArg === "true" ? true : subArg === "false" ? false : undefined;
-          if (val === undefined) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway collect-logs true|false" }]);
-            return true;
-          }
-          const next = { ...cfg, aiGatewayCollectLogPayload: val };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway collect-logs set to ${val}` }]);
-          return true;
-        }
-
-        if (sub === "metadata") {
-          if (subArg === "clear") {
-            const next = { ...cfg, aiGatewayMetadata: undefined };
-            setCfg(next);
-            void saveConfig(next).catch(() => {});
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "gateway metadata cleared" }]);
-            return true;
-          }
-          const eq = subArg.indexOf("=");
-          if (eq === -1) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway metadata KEY=VALUE  or  /gateway metadata clear" }]);
-            return true;
-          }
-          const key = subArg.slice(0, eq).trim();
-          let value: string | number | boolean = subArg.slice(eq + 1).trim();
-          if (value === "true") value = true;
-          else if (value === "false") value = false;
-          else if (/^-?\d+$/.test(value)) value = parseInt(value, 10);
-          const nextMeta = { ...(cfg.aiGatewayMetadata ?? {}), [key]: value };
-          const next = { ...cfg, aiGatewayMetadata: nextMeta };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway metadata: ${key}=${JSON.stringify(value)}` }]);
-          return true;
-        }
-
-        // Default: treat sub as a gateway ID to enable
-        const next = { ...cfg, aiGatewayId: rest[0] };
-        setCfg(next);
-        void saveConfig(next).catch(() => {});
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway enabled: ${rest[0]}` }]);
-        return true;
-      }
-      if (c === "/mode") {
-        if (!arg) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: `current mode: ${mode}  ·  use /mode edit|plan|auto or shift+tab` },
-          ]);
-          return true;
-        }
-        if (arg === "edit" || arg === "plan" || arg === "auto") {
-          setMode(arg);
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: `mode: ${arg}` },
-          ]);
-          return true;
-        }
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "usage: /mode edit|plan|auto" },
-        ]);
-        return true;
-      }
-      if (c === "/theme") {
-        if (!arg) {
-          setShowThemePicker(true);
-          return true;
-        }
-        const next = resolveTheme(arg);
-        if (next.name === DEFAULT_THEME_NAME && arg !== DEFAULT_THEME_NAME) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: `unknown theme "${arg}" — available: ${themeNames().join(", ")}` },
-          ]);
-          return true;
-        }
-        setCfg((prev) => {
-          if (!prev) return prev;
-          const updated = { ...prev, theme: next.name };
-          void saveConfig(updated).catch(() => {});
-          return updated;
-        });
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: `theme: ${next.label} — restart to apply` },
-        ]);
-        return true;
-      }
-      if (c === "/plan") {
-        setMode("plan");
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: plan" }]);
-        return true;
-      }
-      if (c === "/auto") {
-        setMode("auto");
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: auto" }]);
-        return true;
-      }
-      if (c === "/edit") {
-        setMode("edit");
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "mode: edit" }]);
-        return true;
-      }
-      if (c === "/skills") {
-        const sub = rest[0]?.toLowerCase() ?? "";
-        const subRest = rest.slice(1).join(" ").trim();
-
-        if (sub === "list" || sub === "") {
-          void listAllSkills(process.cwd()).then((all) => {
-            const lines: string[] = [];
-            if (all.project.length > 0) {
-              lines.push("project skills:");
-              for (const s of all.project) {
-                const status = s.enabled ? "✓" : "✗";
-                lines.push(`  ${status} ${s.name} — ${s.description || "no description"} (${s.estimatedTokens} tokens)`);
-              }
-            }
-            if (all.global.length > 0) {
-              lines.push("global skills:");
-              for (const s of all.global) {
-                const status = s.enabled ? "✓" : "✗";
-                lines.push(`  ${status} ${s.name} — ${s.description || "no description"} (${s.estimatedTokens} tokens)`);
-              }
-            }
-            if (lines.length === 0) {
-              lines.push("no skills found. create one with /skills add <name>");
-            }
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
-          }).catch((err) => {
-            setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to list skills: ${(err as Error).message}` }]);
-          });
-          return true;
-        }
-
-        if (sub === "add") {
-          const name = subRest.trim();
-          if (!name) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills add <name>" }]);
-            return true;
-          }
-          void createSkill({ name, scope: "project", cwd: process.cwd() }).then((result) => {
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: `created skill '${name}' → ${result.filepath}` },
-              { kind: "info", key: mkKey(), text: `edit the file to add your instructions` },
-            ]);
-          }).catch((err) => {
-            setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to create skill: ${(err as Error).message}` }]);
-          });
-          return true;
-        }
-
-        if (sub === "edit") {
-          const name = subRest.trim();
-          if (!name) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills edit <name>" }]);
-            return true;
-          }
-          void findSkillFile(name, process.cwd()).then((filepath) => {
-            if (!filepath) {
-              setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `skill '${name}' not found` }]);
-              return;
-            }
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: `skill '${name}' → ${filepath}` },
-              { kind: "info", key: mkKey(), text: `open it in your editor to make changes` },
-            ]);
-          }).catch((err) => {
-            setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to find skill: ${(err as Error).message}` }]);
-          });
-          return true;
-        }
-
-        if (sub === "delete") {
-          const name = subRest.trim();
-          if (!name) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills delete <name>" }]);
-            return true;
-          }
-          void deleteSkill(name, process.cwd()).then((result) => {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `deleted skill '${name}' (${result.filepath})` }]);
-          }).catch((err) => {
-            setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to delete skill: ${(err as Error).message}` }]);
-          });
-          return true;
-        }
-
-        if (sub === "enable") {
-          const name = subRest.trim();
-          if (!name) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills enable <name>" }]);
-            return true;
-          }
-          void setSkillEnabled(name, true, process.cwd()).then((result) => {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `enabled skill '${name}' (${result.filepath})` }]);
-          }).catch((err) => {
-            setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to enable skill: ${(err as Error).message}` }]);
-          });
-          return true;
-        }
-
-        if (sub === "disable") {
-          const name = subRest.trim();
-          if (!name) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills disable <name>" }]);
-            return true;
-          }
-          void setSkillEnabled(name, false, process.cwd()).then((result) => {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `disabled skill '${name}' (${result.filepath})` }]);
-          }).catch((err) => {
-            setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to disable skill: ${(err as Error).message}` }]);
-          });
-          return true;
-        }
-
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "usage: /skills list | add <name> | edit <name> | delete <name> | enable <name> | disable <name>" },
-        ]);
-        return true;
-      }
-      if (c === "/memory") {
-        if (!cfg) return true;
-        if (arg === "on") {
-          const next = { ...cfg, memoryEnabled: true };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "memory", key: mkKey(), text: "memory enabled" }]);
-          return true;
-        }
-        if (arg === "off") {
-          const next = { ...cfg, memoryEnabled: false };
-          setCfg(next);
-          void saveConfig(next).catch(() => {});
-          setEvents((e) => [...e, { kind: "memory", key: mkKey(), text: "memory disabled" }]);
-          return true;
-        }
-        if (!cfg.memoryEnabled) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory is disabled. Use /memory on to enable it, or set KIMIFLARE_MEMORY_ENABLED=1" }]);
-          return true;
-        }
-        if (arg === "clear") {
-          const cleared = memoryManagerRef.current?.clearRepo(process.cwd()) ?? 0;
-          setEvents((e) => [...e, { kind: "memory", key: mkKey(), text: `cleared ${cleared} memories for this repo` }]);
-          return true;
-        }
-        if (arg.startsWith("search ")) {
-          const query = arg.slice(7).trim();
-          if (!query) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /memory search <query>" }]);
-            return true;
-          }
-          void memoryManagerRef.current?.recall({ text: query, repoPath: process.cwd(), limit: 10 }).then((results) => {
-            if (results.length === 0) {
-              setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "no memories found" }]);
-            } else {
-              const lines = results.map((r) => `  [${r.memory.category}] ${r.memory.content} (score: ${r.combinedScore.toFixed(2)})`);
-              setEvents((es) => [...es, { kind: "info", key: mkKey(), text: `memories:\n${lines.join("\n")}` }]);
-            }
-          });
-          return true;
-        }
-        const stats = memoryManagerRef.current?.getStats();
-        if (stats) {
-          const sizeKb = Math.round(stats.dbSizeBytes / 1024);
-          const lines = [
-            `total: ${stats.totalCount} memories (${sizeKb} KB)`,
-            `  fact: ${stats.byCategory.fact}, event: ${stats.byCategory.event}, instruction: ${stats.byCategory.instruction}`,
-            `  task: ${stats.byCategory.task}, preference: ${stats.byCategory.preference}`,
-            `last cleanup: ${stats.lastCleanupAt ? new Date(stats.lastCleanupAt).toISOString() : "never"}`,
-          ];
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
-        } else {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory manager not initialized" }]);
-        }
-        return true;
-      }
-      if (c === "/resume") {
-        void openResumePicker();
-        return true;
-      }
-      if (c === "/checkpoint") {
-        const label = rest.join(" ").trim() || `checkpoint ${new Date().toLocaleString()}`;
-        const turnIndex = messagesRef.current.length;
-        if (turnIndex === 0) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "nothing to checkpoint yet" }]);
-          return true;
-        }
-        const cp: Checkpoint = {
-          id: `cp_${Date.now()}`,
-          label,
-          turnIndex,
-          timestamp: new Date().toISOString(),
-          sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
-          artifactStore: serializeArtifactStore(artifactStoreRef.current),
-        };
-        void (async () => {
-          try {
-            ensureSessionId();
-            const { sessionsDir } = await import("./sessions.js");
-            const filePath = join(sessionsDir(), `${sessionIdRef.current}.json`);
-            await addCheckpoint(filePath, cp);
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `checkpoint saved: "${label}"` }]);
-          } catch (e) {
-            setEvents((es) => [
-              ...es,
-              { kind: "error", key: mkKey(), text: `checkpoint failed: ${(e as Error).message}` },
-            ]);
-          }
-        })();
-        return true;
-      }
-      if (c === "/checkpoints") {
-        const currentId = sessionIdRef.current;
-        if (!currentId) {
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no active session" }]);
-          return true;
-        }
-        void (async () => {
-          try {
-            const { sessionsDir } = await import("./sessions.js");
-            const file = await loadSession(join(sessionsDir(), `${currentId}.json`));
-            const cps = file.checkpoints ?? [];
-            if (cps.length === 0) {
-              setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no checkpoints in this session" }]);
-              return;
-            }
-            const lines = ["checkpoints:", ...cps.map((cp, i) => `  ${i + 1}. "${cp.label}" — turn ${cp.turnIndex} · ${new Date(cp.timestamp).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}`)];
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
-          } catch (e) {
-            setEvents((es) => [
-              ...es,
-              { kind: "error", key: mkKey(), text: `failed to list checkpoints: ${(e as Error).message}` },
-            ]);
-          }
-        })();
-        return true;
-      }
-      if (c === "/compact") {
-        void runCompact();
-        return true;
-      }
-      if (c === "/init") {
-        void runInit();
-        return true;
-      }
-      if (c === "/update") {
-        void checkForUpdate(true).then((result) => {
-          if (result.hasUpdate) {
-            setHasUpdate(true);
-            setLatestVersion(result.latestVersion);
-            setEvents((e) => [
-              ...e,
-              {
-                kind: "info",
-                key: mkKey(),
-                text: `update available: ${result.localVersion} → ${result.latestVersion}`,
-              },
-            ]);
-            setEvents((e) => [
-              ...e,
-              {
-                kind: "info",
-                key: mkKey(),
-                text: "run:  npm update -g kimiflare  then restart",
-              },
-            ]);
-          } else {
-            setHasUpdate(false);
-            setLatestVersion(null);
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: "no update available" },
-            ]);
-          }
-        });
-        return true;
-      }
-      if (c === "/mcp") {
-        if (arg === "list") {
-          const servers = mcpManagerRef.current.listServers();
-          if (servers.length === 0) {
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: "no MCP servers connected — add them to ~/.config/kimiflare/config.json" },
-            ]);
-          } else {
-            const lines = servers.map((s) => `  ${s.name} (${s.type}) — ${s.toolCount} tool${s.toolCount === 1 ? "" : "s"}`);
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: "MCP servers:\n" + lines.join("\n") },
-            ]);
-          }
-          return true;
-        }
-        if (arg === "reload") {
-          if (busy) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /mcp reload while model is running" }]);
-            return true;
-          }
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "reloading MCP servers..." }]);
-          for (const tool of mcpToolsRef.current) {
-            executorRef.current.unregister(tool.name);
-          }
-          mcpToolsRef.current = [];
-          mcpInitRef.current = false;
-          void initMcp();
-          return true;
-        }
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "usage: /mcp list | reload" },
-        ]);
-        return true;
-      }
-      if (c === "/lsp") {
-        if (arg === "list") {
-          const servers = lspManagerRef.current.listActive();
-          const scopeLine = lspScope === "project" && lspProjectPath
-            ? ` (project: ${lspProjectPath})`
-            : " (global config)";
-          if (servers.length === 0) {
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: `no LSP servers active${scopeLine}` },
-            ]);
-          } else {
-            const lines = servers.map((s) => `  ${s.id} (${s.rootUri}) — ${s.state}, ${s.toolCount} tool${s.toolCount === 1 ? "" : "s"}`);
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: `LSP servers${scopeLine}:\n` + lines.join("\n") },
-            ]);
-          }
-          return true;
-        }
-        if (arg === "reload") {
-          if (busy) {
-            setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /lsp reload while model is running" }]);
-            return true;
-          }
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "reloading LSP servers..." }]);
-          for (const tool of lspToolsRef.current) {
-            executorRef.current.unregister(tool.name);
-          }
-          lspToolsRef.current = [];
-          lspInitRef.current = false;
-          void initLsp().catch((e) => {
-            setEvents((es) => [...es, { kind: "error", key: mkKey(), text: `LSP reload failed: ${(e as Error).message}` }]);
-          });
-          return true;
-        }
-        if (arg === "scope") {
-          const scopeText = lspScope === "project" && lspProjectPath
-            ? `project scope: ${lspProjectPath}`
-            : "global scope: ~/.config/kimiflare/config.json";
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: scopeText },
-          ]);
-          return true;
-        }
-        if (arg === "config" || arg === "") {
-          setShowLspWizard(true);
-          return true;
-        }
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "usage: /lsp list | reload | scope | config" },
-        ]);
-        return true;
-      }
-      if (c === "/hello") {
-        const session = crypto.randomUUID();
-        const url = `${FEEDBACK_WORKER_URL}/?s=${session}&v=${getAppVersion()}`;
-        openBrowser(url);
-        void (async () => {
-          try {
-            const qr = await QRCode.toString(url, { type: "terminal", small: true });
-            const lines = qr.split("\n").map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
-            setEvents((e) => [
-              ...e,
-              {
-                kind: "qrcode",
-                key: mkKey(),
-                lines,
-                caption: "Scan this QR code with your phone to send a voice note:",
-              },
-              { kind: "info", key: mkKey(), text: "Also opened voice note page in your browser." },
-            ]);
-          } catch {
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: "Opened voice note page in your browser. Record your message there and hit Send when you're done." },
-            ]);
-          }
-        })();
-        return true;
-      }
-      if (c === "/inbox") {
-        setShowInboxModal(true);
-        return true;
-      }
-      if (c === "/report") {
-        const err = lastApiErrorRef.current;
-        if (!err) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: "No recent API error to report." },
-          ]);
-          return true;
-        }
-        const note = rest.join(" ").trim();
-        const isSend = note.toLowerCase() === "send" || note.toLowerCase().startsWith("send ");
-        if (!isSend) {
-          const preview = [
-            "Report preview:",
-            `  Error: ${err.message}`,
-            err.httpStatus !== undefined ? `  HTTP ${err.httpStatus}` : "",
-            err.code !== undefined ? `  Code: ${err.code}` : "",
-            note ? `  Note: ${note}` : "",
-            "",
-            "Type `/report send` to submit or `/report send <note>` to add context.",
-          ].filter(Boolean).join("\n");
-          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: preview }]);
-          return true;
-        }
-        const userNote = note.slice(4).trim() || undefined;
-        const payload = buildReport({
-          errorMessage: err.message,
-          httpStatus: err.httpStatus,
-          errorCode: err.code,
-          sessionId: sessionIdRef.current ?? undefined,
-          userNote,
-          model: cfg?.model,
-          cloudMode: cfg?.cloudMode,
-        });
-        void sendReport(payload, cfg?.cloudToken).then((result) => {
-          setEvents((e) => [
-            ...e,
-            { kind: result.ok ? "info" : "error", key: mkKey(), text: result.message },
-          ]);
-          if (result.ok) {
-            lastApiErrorRef.current = null;
-          }
-        });
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "Sending report…" },
-        ]);
-        return true;
-      }
-      if (c === "/logout") {
-        unlink(configPath()).catch(() => {});
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: `credentials cleared from ${configPath()}` },
-        ]);
-        setCfg(null);
-        return true;
-      }
-      if (c === "/command") {
-        const sub = rest[0]?.toLowerCase() ?? "";
-        if (sub === "create") {
-          setCommandWizard({ mode: "create" });
-          return true;
-        }
-        if (sub === "edit") {
-          setCommandPicker({ mode: "edit" });
-          return true;
-        }
-        if (sub === "delete") {
-          setCommandPicker({ mode: "delete" });
-          return true;
-        }
-        if (sub === "list") {
-          setShowCommandList(true);
-          return true;
-        }
-        setEvents((e) => [
-          ...e,
-          { kind: "info", key: mkKey(), text: "usage: /command create | edit | delete | list" },
-        ]);
-        return true;
-      }
-      if (c === "/remote") {
-        if (arg === "status" || arg === "cancel") {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: `Use \`kimiflare remote ${arg}\` from your shell.` },
-          ]);
-          return true;
-        }
-
-        const prompt = rest.join(" ").trim();
-        if (!prompt) {
-          setShowRemoteDashboard(true);
-          return true;
-        }
-
-        const repo = detectGitHubRepo(cfg?.githubRepo);
-        if (!repo) {
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: "Could not detect GitHub repo. Run from a repo with a GitHub remote, or set githubRepo in config." },
-          ]);
-          return true;
-        }
-
-        (async () => {
-          if (!cfg?.remoteWorkerUrl) {
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: "Remote infrastructure not deployed yet. Setting up now (~2 min)..." },
-            ]);
-
-            try {
-              for await (const step of deployForTui()) {
-                setEvents((e) => [
-                  ...e,
-                  { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
-                ]);
-                if (step.done) break;
-              }
-            } catch {
-              setEvents((e) => [
-                ...e,
-                { kind: "error", key: mkKey(), text: "Deploy failed. Fix the issue above and try /remote again." },
-              ]);
-              return;
-            }
-
-            const { loadConfig: reloadConfig } = await import("./config.js");
-            const newCfg = await reloadConfig();
-            if (newCfg) setCfg(newCfg);
-          }
-
-          const currentCfg = cfg ?? (await loadConfig());
-          if (!currentCfg?.remoteWorkerUrl) {
-            setEvents((e) => [
-              ...e,
-              { kind: "error", key: mkKey(), text: "Deploy seemed to succeed but config wasn't saved. Try again." },
-            ]);
-            return;
-          }
-
-          if (!currentCfg.githubOAuthToken) {
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: "GitHub not authenticated. Starting OAuth device flow..." },
-            ]);
-
-            try {
-              for await (const step of authGitHubForTui()) {
-                setEvents((e) => [
-                  ...e,
-                  { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
-                ]);
-                if (step.done) break;
-              }
-            } catch {
-              setEvents((e) => [
-                ...e,
-                { kind: "error", key: mkKey(), text: "GitHub auth failed. Try `kimiflare auth github` from shell." },
-              ]);
-              return;
-            }
-
-            const { loadConfig: reloadConfig } = await import("./config.js");
-            const newCfg = await reloadConfig();
-            if (newCfg) setCfg(newCfg);
-          }
-
-          const finalCfg = (await loadConfig()) ?? currentCfg;
-
-          const ttl = finalCfg.remoteTtlMinutes ?? 30;
-          const budget = finalCfg.remoteMaxInputTokens ?? 5_000_000;
-          setEvents((e) => [
-            ...e,
-            { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
-            { kind: "info", key: mkKey(), text: `Budget: ${formatTokens(budget)} tokens. TTL: ${ttl} min.` },
-          ]);
-
-          try {
-            const data = await startRemoteSession({
-              prompt,
-              repo,
-              cfg: finalCfg,
-              ttlMinutes: finalCfg.remoteTtlMinutes,
-              tokensBudget: finalCfg.remoteMaxInputTokens,
-            });
-            setEvents((e) => [
-              ...e,
-              { kind: "info", key: mkKey(), text: `Session started: ${data.sessionId}` },
-            ]);
-
-            for await (const ev of streamRemoteProgress(
-              finalCfg.remoteWorkerUrl!,
-              data.sessionId,
-              activeScopeRef.current?.signal,
-            )) {
-              const event = ev as Record<string, unknown>;
-              if (event.type === "text_delta") {
-                setEvents((e) => [
-                  ...e,
-                  { kind: "info", key: mkKey(), text: String(event.text ?? "") },
-                ]);
-              } else if (event.type === "tool_call") {
-                setEvents((e) => [
-                  ...e,
-                  { kind: "info", key: mkKey(), text: `→ ${String(event.name ?? "")}` },
-                ]);
-              } else if (event.type === "done") {
-                const prUrl = event.prUrl as string | undefined;
-                const tokensUsed = event.tokensUsed as number | undefined;
-                const tokensBudget = event.tokensBudget as number | undefined;
-                setEvents((e) => [
-                  ...e,
-                  { kind: "info", key: mkKey(), text: prUrl ? `Done — PR: ${prUrl}` : "Done" },
-                ]);
-                await saveRemoteSession({
-                  sessionId: data.sessionId,
-                  prompt,
-                  repo: `${repo.owner}/${repo.name}`,
-                  workerUrl: finalCfg.remoteWorkerUrl!,
-                  status: "done",
-                  prUrl,
-                  tokensUsed,
-                  tokensBudget,
-                  createdAt: new Date().toISOString(),
-                  updatedAt: new Date().toISOString(),
-                });
-              } else if (event.type === "error") {
-                const message = String(event.message ?? "");
-                const category = event.category as RemoteSession["errorCategory"] | undefined;
-                setEvents((e) => [
-                  ...e,
-                  { kind: "error", key: mkKey(), text: `Remote error: ${message}` },
-                ]);
-                await saveRemoteSession({
-                  sessionId: data.sessionId,
-                  prompt,
-                  repo: `${repo.owner}/${repo.name}`,
-                  workerUrl: finalCfg.remoteWorkerUrl!,
-                  status: "error",
-                  errorCategory: category ?? "unknown",
-                  errorSummary: message,
-                  errorMessage: message,
-                  createdAt: new Date().toISOString(),
-                  updatedAt: new Date().toISOString(),
-                });
-              }
-            }
-          } catch (err) {
-            setEvents((e) => [
-              ...e,
-              { kind: "error", key: mkKey(), text: `Failed: ${err instanceof Error ? err.message : String(err)}` },
-            ]);
-          }
-        })();
-
-        return true;
-      }
-      if (c === "/help") {
-        const lines = [
-          "commands:",
-          "  /mode edit|plan|auto     switch agent mode",
-          "  /skills list|add|edit|... manage skills",
-          "  /memory on|off|clear      manage memory",
-          "  /cost                     show cost report",
-          "  /compact                  summarize old turns",
-          "  /resume                   pick a past session",
-          "  /checkpoint [label]       save current point in session",
-          "  /checkpoints              list checkpoints in session",
-          "  /clear                    clear conversation",
-          "  /init                     scan repo and write KIMI.md",
-          "  /update                   check for updates",
-          "  /exit                     exit kimiflare",
-        ];
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
-        return true;
-      }
-      return false;
-    },
-    [cfg, exit, usage, theme, mode, openResumePicker, runCompact, runInit, initMcp, setCfg, setShowRemoteDashboard, setSelectedRemoteSession],
+    (cmd: string): boolean => dispatchSlashCommand(buildSlashContext(), cmd),
+    [buildSlashContext],
   );
+
 
   const handleCommandSave = useCallback(
     async (opts: SaveCustomCommandOptions) => {

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -1,0 +1,1250 @@
+/**
+ * Slash-command dispatcher extracted from app.tsx.
+ *
+ * Each handler reads/writes app state through the `SlashContext` interface
+ * — the same "deps bag" pattern used by `input-handlers.ts`. The dispatcher
+ * matches the first whitespace-delimited token (lowercased) against the
+ * registry. Behaviorally identical to the previous in-component
+ * `handleSlash` callback.
+ */
+import React from "react";
+import { join } from "node:path";
+import { unlink } from "node:fs/promises";
+import QRCode from "qrcode";
+
+import type { Cfg } from "../app.js";
+import { configPath, loadConfig, saveConfig } from "../config.js";
+import type { ChatEvent } from "./chat.js";
+import type { ChatMessage, Usage } from "../agent/messages.js";
+import type { GatewayMeta } from "../agent/client.js";
+import type { Mode } from "../mode.js";
+import type { DailyUsage } from "../usage-tracker.js";
+import {
+  formatCostReport,
+  formatFeatureBreakdown,
+  formatGatewaySection,
+  getCostReport,
+  getSessionGatewayLogs,
+} from "../usage-tracker.js";
+import { resolveTheme, themeNames, DEFAULT_THEME_NAME } from "./theme.js";
+import { getShellCommand } from "../tools/bash.js";
+import {
+  createSkill,
+  deleteSkill,
+  findSkillFile,
+  listAllSkills,
+  setSkillEnabled,
+} from "../skills/manager.js";
+import {
+  addCheckpoint,
+  loadSession,
+  type Checkpoint,
+} from "../sessions.js";
+import {
+  type ArtifactStore,
+  serializeArtifactStore,
+  type SessionState,
+} from "../agent/session-state.js";
+import type { ToolExecutor } from "../tools/executor.js";
+import type { ToolSpec } from "../tools/registry.js";
+import type { McpManager } from "../mcp/manager.js";
+import type { LspManager } from "../lsp/manager.js";
+import type { MemoryManager } from "../memory/manager.js";
+import type { AbortScope } from "../util/abort-scope.js";
+import type { CustomCommand } from "../commands/types.js";
+import { buildReport, sendReport } from "../cloud/report.js";
+import { checkForUpdate } from "../util/update-check.js";
+import { getAppVersion } from "../util/version.js";
+import {
+  detectGitHubRepo,
+  FEEDBACK_WORKER_URL,
+  formatTokens,
+  openBrowser,
+} from "../app.js";
+import { startRemoteSession, streamRemoteProgress } from "../remote/worker-client.js";
+import { saveRemoteSession, type RemoteSession } from "../remote/session-store.js";
+import { deployForTui } from "../remote/deploy.js";
+import { authGitHubForTui } from "../remote/tui-auth.js";
+
+type SetEvents = React.Dispatch<React.SetStateAction<ChatEvent[]>>;
+
+export interface SlashContext {
+  // App-level
+  exit: () => void;
+  busy: boolean;
+  mkKey: () => string;
+  setEvents: SetEvents;
+
+  // Config
+  cfg: Cfg | null;
+  setCfg: React.Dispatch<React.SetStateAction<Cfg | null>>;
+
+  // Mode / reasoning
+  mode: Mode;
+  setMode: React.Dispatch<React.SetStateAction<Mode>>;
+  setShowReasoning: React.Dispatch<React.SetStateAction<boolean>>;
+
+  // Misc UI state setters
+  setUsage: React.Dispatch<React.SetStateAction<Usage | null>>;
+  setSessionUsage: React.Dispatch<React.SetStateAction<DailyUsage | null>>;
+  setGatewayMeta: React.Dispatch<React.SetStateAction<GatewayMeta | null>>;
+  setHasUpdate: React.Dispatch<React.SetStateAction<boolean>>;
+  setLatestVersion: React.Dispatch<React.SetStateAction<string | null>>;
+
+  // Modal setters
+  setShowThemePicker: (v: boolean) => void;
+  setShowInboxModal: (v: boolean) => void;
+  setShowLspWizard: (v: boolean) => void;
+  setShowRemoteDashboard: (v: boolean) => void;
+  setShowCommandList: (v: boolean) => void;
+  setCommandWizard: (v: { mode: "create" | "edit"; command?: CustomCommand } | null) => void;
+  setCommandPicker: (v: { mode: "edit" | "delete" } | null) => void;
+
+  // LSP scope (for /lsp scope)
+  lspScope: "project" | "global";
+  lspProjectPath: string | null;
+
+  // Async actions exposed by useCallback hooks in App
+  resetSession: () => void;
+  clearTaskTracking: () => void;
+  openResumePicker: () => void | Promise<void>;
+  runCompact: () => Promise<void> | void;
+  runInit: () => Promise<void> | void;
+  initMcp: () => Promise<void> | void;
+  initLsp: () => Promise<void> | void;
+  ensureSessionId: () => unknown;
+
+  // Refs
+  lspManagerRef: React.MutableRefObject<LspManager>;
+  mcpManagerRef: React.MutableRefObject<McpManager>;
+  cacheStableRef: React.MutableRefObject<boolean>;
+  messagesRef: React.MutableRefObject<ChatMessage[]>;
+  flushTimeoutRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  pendingTextRef: React.MutableRefObject<Map<number, { text: string; reasoning: string }>>;
+  activeAsstIdRef: React.MutableRefObject<number | null>;
+  pendingToolCallsRef: React.MutableRefObject<Map<string, string>>;
+  usageRef: React.MutableRefObject<Usage | null>;
+  turnCounterRef: React.MutableRefObject<number>;
+  gatewayMetaRef: React.MutableRefObject<GatewayMeta | null>;
+  executorRef: React.MutableRefObject<ToolExecutor>;
+  mcpToolsRef: React.MutableRefObject<ToolSpec[]>;
+  mcpInitRef: React.MutableRefObject<boolean>;
+  lspToolsRef: React.MutableRefObject<ToolSpec[]>;
+  lspInitRef: React.MutableRefObject<boolean>;
+  sessionIdRef: React.MutableRefObject<string | null>;
+  compactSuggestedRef: React.MutableRefObject<boolean>;
+  updateNudgedRef: React.MutableRefObject<boolean>;
+  memoryManagerRef: React.MutableRefObject<MemoryManager | null>;
+  artifactStoreRef: React.MutableRefObject<ArtifactStore>;
+  sessionStateRef: React.MutableRefObject<SessionState>;
+  compiledContextRef: React.MutableRefObject<boolean>;
+  lastApiErrorRef: React.MutableRefObject<{ httpStatus?: number; code?: number; message: string } | null>;
+  activeScopeRef: React.MutableRefObject<AbortScope | null>;
+}
+
+type Handler = (ctx: SlashContext, rest: string[], arg: string) => boolean;
+
+// ── Handlers ─────────────────────────────────────────────────────────────
+
+const handleExit: Handler = (ctx) => {
+  void ctx.lspManagerRef.current.stopAll().finally(() => ctx.exit());
+  return true;
+};
+
+const handleClear: Handler = (ctx) => {
+  const { busy, mkKey, setEvents } = ctx;
+  if (busy) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "can't /clear while model is running — press Esc to interrupt first" },
+    ]);
+    return true;
+  }
+  if (ctx.cacheStableRef.current && ctx.messagesRef.current.length >= 2) {
+    ctx.messagesRef.current = [ctx.messagesRef.current[0]!, ctx.messagesRef.current[1]!];
+  } else {
+    ctx.messagesRef.current = [ctx.messagesRef.current[0]!];
+  }
+  ctx.resetSession();
+  ctx.executorRef.current.clearArtifacts();
+  if (ctx.flushTimeoutRef.current) {
+    clearTimeout(ctx.flushTimeoutRef.current);
+    ctx.flushTimeoutRef.current = null;
+  }
+  ctx.pendingTextRef.current.clear();
+  ctx.activeAsstIdRef.current = null;
+  ctx.pendingToolCallsRef.current.clear();
+  ctx.usageRef.current = null;
+  ctx.turnCounterRef.current = 0;
+  setEvents([]);
+  ctx.setUsage(null);
+  ctx.setSessionUsage(null);
+  ctx.gatewayMetaRef.current = null;
+  ctx.setGatewayMeta(null);
+  ctx.clearTaskTracking();
+  ctx.compactSuggestedRef.current = false;
+  ctx.updateNudgedRef.current = false;
+  return true;
+};
+
+const handleReasoning: Handler = (ctx) => {
+  ctx.setShowReasoning((s) => {
+    const next = !s;
+    ctx.setEvents((e) => [
+      ...e,
+      { kind: "info", key: ctx.mkKey(), text: `reasoning: ${next ? "shown" : "hidden"}` },
+    ]);
+    return next;
+  });
+  return true;
+};
+
+const handleCost: Handler = (ctx, _rest, arg) => {
+  const { cfg, setCfg, setEvents, mkKey, sessionIdRef } = ctx;
+  if (!cfg) return true;
+  if (arg === "on") {
+    const next = { ...cfg, costAttribution: true };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cost attribution enabled" }]);
+    return true;
+  }
+  if (arg === "off") {
+    const next = { ...cfg, costAttribution: false };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cost attribution disabled" }]);
+    return true;
+  }
+  void getCostReport(sessionIdRef.current ?? undefined)
+    .then(async (report) => {
+      const lines = [formatCostReport(report)];
+      if (cfg?.aiGatewayId && process.env.KIMIFLARE_DISABLE_AI_GATEWAY !== "1") {
+        const sid = sessionIdRef.current;
+        const logs = sid ? await getSessionGatewayLogs(sid).catch(() => []) : [];
+        const gwSection = formatGatewaySection(report, cfg.accountId, cfg.aiGatewayId, logs);
+        if (gwSection) lines.push("", gwSection);
+
+        // Pull per-feature cost from the Gateway logs API (1-hour cache),
+        // and surface drift status alongside the local total.
+        try {
+          const { reconcileWithCloudflare } = await import("../cost-attribution/reconcile.js");
+          const today = new Date().toISOString().slice(0, 10);
+          const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10);
+          const recon = await reconcileWithCloudflare({
+            localCost: report.month.cost,
+            accountId: cfg.accountId,
+            apiToken: cfg.apiToken,
+            gatewayId: cfg.aiGatewayId,
+            startDate: sevenDaysAgo,
+            endDate: today,
+          });
+          const breakdown = formatFeatureBreakdown(recon.featureBreakdown);
+          if (breakdown) lines.push("", breakdown);
+        } catch {
+          /* best-effort; /cost still renders without the breakdown */
+        }
+      }
+      if (cfg?.costAttribution) {
+        const { getCategoryReportText } = await import("../cost-attribution/tui-report.js");
+        const catReport = await getCategoryReportText(sessionIdRef.current ?? undefined);
+        if (catReport) {
+          lines.push("", "─── Cost by task type ───", catReport);
+        }
+      }
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
+    })
+    .catch((err) => {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: `cost report failed: ${(err as Error).message}` },
+      ]);
+    });
+  return true;
+};
+
+const handleShell: Handler = (ctx, _rest, arg) => {
+  const { cfg, setCfg, setEvents, mkKey } = ctx;
+  if (!cfg) return true;
+  if (arg === "auto" || arg === "bash" || arg === "cmd" || arg === "powershell") {
+    const next = { ...cfg, shell: arg === "auto" ? undefined : arg };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `shell set to ${arg}` }]);
+    return true;
+  }
+  if (arg) {
+    // Allow absolute paths as custom shells
+    const next = { ...cfg, shell: arg };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `shell set to ${arg}` }]);
+    return true;
+  }
+  const detected = getShellCommand(cfg.shell);
+  setEvents((e) => [
+    ...e,
+    {
+      kind: "info",
+      key: mkKey(),
+      text: `shell: ${cfg.shell ?? "auto"} (${detected.shell} ${detected.args.join(" ")})`,
+    },
+  ]);
+  return true;
+};
+
+const handleModel: Handler = (ctx) => {
+  ctx.setEvents((e) => [
+    ...e,
+    { kind: "info", key: ctx.mkKey(), text: `current model: ${ctx.cfg?.model ?? "unknown"}` },
+  ]);
+  return true;
+};
+
+const handleGateway: Handler = (ctx, rest) => {
+  const { cfg, setCfg, setEvents, mkKey, sessionIdRef } = ctx;
+  if (!cfg) {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no config loaded" }]);
+    return true;
+  }
+  if (cfg.cloudMode) {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "AI Gateway is managed by Kimiflare Cloud" }]);
+    return true;
+  }
+  const sub = rest[0]?.toLowerCase() ?? "";
+  const subArg = rest.slice(1).join(" ").trim();
+
+  if (!sub || sub === "status") {
+    const lines: string[] = [];
+    if (cfg.aiGatewayId) {
+      lines.push(`gateway: ${cfg.aiGatewayId}`);
+      lines.push(`cache-ttl: ${cfg.aiGatewayCacheTtl ?? "default"}`);
+      lines.push(`skip-cache: ${cfg.aiGatewaySkipCache ?? false}`);
+      lines.push(`collect-logs: ${cfg.aiGatewayCollectLogPayload ?? false}`);
+      const meta = cfg.aiGatewayMetadata;
+      lines.push(`metadata: ${meta && Object.keys(meta).length > 0 ? JSON.stringify(meta) : "none"}`);
+      // Tack on the live cache-hit ratio for the current session — derived
+      // from the cf-aig-cache-status headers we've collected so far.
+      const sid = sessionIdRef.current;
+      if (sid) {
+        void getCostReport(sid)
+          .then((report) => {
+            const req = report.session.gatewayRequests ?? 0;
+            if (req === 0) return;
+            const cached = report.session.gatewayCachedRequests ?? 0;
+            const pct = ((cached / req) * 100).toFixed(1);
+            setEvents((e) => [
+              ...e,
+              { kind: "info", key: mkKey(), text: `cache hits (session): ${cached}/${req} (${pct}%)` },
+            ]);
+          })
+          .catch(() => {});
+      }
+    } else {
+      lines.push("gateway: off (direct Workers AI)");
+    }
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
+    return true;
+  }
+
+  if (sub === "off") {
+    const next = { ...cfg, aiGatewayId: undefined };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "gateway disabled — using direct Workers AI" }]);
+    return true;
+  }
+
+  if (sub === "cache-ttl") {
+    const ttl = parseInt(subArg, 10);
+    if (Number.isNaN(ttl) || ttl < 0) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway cache-ttl <seconds>" }]);
+      return true;
+    }
+    const next = { ...cfg, aiGatewayCacheTtl: ttl };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway cache-ttl set to ${ttl}s` }]);
+    return true;
+  }
+
+  if (sub === "skip-cache") {
+    const val = subArg === "true" ? true : subArg === "false" ? false : undefined;
+    if (val === undefined) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway skip-cache true|false" }]);
+      return true;
+    }
+    const next = { ...cfg, aiGatewaySkipCache: val };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway skip-cache set to ${val}` }]);
+    return true;
+  }
+
+  if (sub === "collect-logs") {
+    const val = subArg === "true" ? true : subArg === "false" ? false : undefined;
+    if (val === undefined) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /gateway collect-logs true|false" }]);
+      return true;
+    }
+    const next = { ...cfg, aiGatewayCollectLogPayload: val };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway collect-logs set to ${val}` }]);
+    return true;
+  }
+
+  if (sub === "metadata") {
+    if (subArg === "clear") {
+      const next = { ...cfg, aiGatewayMetadata: undefined };
+      setCfg(next);
+      void saveConfig(next).catch(() => {});
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "gateway metadata cleared" }]);
+      return true;
+    }
+    const eq = subArg.indexOf("=");
+    if (eq === -1) {
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: "usage: /gateway metadata KEY=VALUE  or  /gateway metadata clear" },
+      ]);
+      return true;
+    }
+    const key = subArg.slice(0, eq).trim();
+    let value: string | number | boolean = subArg.slice(eq + 1).trim();
+    if (value === "true") value = true;
+    else if (value === "false") value = false;
+    else if (/^-?\d+$/.test(value)) value = parseInt(value, 10);
+    const nextMeta = { ...(cfg.aiGatewayMetadata ?? {}), [key]: value };
+    const next = { ...cfg, aiGatewayMetadata: nextMeta };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: `gateway metadata: ${key}=${JSON.stringify(value)}` },
+    ]);
+    return true;
+  }
+
+  // Default: treat sub as a gateway ID to enable
+  const next = { ...cfg, aiGatewayId: rest[0] };
+  setCfg(next);
+  void saveConfig(next).catch(() => {});
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `gateway enabled: ${rest[0]}` }]);
+  return true;
+};
+
+const handleMode: Handler = (ctx, _rest, arg) => {
+  const { setEvents, mkKey } = ctx;
+  if (!arg) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: `current mode: ${ctx.mode}  ·  use /mode edit|plan|auto or shift+tab` },
+    ]);
+    return true;
+  }
+  if (arg === "edit" || arg === "plan" || arg === "auto") {
+    ctx.setMode(arg);
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `mode: ${arg}` }]);
+    return true;
+  }
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /mode edit|plan|auto" }]);
+  return true;
+};
+
+const handleTheme: Handler = (ctx, _rest, arg) => {
+  const { setEvents, mkKey } = ctx;
+  if (!arg) {
+    ctx.setShowThemePicker(true);
+    return true;
+  }
+  const next = resolveTheme(arg);
+  if (next.name === DEFAULT_THEME_NAME && arg !== DEFAULT_THEME_NAME) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: `unknown theme "${arg}" — available: ${themeNames().join(", ")}` },
+    ]);
+    return true;
+  }
+  ctx.setCfg((prev) => {
+    if (!prev) return prev;
+    const updated = { ...prev, theme: next.name };
+    void saveConfig(updated).catch(() => {});
+    return updated;
+  });
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `theme: ${next.label} — restart to apply` }]);
+  return true;
+};
+
+const handlePlan: Handler = (ctx) => {
+  ctx.setMode("plan");
+  ctx.setEvents((e) => [...e, { kind: "info", key: ctx.mkKey(), text: "mode: plan" }]);
+  return true;
+};
+
+const handleAuto: Handler = (ctx) => {
+  ctx.setMode("auto");
+  ctx.setEvents((e) => [...e, { kind: "info", key: ctx.mkKey(), text: "mode: auto" }]);
+  return true;
+};
+
+const handleEdit: Handler = (ctx) => {
+  ctx.setMode("edit");
+  ctx.setEvents((e) => [...e, { kind: "info", key: ctx.mkKey(), text: "mode: edit" }]);
+  return true;
+};
+
+const handleSkills: Handler = (ctx, rest) => {
+  const { setEvents, mkKey } = ctx;
+  const sub = rest[0]?.toLowerCase() ?? "";
+  const subRest = rest.slice(1).join(" ").trim();
+
+  if (sub === "list" || sub === "") {
+    void listAllSkills(process.cwd())
+      .then((all) => {
+        const lines: string[] = [];
+        if (all.project.length > 0) {
+          lines.push("project skills:");
+          for (const s of all.project) {
+            const status = s.enabled ? "✓" : "✗";
+            lines.push(`  ${status} ${s.name} — ${s.description || "no description"} (${s.estimatedTokens} tokens)`);
+          }
+        }
+        if (all.global.length > 0) {
+          lines.push("global skills:");
+          for (const s of all.global) {
+            const status = s.enabled ? "✓" : "✗";
+            lines.push(`  ${status} ${s.name} — ${s.description || "no description"} (${s.estimatedTokens} tokens)`);
+          }
+        }
+        if (lines.length === 0) {
+          lines.push("no skills found. create one with /skills add <name>");
+        }
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
+      })
+      .catch((err) => {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to list skills: ${(err as Error).message}` }]);
+      });
+    return true;
+  }
+
+  if (sub === "add") {
+    const name = subRest.trim();
+    if (!name) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills add <name>" }]);
+      return true;
+    }
+    void createSkill({ name, scope: "project", cwd: process.cwd() })
+      .then((result) => {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `created skill '${name}' → ${result.filepath}` },
+          { kind: "info", key: mkKey(), text: `edit the file to add your instructions` },
+        ]);
+      })
+      .catch((err) => {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to create skill: ${(err as Error).message}` }]);
+      });
+    return true;
+  }
+
+  if (sub === "edit") {
+    const name = subRest.trim();
+    if (!name) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills edit <name>" }]);
+      return true;
+    }
+    void findSkillFile(name, process.cwd())
+      .then((filepath) => {
+        if (!filepath) {
+          setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `skill '${name}' not found` }]);
+          return;
+        }
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: `skill '${name}' → ${filepath}` },
+          { kind: "info", key: mkKey(), text: `open it in your editor to make changes` },
+        ]);
+      })
+      .catch((err) => {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to find skill: ${(err as Error).message}` }]);
+      });
+    return true;
+  }
+
+  if (sub === "delete") {
+    const name = subRest.trim();
+    if (!name) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills delete <name>" }]);
+      return true;
+    }
+    void deleteSkill(name, process.cwd())
+      .then((result) => {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `deleted skill '${name}' (${result.filepath})` }]);
+      })
+      .catch((err) => {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to delete skill: ${(err as Error).message}` }]);
+      });
+    return true;
+  }
+
+  if (sub === "enable") {
+    const name = subRest.trim();
+    if (!name) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills enable <name>" }]);
+      return true;
+    }
+    void setSkillEnabled(name, true, process.cwd())
+      .then((result) => {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `enabled skill '${name}' (${result.filepath})` }]);
+      })
+      .catch((err) => {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to enable skill: ${(err as Error).message}` }]);
+      });
+    return true;
+  }
+
+  if (sub === "disable") {
+    const name = subRest.trim();
+    if (!name) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /skills disable <name>" }]);
+      return true;
+    }
+    void setSkillEnabled(name, false, process.cwd())
+      .then((result) => {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `disabled skill '${name}' (${result.filepath})` }]);
+      })
+      .catch((err) => {
+        setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `failed to disable skill: ${(err as Error).message}` }]);
+      });
+    return true;
+  }
+
+  setEvents((e) => [
+    ...e,
+    {
+      kind: "info",
+      key: mkKey(),
+      text: "usage: /skills list | add <name> | edit <name> | delete <name> | enable <name> | disable <name>",
+    },
+  ]);
+  return true;
+};
+
+const handleMemory: Handler = (ctx, _rest, arg) => {
+  const { cfg, setCfg, setEvents, mkKey, memoryManagerRef } = ctx;
+  if (!cfg) return true;
+  if (arg === "on") {
+    const next = { ...cfg, memoryEnabled: true };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "memory", key: mkKey(), text: "memory enabled" }]);
+    return true;
+  }
+  if (arg === "off") {
+    const next = { ...cfg, memoryEnabled: false };
+    setCfg(next);
+    void saveConfig(next).catch(() => {});
+    setEvents((e) => [...e, { kind: "memory", key: mkKey(), text: "memory disabled" }]);
+    return true;
+  }
+  if (!cfg.memoryEnabled) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "memory is disabled. Use /memory on to enable it, or set KIMIFLARE_MEMORY_ENABLED=1" },
+    ]);
+    return true;
+  }
+  if (arg === "clear") {
+    const cleared = memoryManagerRef.current?.clearRepo(process.cwd()) ?? 0;
+    setEvents((e) => [...e, { kind: "memory", key: mkKey(), text: `cleared ${cleared} memories for this repo` }]);
+    return true;
+  }
+  if (arg.startsWith("search ")) {
+    const query = arg.slice(7).trim();
+    if (!query) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /memory search <query>" }]);
+      return true;
+    }
+    void memoryManagerRef.current?.recall({ text: query, repoPath: process.cwd(), limit: 10 }).then((results) => {
+      if (results.length === 0) {
+        setEvents((es) => [...es, { kind: "info", key: mkKey(), text: "no memories found" }]);
+      } else {
+        const lines = results.map((r) => `  [${r.memory.category}] ${r.memory.content} (score: ${r.combinedScore.toFixed(2)})`);
+        setEvents((es) => [...es, { kind: "info", key: mkKey(), text: `memories:\n${lines.join("\n")}` }]);
+      }
+    });
+    return true;
+  }
+  const stats = memoryManagerRef.current?.getStats();
+  if (stats) {
+    const sizeKb = Math.round(stats.dbSizeBytes / 1024);
+    const lines = [
+      `total: ${stats.totalCount} memories (${sizeKb} KB)`,
+      `  fact: ${stats.byCategory.fact}, event: ${stats.byCategory.event}, instruction: ${stats.byCategory.instruction}`,
+      `  task: ${stats.byCategory.task}, preference: ${stats.byCategory.preference}`,
+      `last cleanup: ${stats.lastCleanupAt ? new Date(stats.lastCleanupAt).toISOString() : "never"}`,
+    ];
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
+  } else {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "memory manager not initialized" }]);
+  }
+  return true;
+};
+
+const handleResume: Handler = (ctx) => {
+  void ctx.openResumePicker();
+  return true;
+};
+
+const handleCheckpoint: Handler = (ctx, rest) => {
+  const { setEvents, mkKey } = ctx;
+  const label = rest.join(" ").trim() || `checkpoint ${new Date().toLocaleString()}`;
+  const turnIndex = ctx.messagesRef.current.length;
+  if (turnIndex === 0) {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "nothing to checkpoint yet" }]);
+    return true;
+  }
+  const cp: Checkpoint = {
+    id: `cp_${Date.now()}`,
+    label,
+    turnIndex,
+    timestamp: new Date().toISOString(),
+    sessionState: ctx.compiledContextRef.current ? ctx.sessionStateRef.current : undefined,
+    artifactStore: serializeArtifactStore(ctx.artifactStoreRef.current),
+  };
+  void (async () => {
+    try {
+      ctx.ensureSessionId();
+      const { sessionsDir } = await import("../sessions.js");
+      const filePath = join(sessionsDir(), `${ctx.sessionIdRef.current}.json`);
+      await addCheckpoint(filePath, cp);
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `checkpoint saved: "${label}"` }]);
+    } catch (e) {
+      setEvents((es) => [
+        ...es,
+        { kind: "error", key: mkKey(), text: `checkpoint failed: ${(e as Error).message}` },
+      ]);
+    }
+  })();
+  return true;
+};
+
+const handleCheckpoints: Handler = (ctx) => {
+  const { setEvents, mkKey, sessionIdRef } = ctx;
+  const currentId = sessionIdRef.current;
+  if (!currentId) {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no active session" }]);
+    return true;
+  }
+  void (async () => {
+    try {
+      const { sessionsDir } = await import("../sessions.js");
+      const file = await loadSession(join(sessionsDir(), `${currentId}.json`));
+      const cps = file.checkpoints ?? [];
+      if (cps.length === 0) {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no checkpoints in this session" }]);
+        return;
+      }
+      const lines = [
+        "checkpoints:",
+        ...cps.map(
+          (cp, i) =>
+            `  ${i + 1}. "${cp.label}" — turn ${cp.turnIndex} · ${new Date(cp.timestamp).toLocaleString(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}`,
+        ),
+      ];
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: lines.join("\n") }]);
+    } catch (e) {
+      setEvents((es) => [
+        ...es,
+        { kind: "error", key: mkKey(), text: `failed to list checkpoints: ${(e as Error).message}` },
+      ]);
+    }
+  })();
+  return true;
+};
+
+const handleCompact: Handler = (ctx) => {
+  void ctx.runCompact();
+  return true;
+};
+
+const handleInit: Handler = (ctx) => {
+  void ctx.runInit();
+  return true;
+};
+
+const handleUpdate: Handler = (ctx) => {
+  const { setEvents, mkKey } = ctx;
+  void checkForUpdate(true).then((result) => {
+    if (result.hasUpdate) {
+      ctx.setHasUpdate(true);
+      ctx.setLatestVersion(result.latestVersion);
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: `update available: ${result.localVersion} → ${result.latestVersion}` },
+      ]);
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: "run:  npm update -g kimiflare  then restart" },
+      ]);
+    } else {
+      ctx.setHasUpdate(false);
+      ctx.setLatestVersion(null);
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "no update available" }]);
+    }
+  });
+  return true;
+};
+
+const handleMcp: Handler = (ctx, _rest, arg) => {
+  const { setEvents, mkKey, busy } = ctx;
+  if (arg === "list") {
+    const servers = ctx.mcpManagerRef.current.listServers();
+    if (servers.length === 0) {
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: "no MCP servers connected — add them to ~/.config/kimiflare/config.json" },
+      ]);
+    } else {
+      const lines = servers.map((s) => `  ${s.name} (${s.type}) — ${s.toolCount} tool${s.toolCount === 1 ? "" : "s"}`);
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "MCP servers:\n" + lines.join("\n") }]);
+    }
+    return true;
+  }
+  if (arg === "reload") {
+    if (busy) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /mcp reload while model is running" }]);
+      return true;
+    }
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "reloading MCP servers..." }]);
+    for (const tool of ctx.mcpToolsRef.current) {
+      ctx.executorRef.current.unregister(tool.name);
+    }
+    ctx.mcpToolsRef.current = [];
+    ctx.mcpInitRef.current = false;
+    void ctx.initMcp();
+    return true;
+  }
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /mcp list | reload" }]);
+  return true;
+};
+
+const handleLsp: Handler = (ctx, _rest, arg) => {
+  const { setEvents, mkKey, busy, lspScope, lspProjectPath } = ctx;
+  if (arg === "list") {
+    const servers = ctx.lspManagerRef.current.listActive();
+    const scopeLine =
+      lspScope === "project" && lspProjectPath ? ` (project: ${lspProjectPath})` : " (global config)";
+    if (servers.length === 0) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `no LSP servers active${scopeLine}` }]);
+    } else {
+      const lines = servers.map(
+        (s) => `  ${s.id} (${s.rootUri}) — ${s.state}, ${s.toolCount} tool${s.toolCount === 1 ? "" : "s"}`,
+      );
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: `LSP servers${scopeLine}:\n` + lines.join("\n") },
+      ]);
+    }
+    return true;
+  }
+  if (arg === "reload") {
+    if (busy) {
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /lsp reload while model is running" }]);
+      return true;
+    }
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "reloading LSP servers..." }]);
+    for (const tool of ctx.lspToolsRef.current) {
+      ctx.executorRef.current.unregister(tool.name);
+    }
+    ctx.lspToolsRef.current = [];
+    ctx.lspInitRef.current = false;
+    void Promise.resolve(ctx.initLsp()).catch((e) => {
+      setEvents((es) => [
+        ...es,
+        { kind: "error", key: mkKey(), text: `LSP reload failed: ${(e as Error).message}` },
+      ]);
+    });
+    return true;
+  }
+  if (arg === "scope") {
+    const scopeText =
+      lspScope === "project" && lspProjectPath
+        ? `project scope: ${lspProjectPath}`
+        : "global scope: ~/.config/kimiflare/config.json";
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: scopeText }]);
+    return true;
+  }
+  if (arg === "config" || arg === "") {
+    ctx.setShowLspWizard(true);
+    return true;
+  }
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /lsp list | reload | scope | config" }]);
+  return true;
+};
+
+const handleHello: Handler = (ctx) => {
+  const { setEvents, mkKey } = ctx;
+  const session = crypto.randomUUID();
+  const url = `${FEEDBACK_WORKER_URL}/?s=${session}&v=${getAppVersion()}`;
+  openBrowser(url);
+  void (async () => {
+    try {
+      const qr = await QRCode.toString(url, { type: "terminal", small: true });
+      const lines = qr.split("\n").map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+      setEvents((e) => [
+        ...e,
+        {
+          kind: "qrcode",
+          key: mkKey(),
+          lines,
+          caption: "Scan this QR code with your phone to send a voice note:",
+        },
+        { kind: "info", key: mkKey(), text: "Also opened voice note page in your browser." },
+      ]);
+    } catch {
+      setEvents((e) => [
+        ...e,
+        {
+          kind: "info",
+          key: mkKey(),
+          text: "Opened voice note page in your browser. Record your message there and hit Send when you're done.",
+        },
+      ]);
+    }
+  })();
+  return true;
+};
+
+const handleInbox: Handler = (ctx) => {
+  ctx.setShowInboxModal(true);
+  return true;
+};
+
+const handleReport: Handler = (ctx, rest) => {
+  const { setEvents, mkKey, cfg, lastApiErrorRef, sessionIdRef } = ctx;
+  const err = lastApiErrorRef.current;
+  if (!err) {
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "No recent API error to report." }]);
+    return true;
+  }
+  const note = rest.join(" ").trim();
+  const isSend = note.toLowerCase() === "send" || note.toLowerCase().startsWith("send ");
+  if (!isSend) {
+    const preview = [
+      "Report preview:",
+      `  Error: ${err.message}`,
+      err.httpStatus !== undefined ? `  HTTP ${err.httpStatus}` : "",
+      err.code !== undefined ? `  Code: ${err.code}` : "",
+      note ? `  Note: ${note}` : "",
+      "",
+      "Type `/report send` to submit or `/report send <note>` to add context.",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    setEvents((e) => [...e, { kind: "info", key: mkKey(), text: preview }]);
+    return true;
+  }
+  const userNote = note.slice(4).trim() || undefined;
+  const payload = buildReport({
+    errorMessage: err.message,
+    httpStatus: err.httpStatus,
+    errorCode: err.code,
+    sessionId: sessionIdRef.current ?? undefined,
+    userNote,
+    model: cfg?.model,
+    cloudMode: cfg?.cloudMode,
+  });
+  void sendReport(payload, cfg?.cloudToken).then((result) => {
+    setEvents((e) => [...e, { kind: result.ok ? "info" : "error", key: mkKey(), text: result.message }]);
+    if (result.ok) {
+      lastApiErrorRef.current = null;
+    }
+  });
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "Sending report…" }]);
+  return true;
+};
+
+const handleLogout: Handler = (ctx) => {
+  unlink(configPath()).catch(() => {});
+  ctx.setEvents((e) => [
+    ...e,
+    { kind: "info", key: ctx.mkKey(), text: `credentials cleared from ${configPath()}` },
+  ]);
+  ctx.setCfg(null);
+  return true;
+};
+
+const handleCommand: Handler = (ctx, rest) => {
+  const { setEvents, mkKey } = ctx;
+  const sub = rest[0]?.toLowerCase() ?? "";
+  if (sub === "create") {
+    ctx.setCommandWizard({ mode: "create" });
+    return true;
+  }
+  if (sub === "edit") {
+    ctx.setCommandPicker({ mode: "edit" });
+    return true;
+  }
+  if (sub === "delete") {
+    ctx.setCommandPicker({ mode: "delete" });
+    return true;
+  }
+  if (sub === "list") {
+    ctx.setShowCommandList(true);
+    return true;
+  }
+  setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /command create | edit | delete | list" }]);
+  return true;
+};
+
+const handleRemote: Handler = (ctx, rest, arg) => {
+  const { setEvents, mkKey, cfg, setCfg, activeScopeRef } = ctx;
+  if (arg === "status" || arg === "cancel") {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: `Use \`kimiflare remote ${arg}\` from your shell.` },
+    ]);
+    return true;
+  }
+
+  const prompt = rest.join(" ").trim();
+  if (!prompt) {
+    ctx.setShowRemoteDashboard(true);
+    return true;
+  }
+
+  const repo = detectGitHubRepo(cfg?.githubRepo);
+  if (!repo) {
+    setEvents((e) => [
+      ...e,
+      {
+        kind: "info",
+        key: mkKey(),
+        text: "Could not detect GitHub repo. Run from a repo with a GitHub remote, or set githubRepo in config.",
+      },
+    ]);
+    return true;
+  }
+
+  (async () => {
+    if (!cfg?.remoteWorkerUrl) {
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: "Remote infrastructure not deployed yet. Setting up now (~2 min)..." },
+      ]);
+
+      try {
+        for await (const step of deployForTui()) {
+          setEvents((e) => [
+            ...e,
+            { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
+          ]);
+          if (step.done) break;
+        }
+      } catch {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: "Deploy failed. Fix the issue above and try /remote again." },
+        ]);
+        return;
+      }
+
+      const { loadConfig: reloadConfig } = await import("../config.js");
+      const newCfg = await reloadConfig();
+      if (newCfg) setCfg(newCfg);
+    }
+
+    const currentCfg = cfg ?? (await loadConfig());
+    if (!currentCfg?.remoteWorkerUrl) {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: "Deploy seemed to succeed but config wasn't saved. Try again." },
+      ]);
+      return;
+    }
+
+    if (!currentCfg.githubOAuthToken) {
+      setEvents((e) => [
+        ...e,
+        { kind: "info", key: mkKey(), text: "GitHub not authenticated. Starting OAuth device flow..." },
+      ]);
+
+      try {
+        for await (const step of authGitHubForTui()) {
+          setEvents((e) => [
+            ...e,
+            { kind: step.error ? "error" : "info", key: mkKey(), text: step.message },
+          ]);
+          if (step.done) break;
+        }
+      } catch {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: "GitHub auth failed. Try `kimiflare auth github` from shell." },
+        ]);
+        return;
+      }
+
+      const { loadConfig: reloadConfig } = await import("../config.js");
+      const newCfg = await reloadConfig();
+      if (newCfg) setCfg(newCfg);
+    }
+
+    const finalCfg = (await loadConfig()) ?? currentCfg;
+
+    const ttl = finalCfg.remoteTtlMinutes ?? 30;
+    const budget = finalCfg.remoteMaxInputTokens ?? 5_000_000;
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: `Starting remote session for ${repo.owner}/${repo.name}...` },
+      { kind: "info", key: mkKey(), text: `Budget: ${formatTokens(budget)} tokens. TTL: ${ttl} min.` },
+    ]);
+
+    try {
+      const data = await startRemoteSession({
+        prompt,
+        repo,
+        cfg: finalCfg,
+        ttlMinutes: finalCfg.remoteTtlMinutes,
+        tokensBudget: finalCfg.remoteMaxInputTokens,
+      });
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `Session started: ${data.sessionId}` }]);
+
+      for await (const ev of streamRemoteProgress(
+        finalCfg.remoteWorkerUrl!,
+        data.sessionId,
+        activeScopeRef.current?.signal,
+      )) {
+        const event = ev as Record<string, unknown>;
+        if (event.type === "text_delta") {
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: String(event.text ?? "") }]);
+        } else if (event.type === "tool_call") {
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `→ ${String(event.name ?? "")}` }]);
+        } else if (event.type === "done") {
+          const prUrl = event.prUrl as string | undefined;
+          const tokensUsed = event.tokensUsed as number | undefined;
+          const tokensBudget = event.tokensBudget as number | undefined;
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: prUrl ? `Done — PR: ${prUrl}` : "Done" },
+          ]);
+          await saveRemoteSession({
+            sessionId: data.sessionId,
+            prompt,
+            repo: `${repo.owner}/${repo.name}`,
+            workerUrl: finalCfg.remoteWorkerUrl!,
+            status: "done",
+            prUrl,
+            tokensUsed,
+            tokensBudget,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        } else if (event.type === "error") {
+          const message = String(event.message ?? "");
+          const category = event.category as RemoteSession["errorCategory"] | undefined;
+          setEvents((e) => [...e, { kind: "error", key: mkKey(), text: `Remote error: ${message}` }]);
+          await saveRemoteSession({
+            sessionId: data.sessionId,
+            prompt,
+            repo: `${repo.owner}/${repo.name}`,
+            workerUrl: finalCfg.remoteWorkerUrl!,
+            status: "error",
+            errorCategory: category ?? "unknown",
+            errorSummary: message,
+            errorMessage: message,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        }
+      }
+    } catch (err) {
+      setEvents((e) => [
+        ...e,
+        { kind: "error", key: mkKey(), text: `Failed: ${err instanceof Error ? err.message : String(err)}` },
+      ]);
+    }
+  })();
+
+  return true;
+};
+
+const handleHelp: Handler = (ctx) => {
+  const lines = [
+    "commands:",
+    "  /mode edit|plan|auto     switch agent mode",
+    "  /skills list|add|edit|... manage skills",
+    "  /memory on|off|clear      manage memory",
+    "  /cost                     show cost report",
+    "  /compact                  summarize old turns",
+    "  /resume                   pick a past session",
+    "  /checkpoint [label]       save current point in session",
+    "  /checkpoints              list checkpoints in session",
+    "  /clear                    clear conversation",
+    "  /init                     scan repo and write KIMI.md",
+    "  /update                   check for updates",
+    "  /exit                     exit kimiflare",
+  ];
+  ctx.setEvents((e) => [...e, { kind: "info", key: ctx.mkKey(), text: lines.join("\n") }]);
+  return true;
+};
+
+// ── Registry ─────────────────────────────────────────────────────────────
+
+const handlers: Record<string, Handler> = {
+  "/exit": handleExit,
+  "/quit": handleExit,
+  "/clear": handleClear,
+  "/reasoning": handleReasoning,
+  "/cost": handleCost,
+  "/shell": handleShell,
+  "/model": handleModel,
+  "/gateway": handleGateway,
+  "/mode": handleMode,
+  "/theme": handleTheme,
+  "/plan": handlePlan,
+  "/auto": handleAuto,
+  "/edit": handleEdit,
+  "/skills": handleSkills,
+  "/memory": handleMemory,
+  "/resume": handleResume,
+  "/checkpoint": handleCheckpoint,
+  "/checkpoints": handleCheckpoints,
+  "/compact": handleCompact,
+  "/init": handleInit,
+  "/update": handleUpdate,
+  "/mcp": handleMcp,
+  "/lsp": handleLsp,
+  "/hello": handleHello,
+  "/inbox": handleInbox,
+  "/report": handleReport,
+  "/logout": handleLogout,
+  "/command": handleCommand,
+  "/remote": handleRemote,
+  "/help": handleHelp,
+};
+
+/**
+ * Match the first whitespace-delimited token of `cmd` (lowercased) against
+ * the slash-command registry. Returns true if a handler consumed the
+ * command, false if `cmd` is unrecognized (so the caller can fall through
+ * to custom-command lookup).
+ */
+export function dispatchSlashCommand(ctx: SlashContext, cmd: string): boolean {
+  const raw = cmd.trim();
+  const [head, ...rest] = raw.split(/\s+/);
+  const c = (head ?? "").toLowerCase();
+  const arg = rest.join(" ").trim().toLowerCase();
+  const handler = handlers[c];
+  if (!handler) return false;
+  return handler(ctx, rest, arg);
+}


### PR DESCRIPTION
## Summary
- Move the ~1000-line `handleSlash` useCallback out of `app.tsx` into `src/ui/slash-commands.ts`, mirroring the deps-bag pattern already used by `input-handlers.ts`.
- `app.tsx` now builds a `SlashContext` and calls `dispatchSlashCommand`; all 30 commands (`/exit`, `/clear`, `/cost`, `/gateway`, `/mode`, `/theme`, `/skills`, `/memory`, `/checkpoint(s)`, `/mcp`, `/lsp`, `/remote`, `/report`, `/help`, …) keep identical behavior.
- `app.tsx`: **3877 → 2923 lines (−954, −24.6%)**.
- Exported a few helpers from `app.tsx` for reuse by the new module: `Cfg`, `FEEDBACK_WORKER_URL`, `openBrowser`, `detectGitHubRepo`, `formatTokens`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 473/473 pass
- [ ] Manual smoke: run each command group at least once (`/help`, `/mode`, `/cost`, `/gateway status`, `/skills list`, `/memory`, `/checkpoint`, `/mcp list`, `/lsp list`, `/theme`, `/clear`, `/remote`, `/report`, `/update`, `/init`, `/compact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)