### PR TITLE
refactor(executor): typed askPermission return (M2.2)

### DIFF
--- a/docs/architecture/development-roadmap.md
+++ b/docs/architecture/development-roadmap.md
@@ -15,7 +15,22 @@ Most-recent-first. When an item ships, move it here in one line so a
 fresh session can pick up where the last one left off without
 re-reading the full roadmap.
 
-- **M2.1** — Structured `ToolError` envelope *(OP-12)* — *(this PR)*.
+- **M2.2** — Typed `askPermission` return *(OP-13)* — *(this PR)*.
+  Replaces the overloaded `"allow" | "allow_session" | "deny"` enum
+  with an orthogonal `{ decision: "allow" | "deny", scope: "once" |
+  "session" | "pattern" }` shape. The new `"pattern"` scope is the
+  load-bearing addition — it's how M6.2's settings.json allowlists
+  (e.g. `"Bash(npm test:*)"`) will be expressed without overloading
+  the decision enum. The legacy string is kept as a deprecated alias
+  in a `PermissionDecision` union; `toPermissionResult()` normalizes
+  either shape at the executor boundary so existing SDK callers keep
+  working unchanged. Executor branches on `scope` now: `"once"` and
+  `"pattern"` skip the session cache, `"session"` adds to it as
+  before. Updated permission modal, controller, SDK event type, and
+  RPC validation. 10 new tests covering the normalizer + executor
+  scope handling under both shapes. **M2 complete — unblocks M6.2
+  pattern allowlists.**
+- **M2.1** — Structured `ToolError` envelope *(OP-12)* — merged in #462.
   New `src/tools/tool-error.ts` exports a `ToolError` class
   (`{ code, message, recoverable, suggestion?, cause? }`) plus the
   factory helpers `toolTimeoutError` / `toolAbortError` /
@@ -343,11 +358,12 @@ that touches many call sites — review carefully.
   the loop's retry behavior is unchanged (no retry policy exists yet
   to gate). Individual tool migrations are opt-in and can land
   one-at-a-time without breaking anything.
-- **M2.2** — `refactor(executor): typed askPermission return`
-  *(OP-13)*
-  - `askPermission` now returns `{ decision, scope: "once" | "session"
-    | "pattern" }`.
-  - Caller can prepare for pattern allowlists in M6.
+- ✅ **M2.2** — `refactor(executor): typed askPermission return`
+  *(OP-13)* — *merged in this PR*. New
+  `PermissionDecisionResult` shape `{ decision, scope }`; legacy
+  string accepted via union + `toPermissionResult()` normalizer.
+  Executor branches on `scope` for caching. Modal, controller, SDK
+  event, and RPC all updated.
 
 **Exit criteria:** Both PRs merged. All existing tools migrated. No
 test regressions.

--- a/src/sdk/rpc.ts
+++ b/src/sdk/rpc.ts
@@ -134,8 +134,27 @@ export async function startRpcServer(
             send({ id: cmd.id, type: "error", error: "No active session" });
             break;
           }
