### PR TITLE
feat(skills): replace gray-matter with custom frontmatter parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "commander": "^12.1.0",
     "diff": "^9.0.0",
     "fast-glob": "^3.3.2",
-    "gray-matter": "^4.0.3",
     "ink": "^7.0.1",
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 import { join, extname } from "node:path";
-import matter from "gray-matter";
+import { parseFrontmatter } from "../util/frontmatter.js";
 import type { Skill, SkillManifest } from "./types.js";
 
 const DEFAULTS: Required<Pick<SkillManifest, "scope" | "priority" | "enabled" | "match">> = {
@@ -29,8 +29,8 @@ function normalizeManifest(raw: Record<string, unknown>, filePath: string): Skil
 
 export async function loadSkillFile(filePath: string): Promise<Skill> {
   const raw = await readFile(filePath, "utf-8");
-  const parsed = matter(raw);
-  const manifest = normalizeManifest(parsed.data as Record<string, unknown>, filePath);
+  const parsed = parseFrontmatter(raw);
+  const manifest = normalizeManifest(parsed.data, filePath);
 
   const body = parsed.content.trim();
   const estimatedTokens = Math.ceil(body.length / 4);

--- a/src/skills/manager.ts
+++ b/src/skills/manager.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile, unlink, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import matter from "gray-matter";
+import { parseFrontmatter } from "../util/frontmatter.js";
 import type { Skill } from "./types.js";
 import { loadSkillsFromDir } from "./loader.js";
 
@@ -84,7 +84,7 @@ export async function setSkillEnabled(
   if (!skill) throw new Error(`skill "${name}" not found`);
 
   const raw = await readFile(skill.filePath, "utf-8");
-  const parsed = matter(raw);
+  const parsed = parseFrontmatter(raw);
   parsed.data.enabled = enabled;
 
   const yaml = Object.entries(parsed.data)

--- a/src/skills/parser.ts
+++ b/src/skills/parser.ts
@@ -1,4 +1,4 @@
-import matter from "gray-matter";
+import { parseFrontmatter } from "../util/frontmatter.js";
 import type { ParsedSkill, ParsedSkillSection } from "./types.js";
 import { createHash } from "node:crypto";
 
@@ -88,7 +88,7 @@ function splitIntoSections(markdown: string): ParsedSkillSection[] {
  * Expects YAML frontmatter with at least `name`.
  */
 export function parseSkillFile(filePath: string, rawText: string): ParsedSkill {
-  const parsed = matter(rawText);
+  const parsed = parseFrontmatter(rawText);
   const name = typeof parsed.data.name === "string" ? parsed.data.name : "";
   const description = typeof parsed.data.description === "string" ? parsed.data.description : "";
 

--- a/src/util/frontmatter.test.ts
+++ b/src/util/frontmatter.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseFrontmatter } from "./frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  it("parses valid frontmatter with string values", () => {
+    const raw = `---
+name: react
+description: Guidelines for React code
+---
+
+# React
+
+Use functional components.
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.name, "react");
+    assert.equal(result.data.description, "Guidelines for React code");
+    assert.equal(result.content, "# React\n\nUse functional components.\n");
+  });
+
+  it("returns whole input as content when no frontmatter fence", () => {
+    const raw = "just body\nno fence";
+    const result = parseFrontmatter(raw);
+    assert.deepEqual(result.data, {});
+    assert.equal(result.content, "just body\nno fence");
+  });
+
+  it("returns empty data and content for empty input", () => {
+    const result = parseFrontmatter("");
+    assert.deepEqual(result.data, {});
+    assert.equal(result.content, "");
+  });
+
+  it("parses empty frontmatter", () => {
+    const raw = "---\n---\nbody here\n";
+    const result = parseFrontmatter(raw);
+    assert.deepEqual(result.data, {});
+    assert.equal(result.content, "body here\n");
+  });
+
+  it("parses boolean values", () => {
+    const raw = `---
+enabled: true
+disabled: false
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.enabled, true);
+    assert.equal(result.data.disabled, false);
+  });
+
+  it("parses number values", () => {
+    const raw = `---
+priority: 10
+ratio: 3.14
+negative: -5
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.priority, 10);
+    assert.equal(result.data.ratio, 3.14);
+    assert.equal(result.data.negative, -5);
+  });
+
+  it("parses inline string arrays", () => {
+    const raw = `---
+match: ["**/*.tsx", "**/*.jsx"]
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.deepEqual(result.data.match, ["**/*.tsx", "**/*.jsx"]);
+  });
+
+  it("parses block string arrays", () => {
+    const raw = `---
+match:
+  - "**/*.tsx"
+  - "**/*.jsx"
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.deepEqual(result.data.match, ["**/*.tsx", "**/*.jsx"]);
+  });
+
+  it("parses unquoted string values", () => {
+    const raw = `---
+name: simple
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.name, "simple");
+  });
+
+  it("strips matched double-quote pairs", () => {
+    const raw = `---
+description: "hello world"
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.description, "hello world");
+  });
+
+  it("strips matched single-quote pairs", () => {
+    const raw = `---
+description: 'hello world'
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.description, "hello world");
+  });
+
+  it("handles CRLF line endings", () => {
+    const raw = "---\r\nname: test\r\n---\r\nbody\r\n";
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.name, "test");
+    assert.equal(result.content, "body\r\n");
+  });
+
+  it("preserves content newlines exactly", () => {
+    const raw = `---
+name: test
+---
+
+First line.
+
+Second line.
+`;
+    const result = parseFrontmatter(raw);
+    // gray-matter strips one leading newline after the closing fence
+    assert.equal(result.content, "First line.\n\nSecond line.\n");
+  });
+
+  it("throws on unsupported nested object", () => {
+    const raw = `---
+config:
+  key: value
+---
+`;
+    assert.throws(() => parseFrontmatter(raw), /Unsupported/);
+  });
+
+  it("throws on unsupported number array", () => {
+    const raw = `---
+nums: [1, 2, 3]
+---
+`;
+    assert.throws(() => parseFrontmatter(raw), /only strings are allowed in arrays/);
+  });
+
+  it("throws on unsupported boolean array", () => {
+    const raw = `---
+flags: [true, false]
+---
+`;
+    assert.throws(() => parseFrontmatter(raw), /only strings are allowed in arrays/);
+  });
+
+  it("throws on unclosed frontmatter", () => {
+    const raw = `---
+name: test
+`;
+    assert.throws(() => parseFrontmatter(raw), /not closed/);
+  });
+
+  it("throws on empty value", () => {
+    const raw = `---
+name:
+---
+`;
+    assert.throws(() => parseFrontmatter(raw), /Unsupported empty value/);
+  });
+
+  it("ignores comments in frontmatter", () => {
+    const raw = `---
+# This is a comment
+name: test
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.name, "test");
+    assert.deepEqual(Object.keys(result.data), ["name"]);
+  });
+
+  it("parses mixed types correctly", () => {
+    const raw = `---
+name: react
+description: Guidelines for React code
+enabled: true
+priority: 10
+match:
+  - "**/*.tsx"
+  - "**/*.jsx"
+---
+`;
+    const result = parseFrontmatter(raw);
+    assert.equal(result.data.name, "react");
+    assert.equal(result.data.description, "Guidelines for React code");
+    assert.equal(result.data.enabled, true);
+    assert.equal(result.data.priority, 10);
+    assert.deepEqual(result.data.match, ["**/*.tsx", "**/*.jsx"]);
+  });
+});

--- a/src/util/frontmatter.ts
+++ b/src/util/frontmatter.ts
@@ -1,0 +1,204 @@
+export interface ParsedFrontmatter {
+  data: Record<string, unknown>;
+  content: string;
+}
+
+const OPEN_FENCE = /^---\s*(?:\r?\n)/;
+const CLOSE_FENCE = /(?:^|\r?\n)---\s*(?:\r?\n|$)/;
+
+function parseYamlValue(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  // Empty
+  if (trimmed === "") {
+    throw new Error(`Unsupported empty value in frontmatter`);
+  }
+
+  // Boolean
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+
+  // Number
+  if (/^-?\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    if (Number.isSafeInteger(n)) return n;
+  }
+  if (/^-?\d+\.\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    if (Number.isFinite(n)) return n;
+  }
+
+  // Inline array [a, b, c]
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (inner === "") return [];
+    const items = splitArrayItems(inner);
+    const result: string[] = [];
+    for (const item of items) {
+      const parsed = parseYamlValue(item);
+      if (typeof parsed !== "string") {
+        throw new Error(
+          `Unsupported array element type in frontmatter: only strings are allowed in arrays, got ${typeof parsed}`
+        );
+      }
+      result.push(parsed);
+    }
+    return result;
+  }
+
+  // String (unquoted, single-quoted, double-quoted)
+  return parseString(trimmed);
+}
+
+function splitArrayItems(inner: string): string[] {
+  const items: string[] = [];
+  let current = "";
+  let inDouble = false;
+  let inSingle = false;
+
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i]!;
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+    } else if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+    } else if (ch === "," && !inDouble && !inSingle) {
+      items.push(current.trim());
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+
+  if (current.trim() !== "") {
+    items.push(current.trim());
+  }
+
+  return items;
+}
+
+function parseString(trimmed: string): string {
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseBlockArray(lines: string[], startIdx: number): { value: string[]; nextIdx: number } {
+  const result: string[] = [];
+  let i = startIdx;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+
+    if (trimmed === "") {
+      i++;
+      continue;
+    }
+
+    if (!trimmed.startsWith("- ")) {
+      break;
+    }
+
+    const itemRaw = trimmed.slice(2).trim();
+    const itemValue = parseYamlValue(itemRaw);
+    if (typeof itemValue !== "string") {
+      throw new Error(
+        `Unsupported array element type in frontmatter: only strings are allowed in arrays, got ${typeof itemValue}`
+      );
+    }
+    result.push(itemValue);
+    i++;
+  }
+
+  return { value: result, nextIdx: i };
+}
+
+function parseYamlBlock(block: string): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  const lines = block.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      i++;
+      continue;
+    }
+
+    // Simple key: value
+    const kvMatch = trimmed.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/);
+    if (!kvMatch) {
+      throw new Error(`Unparseable frontmatter line: ${trimmed}`);
+    }
+
+    const key = kvMatch[1]!;
+    const valueRaw = kvMatch[2]!.trim();
+
+    // Check if next line starts a block array
+    if (valueRaw === "" && i + 1 < lines.length) {
+      const nextLine = lines[i + 1]!.trim();
+      if (nextLine.startsWith("- ")) {
+        const { value, nextIdx } = parseBlockArray(lines, i + 1);
+        data[key] = value;
+        i = nextIdx;
+        continue;
+      }
+    }
+
+    data[key] = parseYamlValue(valueRaw);
+    i++;
+  }
+
+  return data;
+}
+
+export function parseFrontmatter(raw: string): ParsedFrontmatter {
+  // Empty input
+  if (raw === "") {
+    return { data: {}, content: "" };
+  }
+
+  // No opening fence
+  if (!OPEN_FENCE.test(raw)) {
+    return { data: {}, content: raw };
+  }
+
+  // Strip opening fence
+  const afterOpen = raw.replace(OPEN_FENCE, "");
+
+  // Find closing fence
+  const closeMatch = afterOpen.match(CLOSE_FENCE);
+  if (!closeMatch) {
+    throw new Error("Frontmatter not closed with ---");
+  }
+
+  const closeIndex = closeMatch.index!;
+  const yamlBlock = afterOpen.slice(0, closeIndex);
+  const closeMatchLength = closeMatch[0].length;
+  let content = afterOpen.slice(closeIndex + closeMatchLength);
+
+  // Strip one leading \r and one leading \n (matches gray-matter behavior)
+  if (content.startsWith("\r")) {
+    content = content.slice(1);
+  }
+  if (content.startsWith("\n")) {
+    content = content.slice(1);
+  }
+
+  // Empty frontmatter block
+  if (yamlBlock.trim() === "") {
+    return { data: {}, content };
+  }
+
+  const data = parseYamlBlock(yamlBlock);
+  return { data, content };
+}


### PR DESCRIPTION
## Summary

Removes the `gray-matter` npm dependency and replaces it with a zero-dependency custom YAML frontmatter parser.

## What changed

- **New:** `src/util/frontmatter.ts` — custom parser supporting strings, booleans, numbers, and string arrays (inline + block syntax)
- **New:** `src/util/frontmatter.test.ts` — 20 tests covering all supported types, edge cases, CRLF, error handling
- **Updated:** `src/skills/parser.ts`, `src/skills/loader.ts`, `src/skills/manager.ts` — switched from `gray-matter` to `parseFrontmatter`
- **Updated:** `package.json` — removed `gray-matter` from dependencies

## Test cases to verify locally

1. **Run the new parser tests:**
   ```bash
   npx tsx --test src/util/frontmatter.test.ts
   ```

2. **Run the skills tests:**
   ```bash
   npx tsx --test src/skills/parser.test.ts src/skills/router.test.ts src/skills/db.test.ts src/skills/format.test.ts
   ```

3. **Test with the actual CLI (skill loading):**
   ```bash
   npm run dev
   # Then try prompts that trigger skill loading, e.g.:
   # "Load my react skill" or "What skills are available?"
   ```

4. **Test skill creation and toggling:**
   ```bash
   npm run dev
   # Try: "Create a new skill called test-skill"
   # Then: "Disable test-skill"
   # Then: "Enable test-skill"
   ```

## Verification checklist

- [ ] All frontmatter tests pass (20/20)
- [ ] All skills tests pass (45/45 total)
- [ ] `npm run typecheck` passes with zero errors
- [ ] Skill files with frontmatter load correctly in the TUI
- [ ] Creating/enabling/disabling skills works end-to-end

## Notes

The parser intentionally throws on unsupported YAML features (nested objects, non-string arrays) to fail fast if skill files ever contain invalid data. This matches our strict TypeScript philosophy.

Co-authored-by: kimiflare <kimiflare@proton.me>