### PR TITLE
feat(ui): bidirectional turn separators in chat

### DIFF
--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -75,7 +75,9 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
       {events.map((e, i) => {
         const prev = events[i - 1];
         const showSeparator = !!(
-          e.kind === "user" && prev && (prev.kind === "assistant" || prev.kind === "tool")
+          prev &&
+          ((e.kind === "user" && prev.kind !== "user") ||
+            (e.kind === "assistant" && prev.kind !== "assistant" && prev.kind !== "tool"))
         );
         return (
           <Box key={e.key} flexDirection="column">
@@ -131,7 +133,7 @@ const EventView = React.memo(function EventView({
       <Box flexDirection="column">
         <Box>
           <Text bold color={theme.user}>
-            ›{" "}
+            You:{" "}
           </Text>
           <Text bold>{evt.text}</Text>
         </Box>
@@ -147,21 +149,28 @@ const EventView = React.memo(function EventView({
   }
   if (evt.kind === "assistant") {
     return (
-      <Box flexDirection="column" paddingLeft={2}>
-        {showReasoning && evt.reasoning ? (
-          <Box flexDirection="column" marginBottom={1}>
-            <Text color={theme.reasoning.color}>
-              thinking…{" "}
-              {evt.reasoning.length > 400 ? evt.reasoning.slice(0, 400) + "…" : evt.reasoning}
-            </Text>
-          </Box>
-        ) : null}
-        {evt.text ? <MD text={evt.text} /> : null}
-        {evt.streaming && (
-          <Text color={theme.spinner}>
-            <Spinner type="dots" />
+      <Box flexDirection="column">
+        <Box>
+          <Text bold color={theme.assistant ?? theme.info.color}>
+            kimiflare:{" "}
           </Text>
-        )}
+          <Box flexDirection="column">
+            {showReasoning && evt.reasoning ? (
+              <Box flexDirection="column" marginBottom={1}>
+                <Text color={theme.reasoning.color}>
+                  thinking…{" "}
+                  {evt.reasoning.length > 400 ? evt.reasoning.slice(0, 400) + "…" : evt.reasoning}
+                </Text>
+              </Box>
+            ) : null}
+            {evt.text ? <MD text={evt.text} /> : null}
+            {evt.streaming && (
+              <Text color={theme.spinner}>
+                <Spinner type="dots" />
+              </Text>
+            )}
+          </Box>
+        </Box>
       </Box>
     );
   }

--- a/src/ui/themes/catppuccin-latte.json
+++ b/src/ui/themes/catppuccin-latte.json
@@ -9,7 +9,7 @@
     "error": "#d20f39"
   },
   "user": "#1e66f5",
-  "assistant": null,
+  "assistant": "#ea76cb",
   "reasoning": {
     "color": "#737685",
     "dim": false

--- a/src/ui/themes/catppuccin-mocha.json
+++ b/src/ui/themes/catppuccin-mocha.json
@@ -9,7 +9,7 @@
     "error": "#f38ba8"
   },
   "user": "#89b4fa",
-  "assistant": null,
+  "assistant": "#f5c2e7",
   "reasoning": {
     "color": "#8e91a7",
     "dim": false

--- a/src/ui/themes/dracula-dark.json
+++ b/src/ui/themes/dracula-dark.json
@@ -9,7 +9,7 @@
     "error": "#ff5858"
   },
   "user": "#ff79c6",
-  "assistant": null,
+  "assistant": "#bd93f9",
   "reasoning": {
     "color": "#8191c2",
     "dim": false

--- a/src/ui/themes/everforest-dark.json
+++ b/src/ui/themes/everforest-dark.json
@@ -9,7 +9,7 @@
     "error": "#e67e80"
   },
   "user": "#a7c080",
-  "assistant": null,
+  "assistant": "#e69875",
   "reasoning": {
     "color": "#8c968a",
     "dim": false

--- a/src/ui/themes/everforest-light.json
+++ b/src/ui/themes/everforest-light.json
@@ -9,7 +9,7 @@
     "error": "#cf4745"
   },
   "user": "#6f7e01",
-  "assistant": null,
+  "assistant": "#c4715a",
   "reasoning": {
     "color": "#70796f",
     "dim": false

--- a/src/ui/themes/gruvbox-dark.json
+++ b/src/ui/themes/gruvbox-dark.json
@@ -9,7 +9,7 @@
     "error": "#ff5b46"
   },
   "user": "#b8bb26",
-  "assistant": null,
+  "assistant": "#fe8019",
   "reasoning": {
     "color": "#a19283",
     "dim": false

--- a/src/ui/themes/gruvbox-light.json
+++ b/src/ui/themes/gruvbox-light.json
@@ -9,7 +9,7 @@
     "error": "#9d0006"
   },
   "user": "#79740e",
-  "assistant": null,
+  "assistant": "#af3a03",
   "reasoning": {
     "color": "#827467",
     "dim": false

--- a/src/ui/themes/kanagawa-dark.json
+++ b/src/ui/themes/kanagawa-dark.json
@@ -9,7 +9,7 @@
     "error": "#ff5d62"
   },
   "user": "#7e9cd8",
-  "assistant": null,
+  "assistant": "#d27e99",
   "reasoning": {
     "color": "#93938b",
     "dim": false

--- a/src/ui/themes/nord.json
+++ b/src/ui/themes/nord.json
@@ -9,7 +9,7 @@
     "error": "#d08770"
   },
   "user": "#88c0d0",
-  "assistant": null,
+  "assistant": "#b48ead",
   "reasoning": {
     "color": "#8a96a8",
     "dim": false

--- a/src/ui/themes/one-dark.json
+++ b/src/ui/themes/one-dark.json
@@ -9,7 +9,7 @@
     "error": "#e36f78"
   },
   "user": "#61afef",
-  "assistant": null,
+  "assistant": "#c678dd",
   "reasoning": {
     "color": "#8c939e",
     "dim": false

--- a/src/ui/themes/solarized-dark.json
+++ b/src/ui/themes/solarized-dark.json
@@ -9,7 +9,7 @@
     "error": "#ff5956"
   },
   "user": "#359ae1",
-  "assistant": null,
+  "assistant": "#d33682",
   "reasoning": {
     "color": "#81969c",
     "dim": false

--- a/src/ui/themes/solarized-light.json
+++ b/src/ui/themes/solarized-light.json
@@ -9,7 +9,7 @@
     "error": "#c0392b"
   },
   "user": "#227bbb",
-  "assistant": null,
+  "assistant": "#c61b6e",
   "reasoning": {
     "color": "#6e7878",
     "dim": false

--- a/src/ui/themes/tokyo-night.json
+++ b/src/ui/themes/tokyo-night.json
@@ -9,7 +9,7 @@
     "error": "#f7768e"
   },
   "user": "#7aa2f7",
-  "assistant": null,
+  "assistant": "#ff9e64",
   "reasoning": {
     "color": "#8991b5",
     "dim": false


### PR DESCRIPTION
Adds horizontal lines with padding between user and assistant turns so scrolling back makes it easier to distinguish who said what.

- Separator appears before user when previous event is not user
- Separator appears before assistant when previous event is not assistant/tool
- Keeps existing line style (40 chars, theme.info.color, marginY=1)

Test locally by running a few turns and scrolling up.

<img width="922" height="436" alt="CleanShot 2026-05-24 at 10 23 13@2x" src="https://github.com/user-attachments/assets/9b85e7c7-334a-4220-ade8-85378febda63" />