-          const decision = cmd.decision as PermissionDecision;
-          if (decision === "allow" || decision === "allow_session" || decision === "deny") {
+          // M2.2: accept either the legacy string or the typed
+          // `PermissionDecisionResult` shape (`{ decision, scope }`).
+          // Both work because `PermissionDecision` is a union and the
+          // executor normalizes at the boundary.
+          const raw = cmd.decision as unknown;
+          let decision: PermissionDecision | null = null;
+          if (raw === "allow" || raw === "allow_session" || raw === "deny") {
+            decision = raw;
+          } else if (
+            raw !== null &&
+            typeof raw === "object" &&
+            (raw as { decision?: unknown }).decision !== undefined
+          ) {
+            const r = raw as { decision: unknown; scope: unknown };
+            const okDecision = r.decision === "allow" || r.decision === "deny";
+            const okScope = r.scope === "once" || r.scope === "session" || r.scope === "pattern";
+            if (okDecision && okScope) {
+              decision = { decision: r.decision, scope: r.scope } as PermissionDecision;
+            }
+          }
+          if (decision !== null) {
             session.resolvePermission(typeof cmd.requestId === "string" ? cmd.requestId : "", decision);
           }
           send({ id: cmd.id, type: "ok" });

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -59,7 +59,10 @@ export type SessionEvent =
 
   // Permission
   | { type: "permission.request"; requestId: string; toolName: string; args: unknown }
-  | { type: "permission.resolved"; requestId: string; decision: "allow" | "allow_session" | "deny" }
+  // M2.2: accepts either legacy string or typed `PermissionDecisionResult`
+  // shape. Existing wire-format consumers can keep matching on string
+  // values; new consumers can switch on the `{ decision, scope }` shape.
+  | { type: "permission.resolved"; requestId: string; decision: PermissionDecision }
 
   // Tasks
   | { type: "tasks.update"; tasks: Task[] }

--- a/src/tools/executor.test.ts
+++ b/src/tools/executor.test.ts
@@ -1,8 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { isDiffCommand, ToolExecutor } from "./executor.js";
+import { isDiffCommand, ToolExecutor, toPermissionResult } from "./executor.js";
 import { ToolError } from "./tool-error.js";
-import type { ToolSpec } from "./registry.js";
+import type { ToolSpec, ToolContext } from "./registry.js";
+import type { PermissionAsker, PermissionDecisionResult } from "./executor.js";
 
 describe("isDiffCommand", () => {
   it("matches `git show` and its argument forms", () => {
@@ -174,5 +175,122 @@ describe("ToolExecutor — typed error classification", () => {
     assert.strictEqual(res.errorCode, undefined);
     assert.strictEqual(res.recoverable, undefined);
     assert.strictEqual(res.suggestion, undefined);
+  });
+});
+
+// ── M2.2: typed PermissionDecisionResult ─────────────────────────────────
+
+describe("toPermissionResult", () => {
+  it("maps legacy 'allow' to { allow, once }", () => {
+    assert.deepStrictEqual(toPermissionResult("allow"), {
+      decision: "allow",
+      scope: "once",
+    });
+  });
+
+  it("maps legacy 'allow_session' to { allow, session }", () => {
+    assert.deepStrictEqual(toPermissionResult("allow_session"), {
+      decision: "allow",
+      scope: "session",
+    });
+  });
+
+  it("maps legacy 'deny' to { deny, once }", () => {
+    assert.deepStrictEqual(toPermissionResult("deny"), {
+      decision: "deny",
+      scope: "once",
+    });
+  });
+
+  it("passes the typed shape through unchanged", () => {
+    const typed: PermissionDecisionResult = { decision: "allow", scope: "pattern" };
+    assert.strictEqual(toPermissionResult(typed), typed);
+  });
+});
+
+describe("ToolExecutor — typed PermissionDecisionResult handling", () => {
+  function makeTool(name = "needs_perm"): ToolSpec {
+    return {
+      name,
+      description: "test",
+      parameters: { type: "object", properties: {}, additionalProperties: true },
+      needsPermission: true,
+      run: async () => "ok",
+    };
+  }
+  const ctx2: ToolContext = { cwd: process.cwd() };
+
+  it("scope 'once' does NOT cache — re-asks on the next call", async () => {
+    const tool = makeTool();
+    const exec = new ToolExecutor([tool]);
+    let prompts = 0;
+    const ask: PermissionAsker = async () => {
+      prompts += 1;
+      return { decision: "allow", scope: "once" };
+    };
+    await exec.run({ id: "a", name: tool.name, arguments: "{}" }, ask, ctx2);
+    await exec.run({ id: "b", name: tool.name, arguments: "{}" }, ask, ctx2);
+    assert.strictEqual(prompts, 2);
+  });
+
+  it("scope 'session' caches — skips the asker on the second call", async () => {
+    const tool = makeTool();
+    const exec = new ToolExecutor([tool]);
+    let prompts = 0;
+    const ask: PermissionAsker = async () => {
+      prompts += 1;
+      return { decision: "allow", scope: "session" };
+    };
+    await exec.run({ id: "a", name: tool.name, arguments: "{}" }, ask, ctx2);
+    await exec.run({ id: "b", name: tool.name, arguments: "{}" }, ask, ctx2);
+    assert.strictEqual(prompts, 1);
+  });
+
+  it("scope 'pattern' does NOT cache — the pattern itself lives in settings.json", async () => {
+    const tool = makeTool();
+    const exec = new ToolExecutor([tool]);
+    let prompts = 0;
+    const ask: PermissionAsker = async () => {
+      prompts += 1;
+      return { decision: "allow", scope: "pattern" };
+    };
+    await exec.run({ id: "a", name: tool.name, arguments: "{}" }, ask, ctx2);
+    await exec.run({ id: "b", name: tool.name, arguments: "{}" }, ask, ctx2);
+    assert.strictEqual(prompts, 2);
+  });
+
+  it("deny is honored regardless of scope", async () => {
+    const tool = makeTool();
+    const exec = new ToolExecutor([tool]);
+    const ask: PermissionAsker = async () => ({ decision: "deny", scope: "once" });
+    const res = await exec.run({ id: "a", name: tool.name, arguments: "{}" }, ask, ctx2);
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.errorCode, "permission_denied");
+  });
+
+  it("legacy 'allow_session' string is still cached (back-compat)", async () => {
+    const tool = makeTool();
+    const exec = new ToolExecutor([tool]);
+    let prompts = 0;
+    const ask: PermissionAsker = async () => {
+      prompts += 1;
+      return "allow_session";
+    };
+    await exec.run({ id: "a", name: tool.name, arguments: "{}" }, ask, ctx2);
+    await exec.run({ id: "b", name: tool.name, arguments: "{}" }, ask, ctx2);
+    assert.strictEqual(prompts, 1);
+  });
+
+  it("legacy 'allow' string is NOT cached (back-compat)", async () => {
+    const tool = makeTool();
+    const exec = new ToolExecutor([tool]);
+    let prompts = 0;
+    const ask: PermissionAsker = async () => {
+      prompts += 1;
+      return "allow";
+    };
+    await exec.run({ id: "a", name: tool.name, arguments: "{}" }, ask, ctx2);
+    await exec.run({ id: "b", name: tool.name, arguments: "{}" }, ask, ctx2);
+    assert.strictEqual(prompts, 2);
   });
 });

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -35,7 +35,57 @@ export const ALL_TOOLS: ToolSpec[] = [
   memoryForgetTool,
 ];
 
-export type PermissionDecision = "allow" | "allow_session" | "deny";
+/**
+ * Whether the user said yes or no.
+ *
+ * NOTE on naming: the legacy `PermissionDecision` string type
+ * (`"allow" | "allow_session" | "deny"`) also lives below as a
+ * deprecated back-compat alias. New callers should return the typed
+ * `PermissionDecisionResult` shape; the executor normalizes either at
+ * the boundary so existing SDK callers keep working unchanged.
+ */
+export type PermissionDecisionKind = "allow" | "deny";
+
+/**
+ * How broadly an allow applies. M2.1's enum overloaded this with the
+ * decision — `"allow_session"` meant "allow + cache for the session" —
+ * which made the new `"pattern"` scope from M6.2 impossible to express.
+ *
+ *   - `once`    — approved this single call. The executor will ask
+ *                 again next time the same tool is requested.
+ *   - `session` — approved for the rest of the session (existing
+ *                 `"allow_session"` behavior).
+ *   - `pattern` — approved because the call matched a pre-configured
+ *                 glob in settings.json (M6.2). The executor does NOT
+ *                 cache pattern-allow decisions — the pattern itself
+ *                 is the durable record and lives in the config file.
+ *
+ * `scope` is meaningful only when `decision === "allow"`; for `deny`
+ * it's ignored, but we keep it required so the shape stays uniform.
+ */
+export type PermissionScope = "once" | "session" | "pattern";
+
+export interface PermissionDecisionResult {
+  decision: PermissionDecisionKind;
+  scope: PermissionScope;
+}
+
+/**
+ * Legacy single-string decision. Kept for SDK back-compat — callers can
+ * still return `"allow" | "allow_session" | "deny"` and the executor
+ * normalizes via `toPermissionResult`. Prefer
+ * `PermissionDecisionResult` in new code.
+ *
+ * @deprecated since M2.2. Use `PermissionDecisionResult` instead.
+ */
+export type PermissionDecisionLegacy = "allow" | "allow_session" | "deny";
+
+/**
+ * Union of the new typed result and the legacy string. Both shapes are
+ * accepted by `PermissionAsker`; the executor calls
+ * `toPermissionResult` to normalize.
+ */
+export type PermissionDecision = PermissionDecisionLegacy | PermissionDecisionResult;
 
 export interface PermissionRequest {
   tool: ToolSpec;
@@ -44,6 +94,28 @@ export interface PermissionRequest {
 }
 
 export type PermissionAsker = (req: PermissionRequest) => Promise<PermissionDecision>;
+
+/**
+ * Normalize either decision shape into `PermissionDecisionResult`.
+ * Mapping:
+ *   `"allow"`         → `{ decision: "allow", scope: "once" }`
+ *   `"allow_session"` → `{ decision: "allow", scope: "session" }`
+ *   `"deny"`          → `{ decision: "deny", scope: "once" }`
+ *   typed shape       → returned as-is
+ */
+export function toPermissionResult(d: PermissionDecision): PermissionDecisionResult {
+  if (typeof d === "string") {
+    switch (d) {
+      case "allow":
+        return { decision: "allow", scope: "once" };
+      case "allow_session":
+        return { decision: "allow", scope: "session" };
+      case "deny":
+        return { decision: "deny", scope: "once" };
+    }
+  }
+  return d;
+}
 
 export interface ToolInvocation {
   id: string;
@@ -141,8 +213,9 @@ export class ToolExecutor {
     if (tool.needsPermission) {
       const sessionKey = this.permissionKey(tool, args);
       if (!this.sessionAllowed.has(sessionKey)) {
-        const decision = await askPermission({ tool, args, sessionKey });
-        if (decision === "deny") {
+        const raw = await askPermission({ tool, args, sessionKey });
+        const result = toPermissionResult(raw);
+        if (result.decision === "deny") {
           return {
             tool_call_id: call.id,
             name: call.name,
@@ -153,7 +226,11 @@ export class ToolExecutor {
             suggestion: "ask the user what they want to do differently",
           };
         }
-        if (decision === "allow_session") this.sessionAllowed.add(sessionKey);
+        // Only cache when the user said "for this session." `once` is
+        // intentionally not cached (we re-ask), and `pattern` allows
+        // come from settings.json so the pattern itself is the durable
+        // record — no in-memory cache needed.
+        if (result.scope === "session") this.sessionAllowed.add(sessionKey);
       }
     }
 

--- a/src/ui/permission.tsx
+++ b/src/ui/permission.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from "react";
 import { Box, Text, useInput } from "ink";
 import { platform } from "node:os";
 import type { ToolSpec } from "../tools/registry.js";
-import type { PermissionDecision } from "../tools/executor.js";
+import type { PermissionDecision, PermissionDecisionResult } from "../tools/executor.js";
 import { DiffView } from "./diff-view.js";
 import { CustomTextInput } from "./text-input.js";
 import { useTheme } from "./theme-context.js";
@@ -15,11 +15,20 @@ interface Props {
   onFeedback?: (text: string) => void;
 }
 
-const OPTIONS: { value: PermissionDecision; label: string; key: number }[] = [
-  { value: "allow", label: "Allow once", key: 1 },
-  { value: "allow_session", label: "Allow for this session", key: 2 },
-  { value: "deny", label: "Something else", key: 3 },
+/**
+ * Three user-visible choices, each carrying the typed result the
+ * executor will see. Built off the M2.2 `PermissionDecisionResult`
+ * shape — `decision` and `scope` are now orthogonal so M6.2 can layer
+ * pattern allowlists in front of the modal without changing the modal's
+ * output type.
+ */
+const OPTIONS: { value: PermissionDecisionResult; label: string; key: number }[] = [
+  { value: { decision: "allow", scope: "once" }, label: "Allow once", key: 1 },
+  { value: { decision: "allow", scope: "session" }, label: "Allow for this session", key: 2 },
+  { value: { decision: "deny", scope: "once" }, label: "Something else", key: 3 },
 ];
+
+const DENY: PermissionDecisionResult = { decision: "deny", scope: "once" };
 
 const MOD_KEY = platform() === "darwin" ? "\u2325" : "Alt";
 
@@ -46,11 +55,11 @@ export function PermissionModal({ tool, args, onDecide, onFeedback }: Props) {
     (index: number) => {
       const opt = OPTIONS[index];
       if (!opt) return;
-      if (opt.value === "deny") {
+      if (opt.value.decision === "deny") {
         if (onFeedback) {
           setFeedbackActive(true);
         } else {
-          onDecide("deny");
+          onDecide(DENY);
         }
       } else {
         onDecide(opt.value);
@@ -61,7 +70,7 @@ export function PermissionModal({ tool, args, onDecide, onFeedback }: Props) {
 
   const handleFeedbackSubmit = useCallback(
     (text: string) => {
-      onDecide("deny");
+      onDecide(DENY);
       if (text.trim()) {
         onFeedback?.(text);
       }
@@ -72,7 +81,7 @@ export function PermissionModal({ tool, args, onDecide, onFeedback }: Props) {
   );
 
   const handleFeedbackCancel = useCallback(() => {
-    onDecide("deny");
+    onDecide(DENY);
     setFeedbackActive(false);
     setFeedbackValue("");
   }, [onDecide]);
@@ -84,7 +93,7 @@ export function PermissionModal({ tool, args, onDecide, onFeedback }: Props) {
         return;
       }
 
-      // Direct selection via Alt+1-4
+      // Direct selection via Alt+1-3
       if (key.meta && inputChar === "1") {
         handleSelect(0);
         return;
@@ -122,7 +131,7 @@ export function PermissionModal({ tool, args, onDecide, onFeedback }: Props) {
 
       // Escape cancels
       if (key.escape) {
-        onDecide("deny");
+        onDecide(DENY);
       }
     },
     { isActive: !feedbackActive },
@@ -169,7 +178,7 @@ export function PermissionModal({ tool, args, onDecide, onFeedback }: Props) {
       <Box marginTop={1} flexDirection="column">
         {OPTIONS.map((opt, i) => (
           <Text
-            key={opt.value}
+            key={`${opt.value.decision}_${opt.value.scope}`}
             color={i === selectedIndex ? theme.accent : undefined}
             bold={i === selectedIndex}
           >

--- a/src/ui/use-permission-controller.test.ts
+++ b/src/ui/use-permission-controller.test.ts
@@ -16,11 +16,11 @@ describe("decidePermission", () => {
     it("resolves any tool with allow", () => {
       assert.deepStrictEqual(decidePermission(req("bash", { command: "rm -rf /" }), "auto"), {
         kind: "resolve",
-        decision: "allow",
+        decision: { decision: "allow", scope: "once" },
       });
       assert.deepStrictEqual(decidePermission(req("write"), "auto"), {
         kind: "resolve",
-        decision: "allow",
+        decision: { decision: "allow", scope: "once" },
       });
     });
   });
@@ -33,7 +33,7 @@ describe("decidePermission", () => {
     it("auto-allows read-only bash without prompting", () => {
       assert.deepStrictEqual(decidePermission(req("bash", { command: "git status" }), "plan"), {
         kind: "resolve",
-        decision: "allow",
+        decision: { decision: "allow", scope: "once" },
       });
     });
 

--- a/src/ui/use-permission-controller.ts
+++ b/src/ui/use-permission-controller.ts
@@ -1,9 +1,15 @@
 import { useCallback, useRef, useState } from "react";
 import type {
   PermissionDecision,
+  PermissionDecisionResult,
   PermissionRequest,
 } from "../tools/executor.js";
 import { isBlockedInPlanMode, isReadOnlyBash, type Mode } from "../mode.js";
+
+/** Pre-built typed decisions for the two auto-resolve paths so we don't
+ *  recreate them on every call. M2.2 — see `PermissionDecisionResult`. */
+const AUTO_ALLOW: PermissionDecisionResult = { decision: "allow", scope: "once" };
+const AUTO_DENY: PermissionDecisionResult = { decision: "deny", scope: "once" };
 
 export interface PendingPermission {
   tool: PermissionRequest["tool"];
@@ -34,14 +40,14 @@ export function decidePermission(
   mode: Mode,
   opts: DecidePermissionOptions = {},
 ): PermissionOutcome {
-  if (mode === "auto") return { kind: "resolve", decision: "allow" };
+  if (mode === "auto") return { kind: "resolve", decision: AUTO_ALLOW };
   if (mode === "plan" && isBlockedInPlanMode(req.tool.name)) {
     if (
       req.tool.name === "bash" &&
       typeof req.args.command === "string" &&
       isReadOnlyBash(req.args.command)
     ) {
-      return { kind: "resolve", decision: "allow" };
+      return { kind: "resolve", decision: AUTO_ALLOW };
     }
     if (req.tool.name === "bash" && opts.promptOnBlockedBash) {
       return { kind: "prompt" };
@@ -103,7 +109,7 @@ export function usePermissionController(
         }
         if (outcome.kind === "plan_blocked") {
           onPlanModeBlockedRef.current(outcome.toolName);
-          resolve("deny");
+          resolve(AUTO_DENY);
           return;
         }
         // outcome.kind === "prompt"
@@ -127,7 +133,7 @@ export function usePermissionController(
     if (pendingResolve === null) return false;
     resolveRef.current = null;
     setPending(null);
-    pendingResolve("deny");
+    pendingResolve(AUTO_DENY);
     return true;
   }, []);
 


### PR DESCRIPTION
## Summary

Replaces the overloaded \`\"allow\" | \"allow_session\" | \"deny\"\` decision enum with an orthogonal \`{ decision, scope }\` shape. The new \`\"pattern\"\` scope is the load-bearing addition — it's how M6.2's settings.json pattern allowlists (e.g. \`\"Bash(npm test:*)\"\`) will be expressed without overloading the decision enum.

**Closes M2 milestone. Unblocks M6.2.**

## The type change

\`\`\`ts
// Before
type PermissionDecision = \"allow\" | \"allow_session\" | \"deny\";

// After
type PermissionDecisionKind = \"allow\" | \"deny\";
type PermissionScope = \"once\" | \"session\" | \"pattern\";
interface PermissionDecisionResult { decision: PermissionDecisionKind; scope: PermissionScope }
\`\`\`

The legacy string is kept as a deprecated alias inside a \`PermissionDecision\` union. \`PermissionAsker\` accepts either shape; \`toPermissionResult()\` normalizes at the executor boundary so existing SDK callers keep working **unchanged** (no migration required, no deprecation warnings at runtime).

## Executor branching

Was:
\`\`\`ts
if (decision === \"allow_session\") this.sessionAllowed.add(sessionKey);
\`\`\`

Now:
\`\`\`ts
if (result.scope === \"session\") this.sessionAllowed.add(sessionKey);
// \"once\" → re-ask next call (existing behavior)
// \"pattern\" → no cache (the pattern in settings.json is the durable record)
\`\`\`

## Consumers updated

| File | Change |
| --- | --- |
| \`ui/permission.tsx\` | OPTIONS carry \`{ decision, scope }\` rows; \`onDecide\` emits typed result |
| \`ui/use-permission-controller.ts\` | \`AUTO_ALLOW\` / \`AUTO_DENY\` constants for auto / plan-blocked paths |
| \`sdk/types.ts\` | \`permission.resolved\` event widens to \`PermissionDecision\` union |
| \`sdk/rpc.ts\` | \`resolve_permission\` command accepts either shape, structurally validates the typed shape |

All other call sites (loop, code-mode sandbox, init, app.tsx) compile unchanged thanks to the union.

## What this PR does NOT do

- **No pattern matching logic** — that's M6.2. The executor just accepts the \`\"pattern\"\` scope and trusts the caller. The settings.json reader + glob matching land then.
- **No new UI in the modal** — the three user-visible choices are still \"Allow once\", \"Allow for this session\", \"Something else\". M6.2 doesn't need a fourth.
- **No feature flag** — same reasoning as M2.1: no behavior gates on the new fields beyond the cache branch, which already works correctly for both shapes. The roadmap-suggested \`opts.useTypedErrors\` flag was for retry-policy work that doesn't exist yet.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 551/551 pass (10 new)
- [x] \`npm run build\` — clean ESM + DTS (DTS picked up the new public type from \`@kimiflare/sdk\`)
- [x] New tests verify:
  - \`toPermissionResult\` maps each legacy string to the typed shape and passes the typed shape through untouched.
  - Executor: \`scope: \"once\"\` re-asks on the next call, \`scope: \"session\"\` caches, \`scope: \"pattern\"\` re-asks (no cache).
  - \`decision: \"deny\"\` is honored regardless of scope.
  - Legacy \`\"allow_session\"\` still caches; legacy \`\"allow\"\` does not — proves the back-compat path.
- [x] Existing \`decidePermission\` tests updated to assert the typed shape.
- [ ] Manual smoke (not runnable from this non-TTY environment):
  - Trigger a permission prompt, pick \"Allow once\" → next call of the same tool prompts again.
  - Trigger a permission prompt, pick \"Allow for this session\" → next call goes through silently.
  - Trigger a permission prompt, hit Esc / pick deny → tool fails with \`errorCode: \"permission_denied\"\`.

Closes M2.2. Roadmap Progress log and inline M2 section updated.