### PR TITLE
fix(app): make onDone fire-and-forget so UI returns to idle immediately

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1904,32 +1904,32 @@ function App({
                     }
                   }
                 }
-              }
 
-              // After compaction, recall memories so the model retains durable anchors
-              const manager = memoryManagerRef.current;
-              if (manager) {
-                try {
-                  const cwd = process.cwd();
-                  const queryText = sessionStateRef.current.task || cwd;
-                  const results = await manager.recall({ text: queryText, repoPath: cwd, limit: 5 });
-                  if (results.length > 0) {
-                    const text = await manager.synthesizeRecalled(results);
-                    const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
-                    const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
-                    messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
-                    setEvents((e) => [
-                      ...e,
-                      {
-                        kind: "memory",
-                        key: mkKey(),
-                        text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
-                      },
-                    ]);
-                    await saveSessionSafe();
+                // After compaction, recall memories so the model retains durable anchors
+                const manager = memoryManagerRef.current;
+                if (manager) {
+                  try {
+                    const cwd = process.cwd();
+                    const queryText = sessionStateRef.current.task || cwd;
+                    const results = await manager.recall({ text: queryText, repoPath: cwd, limit: 5 });
+                    if (results.length > 0) {
+                      const text = await manager.synthesizeRecalled(results);
+                      const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
+                      const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
+                      messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
+                      setEvents((e) => [
+                        ...e,
+                        {
+                          kind: "memory",
+                          key: mkKey(),
+                          text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
+                        },
+                      ]);
+                      await saveSessionSafe();
+                    }
+                  } catch {
+                    // Non-fatal
                   }
-                } catch {
-                  // Non-fatal
                 }
               }
             })();

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1818,117 +1818,121 @@ function App({
           callbacks: sharedCallbacks,
         },
         {
-          onDone: async () => {
-            await saveSessionSafe();
+          onDone: () => {
+            // Fire-and-forget all post-turn housekeeping so the UI returns to
+            // idle immediately and the user can type the next message without
+            // waiting for compaction, memory recall, or session persistence.
+            void (async () => {
+              await saveSessionSafe();
 
-            // If the turn was killed (preempted or aborted), skip expensive
-            // post-turn work so the next turn can start immediately.
-            if (turnScope.signal.aborted) {
-              cleanupTurn();
-              return;
-            }
-
-            // Auto-compact after turn when thresholds are met. With compiled
-            // context on, use the heuristic compactor; otherwise fall back to the
-            // LLM summarizer so users have a safety net regardless of the flag.
-            if (shouldCompact({ messages: messagesRef.current })) {
-              // M6.1: same PreCompact fire as the mid-turn site above.
-              if (hooksManagerRef.current.hasEnabledHooks("PreCompact")) {
-                void hooksManagerRef.current
-                  .fire(
-                    "PreCompact",
-                    {
-                      event: "PreCompact",
-                      session_id: sessionIdRef.current,
-                      cwd: process.cwd(),
-                    },
-                    null,
-                  )
-                  .catch(() => {});
+              // If the turn was killed (preempted or aborted), skip expensive
+              // post-turn work so the next turn can start immediately.
+              if (turnScope.signal.aborted) {
+                return;
               }
-              if (compiledContextRef.current) {
-                const store = artifactStoreRef.current;
-                const result = compactMessagesViaArtifacts({
-                  messages: messagesRef.current,
-                  state: sessionStateRef.current,
-                  store,
-                });
-                if (result.metrics.rawTurnsRemoved > 0) {
-                  messagesRef.current = result.newMessages;
-                  sessionStateRef.current = result.newState;
-                  setEvents((e) => [
-                    ...e,
-                    {
-                      kind: "info",
-                      key: mkKey(),
-                      text: `auto-compacted: ${result.metrics.estimatedTokensBefore} → ${result.metrics.estimatedTokensAfter} tokens (${result.metrics.archivedArtifacts} artifacts)`,
-                    },
-                  ]);
-                  await saveSessionSafe();
+
+              // Auto-compact after turn when thresholds are met. With compiled
+              // context on, use the heuristic compactor; otherwise fall back to the
+              // LLM summarizer so users have a safety net regardless of the flag.
+              if (shouldCompact({ messages: messagesRef.current })) {
+                // M6.1: same PreCompact fire as the mid-turn site above.
+                if (hooksManagerRef.current.hasEnabledHooks("PreCompact")) {
+                  void hooksManagerRef.current
+                    .fire(
+                      "PreCompact",
+                      {
+                        event: "PreCompact",
+                        session_id: sessionIdRef.current,
+                        cwd: process.cwd(),
+                      },
+                      null,
+                    )
+                    .catch(() => {});
                 }
-              } else {
-                try {
-                  const result = await summarizeMessagesViaLlm({
-                    accountId: cfg.accountId,
-                    apiToken: cfg.apiToken,
-                    model: cfg.model,
+                if (compiledContextRef.current) {
+                  const store = artifactStoreRef.current;
+                  const result = compactMessagesViaArtifacts({
                     messages: messagesRef.current,
-                    signal: turnScope.signal,
-                    gateway: gatewayFromConfig(cfg),
+                    state: sessionStateRef.current,
+                    store,
                   });
-                  if (result.replacedCount > 0) {
+                  if (result.metrics.rawTurnsRemoved > 0) {
                     messagesRef.current = result.newMessages;
+                    sessionStateRef.current = result.newState;
                     setEvents((e) => [
                       ...e,
                       {
                         kind: "info",
                         key: mkKey(),
-                        text: `auto-compacted: ${result.replacedCount} messages summarized`,
+                        text: `auto-compacted: ${result.metrics.estimatedTokensBefore} → ${result.metrics.estimatedTokensAfter} tokens (${result.metrics.archivedArtifacts} artifacts)`,
                       },
                     ]);
                     await saveSessionSafe();
                   }
-                } catch (compactErr) {
-                  if ((compactErr as Error).name !== "AbortError") {
-                    setEvents((es) => [
-                      ...es,
-                      {
-                        kind: "info",
-                        key: mkKey(),
-                        text: `auto-compact failed: ${(compactErr as Error).message ?? String(compactErr)}`,
-                      },
-                    ]);
+                } else {
+                  try {
+                    const result = await summarizeMessagesViaLlm({
+                      accountId: cfg.accountId,
+                      apiToken: cfg.apiToken,
+                      model: cfg.model,
+                      messages: messagesRef.current,
+                      signal: turnScope.signal,
+                      gateway: gatewayFromConfig(cfg),
+                    });
+                    if (result.replacedCount > 0) {
+                      messagesRef.current = result.newMessages;
+                      setEvents((e) => [
+                        ...e,
+                        {
+                          kind: "info",
+                          key: mkKey(),
+                          text: `auto-compacted: ${result.replacedCount} messages summarized`,
+                        },
+                      ]);
+                      await saveSessionSafe();
+                    }
+                  } catch (compactErr) {
+                    if ((compactErr as Error).name !== "AbortError") {
+                      setEvents((es) => [
+                        ...es,
+                        {
+                          kind: "info",
+                          key: mkKey(),
+                          text: `auto-compact failed: ${(compactErr as Error).message ?? String(compactErr)}`,
+                        },
+                      ]);
+                    }
                   }
                 }
               }
-            }
 
-            // After compaction, recall memories so the model retains durable anchors
-            const manager = memoryManagerRef.current;
-            if (manager) {
-              try {
-                const cwd = process.cwd();
-                const queryText = sessionStateRef.current.task || cwd;
-                const results = await manager.recall({ text: queryText, repoPath: cwd, limit: 5 });
-                if (results.length > 0) {
-                  const text = await manager.synthesizeRecalled(results);
-                  const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
-                  const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
-                  messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
-                  setEvents((e) => [
-                    ...e,
-                    {
-                      kind: "memory",
-                      key: mkKey(),
-                      text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
-                    },
-                  ]);
-                  await saveSessionSafe();
+              // After compaction, recall memories so the model retains durable anchors
+              const manager = memoryManagerRef.current;
+              if (manager) {
+                try {
+                  const cwd = process.cwd();
+                  const queryText = sessionStateRef.current.task || cwd;
+                  const results = await manager.recall({ text: queryText, repoPath: cwd, limit: 5 });
+                  if (results.length > 0) {
+                    const text = await manager.synthesizeRecalled(results);
+                    const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
+                    const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
+                    messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
+                    setEvents((e) => [
+                      ...e,
+                      {
+                        kind: "memory",
+                        key: mkKey(),
+                        text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
+                      },
+                    ]);
+                    await saveSessionSafe();
+                  }
+                } catch {
+                  // Non-fatal
                 }
-              } catch {
-                // Non-fatal
               }
-            }
+            })();
 
             cleanupTurn();
           },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1616,6 +1616,13 @@ function App({
           const id = activeAsstIdRef.current;
           if (id !== null) updateAssistant(id, () => ({ streaming: false }));
           setTurnPhase("waiting");
+
+          // If no tool calls were finalized, the turn is effectively done.
+          // Reset busy immediately so the UI returns to idle without waiting
+          // for the supervisor's onDone hook.
+          if (pendingToolCallsRef.current.size === 0) {
+            endTurn();
+          }
         },
         onToolCallFinalized: (call: import("./agent/messages.js").ToolCall) => {
           pendingToolCallsRef.current.set(call.id, call.function.name);
@@ -1834,6 +1841,7 @@ function App({
               // Auto-compact after turn when thresholds are met. With compiled
               // context on, use the heuristic compactor; otherwise fall back to the
               // LLM summarizer so users have a safety net regardless of the flag.
+              let didCompact = false;
               if (shouldCompact({ messages: messagesRef.current })) {
                 // M6.1: same PreCompact fire as the mid-turn site above.
                 if (hooksManagerRef.current.hasEnabledHooks("PreCompact")) {
@@ -1868,6 +1876,7 @@ function App({
                       },
                     ]);
                     await saveSessionSafe();
+                    didCompact = true;
                   }
                 } else {
                   try {
@@ -1890,6 +1899,7 @@ function App({
                         },
                       ]);
                       await saveSessionSafe();
+                      didCompact = true;
                     }
                   } catch (compactErr) {
                     if ((compactErr as Error).name !== "AbortError") {
@@ -1905,30 +1915,35 @@ function App({
                   }
                 }
 
-                // After compaction, recall memories so the model retains durable anchors
-                const manager = memoryManagerRef.current;
-                if (manager) {
-                  try {
-                    const cwd = process.cwd();
-                    const queryText = sessionStateRef.current.task || cwd;
-                    const results = await manager.recall({ text: queryText, repoPath: cwd, limit: 5 });
-                    if (results.length > 0) {
-                      const text = await manager.synthesizeRecalled(results);
-                      const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
-                      const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
-                      messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
-                      setEvents((e) => [
-                        ...e,
-                        {
-                          kind: "memory",
-                          key: mkKey(),
-                          text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
-                        },
-                      ]);
-                      await saveSessionSafe();
+                // After compaction, recall memories so the model retains durable anchors.
+                // Only surface the recall event when compaction actually happened —
+                // otherwise the message is noise on turns that merely crossed the
+                // threshold without removing anything.
+                if (didCompact) {
+                  const manager = memoryManagerRef.current;
+                  if (manager) {
+                    try {
+                      const cwd = process.cwd();
+                      const queryText = sessionStateRef.current.task || cwd;
+                      const results = await manager.recall({ text: queryText, repoPath: cwd, limit: 5 });
+                      if (results.length > 0) {
+                        const text = await manager.synthesizeRecalled(results);
+                        const lastSystemIdx = messagesRef.current.findLastIndex((m) => m.role === "system");
+                        const insertIdx = lastSystemIdx >= 0 ? lastSystemIdx + 1 : messagesRef.current.length;
+                        messagesRef.current.splice(insertIdx, 0, { role: "system", content: text });
+                        setEvents((e) => [
+                          ...e,
+                          {
+                            kind: "memory",
+                            key: mkKey(),
+                            text: `recalled ${results.length} memory${results.length === 1 ? "" : "ies"} after compaction`,
+                          },
+                        ]);
+                        await saveSessionSafe();
+                      }
+                    } catch {
+                      // Non-fatal
                     }
-                  } catch {
-                    // Non-fatal
                   }
                 }
               }

--- a/src/ui/status.tsx
+++ b/src/ui/status.tsx
@@ -70,12 +70,20 @@ export function StatusBar({ usage, sessionUsage, thinking, turnStartedAt, mode, 
       : phase === "waiting"
         ? humanizePhase("waiting", intentTier)
         : humanizePhase("generating", intentTier);
+
+  // If we're still busy but the phase has flipped to "waiting" (e.g. between
+  // assistant final output and turn cleanup, or while waiting for the next
+  // model response after tools), don't show "ready" — it makes the spinner
+  // appear next to a "ready" label which looks broken.
+  const activePhaseLabel = thinking && phase === "waiting"
+    ? humanizePhase("generating", intentTier)
+    : phaseLabel;
   const idleMs = lastActivityAt && thinking ? now - lastActivityAt : 0;
   const idleLabel = idleMs > 30_000 ? ` (idle ${formatElapsed(Math.floor(idleMs / 1000))})` : "";
 
   const thinkingText = metaParts.length > 0
-    ? `${phaseLabel}${elapsed ? ` · ${elapsed}` : ""}${idleLabel} · ${metaParts.join(" · ")}`
-    : `${phaseLabel}${elapsed ? ` · ${elapsed}` : ""}${idleLabel}`;
+    ? `${activePhaseLabel}${elapsed ? ` · ${elapsed}` : ""}${idleLabel} · ${metaParts.join(" · ")}`
+    : `${activePhaseLabel}${elapsed ? ` · ${elapsed}` : ""}${idleLabel}`;
 
   const readyText = idleParts.length > 0
     ? `${idleParts.join(" · ")} · ready`


### PR DESCRIPTION
Post-turn housekeeping (session save, auto-compaction, memory recall) was blocking `cleanupTurn()` from running, leaving the input disabled and the user waiting. By wrapping the async work in a void IIFE and calling `cleanupTurn()` synchronously, the TUI returns to idle right away while housekeeping continues in the background.