### PR TITLE
fix(multi-agent): make experimental mode usable in both UIs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -265,6 +265,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
   const envShell = process.env.KIMIFLARE_SHELL;
   const envProviderKeys = readProviderKeysEnv();
   const envUnifiedBilling = readBooleanEnv("KIMIFLARE_UNIFIED_BILLING");
+  const envMultiAgentEnabled = readBooleanEnv("KIMIFLARE_MULTI_AGENT_ENABLED");
 
   if (envAccount && envToken) {
     return {
@@ -307,7 +308,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       workerBudgetUsd: readNumberEnv("KIMIFLARE_WORKER_BUDGET_USD"),
       workerMaxParallel: readNumberEnv("KIMIFLARE_WORKER_MAX_PARALLEL"),
       workerTimeoutMs: readNumberEnv("KIMIFLARE_WORKER_TIMEOUT_MS"),
-      multiAgentEnabled: readBooleanEnv("KIMIFLARE_MULTI_AGENT_ENABLED"),
+      multiAgentEnabled: envMultiAgentEnabled,
     };
   }
 
@@ -354,7 +355,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         workerBudgetUsd: parsed.workerBudgetUsd,
         workerMaxParallel: parsed.workerMaxParallel,
         workerTimeoutMs: parsed.workerTimeoutMs,
-        multiAgentEnabled: parsed.multiAgentEnabled,
+        multiAgentEnabled: envMultiAgentEnabled ?? parsed.multiAgentEnabled,
       };
     }
   }

--- a/src/intent/classify.test.ts
+++ b/src/intent/classify.test.ts
@@ -20,6 +20,17 @@ describe("classifyIntent", () => {
     assert.strictEqual(r.tier, "heavy");
   });
 
