### PR TITLE
fix(context): prevent API overflow at high context utilization

### DIFF
--- a/src/agent/artifact-compaction.ts
+++ b/src/agent/artifact-compaction.ts
@@ -33,8 +33,14 @@ interface Turn {
   tools: ChatMessage[];
 }
 
+// Approximate tokens from a character count. Char-per-token of 4 is the
+// usual back-of-envelope figure for English prose, but coding-agent
+// content (source code, JSON tool results, file paths) tokenizes denser
+// than that — typically 3 to 3.5 chars/token. We use 3.5 so budget and
+// compaction decisions bias toward over-estimating, which is the safer
+// direction when the alternative is a hard API context-overflow error.
 export function approxTokens(n: number): number {
-  return Math.round(n / 4);
+  return Math.round(n / 3.5);
 }
 
 export function estimateMessageTokens(m: ChatMessage): number {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -212,9 +212,15 @@ function isHighSignalMemory(memory: {
   );
 }
 
-/** Fraction of the model's context window we'll let the prompt occupy before
- *  refusing the call. Leaves headroom for the response. */
-const PROMPT_TOKEN_SOFT_LIMIT_RATIO = 0.92;
+/** Default completion budget if the caller doesn't pin one. Mirrors
+ *  client.ts. The API counts `input + max_completion_tokens` against the
+ *  context window, so this must be subtracted from the soft limit. */
+const DEFAULT_MAX_COMPLETION_TOKENS = 16_384;
+
+/** Extra headroom on top of `max_completion_tokens` to absorb estimator
+ *  drift (we estimate prompt tokens via chars-per-token, which under-counts
+ *  for code- and JSON-heavy content vs. the server-side tokenizer). */
+const BUDGET_SAFETY_MARGIN_TOKENS = 8_192;
 
 /** Max characters for a single tool result message before truncation.
  *  ~10k chars ≈ 2,500 tokens — generous but prevents runaway growth. */
@@ -551,7 +557,11 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
     const promptTokens = estimatePromptTokens(apiMessages);
     const ctxWindow = getModelOrInfer(opts.model).contextWindow;
-    const maxPromptTokens = Math.floor(ctxWindow * PROMPT_TOKEN_SOFT_LIMIT_RATIO);
+    // The API rejects when `input + max_completion_tokens > ctxWindow`,
+    // so compute the budget from those exact terms (plus a safety margin
+    // for estimator drift) rather than a flat percentage.
+    const completionBudget = opts.maxCompletionTokens ?? DEFAULT_MAX_COMPLETION_TOKENS;
+    const maxPromptTokens = ctxWindow - completionBudget - BUDGET_SAFETY_MARGIN_TOKENS;
     if (promptTokens > maxPromptTokens) {
       throw new Error(
         `kimiflare: context window exceeded (~${promptTokens.toLocaleString()} / ${ctxWindow.toLocaleString()} tokens). ` +

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,7 +115,7 @@ import {
   handleRemoteCancel as handleRemoteCancelImpl,
 } from "./ui/command-handlers.js";
 import {
-  AUTO_COMPACT_SUGGEST_PCT,
+  AUTO_COMPACT_THRESHOLD,
   buildFilePickerIgnoreList,
   capEvents,
   compactEventsVisual,
@@ -1968,19 +1968,33 @@ function App({
   submitRef.current = submit;
 
   useEffect(() => {
+    if (usage && usage.prompt_tokens / modelContextLimit < AUTO_COMPACT_THRESHOLD * 0.7) {
+      compactSuggestedRef.current = false;
+    }
     if (compactSuggestedRef.current) return;
-    if (usage && usage.prompt_tokens / modelContextLimit >= AUTO_COMPACT_SUGGEST_PCT) {
-      compactSuggestedRef.current = true;
+    if (busy) return;
+    if (!usage || usage.prompt_tokens / modelContextLimit < AUTO_COMPACT_THRESHOLD) return;
+    compactSuggestedRef.current = true;
+    const pct = Math.round((usage.prompt_tokens / modelContextLimit) * 100);
+    setEvents((e) => [
+      ...e,
+      {
+        kind: "info",
+        key: mkKey(),
+        text: `context ${pct}% full — auto-compacting older turns`,
+      },
+    ]);
+    void runCompact().catch((err) => {
       setEvents((e) => [
         ...e,
         {
-          kind: "info",
+          kind: "error",
           key: mkKey(),
-          text: `context ${Math.round((usage.prompt_tokens / modelContextLimit) * 100)}% full — run /compact to summarize older turns`,
+          text: `auto-compact failed: ${(err as Error).message} — run /compact manually`,
         },
       ]);
-    }
-  }, [usage, modelContextLimit]);
+    });
+  }, [usage, modelContextLimit, busy, runCompact]);
 
   if (!cfg) {
     return (

--- a/src/ui/app-helpers.ts
+++ b/src/ui/app-helpers.ts
@@ -26,7 +26,7 @@ import type { Cfg } from "../app.js";
 
 const MAX_GITIGNORE_SIZE = 1 * 1024 * 1024; // 1 MB
 export const CONTEXT_LIMIT = 262_000;
-export const AUTO_COMPACT_SUGGEST_PCT = 0.8;
+export const AUTO_COMPACT_THRESHOLD = 0.8;
 export const MAX_EVENTS = 500;
 export const MAX_IMAGES_PER_MESSAGE = 10;
 export const FEEDBACK_WORKER_URL = "https://hello.kimiflare.com";


### PR DESCRIPTION
## Summary
Diagnosed from a real failure where a session hit `BadRequestError: 263129 tokens (input 246745 + completion 16384) exceeds 262144` despite the UI showing `ctx 94%` and `/compact recommended`. Three compounding bugs:

### 1. Budget formula ignored `max_completion_tokens`
`src/agent/loop.ts:554` compared prompt tokens to `0.92 * ctxWindow`. The API actually counts `input + max_completion_tokens` against the limit, so the correct budget is `ctxWindow - max_completion - safety_margin`. With `max_completion: 16384` on a 262144 window, the old formula left a ~5k-token gap the API would reject.

### 2. Estimator under-counted tokens
`approxTokens(n) = n / 4` is the English-prose figure. Coding-agent traffic (source, JSON tool results, file paths) tokenizes denser — closer to 3–3.5 chars/token. The estimator told the harness "88%" while the server tokenizer saw 94%, so the 92% soft limit never fired. Now `n / 3.5`, biasing conservative across all budget and compaction decisions.

### 3. \"Auto-compact\" wasn't actually automatic
`AUTO_COMPACT_SUGGEST_PCT = 0.8` in `app-helpers.ts` only printed a hint banner. Nothing triggered compaction. Renamed to `AUTO_COMPACT_THRESHOLD` and wired the effect at `app.tsx:1970` to call `runCompact()` automatically, with a 56% hysteresis floor (\`AUTO_COMPACT_THRESHOLD * 0.7\`) so it can re-arm on subsequent crossings within a long session.

## Changes
- `src/agent/loop.ts` — replace `PROMPT_TOKEN_SOFT_LIMIT_RATIO` with `ctxWindow - completionBudget - BUDGET_SAFETY_MARGIN_TOKENS`
- `src/agent/artifact-compaction.ts` — `approxTokens` from `/4` to `/3.5`
- `src/ui/app-helpers.ts` — rename `AUTO_COMPACT_SUGGEST_PCT` → `AUTO_COMPACT_THRESHOLD`
- `src/app.tsx` — auto-trigger `runCompact()` at threshold; reset the latch when usage drops well below it

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 657/657 pass (estimator change is a global constant; tests using it still pass)
- [ ] Manual: run a long session with code-heavy turns, watch the status bar cross 80% — auto-compact should fire and emit \`context N% full — auto-compacting older turns\` event, followed by the existing compact-summary event. The 94% blowup should not recur.

## Notes
- The safety margin (\`BUDGET_SAFETY_MARGIN_TOKENS = 8192\`) is intentionally large to absorb residual estimator drift. Can be tuned down once we have telemetry on real-world estimate-vs-actual deltas.
- Auto-compact respects \`busy\` — won't fire mid-turn. The post-turn \`onUsageFinal\` triggers the effect.
- If auto-compact fails, the error is surfaced and the user can still run \`/compact\` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)