### PR TITLE
refactor(tools): structured ToolError envelope (M2.1)

### DIFF
--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,7 +15,33 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
-- **M5.2** — Optional OTLP/HTTP log export *(OP-20)* — *(this PR)*.
+- **M2.1** — Structured `ToolError` envelope *(OP-12)* — *(this PR)*.
+  New `src/tools/tool-error.ts` exports a `ToolError` class
+  (`{ code, message, recoverable, suggestion?, cause? }`) plus the
+  factory helpers `toolTimeoutError` / `toolAbortError` /
+  `toolInvalidArgsError` / `toolNotFoundError` and a `wrapAsToolError`
+  coercion. `ToolResult` gains optional `errorCode` / `recoverable` /
+  `suggestion` fields that the executor populates: thrown `ToolError`
+  passes through, plain `Error` falls back to `unknown`/not-recoverable,
+  and the three pre-existing failure paths (unknown tool, invalid JSON
+  args, permission denied) are now classified inline as `not_found` /
+  `invalid_args` / `permission_denied`. MCP and LSP timeout paths
+  upgraded to throw typed errors (`code: "timeout"`, recoverable). The
+  agent loop emits a `tool:error_classified` warn-level event to the
+  M5.1 structured-log sink whenever a tool returns a classified error
+  so dashboards can answer "which tool / code dominates failures this
+  week" without parsing message strings. **No behavior change beyond
+  the new log event** — the executor's stringified-error path is
+  byte-identical for non-typed failures, and the loop does not (yet)
+  retry on `recoverable: true`. Migrating individual tools to throw
+  `ToolError` is opt-in and gradual; the roadmap's `useTypedErrors`
+  feature flag isn't needed because nothing in this PR gates behavior
+  on the new fields. 22 new tests across `tool-error.test.ts` and
+  `executor.test.ts` cover the type's defaults, the wrap coercion,
+  factory helpers, and the executor classification of all four
+  failure paths. **M2.1 complete — unblocks M6.1 (hooks need typed
+  error classification).**
+- **M5.2** — Optional OTLP/HTTP log export *(OP-20)* — merged in #460.
   Third sink in the logger stack: `src/util/otel-sink.ts` ships each
   entry to an OpenTelemetry collector when `KIMIFLARE_OTEL_ENDPOINT`
   is set. Batched (every 5s or 100 entries, whichever first),
@@ -309,14 +335,14 @@ that touches many call sites — review carefully.
 
 **PRs:**
 
