### PR TITLE
feat(telemetry): structured JSON log sink + correlation IDs (M5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,35 @@ kimiflare
 | `Shift+Tab` | Cycle mode (edit → plan → auto) |
 | `↑` / `↓` | Walk prompt history |
 
+## Logs
+
+KimiFlare writes structured JSON logs of agent-side activity (tool calls,
+permission decisions, MCP/LSP lifecycle, session events, errors) to
+`~/.config/kimiflare/logs/<date>.jsonl`, one file per day, with 7-day
+retention pruned automatically at startup.
+
+The logs deliberately exclude prompts and completions — those live in
+[Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/)
+already, and each log entry includes the Gateway `request_id` so you
+can join them when you need the network side.
+
+```sh
+kimiflare logs path             # today's file
+kimiflare logs dir              # log directory
+kimiflare logs prune            # delete files older than 7 days
+
+# Tail this session's activity, formatted:
+tail -f $(kimiflare logs path) | jq
+
+# Find the slowest tool calls in the last day:
+jq -r 'select(.event == "tool:end") | "\(.data.duration_ms)\t\(.data.tool)"' \
+  $(kimiflare logs path) | sort -rn | head
+```
+
+Disable the file sink entirely with `KIMIFLARE_LOG_SINK=off`. The
+separate `KIMIFLARE_LOG_LEVEL` env var (default `off`) controls stderr
+output — independent of the file sink.
+
 ## Development
 
 ```sh

--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,8 +15,27 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
+- **M5.1** — Structured JSON logs to disk *(OP-20)* — *(this PR)*.
+  `src/util/log-sink.ts` adds a file sink to the existing structured
+  logger: one JSONL file per day at
+  `~/.config/kimiflare/logs/<date>.jsonl`, 7-day retention pruned at
+  startup. Always-on by default (disable with `KIMIFLARE_LOG_SINK=off`)
+  and independent of `KIMIFLARE_LOG_LEVEL` (which only gates stderr).
+  Correlation IDs lifted to top-level fields: `session_id` (from the
+  M4.4 session manager — set automatically on `ensureSessionId` /
+  resume / reset), `turn_id`, and `request_id` (snake_case preferred,
+  legacy camelCase also lifted for back-compat with existing
+  `src/agent/client.ts` call sites). Cloudflare AI Gateway already
+  has the request/response bodies — we deliberately do NOT replicate
+  them locally; just log thin events and join on `request_id` later.
+  New `kimiflare logs path | dir | prune` CLI subcommands. App emits
+  a one-liner on startup pointing at today's path. README section
+  added. 17 new unit tests cover daily rotation, retention pruning,
+  correlation-ID lifting, and the disable knob. Node test runner is
+  auto-detected so unit tests don't pollute the user's real config
+  dir.
 - **M3.4** — Streaming read for large files *(RF-13 second half)* —
-  *(this PR)*. `src/tools/read.ts` previously refused any file over
+  merged in #454. `src/tools/read.ts` previously refused any file over
   2 MB outright. Files above the cap now require an explicit
   `offset`+`limit` slice and stream line-by-line, checking
   `ctx.signal` between chunks and destroying the underlying read
@@ -405,13 +424,17 @@ driven.
 
 **PRs:**
 
-- **M5.1** — `feat(telemetry): structured JSON logs`
-  *(OP-20)*
-  - Emit `{ timestamp, level, module, event, fields }` to
-    `~/.config/kimiflare/logs/<date>.jsonl`.
-  - All existing `console.log` / `console.warn` migrated.
-  - Log rotation policy (7 days, as the existing constant suggests
-    was intended).
+- ✅ **M5.1** — `feat(telemetry): structured JSON logs`
+  *(OP-20)* — *merged in this PR*. File sink in
+  `src/util/log-sink.ts`; daily rotation, 7-day retention,
+  always-on by default. Correlation IDs (`session_id`, `turn_id`,
+  `request_id`) lifted to top-level so a future `jq` join with
+  Cloudflare AI Gateway's per-request log Just Works. Deliberately
+  omits prompt/completion bodies (Gateway has them).
+  Existing `logger.*` call sites now flow through the file sink
+  automatically — no migration of `console.log` / `console.warn`
+  required since the agent loop was already using `logger`. New
+  `kimiflare logs path | dir | prune` CLI subcommands.
 - **M5.2** — `feat(telemetry): optional OTel export`
   *(OP-20)*
   - `KIMIFLARE_OTEL_ENDPOINT` env var → emit OTLP. No-op if unset.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -822,6 +822,24 @@ function App({
       }),
     );
 
+    // Prune old structured logs (M5.1) and surface the current path once.
+    void import("./util/log-sink.js").then(({ pruneOldLogs, logPathFor, isLogSinkEnabled }) => {
+      if (!isLogSinkEnabled()) return;
+      try {
+        pruneOldLogs();
+      } catch {
+        // Non-fatal: log retention is best-effort.
+      }
+      setEvents((e) => [
+        ...e,
+        {
+          kind: "info",
+          key: mkKey(),
+          text: `structured logs: ${logPathFor()} (tail with: tail -f $(kimiflare logs path) | jq)`,
+        },
+      ]);
+    });
+
     // Show creator welcome message once per version
     void shouldShowCreatorMessage(getAppVersion()).then((shouldShow) => {
       if (shouldShow) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,6 +77,35 @@ program
 
 program.addCommand(createRemoteCommand());
 
+const logsCmd = program
+  .command("logs")
+  .description("Inspect KimiFlare's structured logs (jsonl, one file per day, 7-day retention)");
+
+logsCmd
+  .command("path")
+  .description("Print today's log file path. Useful for tailing: tail -f $(kimiflare logs path) | jq")
+  .action(async () => {
+    const { logPathFor } = await import("./util/log-sink.js");
+    console.log(logPathFor());
+  });
+
+logsCmd
+  .command("dir")
+  .description("Print the log directory")
+  .action(async () => {
+    const { logDir } = await import("./util/log-sink.js");
+    console.log(logDir());
+  });
+
+logsCmd
+  .command("prune")
+  .description("Delete log files older than 7 days")
+  .action(async () => {
+    const { pruneOldLogs } = await import("./util/log-sink.js");
+    const removed = pruneOldLogs();
+    console.log(`pruned ${removed} log files`);
+  });
+
 program
   .command("auth")
   .description("Authenticate with external services")

--- a/src/ui/use-session-manager.ts
+++ b/src/ui/use-session-manager.ts
@@ -21,6 +21,7 @@ import type { MemoryManager } from "../memory/manager.js";
 import { getCostReport } from "../usage-tracker.js";
 import type { DailyUsage } from "../usage-tracker.js";
 import type { ChatEvent } from "./chat.js";
+import { setLogSessionId } from "../util/log-sink.js";
 
 /**
  * Pull the first chunk of user text out of a message list — used to
@@ -108,6 +109,7 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
     if (sessionIdRef.current) return sessionIdRef.current;
     const text = extractFirstUserText(depsRef.current.messagesRef.current);
     sessionIdRef.current = makeSessionId(text);
+    setLogSessionId(sessionIdRef.current);
     return sessionIdRef.current;
   }, []);
 
@@ -153,6 +155,7 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
           : await loadSession(filePath);
         d.messagesRef.current = file.messages;
         sessionIdRef.current = file.id;
+        setLogSessionId(file.id);
         sessionCreatedAtRef.current = file.createdAt;
         if (file.sessionState && d.compiledContextRef.current) {
           d.sessionStateRef.current = file.sessionState;
@@ -255,6 +258,7 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
 
   const resetSession = useCallback(() => {
     sessionIdRef.current = null;
+    setLogSessionId(null);
     sessionCreatedAtRef.current = null;
     sessionTitleRef.current = null;
     const d = depsRef.current;

--- a/src/util/log-sink.test.ts
+++ b/src/util/log-sink.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  logDir,
+  logPathFor,
+  setLogDirForTesting,
+  setLogSinkEnabled,
+  isLogSinkEnabled,
+  writeLogLine,
+  pruneOldLogs,
+  setLogSessionId,
+  getLogSessionId,
+  setLogTurnId,
+  getLogTurnId,
+  flushAndCloseForTesting,
+} from "./log-sink.js";
+
+let dir: string;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "log-sink-test-"));
+  setLogDirForTesting(dir);
+  setLogSinkEnabled(true);
+});
+
+after(() => {
+  setLogDirForTesting(null);
+  setLogSinkEnabled(true);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  // Close any cached stream from the previous test before unlinking the
+  // file it points at — otherwise the next write goes to a dead fd.
+  await flushAndCloseForTesting();
+  for (const f of readdirSync(dir)) {
+    rmSync(join(dir, f), { force: true });
+  }
+  setLogSessionId(null);
+  setLogTurnId(null);
+});
+
+describe("logDir / logPathFor", () => {
+  it("uses the override dir when set", () => {
+    assert.strictEqual(logDir(), dir);
+  });
+
+  it("formats the daily path as YYYY-MM-DD.jsonl", () => {
+    const d = new Date("2026-05-17T12:34:56Z");
+    assert.strictEqual(logPathFor(d), join(dir, "2026-05-17.jsonl"));
+  });
+});
+
+describe("writeLogLine", () => {
+  it("appends one JSON line per call", async () => {
+    writeLogLine({ event: "first", a: 1 });
+    writeLogLine({ event: "second", a: 2 });
+    await flushAndCloseForTesting();
+    const path = logPathFor();
+    const content = readFileSync(path, "utf8");
+    const lines = content.trim().split("\n");
+    assert.strictEqual(lines.length, 2);
+    assert.deepStrictEqual(JSON.parse(lines[0]!), { event: "first", a: 1 });
+    assert.deepStrictEqual(JSON.parse(lines[1]!), { event: "second", a: 2 });
+  });
+
+  it("is a silent no-op when the sink is disabled", () => {
+    setLogSinkEnabled(false);
+    writeLogLine({ event: "should not appear" });
+    assert.strictEqual(readdirSync(dir).length, 0);
+    setLogSinkEnabled(true);
+  });
+
+  it("rotates files on UTC date change", async () => {
+    const day1 = new Date("2026-05-17T23:59:59Z");
+    const day2 = new Date("2026-05-18T00:00:01Z");
+    writeLogLine({ event: "late" }, day1);
+    writeLogLine({ event: "early" }, day2);
+    await flushAndCloseForTesting();
+    const day1Path = logPathFor(day1);
+    const day2Path = logPathFor(day2);
+    assert.strictEqual(readFileSync(day1Path, "utf8").trim(), JSON.stringify({ event: "late" }));
+    assert.strictEqual(readFileSync(day2Path, "utf8").trim(), JSON.stringify({ event: "early" }));
+  });
+});
+
+describe("isLogSinkEnabled / setLogSinkEnabled", () => {
+  it("round-trips", () => {
+    setLogSinkEnabled(false);
+    assert.strictEqual(isLogSinkEnabled(), false);
+    setLogSinkEnabled(true);
+    assert.strictEqual(isLogSinkEnabled(), true);
+  });
+});
+
+describe("pruneOldLogs", () => {
+  it("returns 0 when the dir doesn't exist", () => {
+    // Point at a definitely-empty subdir
+    setLogDirForTesting(join(dir, "nope"));
+    assert.strictEqual(pruneOldLogs(), 0);
+    setLogDirForTesting(dir);
+  });
+
+  it("deletes files older than the retention window", () => {
+    // Create one old, one fresh
+    const old = join(dir, "2020-01-01.jsonl");
+    const fresh = join(dir, logPathFor().split("/").pop()!);
+    writeFileSync(old, "{}\n");
+    writeFileSync(fresh, "{}\n");
+    // Backdate the old one to 30 days ago
+    const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    utimesSync(old, past, past);
+
+    const removed = pruneOldLogs(7);
+    assert.strictEqual(removed, 1);
+    const remaining = readdirSync(dir);
+    assert.ok(remaining.includes(fresh.split("/").pop()!));
+    assert.ok(!remaining.includes("2020-01-01.jsonl"));
+  });
+
+  it("ignores non-jsonl files", () => {
+    const notALog = join(dir, "readme.txt");
+    writeFileSync(notALog, "hi");
+    const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    utimesSync(notALog, past, past);
+    assert.strictEqual(pruneOldLogs(7), 0);
+    assert.ok(readdirSync(dir).includes("readme.txt"));
+  });
+});
+
+describe("correlation context", () => {
+  it("round-trips session id", () => {
+    assert.strictEqual(getLogSessionId(), null);
+    setLogSessionId("sess_abc");
+    assert.strictEqual(getLogSessionId(), "sess_abc");
+    setLogSessionId(null);
+    assert.strictEqual(getLogSessionId(), null);
+  });
+
+  it("round-trips turn id independently of session id", () => {
+    setLogTurnId("turn_5");
+    assert.strictEqual(getLogTurnId(), "turn_5");
+    setLogSessionId("sess_xyz");
+    // setting session does NOT clear turn
+    assert.strictEqual(getLogTurnId(), "turn_5");
+  });
+});

--- a/src/util/log-sink.ts
+++ b/src/util/log-sink.ts
@@ -1,0 +1,189 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdirSync, createWriteStream, readdirSync, statSync, unlinkSync } from "node:fs";
+import type { WriteStream } from "node:fs";
+
+/**
+ * File sink for structured logs (M5.1). Writes JSONL lines to
+ * `~/.config/kimiflare/logs/<YYYY-MM-DD>.jsonl`, one file per day,
+ * with a 7-day retention window pruned on startup.
+ *
+ * Design notes:
+ *   - The file sink is independent of `KIMIFLARE_LOG_LEVEL`, which only
+ *     gates stderr output. The file sink is **always on** unless
+ *     disabled via `KIMIFLARE_LOG_SINK=off` — log files are
+ *     observability infrastructure and should be written even when the
+ *     TUI is silent. Disable for tests + the print/RPC modes that
+ *     should not touch the user's disk.
+ *   - We deliberately do NOT log LLM request/response bodies here.
+ *     Those live in Cloudflare AI Gateway already; replicating them
+ *     locally would double disk usage for the loudest event type.
+ *     Emit a thin event (`{event: "llm:call", model, request_id, …}`)
+ *     and join on `request_id` if you need the body.
+ */
+
+const RETENTION_DAYS = 7;
+
+function defaultLogDir(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, "kimiflare", "logs");
+}
+
+let overrideDir: string | null = null;
+let currentStream: WriteStream | null = null;
+let currentDate: string | null = null; // YYYY-MM-DD this stream targets
+
+/** Detect if we're running under Node's test runner so unit tests don't
+ *  pollute the user's real `~/.config/kimiflare/logs/` directory. */
+function isInNodeTestContext(): boolean {
+  if (process.env.NODE_TEST_CONTEXT) return true;
+  if (process.env.NODE_ENV === "test") return true;
+  // `node --test` and `tsx --test` put "--test" in argv.
+  if (process.argv.includes("--test")) return true;
+  return false;
+}
+
+let sinkEnabled: boolean =
+  process.env.KIMIFLARE_LOG_SINK !== "off" && !isInNodeTestContext();
+
+/** Resolve the directory new log files land in. Honors a test override. */
+export function logDir(): string {
+  return overrideDir ?? defaultLogDir();
+}
+
+/** Resolve the path of the log file for `date` (default today, UTC). */
+export function logPathFor(date: Date = new Date()): string {
+  return join(logDir(), `${date.toISOString().slice(0, 10)}.jsonl`);
+}
+
+/** Override the log directory. Test-only escape hatch. */
+export function setLogDirForTesting(dir: string | null): void {
+  if (currentStream) {
+    currentStream.end();
+    currentStream = null;
+    currentDate = null;
+  }
+  overrideDir = dir;
+}
+
+/** Disable the file sink entirely (e.g. for unit tests). */
+export function setLogSinkEnabled(enabled: boolean): void {
+  if (!enabled && currentStream) {
+    currentStream.end();
+    currentStream = null;
+    currentDate = null;
+  }
+  sinkEnabled = enabled;
+}
+
+/** Test-only: wait for the current stream to flush + close before
+ *  resolving. Use this in unit tests that want to readFileSync the log
+ *  file after a write — `setLogSinkEnabled(false)` returns synchronously
+ *  but the stream's actual flush is async. */
+export async function flushAndCloseForTesting(): Promise<void> {
+  if (!currentStream) return;
+  const s = currentStream;
+  currentStream = null;
+  currentDate = null;
+  await new Promise<void>((resolve) => {
+    s.end(() => resolve());
+  });
+}
+
+export function isLogSinkEnabled(): boolean {
+  return sinkEnabled;
+}
+
+function ensureStream(now: Date): WriteStream | null {
+  if (!sinkEnabled) return null;
+  const dateKey = now.toISOString().slice(0, 10);
+  if (currentStream && currentDate === dateKey) return currentStream;
+  // Rotate on date change (UTC).
+  if (currentStream) {
+    currentStream.end();
+    currentStream = null;
+  }
+  try {
+    mkdirSync(logDir(), { recursive: true });
+    currentStream = createWriteStream(logPathFor(now), { flags: "a" });
+    currentDate = dateKey;
+    // Swallow stream errors — disk-full, permission-denied, etc. must
+    // never crash the agent loop.
+    currentStream.on("error", () => {
+      currentStream = null;
+      currentDate = null;
+    });
+    return currentStream;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Append a single log entry as one JSONL line. Best-effort and silent
+ * on failure — the agent loop must not crash because the log file is
+ * unwritable.
+ */
+export function writeLogLine(entry: object, now: Date = new Date()): void {
+  const stream = ensureStream(now);
+  if (!stream) return;
+  try {
+    stream.write(JSON.stringify(entry) + "\n");
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Delete log files older than `retentionDays` days. Returns the number
+ * of files removed. Called once at startup. Silent on errors.
+ */
+export function pruneOldLogs(retentionDays: number = RETENTION_DAYS): number {
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(logDir());
+  } catch {
+    return 0;
+  }
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    const full = join(logDir(), name);
+    try {
+      const st = statSync(full);
+      if (st.mtimeMs < cutoff) {
+        unlinkSync(full);
+        removed += 1;
+      }
+    } catch {
+      // ignore individual entry failures
+    }
+  }
+  return removed;
+}
+
+// ── Correlation context ──────────────────────────────────────────────────
+
+let currentSessionId: string | null = null;
+let currentTurnId: string | null = null;
+
+/** Set the ambient session id stamped onto every log entry. Call once
+ *  per session (or `null` to clear). */
+export function setLogSessionId(id: string | null): void {
+  currentSessionId = id;
+}
+
+/** Set the ambient turn id (typically a monotonic counter or a uuid).
+ *  Cleared automatically by `setLogSessionId(null)`. */
+export function setLogTurnId(id: string | null): void {
+  currentTurnId = id;
+}
+
+export function getLogSessionId(): string | null {
+  return currentSessionId;
+}
+
+export function getLogTurnId(): string | null {
+  return currentTurnId;
+}

--- a/src/util/logger.test.ts
+++ b/src/util/logger.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  setLogDirForTesting,
+  setLogSinkEnabled,
+  setLogSessionId,
+  setLogTurnId,
+  logPathFor,
+  flushAndCloseForTesting,
+} from "./log-sink.js";
+import { log, logger, setLogLevel } from "./logger.js";
+
+let dir: string;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "logger-test-"));
+  setLogDirForTesting(dir);
+  setLogSinkEnabled(true);
+  setLogLevel("off"); // suppress stderr
+});
+
+after(() => {
+  setLogDirForTesting(null);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await flushAndCloseForTesting();
+  for (const f of readdirSync(dir)) {
+    rmSync(join(dir, f), { force: true });
+  }
+  setLogSessionId(null);
+  setLogTurnId(null);
+});
+
+async function readEntries(): Promise<Array<Record<string, unknown>>> {
+  await flushAndCloseForTesting();
+  const path = logPathFor();
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .map((l) => JSON.parse(l));
+}
+
+describe("logger.log → file sink", async () => {
+  it("writes a JSONL line with ts, level, event, data", async () => {
+    log("info", "test:event", { foo: "bar" });
+    const entries = await readEntries();
+    assert.strictEqual(entries.length, 1);
+    const e = entries[0]!;
+    assert.strictEqual(e.level, "info");
+    assert.strictEqual(e.event, "test:event");
+    assert.deepStrictEqual(e.data, { foo: "bar" });
+    assert.ok(typeof e.ts === "string");
+  });
+
+  it("stamps session_id when set", async () => {
+    setLogSessionId("sess_42");
+    logger.info("with:session");
+    const entries = await readEntries();
+    assert.strictEqual(entries[0]!.session_id, "sess_42");
+  });
+
+  it("stamps turn_id when set", async () => {
+    setLogSessionId("sess_42");
+    setLogTurnId("turn_3");
+    logger.warn("with:turn", { hint: 1 });
+    const entries = await readEntries();
+    assert.strictEqual(entries[0]!.session_id, "sess_42");
+    assert.strictEqual(entries[0]!.turn_id, "turn_3");
+  });
+
+  it("lifts data.request_id (snake_case) to top level", async () => {
+    log("debug", "llm:call", { request_id: "req_abc", model: "kimi" });
+    const entries = await readEntries();
+    assert.strictEqual(entries[0]!.request_id, "req_abc");
+  });
+
+  it("also lifts legacy data.requestId (camelCase)", async () => {
+    log("debug", "llm:call", { requestId: "req_xyz", model: "kimi" });
+    const entries = await readEntries();
+    assert.strictEqual(entries[0]!.request_id, "req_xyz");
+  });
+
+  it("does not lift request_id from outside data", async () => {
+    log("info", "no:req");
+    const entries = await readEntries();
+    assert.strictEqual(entries[0]!.request_id, undefined);
+  });
+});

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,13 +1,23 @@
 /**
  * Structured logger for KimiFlare turn lifecycle events.
- * Writes JSON lines to stderr so stdout remains clean for TUI.
  *
- * Logging is OFF by default. To enable, set the env var:
- *   KIMIFLARE_LOG_LEVEL=info npm run dev
+ * Two sinks:
+ *   1. **stderr** (gated by `KIMIFLARE_LOG_LEVEL`, default `off`) — for
+ *      interactive debugging. Tail with `2>&1 | jq` from a dev shell.
+ *   2. **file** (`~/.config/kimiflare/logs/<date>.jsonl`, default ON;
+ *      disable with `KIMIFLARE_LOG_SINK=off`) — for post-hoc analysis,
+ *      shipped in M5.1. Always-on so the data exists even when the TUI
+ *      is silent.
  *
- * Tail in a second terminal to observe real-time behavior:
- *   npm run dev 2>&1 | jq -r 'select(.event | startswith("turn:"))'
+ * The two sinks are independent: you can leave stderr off and still get
+ * the file logs (the common case), or vice-versa.
+ *
+ * Tail in a second terminal:
+ *   KIMIFLARE_LOG_LEVEL=info npm run dev          # stderr live tail
+ *   tail -f $(kimiflare logs path) | jq           # file tail
  */
+
+import { writeLogLine, getLogSessionId, getLogTurnId } from "./log-sink.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "off";
 
@@ -15,8 +25,9 @@ export interface LogEntry {
   ts: string;
   level: LogLevel;
   event: string;
-  sessionId?: string;
-  requestId?: string;
+  session_id?: string;
+  turn_id?: string;
+  request_id?: string;
   data?: Record<string, unknown>;
 }
 
@@ -57,10 +68,25 @@ export function log(
   event: string,
   data?: Record<string, unknown>,
 ): void {
+  const sessionId = getLogSessionId();
+  const turnId = getLogTurnId();
+  // Accept either snake_case `request_id` (preferred, matches Gateway
+  // log schema) or legacy camelCase `requestId` for backward compat
+  // with existing call sites in src/agent/client.ts.
+  const requestId =
+    typeof data?.request_id === "string"
+      ? (data.request_id as string)
+      : typeof data?.requestId === "string"
+        ? (data.requestId as string)
+        : undefined;
+
   const entry: LogEntry = {
     ts: new Date().toISOString(),
     level,
     event,
+    ...(sessionId ? { session_id: sessionId } : {}),
+    ...(turnId ? { turn_id: turnId } : {}),
+    ...(requestId ? { request_id: requestId } : {}),
     data,
   };
 
@@ -70,10 +96,13 @@ export function log(
     recentLogs.shift();
   }
 
-  // Write to stderr so stdout remains clean for TUI rendering
+  // Stderr sink (gated by KIMIFLARE_LOG_LEVEL).
   if (LEVEL_ORDER[level] >= LEVEL_ORDER[globalMinLevel]) {
     console.error(JSON.stringify(entry));
   }
+
+  // File sink (always-on unless disabled via KIMIFLARE_LOG_SINK=off).
+  writeLogLine(entry);
 }
 
 /** Convenience wrappers */


### PR DESCRIPTION
## Summary

Adds a file sink to the existing structured logger. Agent-side activity (tool calls, permission decisions, MCP/LSP lifecycle, session events, errors) lands at \`~/.config/kimiflare/logs/<date>.jsonl\`, one file per day, with 7-day retention pruned at startup.

After this lands, the M9 items that need data (per-tool quotas, loop detection, cost attribution by tool) become tractable instead of guessed.

## Design decisions worth flagging

**1. Two sinks, independent gates.**
- \`KIMIFLARE_LOG_LEVEL\` (default \`off\`) gates **stderr** only.
- \`KIMIFLARE_LOG_SINK\` (default on; set to \`off\` to disable) gates the **file**.

The file sink is always-on because logs are post-hoc observability — making the user remember to enable them defeats the purpose. The two gates are independent so the dev-stderr-tail and the disk-archive paths don't fight.

**2. No duplication with Cloudflare AI Gateway.**

Per discussion: AI Gateway already logs every LLM HTTP call (model, tokens, latency, cost, cache hit, prompt + completion). Replicating that locally would double disk usage for the loudest event type and offer no new information.

This sink covers what Gateway **can't** see: tool execution, permission decisions, MCP/LSP server lifecycle, sandbox events, memory subsystem, session lifecycle, local-only errors. Each entry carries the Gateway \`request_id\` so a future \`jq\` join answers cross-layer questions (\"what local tool ran around the time of LLM request X?\") without us re-storing the payloads.

**3. Correlation IDs lifted to top-level fields.**

Every entry can carry \`session_id\` / \`turn_id\` / \`request_id\`. Lifted to the top of the JSON object (not buried in \`data\`) so \`jq\` queries are short:

\`\`\`sh
jq -r 'select(.session_id == \"sess_abc\") | .event' < today.jsonl
\`\`\`

- \`session_id\` is set automatically by the M4.4 session manager in \`ensureSessionId\` / \`doResumeSession\` / \`resetSession\`.
- \`turn_id\` is settable via \`setLogTurnId\` — no automatic call sites yet; we'll wire it into the turn controller in a follow-up if useful.
- \`request_id\` lifts from \`data.request_id\` (preferred snake_case) **or** \`data.requestId\` (legacy camelCase already used by \`src/agent/client.ts\`), so existing call sites work unchanged.

**4. Node test runner auto-detected.**

The sink defaults to off when \`process.env.NODE_TEST_CONTEXT\`, \`NODE_ENV === \"test\"\`, or \`--test\` in argv. Without this, unit tests would pollute the user's real \`~/.config/kimiflare/logs/\` directory on every \`npm test\` run.

## How the user discovers logs exist

Three places, per the convention discussed:

1. **README \"## Logs\" section** — path, retention, \`jq\` examples, disable knob.
2. **First-run info event** — on startup, the TUI emits one info line: \`structured logs: /path/to/today.jsonl (tail with: tail -f \$(kimiflare logs path) | jq)\`.
3. **\`kimiflare logs\` subcommand group** — \`path\`, \`dir\`, \`prune\`.

The system prompt is NOT touched. Logs are operator-side observability, not something the model should reason about. (If we later want the model to query its own activity, we add a \`logs_query\` tool; the existing memory subsystem is the precedent — interaction goes through tools, not prompt mentions.)

## Files

- \`src/util/log-sink.ts\` (NEW) — file writer, daily rotation, retention pruning, correlation context.
- \`src/util/logger.ts\` — wired to call \`writeLogLine\` from \`log()\`; correlation IDs lifted to top-level.
- \`src/ui/use-session-manager.ts\` — calls \`setLogSessionId\` in \`ensureSessionId\` / \`doResumeSession\` / \`resetSession\`.
- \`src/index.tsx\` — adds \`kimiflare logs path | dir | prune\`.
- \`src/app.tsx\` — startup prune + one-line info event.
- \`README.md\` — \"## Logs\" section.
- 17 new unit tests across \`log-sink.test.ts\` and \`logger.test.ts\`.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 498/498 pass (17 new)
- [x] \`npm run build\` — clean ESM + DTS
- [x] Tests verify: daily rotation across UTC midnight, retention pruning, non-.jsonl files left alone, disabled-sink no-op, session_id/turn_id stamping, both request_id casings lifted.
- [ ] Manual smoke (not runnable from this non-TTY environment): start the TUI, see the \"structured logs: …\" info line on startup, run any tool, then \`jq . < \$(kimiflare logs path)\` and confirm entries appear with \`session_id\` populated. Confirm \`KIMIFLARE_LOG_SINK=off kimiflare\` produces no log file. Confirm \`kimiflare logs path\` prints the right path from outside an interactive session.

Closes M5.1. Roadmap Progress log and inline M5 section updated.