+  it("classifies security/audit/research tasks as heavy even without mutating verbs", () => {
+    for (const p of [
+      "Find a security loophole in this project.",
+      "audit the codebase for vulnerabilities",
+      "research the best caching strategy",
+      "read my entire codebase and find exploits",
+    ]) {
+      assert.strictEqual(classifyIntent(p).tier, "heavy", `expected heavy: ${p}`);
+    }
+  });
+
   it("returns a well-formed IntentResult", () => {
     const r = classifyIntent("refactor the parser");
     assert.ok(typeof r.intent === "string");

--- a/src/intent/classify.ts
+++ b/src/intent/classify.ts
@@ -17,6 +17,13 @@ const INTENT_PATTERNS: Record<string, RegExp> = {
   meta: /\b(plan|design|strategy|ontology|roadmap|approach)\b/i,
 };
 
+/** Strong signals that a task needs deep, multi-angle work regardless of
+ *  mutating verbs or file mentions — research, audits, security reviews, and
+ *  whole-codebase exploration. The keyword scorer otherwise reads these as
+ *  trivial because they lack verbs like "implement". */
+const HEAVY_SIGNAL =
+  /\b(research|investigat\w*|audit|deep[\s-]?(dive|thinking)|explorat\w*|comprehensive|end[\s-]?to[\s-]?end|entire\s+(code\s?base|repo\w*|project|app)|whole\s+(code\s?base|repo\w*|project|app)|across\s+the\s+(code\s?base|repo\w*|project)|security|vulnerab\w*|loophole|exploit\w*|threat\s?model|attack\s+surface|penetration)\b/i;
+
 export function classifyIntent(prompt: string): IntentResult {
   let intentScore = 0;
   let matchedIntent = "other";
@@ -32,21 +39,23 @@ export function classifyIntent(prompt: string): IntentResult {
   const hasFileMentions = (prompt.match(/@\w+|\b[\w/-]+\.(ts|tsx|js|jsx|py|go|rs)\b/g) || []).length;
   const hasMutatingVerb = /\b(add|create|write|edit|delete|remove|rename|migrate|implement)\b/i.test(prompt);
   const isQuestion = prompt.trim().endsWith("?") || /\b(what|how|why|is|does|can)\b/i.test(prompt.split(" ")[0] || "");
+  const hasHeavySignal = HEAVY_SIGNAL.test(prompt);
 
   const rawScore = Math.min(
     1.0,
     intentScore * 0.25 +
       (hasFileMentions > 2 ? 0.3 : hasFileMentions * 0.1) +
       (hasMutatingVerb ? 0.25 : 0) +
-      (isQuestion ? 0 : 0.1),
+      (isQuestion ? 0 : 0.1) +
+      (hasHeavySignal ? 0.6 : 0),
   );
 
   const tier = rawScore < 0.3 ? "light" : rawScore < 0.65 ? "medium" : "heavy";
 
   return {
-    intent: matchedIntent,
+    intent: hasHeavySignal && matchedIntent === "other" ? "explore" : matchedIntent,
     rawScore,
     tier,
-    confidence: 0.5 + (intentScore > 0 ? 0.3 : 0) + (hasFileMentions > 0 ? 0.1 : 0),
+    confidence: 0.5 + (intentScore > 0 || hasHeavySignal ? 0.3 : 0) + (hasFileMentions > 0 ? 0.1 : 0),
   };
 }

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -39,6 +39,8 @@ function kimiLog(payload: Record<string, unknown>): void {
 }
 import type { CamouflageHandle } from "camouflage-tui";
 import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
+import { TurnSupervisor } from "./agent/supervisor.js";
+import { classifyIntent } from "./intent/classify.js";
 import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
@@ -133,9 +135,16 @@ const BUILTIN_SLASH_COMMANDS = BUILTIN_COMMANDS.map((c) => ({
   source: "builtin" as const,
 }));
 
-/** Mode names KimiFlare supports + the order /mode and Shift+Tab cycle through. */
-const MODES = ["edit", "plan", "auto"] as const;
+/** Mode names KimiFlare supports + the order /mode and Shift+Tab cycle through.
+ *  `multi-agent-experimental` only appears in the cycle when enabled via
+ *  config (`multiAgentEnabled`) or the KIMIFLARE_MULTI_AGENT_ENABLED env var. */
+const MODES = ["edit", "plan", "auto", "multi-agent-experimental"] as const;
 type Mode = typeof MODES[number];
+
+/** Short status-bar label for a mode (the experimental name is long). */
+function modeLabel(m: Mode): string {
+  return m === "multi-agent-experimental" ? "multi-agent" : m;
+}
 
 function gatewayFromOpts(opts: UiModeOpts): AiGatewayOptions | undefined {
   if (!opts.aiGatewayId) return undefined;
@@ -193,6 +202,18 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
   let currentThemeName = "everforest-dark";
   const branch = tryGitBranch();
   let currentSessionFilePath: string | null = null;
+
+  // Multi-agent (experimental): the mode is hidden from the cycle unless
+  // explicitly enabled. We honor the env var directly in addition to the
+  // loaded config, since loadConfig() ignores the env var when a persisted
+  // config file exists.
+  const startupCfg = await loadConfig().catch(() => null);
+  const multiAgentEnabled =
+    (startupCfg?.multiAgentEnabled ?? false) ||
+    /^(1|true|yes|on)$/i.test(process.env.KIMIFLARE_MULTI_AGENT_ENABLED ?? "");
+  const multiAgentSupervisor = new TurnSupervisor();
+  const availableModes = (): Mode[] =>
+    multiAgentEnabled ? [...MODES] : MODES.filter((m) => m !== "multi-agent-experimental");
 
   if (opts.splash && opts.splash.length > 0) {
     cam.send("Splash", { text: opts.splash });
@@ -276,8 +297,8 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
   const setMode = (next: Mode): void => {
     if (next === currentMode) return;
     currentMode = next;
-    cam.send("StatusUpdate", { segments: { mode: next } });
-    cam.send("ShowToast", { text: `mode: ${next}`, kind: "info", ttl_ms: 1200 });
+    cam.send("StatusUpdate", { segments: { mode: modeLabel(next) } });
+    cam.send("ShowToast", { text: `mode: ${modeLabel(next)}`, kind: "info", ttl_ms: 1200 });
   };
 
   // Default context-window heuristic for the /compact recommended banner.
@@ -370,14 +391,15 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
     }
   });
 
-  // Shift+Tab / Tab cycles edit → plan → auto (and back).
+  // Shift+Tab / Tab cycles edit → plan → auto (→ multi-agent when enabled).
   cam.on("modeChangeRequested", ({ direction }: { direction: "next" | "prev" }) => {
-    const idx = MODES.indexOf(currentMode);
-    const len = MODES.length;
+    const modes = availableModes();
+    const idx = Math.max(0, modes.indexOf(currentMode));
+    const len = modes.length;
     const nextIdx = direction === "prev"
       ? (idx - 1 + len) % len
       : (idx + 1) % len;
-    setMode(MODES[nextIdx] ?? "edit");
+    setMode(modes[nextIdx] ?? "edit");
   });
 
   cam.on("exit", ({ code }) => {
@@ -464,6 +486,55 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
     currentController = new AbortController();
 
     try {
+      // Multi-agent (experimental) two-gate: when the mode is active AND the
+      // prompt classifies as a heavy task, spawn parallel research workers
+      // instead of running a normal local turn. Light/medium tasks fall
+      // through to the normal turn below.
+      if (currentMode === "multi-agent-experimental") {
+        const classification = classifyIntent(text);
+        if (classification.tier !== "heavy") {
+          cam.send("ShowToast", {
+            text: `multi-agent mode active, but task is ${classification.tier} — running locally`,
+            kind: "info",
+            ttl_ms: 2500,
+          });
+        } else {
+          setPhase("thinking");
+          cam.send("ShowToast", { text: "multi-agent mode: spawning parallel research workers…", kind: "info", ttl_ms: 2500 });
+          try {
+            let lastDone = -1;
+            const { plan, conflicts, recommendations } = await multiAgentSupervisor.autoSpawnWorkers(
+              text,
+              `Current project: ${cwd}`,
+              (workers) => {
+                const done = workers.filter((w) => w.status === "completed" || w.status === "failed").length;
+                const running = workers.filter((w) => w.status === "running").length;
+                if (done !== lastDone) {
+                  lastDone = done;
+                  cam.send("ShowToast", { text: `workers: ${running} running · ${done}/${workers.length} done`, kind: "info", ttl_ms: 1500 });
+                }
+              },
+            );
+            // Render the synthesized plan as an assistant message so the user
+            // sees the research output, and keep it in history for follow-ups.
+            const sid = `s${++streamCounter}`;
+            cam.send("AssistantStreamStarted", { stream_id: sid });
+            cam.send("AssistantTokenDelta", { stream_id: sid, token: plan });
+            cam.send("AssistantMessageCompleted", { stream_id: sid });
+            messages.push({ role: "assistant", content: plan });
+            if (conflicts.length > 0) {
+              cam.send("ShowToast", { text: `${conflicts.length} conflict(s) resolved`, kind: "warn", ttl_ms: 3000 });
+            }
+            cam.send("ShowToast", { text: `synthesized ${recommendations.length} recommendation(s)`, kind: "success", ttl_ms: 3000 });
+          } catch (err) {
+            if (!(err instanceof Error && err.name === "AbortError")) {
+              cam.send("ShowToast", { text: `multi-agent spawn failed: ${err instanceof Error ? err.message : String(err)}`, kind: "error", ttl_ms: 4000 });
+            }
+          }
+          return;
+        }
+      }
+
       await runAgentTurn({
         accountId: opts.accountId,
         apiToken: opts.apiToken,
@@ -1299,15 +1370,19 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
       case "auto":
         setMode(name as Mode);
         return true;
-      case "mode":
-        if (args && (MODES as readonly string[]).includes(args)) {
+      case "mode": {
+        const modes = availableModes();
+        if (args && (modes as readonly string[]).includes(args)) {
           setMode(args as Mode);
+        } else if (args === "multi-agent-experimental" && !multiAgentEnabled) {
+          cam.send("ShowToast", { text: "multi-agent mode is disabled — set KIMIFLARE_MULTI_AGENT_ENABLED=1", kind: "error", ttl_ms: 3500 });
         } else {
-          const idx = MODES.indexOf(currentMode);
-          const next = MODES[(idx + 1) % MODES.length] ?? "edit";
+          const idx = Math.max(0, modes.indexOf(currentMode));
+          const next = modes[(idx + 1) % modes.length] ?? "edit";
           setMode(next);
         }
         return true;
+      }
       case "model":
         cam.send("ShowToast", { text: `model: ${opts.model}`, kind: "info", ttl_ms: 2500 });
         return true;


### PR DESCRIPTION
## Summary
Three fixes so the multi-agent feature actually works for a realistic flow (reported: the mode was invisible in React Ink, and a whole-codebase security audit prompt never spawned workers).

### 1. Camouflage UI was missing the mode entirely (`src/ui-mode.ts`)
The camouflage engine keeps its own `MODES` array separate from `mode.ts`, so `multi-agent-experimental` never appeared in its Shift-Tab cycle or `/mode`. Ports the full flow: mode in the cycle (gated by `multiAgentEnabled`), two-gate auto-spawn in `runTurn`, worker progress toasts, and renders the synthesized plan as an assistant message.

### 2. Env flag ignored with a persisted config (`src/config.ts`)
`loadConfig()` read `multiAgentEnabled` from the persisted config file and **ignored `KIMIFLARE_MULTI_AGENT_ENABLED`** when one existed — so the React Ink UI never unlocked the mode despite the env var. The env var now overrides in both config branches. This is what made the mode invisible in Ink.

### 3. Classifier scored research/security tasks as "light" (`src/intent/classify.ts`)
The tier gate needs a `heavy` classification, but the keyword scorer only rewards mutating verbs ("implement"/"add") and file mentions. A prompt like *"find a security loophole in this project"* scored 0.10 (light) and never spawned workers. Adds a `HEAVY_SIGNAL` pattern (research, investigate, audit, security, vulnerab, exploit, explore, entire/whole codebase, threat model, …) that lifts these to heavy.

| Prompt | Before | After |
|--------|--------|-------|
| `find a security loophole in this project` | light | **heavy** |
| `audit the codebase for vulnerabilities` | light | **heavy** |
| `make the app faster` | light | light |
| `what is 2+2?` | medium | medium |

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] unit tests pass (17/17, incl. new security/research classification cases)
- [ ] Manual: both UIs (`node bin/kimiflare.mjs`) with `KIMIFLARE_MULTI_AGENT_ENABLED=1` + mock server → Shift-Tab reaches `multi-agent`; "find a security loophole" auto-spawns workers and the mock server logs the request

🤖 Generated with [Claude Code](https://claude.com/claude-code)