### PR TITLE
docs: refresh README + landing for multi-model + Universal Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## How it works
 
-You bring your own Cloudflare **Account ID** + **API Token**. KimiFlare provisions (or reuses) an **AI Gateway** in your account and routes every model request through it. Nothing leaves your Cloudflare tenancy.
+You bring your own Cloudflare **Account ID** + **API Token**. KimiFlare provisions (or reuses) an **AI Gateway** in your account and routes every model request through it via the [AI Gateway Universal Endpoint](https://developers.cloudflare.com/ai-gateway/universal/) — one URL, eleven models across five providers, with automatic fallback. Nothing leaves your Cloudflare tenancy.
 
 You get this for free:
 
@@ -34,8 +34,9 @@ You get this for free:
 
 ## What to remember
 
-- **262k context window** — Read entire modules, large configs, and full stack traces without the model losing track.
-- **Image understanding** — Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. Great for UI reviews, diagrams, and screenshots.
+- **Coding agent, not a chat box** — Tool-using agent loop with read, write, edit, glob, grep, bash, web search, GitHub, headless browser, LSP, and MCP. Multi-step tasks publish a live task panel with progress, elapsed time, and token deltas. Mid-flight steering, graceful preemption, and a hard-stop loop guardrail keep long turns under control.
+- **11 models across 5 providers, one router** — Kimi K2.6, Claude (Opus 4.7 / Sonnet 4.6 / Haiku 4.5), GPT-5 / GPT-5-mini, Gemini 2.5 Pro / Flash, Llama 3.3 / 4 Scout, and Groq Llama, all reached through the [Cloudflare AI Gateway Universal Endpoint](https://developers.cloudflare.com/ai-gateway/universal/). Swap mid-conversation with `/model`; context windows range from 24k up to 1M.
+- **Image understanding** — Drop image paths (PNG, JPG, WebP, GIF, BMP up to 5 MB) into any prompt. Great for UI reviews, diagrams, and screenshots (model-dependent).
 - **Plan / Edit / Auto modes** — `plan` is a whitelist-only research mode: only read-only tools (read, glob, grep, web search, GitHub read-only, browser fetch) are allowed. Writes, edits, mutating bash, MCP tools, and LSP renames are all blocked. `edit` (default) prompts per mutating call. `auto` approves everything for trusted tasks.
 - **Windows support** — OS-aware shell auto-detects `cmd.exe` / PowerShell on Windows, `bash` on Unix. The `bash` tool works out of the box on all platforms.
 - **Message queuing** — Submit multiple messages while the agent is busy; they queue and auto-drain. Escape interrupts the current turn but preserves the queue.
@@ -93,7 +94,7 @@ Once configured, `/cost` shows the Gateway-confirmed totals, cache hit ratio, pe
 
 ### Model selection
 
-KimiFlare supports **11 models** across multiple providers, all routed through Cloudflare AI Gateway:
+KimiFlare supports **11 models** across five providers, all routed through Cloudflare AI Gateway's [Universal Endpoint](https://developers.cloudflare.com/ai-gateway/universal/) (one URL, automatic provider fallback):
 
 **Cloudflare Workers AI** (default, no API key needed):
 - `@cf/moonshotai/kimi-k2.6` — 262k context, reasoning, tools

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>kimiflare — Claude Code alternative on Cloudflare</title>
-  <meta name="description" content="An open-source terminal coding agent powered by Kimi K2.6, routed through your own Cloudflare AI Gateway — with first-class observability, caching, and authoritative cost.">
+  <meta name="description" content="An open-source terminal coding agent — pick from Kimi K2.6, Claude, GPT-5, Gemini, Llama, and more — routed through your own Cloudflare AI Gateway with first-class observability, caching, and authoritative cost.">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://kimiflare.com/">
   <meta name="theme-color" content="#f48120">
 
   <!-- Open Graph -->
   <meta property="og:title" content="kimiflare — Claude Code alternative on Cloudflare">
-  <meta property="og:description" content="An open-source terminal coding agent powered by Kimi K2.6, routed through your own Cloudflare AI Gateway — with first-class observability, caching, and authoritative cost.">
+  <meta property="og:description" content="An open-source terminal coding agent — pick from Kimi K2.6, Claude, GPT-5, Gemini, Llama, and more — routed through your own Cloudflare AI Gateway with first-class observability, caching, and authoritative cost.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://kimiflare.com/">
   <meta property="og:image" content="https://kimiflare.com/logo.png">
@@ -19,7 +19,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="kimiflare — Claude Code alternative on Cloudflare">
-  <meta name="twitter:description" content="An open-source terminal coding agent powered by Kimi K2.6, routed through your own Cloudflare AI Gateway — with first-class observability, caching, and authoritative cost.">
+  <meta name="twitter:description" content="An open-source terminal coding agent — pick from Kimi K2.6, Claude, GPT-5, Gemini, Llama, and more — routed through your own Cloudflare AI Gateway with first-class observability, caching, and authoritative cost.">
   <meta name="twitter:image" content="https://kimiflare.com/logo.png">
 
   <!-- Cloudflare Web Analytics -->
@@ -35,7 +35,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "kimiflare",
-    "description": "An open-source terminal coding agent powered by Kimi K2.6, routed through your own Cloudflare AI Gateway — with first-class observability, caching, and authoritative cost.",
+    "description": "An open-source terminal coding agent — pick from Kimi K2.6, Claude, GPT-5, Gemini, Llama, and more — routed through your own Cloudflare AI Gateway with first-class observability, caching, and authoritative cost.",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux, Windows",
     "offers": {
@@ -709,12 +709,12 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-label fade-in">Kimi-K2.6 · Cloudflare AI Gateway</div>
+    <div class="hero-label fade-in">11 models · Cloudflare AI Gateway · Universal Endpoint</div>
     <h1 class="fade-in delay-1">
       Claude Code alternative, on your own Cloudflare account.
     </h1>
     <p class="hero-subtitle fade-in delay-2">
-      An open-source terminal coding agent powered by Kimi K2.6 and routed through your own Cloudflare AI Gateway — with per-request logs, response caching, and authoritative cost out of the box.
+      An open-source terminal coding agent — pick from Kimi K2.6, Claude, GPT-5, Gemini, Llama, and more. Every request is routed through your own Cloudflare AI Gateway via the Universal Endpoint, with per-request logs, response caching, and authoritative cost out of the box.
     </p>
     <div class="hero-cta fade-in delay-3">
       <a href="#install" class="btn btn-primary">Install</a>
@@ -723,7 +723,7 @@
 
     <div class="fade-in delay-3" style="margin-top: 1.5rem;">
       <a href="https://www.producthunt.com/products/kimiflare?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-kimiflare" target="_blank" rel="noopener noreferrer">
-        <img alt="kimiflare - kimi k2.6 cli code editor on cloudflare ai gateway | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1129412&theme=light&t=1776822277935">
+        <img alt="kimiflare - multi-model terminal coding agent on cloudflare ai gateway | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1129412&theme=light&t=1776822277935">
       </a>
     </div>
 
@@ -818,7 +818,7 @@
 
           <div style="margin-bottom:0.4rem;">
             <span class="mode-badge">[edit]</span>
-            <span class="term-dim">  k2.6  ·  medium  ·  thinking…</span>
+            <span class="term-dim">  claude-sonnet-4-6  ·  medium  ·  thinking…</span>
           </div>
           <div class="term-dim" style="margin-bottom:0.6rem;font-size:0.75rem;">
             in 2,847 (1,203 cached)  ·  out 412  ·  ctx 12%  ·  0.00321
@@ -925,8 +925,8 @@
       </div>
       <div class="feature-item">
         <span class="feature-num">11</span>
-        <h3>262K context window</h3>
-        <p>Read entire modules, large configs, and full stack traces without the model losing track. All on your Cloudflare account.</p>
+        <h3>11 models, one router</h3>
+        <p>Kimi K2.6, Claude (Opus 4.7 / Sonnet 4.6 / Haiku 4.5), GPT-5, Gemini 2.5, Llama, and Groq — all reached through the AI Gateway Universal Endpoint with automatic fallback. Swap mid-conversation with <code>/model</code>; context windows up to 1M.</p>
       </div>
       <div class="feature-item">
         <span class="feature-num">12</span>
@@ -948,12 +948,16 @@
     <div class="arch-section">
       <span class="section-label">Architecture</span>
       <div class="arch-flow">
-        <strong>kimiflare</strong> <span class="accent">Node.js TUI</span><br>
-        <span class="arrow">↓</span> user msg → agent loop → runKimi()<br>
-        <span class="arrow">↓</span> <span class="accent">POST SSE</span> via your AI Gateway<br>
-        <strong>gateway.ai.cloudflare.com</strong> <span class="accent">logs · cache · cost</span><br>
-        <span class="arrow">↓</span><br>
-        <strong>Workers AI</strong> <span class="accent">@cf/moonshotai/kimi-k2.6</span><br>
+        <strong>kimiflare</strong> <span class="accent">Node.js TUI · agent loop</span><br>
+        <span class="arrow">↓</span> user msg → tool-using agent → model request<br>
+        <span class="arrow">↓</span> <span class="accent">POST SSE</span> to AI Gateway Universal Endpoint<br>
+        <strong>gateway.ai.cloudflare.com</strong> <span class="accent">routing · logs · cache · cost</span><br>
+        <span class="arrow">↓</span> dispatches to the picked provider:<br>
+        <strong>Workers AI</strong> <span class="accent">Kimi K2.6 · Llama 3.3 / 4 Scout</span><br>
+        <strong>Anthropic</strong> <span class="accent">Claude Opus 4.7 / Sonnet 4.6 / Haiku 4.5</span><br>
+        <strong>OpenAI</strong> <span class="accent">GPT-5 · GPT-5-mini</span><br>
+        <strong>Google AI Studio</strong> <span class="accent">Gemini 2.5 Pro / Flash</span><br>
+        <strong>Groq</strong> <span class="accent">Llama 3.3 70B Versatile</span><br>
         <span class="arrow">↑</span> tool result ← tool executor ← tool_calls<br>
         <span class="arrow">↑</span> permission modal for write / edit / bash
       </div>


### PR DESCRIPTION
## Summary
- README and `docs/index.html` were still leading with Kimi K2.6 even though [#468](https://github.com/sinameraji/kimiflare/pull/468) shipped multi-provider routing. Refresh both to match current reality.
- Lead "What to remember" with the coding-agent + 11-models-one-router story; surface the AI Gateway **Universal Endpoint** as the routing tech in How-it-works and the model-selection section.
- Landing page: meta / OG / Twitter / JSON-LD descriptions, hero label + subtitle, Product Hunt alt text, terminal status badge (`k2.6` → `claude-sonnet-4-6`), feature card #11 (262k context → "11 models, one router"), and the architecture flow now lists all five providers reached through the Universal Endpoint.

## Test plan
- [ ] Eyeball rendered README on the PR diff view
- [ ] Deploy `docs/` as a Pages preview and verify hero, terminal, feature grid, and architecture render correctly
- [ ] Confirm no remaining "Kimi K2.6"-only framing in README / landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)