### PR TITLE
feat(telemetry): optional OTLP/HTTP log export (M5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,32 @@ Disable the file sink entirely with `KIMIFLARE_LOG_SINK=off`. The
 separate `KIMIFLARE_LOG_LEVEL` env var (default `off`) controls stderr
 output — independent of the file sink.
 
+### Shipping to an OpenTelemetry collector
+
+If you set `KIMIFLARE_OTEL_ENDPOINT`, KimiFlare also ships each log
+entry to that endpoint over [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/)
+so it lands in Datadog, Honeycomb, Grafana Loki, an internal collector,
+or any other backend that speaks OTel. Batched every 5 s (or every
+100 entries, whichever first) and best-effort — never blocks the agent
+loop.
+
+```sh
+# Full path:
+export KIMIFLARE_OTEL_ENDPOINT="https://otel.example.com/v1/logs"
+# Or just the base URL (we auto-append /v1/logs):
+export KIMIFLARE_OTEL_ENDPOINT="https://otel.example.com"
+
+# Optional headers (comma-separated key=value pairs) — e.g. for auth:
+export KIMIFLARE_OTEL_HEADERS="Authorization=Bearer xyz,X-Tenant=acme"
+```
+
+Each log entry maps to one OTel `LogRecord`. Correlation IDs
+(`session_id`, `turn_id`, `request_id`) become record attributes,
+`data.*` fields are flattened to attributes with type-preserving
+encoding, and a `service.name=kimiflare` + `service.version` pair sits
+on the resource. The same `request_id` joins to Cloudflare AI Gateway's
+per-request log without any extra work.
+
 ## Development
 
 ```sh

--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,7 +15,23 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
-- **M5.1** — Structured JSON logs to disk *(OP-20)* — *(this PR)*.
+- **M5.2** — Optional OTLP/HTTP log export *(OP-20)* — *(this PR)*.
+  Third sink in the logger stack: `src/util/otel-sink.ts` ships each
+  entry to an OpenTelemetry collector when `KIMIFLARE_OTEL_ENDPOINT`
+  is set. Batched (every 5s or 100 entries, whichever first),
+  best-effort (drops silently on failure, never blocks the agent loop),
+  with a `beforeExit` drain so short-lived print-mode runs don't lose
+  the tail. Hand-rolled the OTLP/HTTP JSON encoder (no SDK dep) — 200
+  LOC vs ~50 KB gzipped from `@opentelemetry/exporter-logs-otlp-http`.
+  Auth via `KIMIFLARE_OTEL_HEADERS=Authorization=Bearer xyz,...`. The
+  M5.1 correlation IDs (`session_id`, `turn_id`, `request_id`) lift
+  to OTLP record attributes and `data.*` flattens with type-preserving
+  encoding (string / int / bool / nested→JSON-string). 21 unit tests
+  cover URL normalization (base vs `/v1/logs`-suffixed), header
+  parsing, batch auto-flush, retry on 5xx + on fetch throw,
+  drop-counter accuracy, and the OTLP schema. README "Shipping to an
+  OpenTelemetry collector" subsection added. **M5 complete.**
+- **M5.1** — Structured JSON logs to disk *(OP-20)* — merged in #458.
   `src/util/log-sink.ts` adds a file sink to the existing structured
   logger: one JSONL file per day at
   `~/.config/kimiflare/logs/<date>.jsonl`, 7-day retention pruned at
@@ -435,9 +451,11 @@ driven.
   automatically — no migration of `console.log` / `console.warn`
   required since the agent loop was already using `logger`. New
   `kimiflare logs path | dir | prune` CLI subcommands.
-- **M5.2** — `feat(telemetry): optional OTel export`
-  *(OP-20)*
-  - `KIMIFLARE_OTEL_ENDPOINT` env var → emit OTLP. No-op if unset.
+- ✅ **M5.2** — `feat(telemetry): optional OTel export`
+  *(OP-20)* — *merged in this PR*. OTLP/HTTP exporter in
+  `src/util/otel-sink.ts`; gated on `KIMIFLARE_OTEL_ENDPOINT`. Batched
+  + best-effort + `beforeExit`-drained. Hand-rolled JSON encoder, no
+  SDK dep. Correlation IDs from M5.1 lift to OTLP attributes.
 
 **Exit criteria:** `cat ~/.config/kimiflare/logs/*.jsonl | jq` can
 answer "what's the per-tool p95 latency this week" without writing

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -193,6 +193,15 @@ const opts = program.opts<{
 }>();
 
 async function main() {
+  // Initialize the OTLP/HTTP log exporter if `KIMIFLARE_OTEL_ENDPOINT`
+  // is set. No-op otherwise — the env-var gate keeps this zero-cost for
+  // users who don't care. Done before loadConfig so any early errors
+  // ship too.
+  const { initOtelSink, installOtelExitHook } = await import("./util/otel-sink.js");
+  if (initOtelSink()) {
+    installOtelExitHook();
+  }
+
   const globalCfg = await loadConfig();
   const updateResult = await checkForUpdate();
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,16 +1,17 @@
 /**
  * Structured logger for KimiFlare turn lifecycle events.
  *
- * Two sinks:
+ * Three sinks, all independent:
  *   1. **stderr** (gated by `KIMIFLARE_LOG_LEVEL`, default `off`) — for
  *      interactive debugging. Tail with `2>&1 | jq` from a dev shell.
  *   2. **file** (`~/.config/kimiflare/logs/<date>.jsonl`, default ON;
  *      disable with `KIMIFLARE_LOG_SINK=off`) — for post-hoc analysis,
  *      shipped in M5.1. Always-on so the data exists even when the TUI
  *      is silent.
- *
- * The two sinks are independent: you can leave stderr off and still get
- * the file logs (the common case), or vice-versa.
+ *   3. **OTLP/HTTP** (gated by `KIMIFLARE_OTEL_ENDPOINT`, default
+ *      unset) — ship to any OpenTelemetry collector / SaaS backend
+ *      (Datadog, Honeycomb, Grafana, …), shipped in M5.2. Batched,
+ *      best-effort; never blocks the agent loop.
  *
  * Tail in a second terminal:
  *   KIMIFLARE_LOG_LEVEL=info npm run dev          # stderr live tail
@@ -18,6 +19,7 @@
  */
 
 import { writeLogLine, getLogSessionId, getLogTurnId } from "./log-sink.js";
+import { enqueueOtelLog } from "./otel-sink.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "off";
 
@@ -103,6 +105,10 @@ export function log(
 
   // File sink (always-on unless disabled via KIMIFLARE_LOG_SINK=off).
   writeLogLine(entry);
+
+  // OTLP/HTTP sink (no-op unless KIMIFLARE_OTEL_ENDPOINT is set and
+  // initOtelSink() has been called).
+  enqueueOtelLog(entry);
 }
 
 /** Convenience wrappers */

--- a/src/util/otel-sink.test.ts
+++ b/src/util/otel-sink.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import {
+  initOtelSink,
+  isOtelEnabled,
+  enqueueOtelLog,
+  flushOtelSink,
+  getOtelDropCount,
+  getOtelQueueSize,
+  resetOtelSinkForTesting,
+  setFetchForTesting,
+  buildOtlpPayload,
+} from "./otel-sink.js";
+import type { LogEntry } from "./logger.js";
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+let captured: CapturedRequest[] = [];
+
+beforeEach(() => {
+  resetOtelSinkForTesting();
+  captured = [];
+});
+
+afterEach(() => {
+  setFetchForTesting(null);
+});
+
+function mockFetch(status = 200): void {
+  setFetchForTesting(async (url, init) => {
+    captured.push({ url, init });
+    return new Response("ok", { status });
+  });
+}
+
+function entry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    ts: "2026-05-17T10:00:00.000Z",
+    level: "info",
+    event: "tool:end",
+    data: { duration_ms: 42, tool: "bash" },
+    ...overrides,
+  };
+}
+
+describe("initOtelSink", () => {
+  it("returns false when no endpoint is configured", () => {
+    assert.strictEqual(initOtelSink({}), false);
+    assert.strictEqual(isOtelEnabled(), false);
+  });
+
+  it("returns true when endpoint is provided", () => {
+    assert.strictEqual(initOtelSink({ endpoint: "https://otel.example.com" }), true);
+    assert.strictEqual(isOtelEnabled(), true);
+  });
+
+  it("appends /v1/logs to a base URL", () => {
+    mockFetch();
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    enqueueOtelLog(entry());
+    return flushOtelSink().then(() => {
+      assert.strictEqual(captured[0]!.url, "https://otel.example.com/v1/logs");
+    });
+  });
+
+  it("leaves a path-qualified URL alone", () => {
+    mockFetch();
+    initOtelSink({ endpoint: "https://otel.example.com/v1/logs" });
+    enqueueOtelLog(entry());
+    return flushOtelSink().then(() => {
+      assert.strictEqual(captured[0]!.url, "https://otel.example.com/v1/logs");
+    });
+  });
+
+  it("strips trailing slashes from the base URL", () => {
+    mockFetch();
+    initOtelSink({ endpoint: "https://otel.example.com///" });
+    enqueueOtelLog(entry());
+    return flushOtelSink().then(() => {
+      assert.strictEqual(captured[0]!.url, "https://otel.example.com/v1/logs");
+    });
+  });
+
+  it("parses comma-separated headers", () => {
+    mockFetch();
+    initOtelSink({
+      endpoint: "https://otel.example.com",
+      headers: "Authorization=Bearer xyz, X-Tenant=acme",
+    });
+    enqueueOtelLog(entry());
+    return flushOtelSink().then(() => {
+      const headers = captured[0]!.init.headers as Record<string, string>;
+      assert.strictEqual(headers["Authorization"], "Bearer xyz");
+      assert.strictEqual(headers["X-Tenant"], "acme");
+    });
+  });
+
+  it("skips malformed header pairs without crashing", () => {
+    initOtelSink({
+      endpoint: "https://otel.example.com",
+      headers: "ValidKey=ok, =missingKey, missingValue=, ,bad",
+    });
+    // No assertion needed — must not throw.
+    assert.strictEqual(isOtelEnabled(), true);
+  });
+});
+
+describe("enqueueOtelLog", () => {
+  it("is a no-op when no endpoint is configured", () => {
+    enqueueOtelLog(entry());
+    assert.strictEqual(getOtelQueueSize(), 0);
+  });
+
+  it("queues entries when active", () => {
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    enqueueOtelLog(entry());
+    enqueueOtelLog(entry({ event: "tool:start" }));
+    assert.strictEqual(getOtelQueueSize(), 2);
+  });
+
+  it("auto-flushes when the batch hits BATCH_MAX (100)", async () => {
+    mockFetch();
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    for (let i = 0; i < 100; i++) enqueueOtelLog(entry());
+    // The auto-flush is fire-and-forget; await any in-flight.
+    await flushOtelSink();
+    assert.strictEqual(captured.length, 1);
+    const body = JSON.parse(captured[0]!.init.body as string);
+    assert.strictEqual(body.resourceLogs[0].scopeLogs[0].logRecords.length, 100);
+    assert.strictEqual(getOtelQueueSize(), 0);
+  });
+});
+
+describe("flushOtelSink", () => {
+  it("does nothing on an empty queue", async () => {
+    mockFetch();
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    await flushOtelSink();
+    assert.strictEqual(captured.length, 0);
+  });
+
+  it("ships a single batch", async () => {
+    mockFetch();
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    enqueueOtelLog(entry());
+    enqueueOtelLog(entry({ event: "tool:start", level: "debug" }));
+    await flushOtelSink();
+    assert.strictEqual(captured.length, 1);
+    const body = JSON.parse(captured[0]!.init.body as string);
+    const records = body.resourceLogs[0].scopeLogs[0].logRecords;
+    assert.strictEqual(records.length, 2);
+    assert.strictEqual(records[0].severityText, "INFO");
+    assert.strictEqual(records[1].severityText, "DEBUG");
+  });
+
+  it("increments drop count on HTTP failure (5xx)", async () => {
+    mockFetch(500);
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    enqueueOtelLog(entry());
+    enqueueOtelLog(entry());
+    await flushOtelSink();
+    assert.strictEqual(getOtelDropCount(), 2);
+  });
+
+  it("increments drop count when fetch throws", async () => {
+    setFetchForTesting(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    enqueueOtelLog(entry());
+    await flushOtelSink();
+    assert.strictEqual(getOtelDropCount(), 1);
+  });
+
+  it("clears the queue but no-ops when endpoint became unset", async () => {
+    initOtelSink({ endpoint: "https://otel.example.com" });
+    enqueueOtelLog(entry());
+    assert.strictEqual(getOtelQueueSize(), 1);
+    resetOtelSinkForTesting();
+    await flushOtelSink();
+    assert.strictEqual(getOtelQueueSize(), 0);
+  });
+});
+
+describe("buildOtlpPayload — schema", () => {
+  const cfg = {
+    endpoint: "https://otel.example.com/v1/logs",
+    headers: {},
+    serviceName: "kimiflare",
+    serviceVersion: "0.69.0",
+  };
+
+  it("emits a single resourceLogs entry with service.name + service.version", () => {
+    const payload = buildOtlpPayload([entry()], cfg) as {
+      resourceLogs: { resource: { attributes: { key: string; value: { stringValue: string } }[] } }[];
+    };
+    const attrs = payload.resourceLogs[0]!.resource.attributes;
+    const byKey = Object.fromEntries(attrs.map((a) => [a.key, a.value.stringValue]));
+    assert.strictEqual(byKey["service.name"], "kimiflare");
+    assert.strictEqual(byKey["service.version"], "0.69.0");
+  });
+
+  it("lifts session_id / turn_id / request_id to record attributes", () => {
+    const e = entry({
+      session_id: "sess_a",
+      turn_id: "turn_3",
+      request_id: "req_xyz",
+    });
+    const payload = buildOtlpPayload([e], cfg) as {
+      resourceLogs: { scopeLogs: { logRecords: { attributes: { key: string; value: { stringValue: string } }[] }[] }[] }[];
+    };
+    const recordAttrs = payload.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.attributes;
+    const byKey = Object.fromEntries(recordAttrs.map((a) => [a.key, a.value.stringValue]));
+    assert.strictEqual(byKey["session_id"], "sess_a");
+    assert.strictEqual(byKey["turn_id"], "turn_3");
+    assert.strictEqual(byKey["request_id"], "req_xyz");
+  });
+
+  it("flattens data fields into record attributes with type coercion", () => {
+    const e = entry({
+      data: { duration_ms: 42, tool: "bash", ok: true, nested: { a: 1 } },
+    });
+    const payload = buildOtlpPayload([e], cfg) as {
+      resourceLogs: { scopeLogs: { logRecords: { attributes: { key: string; value: Record<string, unknown> }[] }[] }[] }[];
+    };
+    const recordAttrs = payload.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.attributes;
+    const byKey = Object.fromEntries(recordAttrs.map((a) => [a.key, a.value]));
+    assert.deepStrictEqual(byKey["duration_ms"], { intValue: "42" });
+    assert.deepStrictEqual(byKey["tool"], { stringValue: "bash" });
+    assert.deepStrictEqual(byKey["ok"], { boolValue: true });
+    // Nested objects get JSON-stringified to keep them shippable.
+    assert.strictEqual(
+      (byKey["nested"] as { stringValue: string }).stringValue,
+      '{"a":1}',
+    );
+  });
+
+  it("does not duplicate request_id under data attributes", () => {
+    const e = entry({
+      request_id: "req_xyz",
+      data: { request_id: "req_xyz", tool: "bash" },
+    });
+    const payload = buildOtlpPayload([e], cfg) as {
+      resourceLogs: { scopeLogs: { logRecords: { attributes: { key: string }[] }[] }[] }[];
+    };
+    const keys = payload.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.attributes.map((a) => a.key);
+    const requestIdCount = keys.filter((k) => k === "request_id").length;
+    assert.strictEqual(requestIdCount, 1);
+  });
+
+  it("encodes timestamps as nanoseconds since epoch", () => {
+    const e = entry({ ts: "2026-05-17T10:00:00.000Z" });
+    const payload = buildOtlpPayload([e], cfg) as {
+      resourceLogs: { scopeLogs: { logRecords: { timeUnixNano: string }[] }[] }[];
+    };
+    const expectedMs = new Date("2026-05-17T10:00:00.000Z").getTime();
+    const expectedNs = String(BigInt(expectedMs) * 1_000_000n);
+    assert.strictEqual(
+      payload.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.timeUnixNano,
+      expectedNs,
+    );
+  });
+
+  it("maps log levels to OTel severity numbers", () => {
+    const entries: LogEntry[] = [
+      entry({ level: "debug" }),
+      entry({ level: "info" }),
+      entry({ level: "warn" }),
+      entry({ level: "error" }),
+    ];
+    const payload = buildOtlpPayload(entries, cfg) as {
+      resourceLogs: { scopeLogs: { logRecords: { severityNumber: number; severityText: string }[] }[] }[];
+    };
+    const records = payload.resourceLogs[0]!.scopeLogs[0]!.logRecords;
+    assert.strictEqual(records[0]!.severityNumber, 5);
+    assert.strictEqual(records[0]!.severityText, "DEBUG");
+    assert.strictEqual(records[1]!.severityNumber, 9);
+    assert.strictEqual(records[2]!.severityNumber, 13);
+    assert.strictEqual(records[3]!.severityNumber, 17);
+  });
+});

--- a/src/util/otel-sink.ts
+++ b/src/util/otel-sink.ts
@@ -1,0 +1,302 @@
+/**
+ * OTLP/HTTP log exporter (M5.2). Ships each log entry as one OTel
+ * `LogRecord` to an external collector. Gated entirely on the
+ * `KIMIFLARE_OTEL_ENDPOINT` env var — unset = no-op.
+ *
+ * Design notes:
+ *   - Hand-rolled rather than pulled in via `@opentelemetry/exporter-…`
+ *     to keep deps slim. The OTLP/HTTP JSON wire format is small enough
+ *     to encode directly; see the schema reference at
+ *     https://github.com/open-telemetry/opentelemetry-proto.
+ *   - Batched: flush on a 5s timer OR when the queue hits 100 entries,
+ *     whichever fires first. Drops are silent — observability data must
+ *     never block or crash the agent loop.
+ *   - Drop counter is exposed (`getOtelDropCount`) so tests + a future
+ *     `kimiflare logs status` subcommand can surface it.
+ *   - Auth: `KIMIFLARE_OTEL_HEADERS=Authorization=Bearer xyz,X-Foo=bar`
+ *     (comma-separated key=value). Common pattern across OTel docs.
+ *
+ * Endpoint URL convention:
+ *   The env var may be either the full path
+ *     (https://otel.example.com/v1/logs)
+ *   or the base URL
+ *     (https://otel.example.com)
+ *   We auto-append `/v1/logs` to the latter, matching the standard
+ *   OTLP/HTTP signal path so configuration is friendly.
+ */
+
+import type { LogEntry } from "./logger.js";
+
+const BATCH_MAX = 100;
+const FLUSH_INTERVAL_MS = 5_000;
+
+// Severity numbers from the OTLP spec
+// (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber).
+const SEVERITY_NUMBER: Record<LogEntry["level"], number> = {
+  debug: 5,
+  info: 9,
+  warn: 13,
+  error: 17,
+  off: 0, // never actually emitted, but maps cleanly
+};
+
+const SEVERITY_TEXT: Record<LogEntry["level"], string> = {
+  debug: "DEBUG",
+  info: "INFO",
+  warn: "WARN",
+  error: "ERROR",
+  off: "OFF",
+};
+
+interface OtelConfig {
+  endpoint: string; // full URL
+  headers: Record<string, string>;
+  serviceName: string;
+  serviceVersion: string;
+}
+
+let config: OtelConfig | null = null;
+let queue: LogEntry[] = [];
+let timer: ReturnType<typeof setTimeout> | null = null;
+let dropCount = 0;
+let inFlightFlush: Promise<void> | null = null;
+
+// Test seam — replaced in unit tests with a mock that captures requests.
+type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
+let fetchImpl: FetchLike = (url, init) => fetch(url, init);
+
+/** Inject a fetch implementation. Test-only. */
+export function setFetchForTesting(f: FetchLike | null): void {
+  fetchImpl = f ?? ((url, init) => fetch(url, init));
+}
+
+function parseHeaders(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  const out: Record<string, string> = {};
+  for (const pair of raw.split(",")) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue; // skip malformed entries
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+function normalizeEndpoint(raw: string): string {
+  const stripped = raw.replace(/\/+$/, "");
+  // If the user already included a /v1/<signal> path, leave it alone.
+  if (/\/v1\/(logs|traces|metrics)$/.test(stripped)) return stripped;
+  return `${stripped}/v1/logs`;
+}
+
+/** Read env vars and initialize the exporter. Idempotent — safe to call
+ *  multiple times. Returns true if the exporter is now active. */
+export function initOtelSink(opts: {
+  endpoint?: string;
+  headers?: string;
+  serviceName?: string;
+  serviceVersion?: string;
+} = {}): boolean {
+  const endpoint = opts.endpoint ?? process.env.KIMIFLARE_OTEL_ENDPOINT;
+  if (!endpoint) {
+    config = null;
+    return false;
+  }
+  config = {
+    endpoint: normalizeEndpoint(endpoint),
+    headers: parseHeaders(opts.headers ?? process.env.KIMIFLARE_OTEL_HEADERS),
+    serviceName: opts.serviceName ?? "kimiflare",
+    serviceVersion: opts.serviceVersion ?? process.env.npm_package_version ?? "0.0.0",
+  };
+  return true;
+}
+
+/** True when the exporter has a configured endpoint. */
+export function isOtelEnabled(): boolean {
+  return config !== null;
+}
+
+/** Test-only helper to clear all in-memory state (queue, timer, drop
+ *  count, config). Use in `beforeEach` to isolate exporter tests. */
+export function resetOtelSinkForTesting(): void {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  queue = [];
+  config = null;
+  dropCount = 0;
+  inFlightFlush = null;
+}
+
+/** Number of log entries that failed to ship. Useful for surfacing
+ *  collector-side outages without crashing the agent. */
+export function getOtelDropCount(): number {
+  return dropCount;
+}
+
+/** Number of entries currently waiting in the batch. Test-only. */
+export function getOtelQueueSize(): number {
+  return queue.length;
+}
+
+/**
+ * Enqueue a log entry for shipping. Silent no-op if the exporter is not
+ * configured. Triggers a flush either when the batch fills or when the
+ * timer fires.
+ */
+export function enqueueOtelLog(entry: LogEntry): void {
+  if (!config) return;
+  queue.push(entry);
+  if (queue.length >= BATCH_MAX) {
+    void flushOtelSink();
+    return;
+  }
+  scheduleFlush();
+}
+
+function scheduleFlush(): void {
+  if (timer) return;
+  timer = setTimeout(() => {
+    timer = null;
+    void flushOtelSink();
+  }, FLUSH_INTERVAL_MS);
+  // Don't keep the event loop alive solely for the flush timer; the
+  // process exit hook below handles draining anything left.
+  if (typeof timer === "object" && timer && "unref" in timer) {
+    (timer as { unref: () => void }).unref();
+  }
+}
+
+/** Drain the queue and POST as a single OTLP/HTTP payload. Returns
+ *  once the in-flight request settles. Silent on failure (increments
+ *  the drop counter). */
+export async function flushOtelSink(): Promise<void> {
+  if (!config) {
+    queue = [];
+    return;
+  }
+  if (queue.length === 0) return;
+  if (inFlightFlush) return inFlightFlush;
+
+  const batch = queue;
+  queue = [];
+  const payload = buildOtlpPayload(batch, config);
+
+  inFlightFlush = (async () => {
+    try {
+      const res = await fetchImpl(config!.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...config!.headers,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        dropCount += batch.length;
+      }
+    } catch {
+      dropCount += batch.length;
+    } finally {
+      inFlightFlush = null;
+    }
+  })();
+  return inFlightFlush;
+}
+
+// ── OTLP/HTTP JSON payload encoding ──────────────────────────────────────
+
+interface OtlpAttribute {
+  key: string;
+  value: { stringValue?: string; intValue?: string; boolValue?: boolean };
+}
+
+function attr(key: string, value: unknown): OtlpAttribute | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return { key, value: { stringValue: value } };
+  if (typeof value === "boolean") return { key, value: { boolValue: value } };
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return { key, value: { intValue: String(Math.trunc(value)) } };
+  }
+  // Fallback: JSON-stringify so structured data still gets shipped.
+  return { key, value: { stringValue: JSON.stringify(value) } };
+}
+
+function flattenDataAttrs(data: Record<string, unknown> | undefined): OtlpAttribute[] {
+  if (!data) return [];
+  const out: OtlpAttribute[] = [];
+  for (const [key, value] of Object.entries(data)) {
+    // Skip the request_id field — it's lifted to top-level and emitted
+    // as `request_id` on the LogRecord attributes directly.
+    if (key === "request_id" || key === "requestId") continue;
+    const a = attr(key, value);
+    if (a) out.push(a);
+  }
+  return out;
+}
+
+export function buildOtlpPayload(
+  entries: LogEntry[],
+  cfg: OtelConfig,
+): unknown {
+  const resourceAttrs: OtlpAttribute[] = [
+    attr("service.name", cfg.serviceName)!,
+    attr("service.version", cfg.serviceVersion)!,
+    ...(process.env.HOSTNAME ? [attr("host.name", process.env.HOSTNAME)!] : []),
+  ];
+
+  const logRecords = entries.map((e) => {
+    const attrs: OtlpAttribute[] = [];
+    if (e.session_id) attrs.push(attr("session_id", e.session_id)!);
+    if (e.turn_id) attrs.push(attr("turn_id", e.turn_id)!);
+    if (e.request_id) attrs.push(attr("request_id", e.request_id)!);
+    attrs.push(attr("event", e.event)!);
+    attrs.push(...flattenDataAttrs(e.data));
+
+    const timeNs = String(BigInt(new Date(e.ts).getTime()) * 1_000_000n);
+    return {
+      timeUnixNano: timeNs,
+      observedTimeUnixNano: timeNs,
+      severityNumber: SEVERITY_NUMBER[e.level],
+      severityText: SEVERITY_TEXT[e.level],
+      body: { stringValue: e.event },
+      attributes: attrs,
+    };
+  });
+
+  return {
+    resourceLogs: [
+      {
+        resource: { attributes: resourceAttrs },
+        scopeLogs: [
+          {
+            scope: { name: "kimiflare", version: cfg.serviceVersion },
+            logRecords,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ── Process-exit drain ───────────────────────────────────────────────────
+
+let exitHookInstalled = false;
+
+/** Register a best-effort exit drain. Without this, a fast process exit
+ *  (e.g. `kimiflare -p "..."` print mode) could drop the last batch
+ *  before the 5s flush timer fires. */
+export function installOtelExitHook(): void {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  const drain = () => {
+    if (queue.length === 0 && !inFlightFlush) return;
+    // Node "beforeExit" is async-friendly — we get to await the flush.
+    void flushOtelSink();
+  };
+  process.on("beforeExit", drain);
+}


### PR DESCRIPTION
## Summary

Closes the **M5 telemetry milestone**. M5.1 (#458) gave us structured JSON logs on disk; M5.2 adds a third sink that ships those same entries to any OpenTelemetry collector / SaaS backend (Datadog, Honeycomb, Grafana Loki, an in-house OTLP collector, …).

Entirely gated on \`KIMIFLARE_OTEL_ENDPOINT\` — unset means zero cost for users who don't want it.

## How it works

\`\`\`
log()  ──┬──> stderr      (KIMIFLARE_LOG_LEVEL, default off)
         ├──> JSONL file  (KIMIFLARE_LOG_SINK,  default on)    ── M5.1
         └──> OTLP/HTTP   (KIMIFLARE_OTEL_ENDPOINT, default unset) ── M5.2 (this PR)
\`\`\`

Each \`logger.*\` call:
1. Buffers in the in-memory ring (existing).
2. Goes to stderr if level passes (existing).
3. Goes to today's JSONL file (M5.1).
4. Goes onto a batch queue. The batch flushes when it hits 100 entries OR every 5 s, whichever fires first. On process exit, a \`beforeExit\` hook drains any tail so short-lived \`kimiflare -p \"…\"\` runs don't lose the last few events.

## Design decisions

**1. Hand-rolled OTLP/HTTP encoder, no SDK dep.**

\`@opentelemetry/exporter-logs-otlp-http\` would be the \"correct\" choice but pulls ~50 KB gzipped of transitive deps and adds setup complexity. The OTLP/HTTP JSON wire format is small enough that a hand-rolled encoder (~80 LOC) is clearer and faster to test. Tradeoff: if OTel ever changes the wire format we have to update one file instead of bumping a dep.

**2. Best-effort, never blocks the agent.**

On failure (network down, collector returns 5xx, fetch throws) we silently increment a drop counter and move on. Observability data must never crash or block the agent loop. The drop counter is exposed via \`getOtelDropCount()\` for tests and a future \`kimiflare logs status\` subcommand if anyone asks.

**3. Friendly URL convention.**

\`KIMIFLARE_OTEL_ENDPOINT\` accepts either the full signal path (\`https://otel.example.com/v1/logs\`) or just the base URL (\`https://otel.example.com\`) — we auto-append \`/v1/logs\` to the latter and strip trailing slashes. Matches what most OTel docs suggest as friendly UX.

**4. Auth via comma-separated key=value headers.**

\`KIMIFLARE_OTEL_HEADERS=Authorization=Bearer xyz,X-Tenant=acme\`. Standard pattern across the OTel ecosystem. Malformed pairs are silently skipped so a typo doesn't break the whole exporter.

## OTLP mapping

Each \`LogEntry\` from \`logger.ts\` becomes one OTel \`LogRecord\`:

| KimiFlare field | OTLP location |
| --- | --- |
| \`level\` | \`severityNumber\` (debug=5, info=9, warn=13, error=17) + \`severityText\` |
| \`event\` | \`body.stringValue\` + \`attributes.event\` |
| \`ts\` | \`timeUnixNano\` + \`observedTimeUnixNano\` (nanoseconds since epoch) |
| \`session_id\` | record attribute |
| \`turn_id\` | record attribute |
| \`request_id\` | record attribute |
| \`data.*\` | flattened to record attributes (string / int / bool / nested→JSON-string) |

Resource attributes:
- \`service.name=kimiflare\`
- \`service.version=$npm_package_version\`
- \`host.name\` (from \`HOSTNAME\` when present)

The same \`request_id\` joins to Cloudflare AI Gateway's per-request log without any extra wiring — so a query \"show me all activity for request X\" works across both telemetry sources.

## What's NOT in this PR (intentional)

- **Spans / tracing.** OTel logs alone cover the M9 use cases (per-tool quotas, cost attribution, loop detection). Spans are a bigger model; deferred to a hypothetical M5.3 if anyone asks.
- **Metrics.** The JSONL file is already queryable with \`jq\`; derived metrics can come from the OTel backend.
- **gRPC transport.** OTLP/HTTP is enough for ~every backend. gRPC needs proto + a TLS dance that's not worth the complexity here.

## Files

- \`src/util/otel-sink.ts\` (NEW, ~270 LOC) — exporter + encoder + batch / drain.
- \`src/util/logger.ts\` — wired \`enqueueOtelLog(entry)\` into \`log()\`.
- \`src/index.tsx\` — calls \`initOtelSink()\` + \`installOtelExitHook()\` at \`main()\` startup.
- \`src/util/otel-sink.test.ts\` (NEW, 21 tests) — mock-fetch coverage of URL normalization, header parsing, batch auto-flush, retry / drop semantics, and the OTLP schema.
- \`README.md\` — \"Shipping to an OpenTelemetry collector\" subsection.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 519/519 pass (21 new)
- [x] \`npm run build\` — clean ESM + DTS
- [x] Tests verify: URL normalization (base vs path-qualified vs trailing-slash), header parsing (well-formed and malformed), 100-entry auto-flush, drop counter increments on HTTP 5xx and on fetch throw, queue clears on reset, OTLP schema (resource attrs, lifted correlation IDs, no \`request_id\` duplication, nanosecond timestamps, severity number map).
- [ ] Manual smoke (not runnable from this non-TTY environment):
  - \`KIMIFLARE_OTEL_ENDPOINT=http://localhost:4318 kimiflare\` and run any tool; check the local collector receives the batch.
  - Unset → no requests fire (verify by pointing a mock collector with \`tcpdump\`).

Closes M5.2. Roadmap Progress log and inline M5 section updated.