### PR TITLE
fix(agent): prevent 'Body is unusable' error and handle it gracefully

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -163,6 +163,13 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
     // for transient capacity errors. It also returns HTTP 5xx or OpenAI-style error objects
     // for transient internal failures. Retry those; surface everything else.
     if (!contentType.includes("text/event-stream")) {
+      if (res.bodyUsed) {
+        throw new KimiApiError(
+          `kimiflare: Received HTTP ${res.status} but could not read the response body. Please try again.`,
+          undefined,
+          res.status,
+        );
+      }
       const text = await res.text();
       let parsed: unknown = null;
       try {

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -34,7 +34,12 @@ export function isKillSwitchError(err: unknown): err is KillSwitchError {
  *  Throws KillSwitchError when matched; otherwise returns silently. */
 export async function detectKillSwitch(res: Response): Promise<void> {
   if (res.status === 503) {
-    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    let data: Record<string, unknown> = {};
+    try {
+      data = (await res.clone().json()) as Record<string, unknown>;
+    } catch {
+      /* ignore parse/clone errors */
+    }
     if (data.error === "SERVICE_ENDED") {
       throw new KillSwitchError(typeof data.ended_at === "string" ? data.ended_at : undefined);
     }


### PR DESCRIPTION
## Problem

The error `! Body is unusable: Body has already been read` could occur when the AI API returned an HTTP 503 that was **not** the cloud kill-switch. `detectKillSwitch` consumed the response body with `res.json()`, but because the error was not `SERVICE_ENDED`, it returned silently. Downstream code then tried to read the same body again with `res.text()`, causing the raw error to bubble up to the TUI as a fatal-looking red `!` message.

## Changes

1. **`src/util/errors.ts`** — `detectKillSwitch` now clones the response (`res.clone().json()`) before reading its body, leaving the original response intact for downstream consumers. This fixes the root cause.

2. **`src/agent/client.ts`** — Added a safety net around `res.text()`. If the body is somehow still unusable, we catch it and convert it into a `KimiApiError` carrying the original HTTP status. This ensures the TUI renders it as an `api_error` event (non-fatal, user can continue) instead of a raw error.

## Result

Users now see a graceful bordered message like other retryable server errors, and can simply say "go on" or send a new message to retry the turn.

Co-authored-by: kimiflare <kimiflare@proton.me>