### PR TITLE
chore: track camouflage-tui via the `beta` dist-tag [blocked on camouflage#8]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "camouflage-tui": "^1.0.0-beta.1",
+        "camouflage-tui": "beta",
         "isolated-vm": "^6.1.2"
       }
     },
@@ -1327,9 +1327,9 @@
       }
     },
     "node_modules/camouflage-tui": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/camouflage-tui/-/camouflage-tui-1.0.0-beta.1.tgz",
-      "integrity": "sha512-D9VKgkqPn94tF9a/4aS7Vidao3/+K5JsOitBiSpDaCZUmS0DyJVGGEXtuCOyUE6JPCTOGHqzjRPPOCAWTXKhbQ==",
+      "version": "1.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/camouflage-tui/-/camouflage-tui-1.1.0-beta.1.tgz",
+      "integrity": "sha512-TyfyBYb3Qhygn1JSHRrXRC9hscsqsMXSs4nXk+SK2k+smxpn6M0yGY2oM5er4PNRNcYGynhOq2gJ+JcW+ZNH0g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "vscode-languageserver-protocol": "^3.17.5"
   },
   "optionalDependencies": {
-    "camouflage-tui": "^1.0.0-beta.1",
+    "camouflage-tui": "beta",
     "isolated-vm": "^6.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Switch the `camouflage-tui` optionalDependency from the semver range `^1.0.0-beta.1` to the **`beta` dist-tag**, and re-resolve the lockfile to the current beta (`1.1.0-beta.1`).

## Why

`^1.0.0-beta.1` is a **caret on a prerelease**, which npm only matches against other prereleases sharing the same `major.minor.patch` base (`1.0.0`). So it matches `1.0.0-beta.*` and stable `1.x`, but **not** new-base betas like `1.0.1-beta.1` or `1.1.0-beta.1`. kimiflare was therefore frozen on `1.0.0-beta.1`, silently ignoring every newer camouflage beta (verified with `semver.maxSatisfying` → `1.0.0-beta.1`).

Pointing at the `beta` dist-tag means each release-please beta publish flows in on the next install/update, with no manual range bumping.

## ⚠️ Blocked — do not merge yet

The currently-published betas (`1.0.1-beta.1`, `1.1.0-beta.1`) ship **no binary** due to a release-tag mismatch in camouflage's pipeline. Merging this before that's fixed would **regress** the camouflage UI from the working `1.0.0-beta.1` to a binary-less beta.

**Merge only after** [sinameraji/camouflage#8](https://github.com/sinameraji/camouflage/pull/8) lands and a beta is published with a working binary. At that point, re-run `npm update camouflage-tui` to refresh the lockfile to that beta before merging.

## Diff

- `package.json`: `"camouflage-tui": "^1.0.0-beta.1"` → `"beta"`
- `package-lock.json`: re-resolved `1.0.0-beta.1` → `1.1.0-beta.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)