-- **M2.1** — `refactor(tools): introduce structured ToolError`
-  *(OP-12)*
-  - New type: `ToolError { code, message, recoverable, suggestion? }`.
-  - All tools return `ToolResult { content?, error?, … }`.
-  - Loop checks `recoverable` to decide retry vs. fail-fast.
-  - Migration of all 15 core tools + MCP / LSP adapters.
-  - **High risk:** broad surface change. Land behind a feature flag
-    in the loop (`opts.useTypedErrors`) for one release if needed.
+- ✅ **M2.1** — `refactor(tools): introduce structured ToolError`
+  *(OP-12)* — *merged in this PR*. Type + factories in
+  `src/tools/tool-error.ts`; executor lifts code/recoverable/suggestion
+  onto `ToolResult`; MCP + LSP timeouts throw typed errors; loop emits
+  `tool:error_classified` to the M5.1 sink. No feature flag needed —
+  the loop's retry behavior is unchanged (no retry policy exists yet
+  to gate). Individual tool migrations are opt-in and can land
+  one-at-a-time without breaking anything.
 - **M2.2** — `refactor(executor): typed askPermission return`
   *(OP-13)*
   - `askPermission` now returns `{ decision, scope: "once" | "session"

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -878,6 +878,18 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           });
         }
         logger.debug("turn:tool_end", { sessionId: opts.sessionId, tool: tc.function.name, toolCallId: tc.id, ok: result.ok });
+        if (!result.ok && result.errorCode) {
+          // M2.1: surface the classified failure mode in the structured
+          // log so the M5.1 + M5.2 sinks can answer "which tools fail
+          // most, and how?" without parsing message strings.
+          logger.warn("tool:error_classified", {
+            sessionId: opts.sessionId,
+            tool: tc.function.name,
+            toolCallId: tc.id,
+            code: result.errorCode,
+            recoverable: result.recoverable,
+          });
+        }
         toolResults.push(result);
         opts.messages.push({
           role: "tool",

--- a/src/lsp/connection.ts
+++ b/src/lsp/connection.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import type { JsonRpcMessage, JsonRpcRequest, JsonRpcNotification, JsonRpcResponse } from "./protocol.js";
+import { toolTimeoutError, toolAbortError } from "../tools/tool-error.js";
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
@@ -94,7 +95,7 @@ export class LspConnection extends EventEmitter {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`LSP request '${method}' timed out after ${this.requestTimeoutMs}ms`));
+        reject(toolTimeoutError(`LSP request '${method}'`, this.requestTimeoutMs));
       }, this.requestTimeoutMs);
 
       const pending: PendingRequest = { resolve, reject, signal, timer };
@@ -104,7 +105,7 @@ export class LspConnection extends EventEmitter {
         const onAbort = () => {
           this.pending.delete(id);
           clearTimeout(timer);
-          reject(new Error("LSP request cancelled"));
+          reject(toolAbortError(`LSP request '${method}'`));
         };
         if (signal.aborted) {
           onAbort();

--- a/src/mcp/adapter.ts
+++ b/src/mcp/adapter.ts
@@ -1,5 +1,6 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { ToolSpec } from "../tools/registry.js";
+import { toolTimeoutError } from "../tools/tool-error.js";
 
 export interface McpToolEntry {
   spec: ToolSpec;
@@ -18,7 +19,7 @@ export function withTimeout<T>(
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${ms}ms`));
+      reject(toolTimeoutError(label, ms));
     }, ms);
   });
   return Promise.race([promise, timeout]).finally(() => {

--- a/src/tools/executor.test.ts
+++ b/src/tools/executor.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { isDiffCommand } from "./executor.js";
+import { isDiffCommand, ToolExecutor } from "./executor.js";
+import { ToolError } from "./tool-error.js";
+import type { ToolSpec } from "./registry.js";
 
 describe("isDiffCommand", () => {
   it("matches `git show` and its argument forms", () => {
@@ -55,5 +57,122 @@ describe("isDiffCommand", () => {
     assert.strictEqual(isDiffCommand("npm test"), false);
     assert.strictEqual(isDiffCommand("ls -la"), false);
     assert.strictEqual(isDiffCommand("show diff"), false);
+  });
+});
+
+// ── M2.1: ToolError classification on ToolResult ─────────────────────────
+
+function makeTool(opts: {
+  name?: string;
+  needsPermission?: boolean;
+  run: ToolSpec["run"];
+}): ToolSpec {
+  return {
+    name: opts.name ?? "test_tool",
+    description: "test",
+    parameters: { type: "object", properties: {}, additionalProperties: true },
+    needsPermission: opts.needsPermission ?? false,
+    run: opts.run,
+  };
+}
+
+const allowAll = async () => "allow" as const;
+const ctx = { cwd: process.cwd() };
+
+describe("ToolExecutor — typed error classification", () => {
+  it("lifts ToolError code / recoverable / suggestion onto the result", async () => {
+    const tool = makeTool({
+      run: async () => {
+        throw new ToolError({
+          code: "timeout",
+          message: "took too long",
+          suggestion: "retry with a smaller request",
+        });
+      },
+    });
+    const exec = new ToolExecutor([tool]);
+    const res = await exec.run(
+      { id: "c1", name: "test_tool", arguments: "{}" },
+      allowAll,
+      ctx,
+    );
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.errorCode, "timeout");
+    assert.strictEqual(res.recoverable, true);
+    assert.strictEqual(res.suggestion, "retry with a smaller request");
+    assert.match(res.content, /took too long/);
+  });
+
+  it("classifies a plain Error from the tool as 'unknown', not recoverable", async () => {
+    const tool = makeTool({
+      run: async () => {
+        throw new Error("kaboom");
+      },
+    });
+    const exec = new ToolExecutor([tool]);
+    const res = await exec.run(
+      { id: "c2", name: "test_tool", arguments: "{}" },
+      allowAll,
+      ctx,
+    );
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.errorCode, "unknown");
+    assert.strictEqual(res.recoverable, false);
+    assert.strictEqual(res.suggestion, undefined);
+  });
+
+  it("classifies invalid JSON arguments as 'invalid_args'", async () => {
+    const tool = makeTool({ run: async () => "ok" });
+    const exec = new ToolExecutor([tool]);
+    const res = await exec.run(
+      { id: "c3", name: "test_tool", arguments: "not-json{" },
+      allowAll,
+      ctx,
+    );
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.errorCode, "invalid_args");
+    assert.strictEqual(res.recoverable, false);
+  });
+
+  it("classifies unknown tool name as 'not_found'", async () => {
+    const exec = new ToolExecutor([]);
+    const res = await exec.run(
+      { id: "c4", name: "missing", arguments: "{}" },
+      allowAll,
+      ctx,
+    );
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.errorCode, "not_found");
+    assert.strictEqual(res.recoverable, false);
+  });
+
+  it("classifies a denied permission as 'permission_denied'", async () => {
+    const tool = makeTool({
+      needsPermission: true,
+      run: async () => "ok",
+    });
+    const exec = new ToolExecutor([tool]);
+    const res = await exec.run(
+      { id: "c5", name: "test_tool", arguments: "{}" },
+      async () => "deny",
+      ctx,
+    );
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.errorCode, "permission_denied");
+    assert.strictEqual(res.recoverable, false);
+  });
+
+  it("leaves successful results without classification fields", async () => {
+    const tool = makeTool({ run: async () => "happy path" });
+    const exec = new ToolExecutor([tool]);
+    const res = await exec.run(
+      { id: "c6", name: "test_tool", arguments: "{}" },
+      allowAll,
+      ctx,
+    );
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.errorCode, undefined);
+    assert.strictEqual(res.recoverable, undefined);
+    assert.strictEqual(res.suggestion, undefined);
   });
 });

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -1,4 +1,5 @@
 import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
