### PR TITLE
fix: make camouflage-tui an optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
-        "camouflage": "file:../camouflage/sdk/node",
+        "camouflage-tui": "1.0.0-beta.1",
         "commander": "^12.1.0",
         "ink": "^7.0.1",
         "ink-select-input": "^6.2.0",
@@ -40,13 +40,19 @@
         "node": ">=20"
       },
       "optionalDependencies": {
+        "camouflage-tui": "^1.0.0-beta.1",
         "isolated-vm": "^6.1.2"
       }
     },
     "../camouflage/sdk/node": {
-      "name": "camouflage",
-      "version": "0.4.6",
+      "name": "camouflage-tui",
+      "version": "1.0.0-beta.1",
+      "extraneous": true,
+      "hasInstallScript": true,
       "license": "Apache-2.0",
+      "bin": {
+        "camouflage-tui": "bin/camouflage-tui"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -1321,9 +1327,19 @@
         "node": ">=6"
       }
     },
-    "node_modules/camouflage": {
-      "resolved": "../camouflage/sdk/node",
-      "link": true
+    "node_modules/camouflage-tui": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/camouflage-tui/-/camouflage-tui-1.0.0-beta.1.tgz",
+      "integrity": "sha512-D9VKgkqPn94tF9a/4aS7Vidao3/+K5JsOitBiSpDaCZUmS0DyJVGGEXtuCOyUE6JPCTOGHqzjRPPOCAWTXKhbQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "camouflage-tui": "bin/camouflage-tui"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
-    "camouflage": "file:../camouflage/sdk/node",
     "commander": "^12.1.0",
     "ink": "^7.0.1",
     "ink-select-input": "^6.2.0",
@@ -78,6 +77,7 @@
     "vscode-languageserver-protocol": "^3.17.5"
   },
   "optionalDependencies": {
+    "camouflage-tui": "^1.0.0-beta.1",
     "isolated-vm": "^6.1.2"
   },
   "devDependencies": {

--- a/src/camouflage-resume.ts
+++ b/src/camouflage-resume.ts
@@ -8,7 +8,6 @@
  * round-trip end-to-end against real session data.
  */
 
-import { mount, selectList } from "camouflage";
 import { listSessions, type SessionSummary } from "./sessions.js";
 
 export interface CamouflageResumeOpts {
@@ -17,6 +16,19 @@ export interface CamouflageResumeOpts {
 }
 
 export async function runCamouflageResume(opts: CamouflageResumeOpts = {}): Promise<void> {
+  let camMod: typeof import("camouflage-tui");
+  try {
+    camMod = await import("camouflage-tui");
+  } catch {
+    process.stderr.write(
+      "kimiflare resume: the 'camouflage-tui' package is required.\n" +
+        "Install it with: npm install -g camouflage-tui\n",
+    );
+    process.exitCode = 2;
+    return;
+  }
+  const { mount, selectList } = camMod;
+
   const sessions = await listSessions(opts.limit ?? 20, process.cwd());
 
   if (sessions.length === 0) {

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -25,8 +25,6 @@ import { appendFileSync, openSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { platform } from "node:os";
-import { mount } from "camouflage";
-
 /** File logger gated by KIMIFLARE_EVENT_LOG. One JSON object per line. */
 const KIMI_LOG_PATH = process.env.KIMIFLARE_EVENT_LOG ?? null;
 if (KIMI_LOG_PATH) {
@@ -39,7 +37,7 @@ function kimiLog(payload: Record<string, unknown>): void {
     appendFileSync(KIMI_LOG_PATH, line);
   } catch { /* swallow — diagnostic only */ }
 }
-import type { CamouflageHandle } from "camouflage";
+import type { CamouflageHandle } from "camouflage-tui";
 import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
 import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
@@ -47,7 +45,37 @@ import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ChatMessage } from "./agent/messages.js";
 import { KimiApiError, humanizeCloudflareError } from "./util/errors.js";
 import { BUILTIN_COMMANDS } from "./commands/builtins.js";
-import { selectList, form, confirm } from "camouflage";
+
+async function requireCamouflage(): Promise<typeof import("camouflage-tui")> {
+  try {
+    return await import("camouflage-tui");
+  } catch {
+    console.error(
+      "kimiflare: the 'camouflage-tui' package is required for the Camouflage UI.\n" +
+        "Install it with:\n" +
+        "  npm install -g camouflage-tui\n" +
+        "Or switch to the default Ink UI:\n" +
+        "  kimiflare --ui ink",
+    );
+    process.exit(2);
+  }
+}
+
+let _loaded = false;
+let mount: Awaited<ReturnType<typeof requireCamouflage>>["mount"];
+let selectList: Awaited<ReturnType<typeof requireCamouflage>>["selectList"];
+let form: Awaited<ReturnType<typeof requireCamouflage>>["form"];
+let confirm: Awaited<ReturnType<typeof requireCamouflage>>["confirm"];
+
+async function loadCamouflage() {
+  if (_loaded) return;
+  const mod = await requireCamouflage();
+  mount = mod.mount;
+  selectList = mod.selectList;
+  form = mod.form;
+  confirm = mod.confirm;
+  _loaded = true;
+}
 import { listSessions, loadSession, addCheckpoint, loadSessionFromCheckpoint } from "./sessions.js";
 import { summarizeMessagesViaLlm } from "./agent/llm-summarize.js";
 import { buildWelcome } from "./ui/greetings.js";
@@ -115,6 +143,7 @@ function gatewayFromOpts(opts: UiModeOpts): AiGatewayOptions | undefined {
 }
 
 export async function runUiMode(opts: UiModeOpts): Promise<void> {
+  await loadCamouflage();
   // Spawn the renderer as a child. renderToTerminal=true means: TUI
   // draws to the user's terminal; outbound NDJSON arrives on fd 3.
   let cam: CamouflageHandle;
@@ -2198,6 +2227,7 @@ function tryGitBranch(): string {
 export async function runCamouflageOnboarding(opts: {
   camouflageBin?: string;
 }): Promise<KimiConfig | null> {
+  await loadCamouflage();
   const cam = await mount({ bin: opts.camouflageBin, renderToTerminal: true });
   cam.send("SessionStarted", {});
   cam.send("StatusUpdate", { segments: { mode: "setup", phase: "onboarding" } });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
     "react",
     "commander",
     "turndown",
+    "camouflage-tui",
   ],
 });


### PR DESCRIPTION
## Summary
- Renames the dependency from `camouflage` (local `file:` path) to `camouflage-tui` (the [published npm package](https://www.npmjs.com/package/camouflage-tui))
- Moves it from `dependencies` to `optionalDependencies` so `npm install -g kimiflare` doesn't fail when camouflage-tui isn't available
- Converts top-level `import { mount, selectList, ... } from "camouflage"` to dynamic `await import("camouflage-tui")` in `ui-mode.ts` and `camouflage-resume.ts`, with a clear error message if the package is missing
- Adds `camouflage-tui` to tsup's `external` list so it stays as a runtime import instead of being bundled

Fixes the `ERR_MODULE_NOT_FOUND: Cannot find package 'camouflage'` crash that broke v0.76.0 on startup.

## Test plan
- [ ] `npm run build` succeeds
- [ ] `kimiflare` (default Ink UI) starts without error when `camouflage-tui` is not installed
- [ ] `kimiflare --ui camouflage` shows a helpful install message when `camouflage-tui` is not installed
- [ ] `kimiflare --ui camouflage` works when `camouflage-tui` is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)