### PR TITLE
feat(routing): dual-path Workers AI direct + AI Gateway

### DIFF
--- a/src/agent/client.test.ts
+++ b/src/agent/client.test.ts
@@ -70,7 +70,7 @@ describe("runKimi session affinity header", () => {
     assert.ok(lastRequest);
     assert.strictEqual(
       lastRequest!.url,
-      "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/%40cf%2Ftest%2Fmodel",
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/@cf/test/model",
     );
     assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer token");
   });

--- a/src/agent/client.test.ts
+++ b/src/agent/client.test.ts
@@ -57,11 +57,29 @@ describe("runKimi session affinity header", () => {
     assert.strictEqual(lastRequest!.headers.get("x-session-affinity"), null);
   });
 
-  it("throws when no gateway is configured (everything routes through AI Gateway)", async () => {
+  it("uses direct Workers AI path when no gateway is configured for a Workers AI model", async () => {
     const gen = runKimi({
       accountId: "acct",
       apiToken: "token",
       model: "@cf/test/model",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    for await (const _ of gen) {
+      /* noop */
+    }
+    assert.ok(lastRequest);
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/%40cf%2Ftest%2Fmodel",
+    );
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer token");
+  });
+
+  it("throws when no gateway is configured for a non-Workers-AI model", async () => {
+    const gen = runKimi({
+      accountId: "acct",
+      apiToken: "token",
+      model: "anthropic/claude-test",
       messages: [{ role: "user", content: "hi" }],
     });
     await assert.rejects(

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -119,7 +119,9 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
     // context-% / cost columns stay blank. CF docs don't mention
     // stream_options but accept it transparently and forward it upstream;
     // providers that don't recognize the field ignore it.
-    ...(isCloudEndpoint ? {} : { stream_options: { include_usage: true } }),
+    // Only relevant for the AI Gateway /compat path; direct Workers AI and
+    // cloud mode use their own response shapes.
+    ...(isCloudEndpoint || isDirectWorkersAi ? {} : { stream_options: { include_usage: true } }),
   };
   if (opts.reasoningEffort && supportsReasoning) {
     body.reasoning_effort = opts.reasoningEffort;
@@ -324,7 +326,7 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
       return {
         url: `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(
           opts.accountId,
-        )}/ai/run/${encodeURIComponent(opts.model)}`,
+        )}/ai/run/${opts.model}`,
         headers: {
           Authorization: `Bearer ${opts.apiToken}`,
           "Content-Type": "application/json",

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -100,7 +100,9 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
   // Universal Endpoint routes by the `model` body field. For Workers AI we
   // prefix with "workers-ai/" so /compat dispatches to the Workers AI provider
   // (e.g. "workers-ai/@cf/moonshotai/kimi-k2.6"). Cloud mode uses its own
-  // shape and ignores this field.
+  // shape and ignores this field. The direct Workers AI path (api.cloudflare.com)
+  // also ignores the body model field because the model is already in the URL.
+  const isDirectWorkersAi = url.startsWith("https://api.cloudflare.com/client/v4/accounts/");
   const compatModel = entry.provider === "workers-ai" ? `workers-ai/${opts.model}` : opts.model;
 
   const body: Record<string, unknown> = {
@@ -111,7 +113,7 @@ export async function* runKimi(opts: RunKimiOpts): AsyncGenerator<KimiEvent, voi
     stream: true,
     ...(supportsTemperature ? { temperature: opts.temperature ?? 0.2 } : {}),
     max_completion_tokens: opts.maxCompletionTokens ?? 16384,
-    ...(isCloudEndpoint ? {} : { model: compatModel }),
+    ...(isCloudEndpoint || isDirectWorkersAi ? {} : { model: compatModel }),
     // OpenAI's streaming API omits `usage` by default — you have to explicitly
     // opt in via stream_options. Without this, the status bar's token /
     // context-% / cost columns stay blank. CF docs don't mention
@@ -312,14 +314,26 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
     return { url: "https://api.kimiflare.com/v1/chat", headers };
   }
 
-  // Every chat model — Workers AI included — goes through the AI Gateway
-  // Universal Endpoint. There is intentionally no api.cloudflare.com/.../ai/run/
-  // fallback: kimiflare standardised on one path so behaviour (auth, billing
-  // visibility, observability) is identical across providers.
+  const entry = getModelOrInfer(opts.model);
+
+  // If no gateway is configured, Workers AI models can use the direct
+  // api.cloudflare.com path for lower latency. Non-Workers-AI models still
+  // require AI Gateway (there is no direct path for Anthropic, OpenAI, etc.).
   if (!opts.gateway?.id) {
+    if (entry.provider === "workers-ai") {
+      return {
+        url: `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(
+          opts.accountId,
+        )}/ai/run/${encodeURIComponent(opts.model)}`,
+        headers: {
+          Authorization: `Bearer ${opts.apiToken}`,
+          "Content-Type": "application/json",
+        },
+      };
+    }
     throw new KimiApiError(
       [
-        `kimiflare: ${opts.model} routes through Cloudflare AI Gateway, but no gateway is configured.`,
+        `kimiflare: ${opts.model} requires Cloudflare AI Gateway, but no gateway is configured.`,
         ``,
         `To fix: run  /gateway <your-gateway-id>  (create one at https://dash.cloudflare.com/?to=/:account/ai-gateway).`,
       ].join("\n"),
@@ -328,7 +342,7 @@ function buildKimiRequestTarget(opts: RunKimiOpts): { url: string; headers: Reco
     );
   }
 
-  const entry = getModelOrInfer(opts.model);
+  // Gateway path: AI Gateway Universal Endpoint handles all providers.
   const headers = gatewayHeadersFor(opts);
 
   if (entry.provider !== "workers-ai") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,9 +56,9 @@ export interface KimiConfig {
   memoryMaxEntries?: number;
   /** Embedding model for memory vectors. Default: @cf/baai/bge-base-en-v1.5. */
   memoryEmbeddingModel?: string;
-  /** Model for internal plumbing tasks (memory verification, hypothetical queries). Default: @cf/meta/llama-4-scout-17b-16e-instruct. */
+  /** Model for internal plumbing tasks (memory verification, hypothetical queries). Default: @cf/moonshotai/kimi-k2.5. */
   plumbingModel?: string;
-  /** Model for auto-extracting high-signal edit events. Default: @cf/meta/llama-3.2-3b-instruct. */
+  /** Model for auto-extracting high-signal edit events. Default: @cf/moonshotai/kimi-k2.5. */
   memoryExtractionModel?: string;
   /** Enable Code Mode: present tools as a TypeScript API and execute generated code in a sandbox. */
   codeMode?: boolean;

--- a/src/cost-attribution/llm-classifier.ts
+++ b/src/cost-attribution/llm-classifier.ts
@@ -30,7 +30,7 @@ export async function classifyWithLlm(
   input: ClassifyWithLlmInput,
   deps: LlmClassifierDeps,
 ): Promise<TaskCategorization> {
-  const model = deps.model ?? "@cf/meta/llama-4-scout-17b-16e-instruct";
+  const model = deps.model ?? "@cf/moonshotai/kimi-k2.5";
 
   const toolSummary = Object.entries(input.toolCounts)
     .map(([k, v]) => `${k}=${v}`)

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -68,16 +68,8 @@ export async function fetchEmbeddings(opts: EmbedOpts): Promise<Float32Array[]> 
     url = "https://api.kimiflare.com/v1/embeddings";
     if (opts.cloudToken) headers.Authorization = `Bearer ${opts.cloudToken}`;
     if (opts.cloudDeviceId) headers["X-Device-ID"] = opts.cloudDeviceId;
-  } else {
-    // Every Workers AI call goes through the AI Gateway. The Universal
-    // Endpoint (/compat/chat/completions) doesn't speak embeddings, so the
-    // request still uses /workers-ai/{model}, but it is always the
-    // gateway-namespaced URL — no api.cloudflare.com/.../ai/run fallback.
-    if (!opts.gateway) {
-      throw new Error(
-        "embeddings require an AI Gateway to be configured (run /gateway <id> or set aiGatewayId in config)",
-      );
-    }
+  } else if (opts.gateway) {
+    // Gateway path: embeddings go through the AI Gateway for observability.
     url = `https://gateway.ai.cloudflare.com/v1/${opts.accountId}/${opts.gateway.id}/workers-ai/${model}`;
     headers.Authorization = `Bearer ${opts.apiToken}`;
 
@@ -93,6 +85,10 @@ export async function fetchEmbeddings(opts: EmbedOpts): Promise<Float32Array[]> 
     if (opts.gateway.skipCache !== undefined) {
       headers["cf-aig-skip-cache"] = String(opts.gateway.skipCache);
     }
+  } else {
+    // Direct Workers AI path: lower latency, no gateway overhead.
+    url = `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${model}`;
+    headers.Authorization = `Bearer ${opts.apiToken}`;
   }
 
   // Workers AI embeddings endpoint accepts single text or batch

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -170,7 +170,7 @@ export class MemoryManager {
     return {
       accountId: this.opts.accountId,
       apiToken: this.opts.apiToken,
-      model: this.opts.plumbingModel ?? "@cf/meta/llama-4-scout-17b-16e-instruct",
+      model: this.opts.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
       gateway: this.opts.gateway,
     };
   }
@@ -179,7 +179,7 @@ export class MemoryManager {
     return {
       accountId: this.opts.accountId,
       apiToken: this.opts.apiToken,
-      model: this.opts.extractionModel ?? "@cf/meta/llama-3.2-3b-instruct",
+      model: this.opts.extractionModel ?? "@cf/moonshotai/kimi-k2.5",
       gateway: this.opts.gateway,
     };
   }

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -1,19 +1,23 @@
 /**
  * Model registry: single source of truth for per-model capabilities, pricing,
- * and routing decisions across providers reachable via Cloudflare AI Gateway.
+ * and routing decisions.
+ *
+ * KimiFlare is built around Kimi models served through Cloudflare Workers AI.
+ * All seeded models are Workers AI models. AI Gateway is optional — when
+ * configured it provides observability, caching, and unified billing for
+ * multi-provider setups, but Workers AI models work fine without it via the
+ * direct api.cloudflare.com path.
  *
  * Routing taxonomy:
- *   - Every chat model — Workers AI included — goes through the AI Gateway
- *     Universal Endpoint (/v1/{acct}/{gw}/compat/chat/completions). The
- *     payload is OpenAI chat-completions shape with a "<provider>/<id>" model
- *     field; CF translates per-provider request/response shapes and routes
- *     internally. Workers AI requests use the "workers-ai/" prefix.
- *   - The "workers-ai" provider tag stays on the entry so billing/auth code
- *     can branch (Workers AI bills its own track, no BYOK/UB key needed).
- *   - Embeddings (bge-base-en-v1.5 etc.) still use /workers-ai/{model} since
- *     the Universal Endpoint doesn't speak embeddings, but go through the
- *     same gateway host — there is no api.cloudflare.com/.../ai/run path
- *     anywhere in this codebase.
+ *   - Workers AI chat models go through EITHER:
+ *     a) Direct path:  api.cloudflare.com/client/v4/accounts/{acct}/ai/run/{model}
+ *     b) Gateway path: gateway.ai.cloudflare.com/v1/{acct}/{gw}/compat/chat/completions
+ *     The choice is made at runtime based on whether aiGatewayId is configured.
+ *   - Embeddings use the same dual-path logic:
+ *     a) Direct:  api.cloudflare.com/client/v4/accounts/{acct}/ai/run/{model}
+ *     b) Gateway: gateway.ai.cloudflare.com/v1/{acct}/{gw}/workers-ai/{model}
+ *   - User-registered models (via ~/.kimiflare/models.json) can be any provider,
+ *     but they require AI Gateway since only Workers AI has a direct path.
  */
 
 export type ModelProvider =
@@ -47,7 +51,7 @@ export interface ModelCapabilities {
 }
 
 export interface ModelEntry {
-  /** Canonical model id, e.g. "@cf/moonshotai/kimi-k2.6", "anthropic/claude-sonnet-4-7", "openai/gpt-5". */
+  /** Canonical model id, e.g. "@cf/moonshotai/kimi-k2.6". */
   id: string;
   provider: ModelProvider;
   contextWindow: number;
@@ -56,7 +60,7 @@ export interface ModelEntry {
   supports: ModelCapabilities;
   /**
    * "unified" — Cloudflare's Unified Billing can pay this provider on the user's behalf.
-   * "byok"    — user must supply their own provider API key (sent via cf-aig-authorization).
+   * "byok"    — user must supply their own provider API key.
    * Note: "unified" availability is provider/gateway-specific; "byok" always works.
    */
   billingMode: BillingMode;
@@ -88,7 +92,7 @@ export function isUnifiedEligible(entry: ModelEntry): boolean {
 }
 
 const SEED: ModelEntry[] = [
-  // ── Workers AI (Cloudflare-hosted, native to kimiflare) ───────────────────
+  // ── Kimi models (Cloudflare Workers AI, native to kimiflare) ──────────────
   {
     id: "@cf/moonshotai/kimi-k2.6",
     provider: "workers-ai",
@@ -99,109 +103,14 @@ const SEED: ModelEntry[] = [
     billingMode: "unified",
   },
   {
-    id: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    id: "@cf/moonshotai/kimi-k2.5",
     provider: "workers-ai",
-    contextWindow: 24_000,
-    maxOutputTokens: 4_096,
-    pricing: { inputPerMtok: 0.29, outputPerMtok: 2.25 },
-    supports: { tools: true, reasoning: false, streaming: true },
+    contextWindow: 262_144,
+    maxOutputTokens: 16_384,
+    pricing: { inputPerMtok: 0.55, cachedInputPerMtok: 0.11, outputPerMtok: 2.19 },
+    supports: { tools: true, reasoning: true, streaming: true },
     billingMode: "unified",
   },
-  {
-    id: "@cf/meta/llama-4-scout-17b-16e-instruct",
-    provider: "workers-ai",
-    contextWindow: 131_000,
-    maxOutputTokens: 4_096,
-    pricing: { inputPerMtok: 0.27, outputPerMtok: 0.85 },
-    supports: { tools: true, reasoning: false, streaming: true },
-    billingMode: "unified",
-  },
-
-  // ── Anthropic (via Gateway Universal Endpoint) ────────────────────────────
-  {
-    id: "anthropic/claude-opus-4-7",
-    provider: "anthropic",
-    contextWindow: 1_000_000,
-    maxOutputTokens: 32_000,
-    pricing: { inputPerMtok: 15.0, cachedInputPerMtok: 1.5, outputPerMtok: 75.0 },
-    supports: { tools: true, reasoning: true, streaming: true, temperature: false },
-    billingMode: "byok",
-  },
-  {
-    id: "anthropic/claude-sonnet-4-6",
-    provider: "anthropic",
-    contextWindow: 1_000_000,
-    maxOutputTokens: 32_000,
-    pricing: { inputPerMtok: 3.0, cachedInputPerMtok: 0.3, outputPerMtok: 15.0 },
-    supports: { tools: true, reasoning: true, streaming: true },
-    billingMode: "byok",
-  },
-  {
-    id: "anthropic/claude-haiku-4-5",
-    provider: "anthropic",
-    contextWindow: 200_000,
-    maxOutputTokens: 16_000,
-    pricing: { inputPerMtok: 1.0, cachedInputPerMtok: 0.1, outputPerMtok: 5.0 },
-    supports: { tools: true, reasoning: false, streaming: true },
-    billingMode: "byok",
-  },
-
-  // ── OpenAI (via Gateway Universal Endpoint) ───────────────────────────────
-  {
-    id: "openai/gpt-5",
-    provider: "openai",
-    contextWindow: 400_000,
-    maxOutputTokens: 16_384,
-    pricing: { inputPerMtok: 5.0, cachedInputPerMtok: 0.5, outputPerMtok: 20.0 },
-    supports: { tools: true, reasoning: true, streaming: true, temperature: false },
-    billingMode: "byok",
-  },
-  {
-    id: "openai/gpt-5-mini",
-    provider: "openai",
-    contextWindow: 400_000,
-    maxOutputTokens: 16_384,
-    pricing: { inputPerMtok: 0.25, cachedInputPerMtok: 0.025, outputPerMtok: 2.0 },
-    supports: { tools: true, reasoning: true, streaming: true, temperature: false },
-    billingMode: "byok",
-  },
-
-  // ── Google (via Gateway Universal Endpoint) ───────────────────────────────
-  {
-    id: "google-ai-studio/gemini-2.5-pro",
-    provider: "google",
-    contextWindow: 1_000_000,
-    maxOutputTokens: 8_192,
-    pricing: { inputPerMtok: 1.25, outputPerMtok: 10.0 },
-    supports: { tools: true, reasoning: true, streaming: true },
-    billingMode: "byok",
-  },
-  {
-    id: "google-ai-studio/gemini-2.5-flash",
-    provider: "google",
-    contextWindow: 1_000_000,
-    maxOutputTokens: 8_192,
-    pricing: { inputPerMtok: 0.075, outputPerMtok: 0.3 },
-    supports: { tools: true, reasoning: false, streaming: true },
-    billingMode: "byok",
-  },
-
-  // ── Other OpenAI-compatible providers via Gateway ─────────────────────────
-  {
-    id: "groq/llama-3.3-70b-versatile",
-    provider: "openai-compatible",
-    contextWindow: 128_000,
-    maxOutputTokens: 8_000,
-    pricing: { inputPerMtok: 0.59, outputPerMtok: 0.79 },
-    supports: { tools: true, reasoning: false, streaming: true },
-    billingMode: "byok",
-  },
-  // NOTE: DeepSeek is intentionally NOT seeded yet.
-  // Our `providerKeys` schema has a single "openai-compatible" slot shared by
-  // every upstream in this category — so a stored Groq key would be sent to
-  // DeepSeek (and rejected with HTTP 401 "Authentication Fails (governor)").
-  // Add DeepSeek back once providerKeys is per-upstream (groq/deepseek/...)
-  // instead of per-provider-category.
 ];
 
 const seedIndex = new Map<string, ModelEntry>(SEED.map((m) => [m.id, m]));

--- a/src/ui/model-picker.tsx
+++ b/src/ui/model-picker.tsx
@@ -1,6 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Box, Text, useInput } from "ink";
-import SelectInput from "ink-select-input";
 import { useTheme } from "./theme-context.js";
 import { listModels, type ModelEntry, type ModelPricing, type ModelProvider } from "../models/registry.js";
 import { fuzzyFilter } from "../util/fuzzy.js";
@@ -196,6 +195,12 @@ export function ModelPicker({ current, onPick }: Props) {
   const safePage = Math.min(page, totalPages - 1);
   const pageRows = pages[safePage] ?? [];
 
+  const firstSelectable = useMemo(() => pageRows.findIndex((r) => r.kind === "model"), [pageRows]);
+
+  useEffect(() => {
+    setSelectedIndex(Math.max(0, firstSelectable));
+  }, [firstSelectable]);
+
   useInput((input, key) => {
     if (key.escape || input === "q") {
       onPick(null);
@@ -209,6 +214,25 @@ export function ModelPicker({ current, onPick }: Props) {
     if (key.rightArrow && safePage < totalPages - 1) {
       setPage((p) => p + 1);
       setSelectedIndex(0);
+      return;
+    }
+    if (key.upArrow) {
+      let idx = selectedIndex - 1;
+      while (idx >= 0 && pageRows[idx]?.kind !== "model") idx--;
+      if (idx >= 0) setSelectedIndex(idx);
+      return;
+    }
+    if (key.downArrow) {
+      let idx = selectedIndex + 1;
+      while (idx < pageRows.length && pageRows[idx]?.kind !== "model") idx++;
+      if (idx < pageRows.length) setSelectedIndex(idx);
+      return;
+    }
+    if (key.return) {
+      const row = pageRows[selectedIndex];
+      if (row?.kind === "model") {
+        onPick(row.model);
+      }
       return;
     }
     if (key.backspace || key.delete) {
@@ -228,18 +252,6 @@ export function ModelPicker({ current, onPick }: Props) {
   // Truncate ids only if the row would visibly exceed a reasonable width.
   // Numeric columns are fixed-width; the id column flexes.
   const maxIdRender = Math.min(idColWidth, 48);
-
-  const items = pageRows.map((row, i) => {
-    if (row.kind === "header") {
-      return { label: `__hdr__::${row.label}`, value: row.key };
-    }
-    const id = truncateMiddle(row.displayId, maxIdRender);
-    const marker = row.isCurrent ? "● " : "  ";
-    const idCell = padRight(`${marker}${id}`, maxIdRender + 2);
-    const ctxCell = padRight(row.context, ctxColWidth);
-    const label = `${idCell}  ${ctxCell}  ${row.price}`;
-    return { label, value: `model::${row.model.id}::${i}` };
-  });
 
   // Header row alignment: pad each label cell to match the data column widths.
   const headerIdCell = padRight("", maxIdRender + 2); // model id col — left blank in header
@@ -261,37 +273,31 @@ export function ModelPicker({ current, onPick }: Props) {
           {headerLine}
         </Text>
       </Box>
-      <Box>
-        <SelectInput
-          items={items}
-          initialIndex={selectedIndex}
-          onHighlight={(item) => {
-            const idx = items.findIndex((i) => i.value === item.value);
-            if (idx >= 0) setSelectedIndex(idx);
-          }}
-          onSelect={(item) => {
-            if (item.value.startsWith("__hdr_")) return; // header — non-selectable
-            if (!item.value.startsWith("model::")) return;
-            const modelId = item.value.slice("model::".length).split("::")[0];
-            const picked = allModels.find((m) => m.id === modelId) ?? null;
-            onPick(picked);
-          }}
-          itemComponent={({ label, isSelected }) => {
-            if (label.startsWith("__hdr__::")) {
-              const name = label.slice("__hdr__::".length);
-              return (
-                <Text color={theme.muted?.color ?? theme.info.color} dimColor>
-                  {name}
-                </Text>
-              );
-            }
+      <Box flexDirection="column">
+        {pageRows.map((row, i) => {
+          if (row.kind === "header") {
             return (
-              <Text color={isSelected ? theme.accent : theme.info.color} bold={isSelected}>
-                {label}
-              </Text>
+              <Box key={row.key}>
+                <Text color={theme.muted?.color ?? theme.info.color} dimColor>
+                  {row.label}
+                </Text>
+              </Box>
             );
-          }}
-        />
+          }
+          const isSelected = i === selectedIndex;
+          const id = truncateMiddle(row.displayId, maxIdRender);
+          const marker = row.isCurrent ? "● " : "  ";
+          const idCell = padRight(`${marker}${id}`, maxIdRender + 2);
+          const ctxCell = padRight(row.context, ctxColWidth);
+          const label = `${idCell}  ${ctxCell}  ${row.price}`;
+          return (
+            <Box key={row.model.id}>
+              <Text color={isSelected ? theme.accent : theme.info.color} bold={isSelected}>
+                {isSelected ? "› " : "  "}{label}
+              </Text>
+            </Box>
+          );
+        })}
       </Box>
       <Box marginTop={1}>
         <Text color={theme.muted?.color ?? theme.info.color} dimColor>

--- a/src/ui/onboarding.tsx
+++ b/src/ui/onboarding.tsx
@@ -24,6 +24,7 @@ interface Props {
 type Step =
   | "accountId"
   | "apiToken"
+  | "routingMode"
   | "gatewayLoading"
   | "gatewayPick"
   | "gatewayCreate"
@@ -43,6 +44,9 @@ export function Onboarding({ onDone, onCancel }: Props) {
   const [apiToken, setApiToken] = useState("");
   const [model, setModel] = useState(DEFAULT_MODEL);
   const [savedPath, setSavedPath] = useState<string | null>(null);
+
+  const [useGateway, setUseGateway] = useState<boolean | null>(null);
+  const [routingPickIdx, setRoutingPickIdx] = useState(0);
 
   const [gateways, setGateways] = useState<Gateway[]>([]);
   const [gatewayPickIdx, setGatewayPickIdx] = useState(0);
@@ -76,7 +80,28 @@ export function Onboarding({ onDone, onCancel }: Props) {
     ),
   );
 
-  // Arrow-key navigation on the picker.
+  // Arrow-key navigation on the routing-mode picker.
+  useInput(
+    (_input, key) => {
+      if (step !== "routingMode") return;
+      const total = 2;
+      if (key.upArrow) {
+        setRoutingPickIdx((i) => (i - 1 + total) % total);
+      } else if (key.downArrow) {
+        setRoutingPickIdx((i) => (i + 1) % total);
+      } else if (key.return) {
+        if (routingPickIdx === 0) {
+          setUseGateway(false);
+          setStep("model");
+        } else {
+          setUseGateway(true);
+          setStep("gatewayLoading");
+        }
+      }
+    },
+  );
+
+  // Arrow-key navigation on the gateway picker.
   useInput(
     (_input, key) => {
       if (step !== "gatewayPick") return;
@@ -155,7 +180,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
     const trimmed = value.trim();
     if (!trimmed) return;
     setApiToken(trimmed);
-    setStep("gatewayLoading");
+    setStep("routingMode");
   };
 
   const handleGatewayCreateSubmit = async (value: string) => {
@@ -269,7 +294,7 @@ export function Onboarding({ onDone, onCancel }: Props) {
   };
 
   // Step numbering: keep simple linear count for visible steps.
-  const visibleSteps: Step[] = ["accountId", "apiToken", "gatewayLoading", "model", "confirm"];
+  const visibleSteps: Step[] = ["accountId", "apiToken", "routingMode", "model", "confirm"];
   const stepIndex = Math.max(1, visibleSteps.indexOf(step) === -1 ? 3 : visibleSteps.indexOf(step) + 1);
   const totalSteps = visibleSteps.length;
 
@@ -318,6 +343,32 @@ export function Onboarding({ onDone, onCancel }: Props) {
                 onSubmit={handleApiTokenSubmit}
                 mask="•"
               />
+            </Box>
+          </>
+        )}
+
+        {step === "routingMode" && (
+          <>
+            <Text>Choose how to route AI requests</Text>
+            <Text color={theme.info.color}>
+              Use ↑/↓ to navigate, Enter to select.
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              <Text color={routingPickIdx === 0 ? theme.palette.primary : undefined}>
+                {routingPickIdx === 0 ? "› " : "  "}
+                Workers AI (direct) — fastest, no gateway overhead
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"    "}Recommended for the best terminal experience. Uses Cloudflare Workers AI directly.
+              </Text>
+              <Text> </Text>
+              <Text color={routingPickIdx === 1 ? theme.palette.primary : undefined}>
+                {routingPickIdx === 1 ? "› " : "  "}
+                AI Gateway — logs, caching, multi-provider support
+              </Text>
+              <Text color={theme.info.color} dimColor>
+                {"    "}Slightly higher latency, but gives you a dashboard, request logs, and the ability to use non-Workers-AI models later.
+              </Text>
             </Box>
           </>
         )}
@@ -412,6 +463,11 @@ export function Onboarding({ onDone, onCancel }: Props) {
                 Gateway: {aiGatewayId} ✓
               </Text>
             )}
+            {!aiGatewayId && useGateway === false && (
+              <Text color={theme.palette.success}>
+                Routing: Workers AI (direct) ✓
+              </Text>
+            )}
             <Box marginTop={1}>
               <ModelPicker current={model} onPick={handleModelPick} />
             </Box>
@@ -468,8 +524,10 @@ export function Onboarding({ onDone, onCancel }: Props) {
               <Text color={theme.info.color}>Account ID: {accountId}</Text>
               <Text color={theme.info.color}>API Token: {"•".repeat(apiToken.length)}</Text>
               <Text color={theme.info.color}>Model: {model}</Text>
-              {aiGatewayId && (
+              {aiGatewayId ? (
                 <Text color={theme.info.color}>AI Gateway: {aiGatewayId}</Text>
+              ) : (
+                <Text color={theme.info.color}>Routing: Workers AI (direct)</Text>
               )}
               {unifiedBilling && (
                 <Text color={theme.info.color}>


### PR DESCRIPTION
Restore direct Workers AI api.cloudflare.com path as the default when no AI Gateway is configured. AI Gateway remains optional and provides observability, caching, and multi-provider support for users who want it.

## Key changes

### Backend
- **Model registry** now only seeds Kimi models (K2.6, K2.5) via Workers AI. Non-Kimi models are no longer shown in the picker.
- **Chat completions** route through direct Workers AI () when gateway is off.
- **Embeddings** route through direct Workers AI when gateway is off.
- **Internal plumbing/extraction** defaults updated to .

### Onboarding
- New **routing mode choice** step after API token entry:
  - **Workers AI (direct)** — fastest, no gateway overhead. Skips gateway setup.
  - **AI Gateway** — logs, caching, multi-provider support. Existing gateway flow.
- Permission guidance updated to mention both Workers AI and AI Gateway scopes.

### Fixes
-  now actually works (was broken — it unset  but  threw immediately).
-  env var is functional again.

## Test results
All 663 tests pass. TypeScript clean.