### PR TITLE
fix(agent): prevent TurnSupervisor crash on race-conditioned turn starts

### DIFF
--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -38,7 +38,9 @@ export class TurnSupervisor {
   startTurn(opts: AgentTurnOpts, callbacks?: SupervisorCallbacks): void {
     if (this.isRunning) {
       logger.warn("supervisor:start_rejected", { reason: "turn_already_running", phase: this._phase });
-      throw new Error("TurnSupervisor: turn already in progress");
+      // Graceful no-op instead of throwing — prevents unhandled crashes when
+      // queued messages or rapid submissions race into processMessage().
+      return;
     }
     this._phase = "preparing";
     this._killRequested = false;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1796,6 +1796,14 @@ function App({
       // Clear the one-shot session-start recall so it is not reused.
       sessionStartRecallRef.current = null;
 
+      // Last-resort guard against race conditions (e.g. queued messages draining
+      // while a slash-command-initiated turn like /compact is still winding down).
+      // If the supervisor is already running, undo beginTurn() and bail out.
+      if (supervisorRef.current.isRunning) {
+        endTurn();
+        return;
+      }
+
       supervisorRef.current.startTurn(
         {
           accountId: cfg.accountId,
@@ -2062,7 +2070,7 @@ function App({
 
       const historyEntry = trimmedDisplay;
 
-      if (busyRef.current) {
+      if (busyRef.current || supervisorRef.current.isRunning) {
         const key = mkKey();
         setEvents((e) => [...e, { kind: "user", key, text: trimmedDisplay, queued: true }]);
         setQueue((q) => [...q, { full: trimmedFull, display: trimmedDisplay, key }]);


### PR DESCRIPTION
When a long-running slash command like `/compact` finishes, queued messages can drain into `processMessage()` while the supervisor still considers a turn in progress. This caused `startTurn()` to throw synchronously, crashing the entire Node process.

## Root cause

- `/compact` and `/init` bypass `TurnSupervisor` and call `runAgentTurn` directly.
- When they finish, `endTurn()` sets `busy = false`.
- The queue-drain `useEffect` sees `!busy && queue.length > 0 && phase === 'idle'` and eagerly drains queued messages.
- If two queued messages enter `processMessage()\'s async setup before the first reaches `startTurn()`, the second call hits the synchronous `throw`.

## Changes

- **`src/agent/supervisor.ts`**: `startTurn()` now returns early instead of throwing when a turn is already in progress. This is the safety net that ensures the app can never crash from this path again.
- **`src/app.tsx` `submit()`**: Now checks `supervisorRef.current.isRunning` in addition to `busyRef.current`, so messages get queued instead of entering the race window.
- **`src/app.tsx` `processMessage()`**: Last-resort guard right before `startTurn()` — if the supervisor is still running, calls `endTurn()` to undo the `beginTurn()` and bails out cleanly.

Fixes unhandled `TurnSupervisor: turn already in progress` errors.

Co-authored-by: kimiflare <kimiflare@proton.me>