### PR TITLE
fix(status): suppress 'AI Gateway · cache miss' indicator

### DIFF
--- a/src/ui/status.test.ts
+++ b/src/ui/status.test.ts
@@ -27,4 +27,23 @@ describe("status gateway cache formatting", () => {
   it("omits gateway cache status when Cloudflare does not return it", () => {
     assert.strictEqual(formatGatewayCacheStatus({ logId: "log_123" }), null);
   });
+
+  it("suppresses MISS so users without caching don't see a constant 'cache miss'", () => {
+    // Cloudflare returns cf-aig-cache-status: MISS on every uncached request,
+    // including when caching isn't configured. Surfacing it would read as a
+    // failure indicator on every turn.
+    assert.strictEqual(formatGatewayCacheStatus({ cacheStatus: "MISS" }), null);
+    assert.strictEqual(formatGatewayCacheStatus({ cacheStatus: "miss" }), null);
+  });
+
+  it("still surfaces non-miss cache statuses (hit, revalidated, bypass)", () => {
+    assert.strictEqual(
+      formatGatewayCacheStatus({ cacheStatus: "HIT" }),
+      "AI Gateway · cache hit",
+    );
+    assert.strictEqual(
+      formatGatewayCacheStatus({ cacheStatus: "REVALIDATED" }),
+      "AI Gateway · cache revalidated",
+    );
+  });
 });

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -186,7 +186,13 @@ function formatTokens(n: number): string {
 
 export function formatGatewayCacheStatus(gatewayMeta?: GatewayMeta | null): string | null {
   const status = gatewayMeta?.cacheStatus?.trim();
-  return status ? `AI Gateway · cache ${status.toLowerCase()}` : null;
+  if (!status) return null;
+  // Suppress "miss" — the gateway returns MISS on every uncached request,
+  // including when caching isn't configured at all, so it'd otherwise read
+  // like a constant failure. Hits (and other non-miss statuses like
+  // REVALIDATED / BYPASS) are still surfaced — those are the useful signals.
+  if (status.toUpperCase() === "MISS") return null;
+  return `AI Gateway · cache ${status.toLowerCase()}`;
 }
 
 function formatDuration(ms: number): string {


### PR DESCRIPTION
## Summary
Cloudflare returns `cf-aig-cache-status: MISS` on every uncached request — including when caching isn't configured on the gateway at all. The status bar was rendering "AI Gateway · cache miss" after every turn, which looked like a constant failure for users who haven't enabled response caching.

Now: hide `MISS` entirely. Hits and other useful statuses (`REVALIDATED`, `BYPASS`) still surface — those are the actionable signals.

### Before
```
in 100  ctx 10%  $0.00  AI Gateway · cache miss
```
(every turn, regardless of caching config)

### After
```
in 100  ctx 10%  $0.00
```
(when caching is off / hasn't filled yet — no noise)

```
in 100  ctx 10%  $0.00  AI Gateway · cache hit
```
(when caching is on and the request hits — useful signal)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 543/543 pass, including two new test cases covering MISS suppression and non-miss passthrough
- [ ] Manual: run a turn without gateway caching enabled — status bar no longer shows "cache miss"

🤖 Generated with [Claude Code](https://claude.com/claude-code)