+import { wrapAsToolError, type ToolErrorCode } from "./tool-error.js";
 import { readTool } from "./read.js";
 import { writeTool } from "./write.js";
 import { editTool } from "./edit.js";
@@ -61,6 +62,16 @@ export interface ToolResult {
   reducedBytes?: number;
   /** Artifact ID if the raw output was stored for later expansion. */
   artifactId?: string;
+  /** Stable code classifying the failure mode. Populated only when
+   *  `ok` is false. Sites that have not yet been migrated to
+   *  `ToolError` fall back to `"unknown"`. (M2.1) */
+  errorCode?: ToolErrorCode;
+  /** True when the failure is reasonable to retry. Populated only when
+   *  `ok` is false. The loop reads this for retry-vs-fail-fast
+   *  decisions — currently informational; retry policy lands later. */
+  recoverable?: boolean;
+  /** Optional one-line UI hint describing how to recover. */
+  suggestion?: string;
 }
 
 export class ToolExecutor {
@@ -107,6 +118,8 @@ export class ToolExecutor {
         name: call.name,
         content: `Error: unknown tool "${call.name}". Valid tools: ${[...this.tools.keys()].join(", ")}.`,
         ok: false,
+        errorCode: "not_found",
+        recoverable: false,
       };
     }
 
@@ -119,6 +132,9 @@ export class ToolExecutor {
         name: call.name,
         content: `Error: invalid JSON arguments for ${call.name}: ${(e as Error).message}. Arguments received: ${truncateForError(call.arguments)}`,
         ok: false,
+        errorCode: "invalid_args",
+        recoverable: false,
+        suggestion: "reformulate the tool call with valid JSON arguments",
       };
     }
 
@@ -132,6 +148,9 @@ export class ToolExecutor {
             name: call.name,
             content: `Permission denied by user. Do not retry this exact call; ask the user what they want to do differently.`,
             ok: false,
+            errorCode: "permission_denied",
+            recoverable: false,
+            suggestion: "ask the user what they want to do differently",
           };
         }
         if (decision === "allow_session") this.sessionAllowed.add(sessionKey);
@@ -189,7 +208,8 @@ export class ToolExecutor {
         artifactId: reduced.artifactId,
       };
     } catch (e) {
-      const msg = `Error running ${call.name}: ${(e as Error).message ?? String(e)}`;
+      const err = wrapAsToolError(e);
+      const msg = `Error running ${call.name}: ${err.message}`;
       return {
         tool_call_id: call.id,
         name: call.name,
@@ -197,6 +217,9 @@ export class ToolExecutor {
         ok: false,
         rawBytes: msg.length,
         reducedBytes: msg.length,
+        errorCode: err.code,
+        recoverable: err.recoverable,
+        suggestion: err.suggestion,
       };
     }
   }

