### PR TITLE
feat(cli): add --no-cloud to bypass cloud mode for a single run

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ program
   .option("-p, --print <prompt>", "one-shot mode: send prompt, stream reply to stdout, exit")
   .option("-m, --model <id>", "model id (defaults to @cf/moonshotai/kimi-k2.6)")
   .option("--cloud", "use Kimiflare Cloud (api.kimiflare.com) instead of direct Workers AI")
+  .option("--no-cloud", "force-disable cloud mode for this run (overrides cloudMode in config.json)")
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")
   .option("--reasoning", "include reasoning in stdout (print mode only)")
   .option("--continue-on-limit", "reset tool-call counter and continue when the 50-call limit is hit (print mode only)")


### PR DESCRIPTION
## Summary

When `cloudMode: true` is persisted in `~/.config/kimiflare/config.json` but the cloud token is absent or expired, every `kimiflare` invocation exits with `kimiflare: cloud mode requires authentication` (exit 2). Users who *also* have valid BYOK credentials in the same config currently have no way to opt out for one run — they have to hand-edit JSON to drop `cloudMode`, then put it back later if they want cloud again.

Add `--no-cloud` so the run uses Workers AI directly via the stored BYOK creds without touching any persisted state.

## What changed

- `src/index.tsx` — one new commander option:
  ```ts
  .option("--no-cloud", "force-disable cloud mode for this run (overrides cloudMode in config.json)")
  ```

No resolution-site change needed. The existing line `const cloudMode = opts.cloud ?? cfg?.cloudMode ?? false;` already does the right thing: commander sets `opts.cloud = false` for `--no-cloud`, and `??` doesn't fall through on `false`, so the CLI flag wins over the stored config.

## Test plan

- [x] `npm run build` — clean
- [x] `node dist/index.js --help` — shows `--no-cloud` with description
- [ ] With `cloudMode: true` in config and no `cloud.json` present, `node dist/index.js --no-cloud` runs without the auth error and uses the stored BYOK creds
- [ ] `node dist/index.js` (without the flag) still hits the cloud auth path as before — no regression

## Why this is a flag, not a subcommand

- One-off escape hatch, not an intentional sign-out. State on disk stays as the user left it.
- A persistent "sign out of cloud" command is a follow-up (would clear `cloud.json` and write `cloudMode: false`); intentionally out of scope here so the change is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)