### PR TITLE
fix(app): unblock UI between iterations during onIterationEnd housekeeping

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -886,7 +886,7 @@ function App({
         resumeSessions !== null ||
         checkpointSession !== null ||
         showThemePicker;
-      if (!modalOpen && busyRef.current && activeScopeRef.current && !isAbortingRef.current && now - lastEscapeAtRef.current > 500) {
+      if (!modalOpen && (busyRef.current || supervisorRef.current.isRunning) && activeScopeRef.current && !isAbortingRef.current && now - lastEscapeAtRef.current > 500) {
         lastEscapeAtRef.current = now;
         runInterruptTurn(interruptDepsRef.current!);
         return;
@@ -1595,6 +1595,7 @@ function App({
         onAssistantStart: () => {
           const id = mkAssistantId();
           activeAsstIdRef.current = id;
+          beginTurn();
           setTurnPhase("generating");
           setLastActivityAt(Date.now());
           setEvents((e) => [
@@ -1663,6 +1664,10 @@ function App({
           if (pendingToolCallsRef.current.size === 0) {
             setTurnPhase("waiting");
             setCurrentToolName(null);
+            // Unblock the UI before onIterationEnd (compaction / memory recall)
+            // so the user isn't stuck watching a spinner while housekeeping runs
+            // between iterations.
+            endTurn();
           }
           updateTool(r.tool_call_id, {
             status: !r.ok && typeof r.content === "string" && r.content.startsWith("Permission denied") ? "rejected" : r.ok ? "done" : "error",

--- a/src/ui/input-handlers.ts
+++ b/src/ui/input-handlers.ts
@@ -92,7 +92,7 @@ export function interruptTurn(deps: InterruptDeps): InterruptOutcome {
   const { hadLimit, hadLoop } = clearLimitLoopResolvers(deps);
 
   if (
-    deps.busyRef.current &&
+    (deps.busyRef.current || deps.supervisorRef.current.isRunning) &&
     deps.activeScopeRef.current &&
     !deps.isAbortingRef.current
   ) {


### PR DESCRIPTION
The onDone fire-and-forget fix only unblocks the UI at the very end of a turn. For multi-iteration turns (assistant → tools → assistant), there is a long blocking gap between iterations while `onIterationEnd` runs compaction and memory recall. During that gap `busy=true` and `phase=waiting`, so the user sees 'waiting' with a spinner for 5–10+ seconds and cannot interact.

## Changes

- **Call `endTurn()` in `onToolResult`** when the last tool of an iteration completes, so the UI returns to 'ready' before `onIterationEnd` runs.
- **Call `beginTurn()` in `onAssistantStart`** at the start of every iteration, ensuring `busy=true` again when the model starts generating.
- **Update `interruptTurn` and the Esc handler** to check `supervisor.isRunning` in addition to `busyRef`, so Ctrl+C/Esc still abort the turn (instead of quitting the app) during the gap.

## Edge cases handled

- **Auto-compact mid-turn** — `runCompact` already guards with `supervisorRef.current.isRunning`, so it bails out with a polite message.
- **Queued messages** — `submit` checks `supervisorRef.current.isRunning`, so new messages are queued rather than starting a new turn.
- **Multiple `endTurn()` calls** — `endTurn()` is idempotent; calling it multiple times is harmless.
- **Permission / limit / loop modals** — These are triggered during tool execution, not during the gap.