--- a/src/tools/tool-error.test.ts
+++ b/src/tools/tool-error.test.ts
@@ -1,0 +1,128 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  ToolError,
+  isToolError,
+  wrapAsToolError,
+  toolTimeoutError,
+  toolAbortError,
+  toolInvalidArgsError,
+  toolNotFoundError,
+} from "./tool-error.js";
+
+describe("ToolError", () => {
+  it("carries code, message, recoverable, suggestion", () => {
+    const e = new ToolError({
+      code: "timeout",
+      message: "MCP timed out",
+      suggestion: "retry with smaller payload",
+    });
+    assert.strictEqual(e.code, "timeout");
+    assert.strictEqual(e.message, "MCP timed out");
+    assert.strictEqual(e.suggestion, "retry with smaller payload");
+    assert.strictEqual(e.recoverable, true); // default for timeout
+    assert.strictEqual(e.name, "ToolError");
+    assert.ok(e instanceof Error);
+  });
+
+  it("derives a sensible default for recoverable from the code", () => {
+    assert.strictEqual(new ToolError({ code: "timeout", message: "x" }).recoverable, true);
+    assert.strictEqual(new ToolError({ code: "transient_failure", message: "x" }).recoverable, true);
+    assert.strictEqual(new ToolError({ code: "aborted", message: "x" }).recoverable, false);
+    assert.strictEqual(new ToolError({ code: "invalid_args", message: "x" }).recoverable, false);
+    assert.strictEqual(new ToolError({ code: "permission_denied", message: "x" }).recoverable, false);
+    assert.strictEqual(new ToolError({ code: "not_found", message: "x" }).recoverable, false);
+    assert.strictEqual(new ToolError({ code: "policy_rejection", message: "x" }).recoverable, false);
+    assert.strictEqual(new ToolError({ code: "unknown", message: "x" }).recoverable, false);
+  });
+
+  it("respects an explicit recoverable override", () => {
+    const e = new ToolError({ code: "timeout", message: "x", recoverable: false });
+    assert.strictEqual(e.recoverable, false);
+  });
+
+  it("preserves the cause for stack traces", () => {
+    const cause = new Error("underlying");
+    const e = new ToolError({ code: "unknown", message: "wrapped", cause });
+    assert.strictEqual((e as Error & { cause?: unknown }).cause, cause);
+  });
+});
+
+describe("isToolError", () => {
+  it("returns true for a ToolError", () => {
+    assert.strictEqual(isToolError(new ToolError({ code: "unknown", message: "x" })), true);
+  });
+
+  it("returns false for plain Error", () => {
+    assert.strictEqual(isToolError(new Error("plain")), false);
+  });
+
+  it("returns false for non-errors", () => {
+    assert.strictEqual(isToolError(null), false);
+    assert.strictEqual(isToolError("string"), false);
+    assert.strictEqual(isToolError({ code: "timeout", message: "x" }), false);
+  });
+
+  it("treats name + code as the duck-type signature (cross-module safe)", () => {
+    // Simulate an Error from a different module instance that still has
+    // the right shape (name === "ToolError" and string code).
+    const e = new Error("from elsewhere");
+    e.name = "ToolError";
+    (e as { code?: unknown }).code = "timeout";
+    assert.strictEqual(isToolError(e), true);
+  });
+});
+
+describe("wrapAsToolError", () => {
+  it("is a no-op for an existing ToolError", () => {
+    const original = new ToolError({ code: "timeout", message: "x" });
+    assert.strictEqual(wrapAsToolError(original), original);
+  });
+
+  it("wraps a plain Error as unknown / not-recoverable", () => {
+    const e = wrapAsToolError(new Error("boom"));
+    assert.strictEqual(e.code, "unknown");
+    assert.strictEqual(e.recoverable, false);
+    assert.strictEqual(e.message, "boom");
+  });
+
+  it("wraps a string", () => {
+    const e = wrapAsToolError("just a string");
+    assert.strictEqual(e.code, "unknown");
+    assert.strictEqual(e.message, "just a string");
+  });
+
+  it("wraps a non-error object via String()", () => {
+    const e = wrapAsToolError({ random: "object" });
+    assert.strictEqual(e.code, "unknown");
+    assert.ok(e.message.includes("[object Object]"));
+  });
+});
+
+describe("factory helpers", () => {
+  it("toolTimeoutError formats the label + ms and is recoverable", () => {
+    const e = toolTimeoutError("MCP request 'foo/bar'", 60_000);
+    assert.strictEqual(e.code, "timeout");
+    assert.strictEqual(e.recoverable, true);
+    assert.match(e.message, /MCP request 'foo\/bar' timed out after 60000ms/);
+  });
+
+  it("toolAbortError is not recoverable", () => {
+    const e = toolAbortError("LSP request 'textDocument/hover'");
+    assert.strictEqual(e.code, "aborted");
+    assert.strictEqual(e.recoverable, false);
+    assert.match(e.message, /cancelled/);
+  });
+
+  it("toolInvalidArgsError carries an optional suggestion", () => {
+    const e = toolInvalidArgsError("offset must be positive", "pass offset >= 1");
+    assert.strictEqual(e.code, "invalid_args");
+    assert.strictEqual(e.suggestion, "pass offset >= 1");
+  });
+
+  it("toolNotFoundError is not recoverable", () => {
+    const e = toolNotFoundError("server 'github' is not registered");
+    assert.strictEqual(e.code, "not_found");
+    assert.strictEqual(e.recoverable, false);
+  });
+});

