### PR TITLE
fix(agent): close race window in processMessage and harden runInit/runCompact

### DIFF
--- a/src/agent/run-compact.ts
+++ b/src/agent/run-compact.ts
@@ -20,6 +20,7 @@ import type { AbortScope } from "../util/abort-scope.js";
 import { logger } from "../util/logger.js";
 import { compactEventsVisual, gatewayFromConfig } from "../ui/app-helpers.js";
 import type { HooksManager } from "../hooks/manager.js";
+import type { TurnSupervisor } from "./supervisor.js";
 
 type SetEvents = React.Dispatch<React.SetStateAction<ChatEvent[]>>;
 
@@ -46,6 +47,7 @@ export interface RunCompactDeps {
    *  omitted, no hooks fire (back-compat for SDK callers). */
   hooks?: HooksManager;
   sessionId?: string | null;
+  supervisorRef: React.MutableRefObject<TurnSupervisor>;
 }
 
 export async function runCompact(deps: RunCompactDeps): Promise<void> {
@@ -56,9 +58,10 @@ export async function runCompact(deps: RunCompactDeps): Promise<void> {
     artifactStoreRef, messagesRef, sessionStateRef,
     limitResolveRef, pendingToolCallsRef,
     hooks, sessionId,
+    supervisorRef,
   } = deps;
 
-  if (busy) {
+  if (busy || supervisorRef.current.isRunning) {
     setEvents((e) => [
       ...e,
       { kind: "info", key: mkKey(), text: "can't compact while model is running" },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1031,6 +1031,7 @@ function App({
       pendingToolCallsRef,
       hooks: hooksManagerRef.current,
       sessionId: sessionIdRef.current,
+      supervisorRef,
     });
   }, [cfg, busy, saveSessionSafe]);
 
@@ -1078,6 +1079,7 @@ function App({
       lastApiErrorRef,
       limitResolveRef,
       loopResolveRef,
+      supervisorRef,
     });
   }, [cfg, busy, updateAssistant, updateTool, updateGatewayMeta]);
 
@@ -1393,14 +1395,25 @@ function App({
       let trimmed = text.trim();
       if (!trimmed) return;
 
+      // Mark busy immediately so no other path can race into processMessage
+      // while async setup (image encoding, hooks, etc.) is in flight.
+      beginTurn();
+
       let overrideModel: string | undefined;
       let overrideEffort: ReasoningEffort | undefined;
       let display = displayText?.trim() || trimmed;
 
       if (trimmed.startsWith("/")) {
-        if (handleSlash(trimmed)) return;
-        const head = trimmed.split(/\s+/)[0]!.slice(1);
-        const custom = customCommandsRef.current.find((c) => c.name === head);
+        const head = trimmed.split(/\s+/)[0]!.toLowerCase();
+        const selfManaged = ["/compact", "/init"].includes(head);
+        if (handleSlash(trimmed)) {
+          if (!selfManaged) {
+            endTurn();
+          }
+          return;
+        }
+        const cmdName = head.slice(1);
+        const custom = customCommandsRef.current.find((c) => c.name === cmdName);
         if (custom) {
           const info = (text: string) =>
             setEvents((e) => [...e, { kind: "info", key: mkKey(), text }]);
@@ -1411,7 +1424,10 @@ function App({
           if (custom.shell) {
             info(`/${custom.name}: executing shell code from template`);
           }
-          if (!rendered.trim()) return;
+          if (!rendered.trim()) {
+            endTurn();
+            return;
+          }
           const parts: string[] = [];
           if (custom.model) {
             overrideModel = custom.model;
@@ -1511,6 +1527,7 @@ function App({
             ...e,
             { kind: "info", key: mkKey(), text: `hook blocked the prompt: ${reason}` },
           ]);
+          endTurn();
           return;
         }
       }
@@ -1546,7 +1563,6 @@ function App({
         ]);
       }
 
-      beginTurn();
       gatewayMetaRef.current = null;
       setGatewayMeta(null);
 

--- a/src/init/run-init.ts
+++ b/src/init/run-init.ts
@@ -25,6 +25,7 @@ import { classifyIntent } from "../intent/classify.js";
 import type { ReasoningEffort } from "../config.js";
 import type { TurnPhase } from "../ui/status.js";
 import type { DailyUsage } from "../usage-tracker.js";
+import type { TurnSupervisor } from "../agent/supervisor.js";
 import {
   KimiApiError,
   humanizeCloudflareError,
@@ -92,6 +93,7 @@ export interface RunInitDeps {
   lastApiErrorRef: React.MutableRefObject<{ httpStatus?: number; code?: number; message: string } | null>;
   limitResolveRef: React.MutableRefObject<unknown>;
   loopResolveRef: React.MutableRefObject<((d: LoopDecision) => void) | null>;
+  supervisorRef: React.MutableRefObject<TurnSupervisor>;
 }
 
 export async function runInit(deps: RunInitDeps): Promise<void> {
@@ -108,9 +110,10 @@ export async function runInit(deps: RunInitDeps): Promise<void> {
     pendingToolCallsRef, recentFilesRef, usageRef, activeAsstIdRef,
     gatewayMetaRef, kimiMdStaleNudgedRef, lspManagerRef, modeRef,
     cacheStableRef, lastApiErrorRef, limitResolveRef, loopResolveRef,
+    supervisorRef,
   } = deps;
 
-  if (busy) {
+  if (busy || supervisorRef.current.isRunning) {
     setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "can't /init while model is running" }]);
     return;
   }


### PR DESCRIPTION
## Problem

When a long-running task (e.g. auto-compact) was active and the user queued 3–4 additional messages, the queued messages could race into `processMessage()` during the async setup window (image encoding, hooks, session save) before `beginTurn()` had a chance to set `busyRef`. This led to overlapping turns and the `TurnSupervisor: turn already in progress` crash.

## Changes

1. **Move `beginTurn()` to the top of `processMessage()`**  
   Sets `busyRef` immediately so no other path can enter while async setup is in flight.

2. **Add `endTurn()` calls for early returns**  
   Custom commands that render to empty strings, hook vetoes, and non-turn slash commands (`/memory`, `/help`, etc.) now properly reset busy state so it is never leaked.

3. **Harden `runInit` and `runCompact`**  
   Both now check `supervisorRef.current.isRunning` in addition to the React `busy` state. This prevents them from starting while a supervisor-managed turn is already in flight.

## Testing

- `npm run typecheck` passes.
- The supervisor already has a graceful no-op (merged in #1), so even if a race occurs it will not throw.
- These changes close the remaining window where the race could enter.

Co-authored-by: kimiflare <kimiflare@proton.me>