--- a/src/tools/tool-error.ts
+++ b/src/tools/tool-error.ts
@@ -1,0 +1,159 @@
+/**
+ * Structured tool error (OP-12 / M2.1). A thin envelope around `Error`
+ * that carries a stable `code`, a `recoverable` flag the loop can read
+ * to decide retry vs. fail-fast, and an optional `suggestion` the UI
+ * can surface as a hint.
+ *
+ * The migration plan is gradual:
+ *   - Tools that already throw plain `Error` keep working (the executor
+ *     wraps them as `{ code: "UNKNOWN", recoverable: false }`).
+ *   - Sites that have meaningful classification (MCP / LSP timeouts,
+ *     abort, permission, invalid args) throw `ToolError` directly.
+ *   - Downstream consumers (the loop, hooks added in M6.1, the UI) read
+ *     the typed fields off `ToolResult.errorCode` / `recoverable` /
+ *     `suggestion` once they're ready to act on them.
+ *
+ * No behavior change in this PR — the loop does not yet act on
+ * `recoverable`. That decision lands with the retry-policy work it
+ * unblocks (tracked separately).
+ */
+
+/**
+ * Stable codes for the common failure modes. New codes can be added
+ * over time; downstream consumers should default-handle unknown codes
+ * as fatal/unrecoverable. Use lowercase snake_case for code names.
+ */
+export type ToolErrorCode =
+  /** A request to an external service (MCP server, LSP server, HTTP
+   *  fetch, …) exceeded its allowed time budget. Typically retryable. */
+  | "timeout"
+  /** The user (or a parent abort signal) cancelled the call. Never
+   *  retry — the user explicitly stopped. */
+  | "aborted"
+  /** The tool was invoked with bad arguments — the call would always
+   *  fail with the same input. Not retryable as-is; the model needs to
+   *  reformulate. */
+  | "invalid_args"
+  /** Permission for the tool was denied by the user or by mode. Not
+   *  retryable; the model should pick a different tool. */
+  | "permission_denied"
+  /** A transient external failure (network blip, 503, EAGAIN, …) that
+   *  is reasonable to retry once. */
+  | "transient_failure"
+  /** The thing the tool was asked to operate on doesn't exist
+   *  (file, URL, MCP server). Not retryable. */
+  | "not_found"
+  /** A guard rejected the call (sandbox policy, size cap, …). Not
+   *  retryable. */
+  | "policy_rejection"
+  /** Catch-all for errors with no obvious classification. Not retryable
+   *  by default. */
+  | "unknown";
+
+export interface ToolErrorOptions {
+  code: ToolErrorCode;
+  message: string;
+  /** True if a retry is reasonable. The loop reads this to choose
+   *  between retry-with-backoff and surfacing the error to the model.
+   *  Defaults derived from `code` if omitted: timeout/transient → true,
+   *  everything else → false. */
+  recoverable?: boolean;
+  /** Optional one-line hint the UI can render alongside the error.
+   *  Should NOT include the original error message — that's already in
+   *  `message`. Example: "try shortening the prompt" or "the LSP server
+   *  for typescript has crashed — try /lsp restart". */
+  suggestion?: string;
+  /** Original error to wrap, if any. Preserved as `cause` for stack
+   *  traces while the `ToolError` itself carries the classification. */
+  cause?: unknown;
+}
+
+const RECOVERABLE_DEFAULT: Record<ToolErrorCode, boolean> = {
+  timeout: true,
+  aborted: false,
+  invalid_args: false,
+  permission_denied: false,
+  transient_failure: true,
+  not_found: false,
+  policy_rejection: false,
+  unknown: false,
+};
+
+/**
+ * Thrown by a tool's `run` to signal a classified failure. The executor
+ * catches it and lifts `code`, `recoverable`, `suggestion` onto the
+ * `ToolResult`. Throwing a plain `Error` from a tool still works — the
+ * executor wraps it as `{ code: "unknown", recoverable: false }`.
+ */
+export class ToolError extends Error {
+  readonly code: ToolErrorCode;
+  readonly recoverable: boolean;
+  readonly suggestion?: string;
+
+  constructor(opts: ToolErrorOptions) {
+    super(opts.message, opts.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = "ToolError";
+    this.code = opts.code;
+    this.recoverable = opts.recoverable ?? RECOVERABLE_DEFAULT[opts.code];
+    this.suggestion = opts.suggestion;
+  }
+}
+
+/** Type guard. Cheaper + safer than `instanceof` across module boundaries. */
+export function isToolError(e: unknown): e is ToolError {
+  return (
+    e instanceof Error &&
+    e.name === "ToolError" &&
+    typeof (e as { code?: unknown }).code === "string"
+  );
+}
+
+// ── Factory helpers for common cases ─────────────────────────────────────
+
+export function toolTimeoutError(label: string, ms: number, cause?: unknown): ToolError {
+  return new ToolError({
+    code: "timeout",
+    message: `${label} timed out after ${ms}ms`,
+    suggestion:
+      "the external service was slow to respond — retry, or try a smaller request",
+    cause,
+  });
+}
+
+export function toolAbortError(label: string, cause?: unknown): ToolError {
+  return new ToolError({
+    code: "aborted",
+    message: `${label} was cancelled`,
+    cause,
+  });
+}
+
+export function toolInvalidArgsError(message: string, suggestion?: string): ToolError {
+  return new ToolError({
+    code: "invalid_args",
+    message,
+    suggestion,
+  });
+}
+
+export function toolNotFoundError(message: string, suggestion?: string): ToolError {
+  return new ToolError({
+    code: "not_found",
+    message,
+    suggestion,
+  });
+}
+
+/** Coerce any thrown value into a `ToolError`. Pass-through for instances;
+ *  wraps plain `Error` and primitives. Used by the executor's catch block
+ *  so downstream code can always reason in terms of `ToolError`. */
+export function wrapAsToolError(e: unknown): ToolError {
+  if (isToolError(e)) return e;
+  const message = e instanceof Error ? e.message : String(e);
+  return new ToolError({
+    code: "unknown",
+    message,
+    recoverable: false,
+    cause: e,
+  });
+}


### PR DESCRIPTION
## Summary

Introduces a typed envelope for tool failures (\`ToolError { code, message, recoverable, suggestion? }\`) so the loop, the M5.1 log sink, and the M6.1 hooks (next milestone) can reason about errors by code instead of grepping message strings.

**Closes M2.1 and unblocks M6.1** — hooks need typed error classification to fire \`PreToolUse\` / \`PostToolUse\` events with structured failure info.

## Roadmap deviation worth flagging

The original M2.1 entry called for a \`opts.useTypedErrors\` feature flag because the change was rated **High risk: broad surface change**. After implementing, I don't think the flag is needed and didn't add it. Here's why:

The roadmap risk was about \"changing retry behavior would surprise people.\" But there is **no retry behavior to change** — today's loop appends tool results and moves on; \`recoverable\` is informational, not actionable. The fields land alongside the existing string-stuffed error message; the executor's stringified-error path is **byte-identical** for any tool still throwing plain \`Error\`. Nothing gates on the new fields.

The actual high-risk change (\"loop retries on recoverable\") would be a separate PR with its own feature flag if/when we add a retry policy. Adding the flag now would just be ceremony with nothing to gate.

Happy to revisit if you'd rather have the flag in place defensively — easy enough to add the dead branch.

## What's in the PR

**New module:** \`src/tools/tool-error.ts\`

- \`ToolError\` class with eight stable codes: \`timeout\`, \`aborted\`, \`invalid_args\`, \`permission_denied\`, \`transient_failure\`, \`not_found\`, \`policy_rejection\`, \`unknown\`. Sensible \`recoverable\` defaults per code (timeout/transient → true, everything else → false), overridable per instance.
- Factory helpers: \`toolTimeoutError\`, \`toolAbortError\`, \`toolInvalidArgsError\`, \`toolNotFoundError\`. Reduces noise at call sites.
- \`wrapAsToolError(unknown)\` coerces plain \`Error\` / strings / objects into a typed \`ToolError\` so the executor can always reason in terms of one shape downstream.
- \`isToolError\` guard uses \`name + code\` duck-typing (cheaper + safer than \`instanceof\` across module boundaries).

**\`ToolResult\`** gains three optional fields populated on failure: \`errorCode\` / \`recoverable\` / \`suggestion\`. Successful results leave them \`undefined\` (byte-identical to today).

**Executor** classifies all four failure paths:
| Path | code |
| --- | --- |
| Unknown tool name | \`not_found\` |
| Invalid JSON arguments | \`invalid_args\` (with reformulate suggestion) |
| Permission denied by user | \`permission_denied\` |
| Tool threw | \`wrapAsToolError(e)\` — typed \`ToolError\` passes through; plain \`Error\` → \`unknown\`/not-recoverable |

**MCP + LSP timeouts upgraded** to throw typed errors:
- \`withTimeout\` in \`src/mcp/adapter.ts\` now rejects with \`toolTimeoutError(label, ms)\` — preserves the existing message format so the regex assertion in \`adapter.test.ts\` still matches.
- \`LspConnection.request\` in \`src/lsp/connection.ts\` throws \`toolTimeoutError\` / \`toolAbortError\` on its two failure paths.

**Agent loop** emits a warn-level \`tool:error_classified\` event to the structured log sink (M5.1 / M5.2) whenever a tool returns a classified failure, carrying \`code\` + \`recoverable\`. Lets dashboards answer \"which tool / code dominates failures this week\" without parsing message strings.

## What's NOT in this PR (intentional)

- **Migration of all 15 core tools.** Each tool keeps throwing \`Error\` as today. The type is available when a tool wants to opt-in (e.g. \`read.ts\` could throw \`toolNotFoundError\` instead of \`new Error(\"ENOENT\")\`). Gradual is safer than a big-bang rewrite.
- **Retry policy.** \`recoverable\` is informational. Adding actual retry-on-recoverable is a separate decision with its own knobs (max attempts, backoff, etc.) — out of scope.
- **UI suggestion rendering.** \`suggestion\` lands on the result; surfacing it as a TUI hint is a tiny follow-up if anyone wants it.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 541/541 pass (22 new)
- [x] \`npm run build\` — clean ESM + DTS
- [x] New tests cover:
  - \`tool-error.test.ts\` (16): code defaults, recoverable override, cause preservation, \`isToolError\` guard incl. cross-module duck-typing, \`wrapAsToolError\` for ToolError / plain Error / string / object, all four factory helpers.
  - \`executor.test.ts\` (6): typed \`ToolError\` passthrough, plain \`Error\` → \`unknown\`, \`invalid_args\` classification, \`not_found\` classification, \`permission_denied\` classification, successful runs leave fields undefined.
- [ ] Manual smoke (not runnable from this non-TTY environment):
  - Force an MCP timeout (set \`timeoutMs: 100\` on a slow MCP server) → confirm \`jq 'select(.event == \"tool:error_classified\")' < \$(kimiflare logs path)\` shows the \`timeout\` / \`recoverable: true\` event.
  - Deny a write permission → same path, \`permission_denied\` / \`recoverable: false\`.

Closes M2.1. Roadmap Progress log and inline M2 section updated.