### PR TITLE
feat(multi-agent): teardown, cleanup scripts, and workerName tracking

### DIFF
--- a/scripts/cleanup-multi-agent.ts
+++ b/scripts/cleanup-multi-agent.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+/**
+ * Audit and clean up leftover multi-agent Cloudflare primitives.
+ * Reads credentials from ~/.config/kimiflare/config.json
+ */
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CF_API = "https://api.cloudflare.com/client/v4";
+
+interface Config {
+  accountId?: string;
+  apiToken?: string;
+}
+
+async function loadConfig(): Promise<Config | null> {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  const path = join(xdg, "kimiflare", "config.json");
+  try {
+    const raw = await readFile(path, "utf8");
+    return JSON.parse(raw) as Config;
+  } catch {
+    return null;
+  }
+}
+
+async function cfFetch<T>(accountId: string, token: string, path: string, init?: RequestInit): Promise<{ success: boolean; result?: T; errors?: Array<{ message?: string }> }> {
+  const url = `${CF_API}/accounts/${encodeURIComponent(accountId)}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+  return (await res.json()) as { success: boolean; result?: T; errors?: Array<{ message?: string }> };
+}
+
+async function listWorkers(accountId: string, token: string): Promise<Array<{ id: string; tag: string }>> {
+  const json = await cfFetch<Array<{ id: string; tag: string }>>(accountId, token, "/workers/scripts");
+  return json.result ?? [];
+}
+
+async function deleteWorker(accountId: string, token: string, name: string): Promise<void> {
+  const json = await cfFetch<unknown>(accountId, token, `/workers/scripts/${encodeURIComponent(name)}`, { method: "DELETE" });
+  if (!json.success) throw new Error(json.errors?.map((e) => e.message).join(", ") ?? "delete failed");
+}
+
+async function listDoNamespaces(accountId: string, token: string): Promise<Array<{ id: string; name: string; script: string; class: string }>> {
+  const json = await cfFetch<Array<{ id: string; name: string; script: string; class: string }>>(accountId, token, "/workers/durable_objects/namespaces");
+  return json.result ?? [];
+}
+
+async function deleteDoNamespace(accountId: string, token: string, id: string): Promise<void> {
+  const json = await cfFetch<unknown>(accountId, token, `/workers/durable_objects/namespaces/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!json.success) throw new Error(json.errors?.map((e) => e.message).join(", ") ?? "delete failed");
+}
+
+async function listKvNamespaces(accountId: string, token: string): Promise<Array<{ id: string; title: string }>> {
+  const json = await cfFetch<Array<{ id: string; title: string }>>(accountId, token, "/storage/kv/namespaces");
+  return json.result ?? [];
+}
+
+async function deleteKvNamespace(accountId: string, token: string, id: string): Promise<void> {
+  const json = await cfFetch<unknown>(accountId, token, `/storage/kv/namespaces/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!json.success) throw new Error(json.errors?.map((e) => e.message).join(", ") ?? "delete failed");
+}
+
+async function listContainerApps(accountId: string, token: string): Promise<Array<{ id: string; name: string }>> {
+  const json = await cfFetch<Array<{ id: string; name: string }>>(accountId, token, "/containers/applications");
+  return json.result ?? [];
+}
+
+async function deleteContainerApp(accountId: string, token: string, id: string): Promise<void> {
+  const json = await cfFetch<unknown>(accountId, token, `/containers/applications/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!json.success) throw new Error(json.errors?.map((e) => e.message).join(", ") ?? "delete failed");
+}
+
+function isMultiAgent(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower.includes("kimiflare-multi-agent") || lower.includes("kimiflare-commute");
+}
+
+async function main() {
+  const cfg = await loadConfig();
+  if (!cfg?.accountId || !cfg?.apiToken) {
+    console.error("Cloudflare credentials not found in ~/.config/kimiflare/config.json");
+    console.error("Run /init in kimiflare first.");
+    process.exit(1);
+  }
+
+  const { accountId, apiToken } = cfg;
+
+  console.log("🔍 Scanning your Cloudflare account for multi-agent leftovers…\n");
+
+  const workers = (await listWorkers(accountId, apiToken)).filter((w) => isMultiAgent(w.id));
+  const doNs = (await listDoNamespaces(accountId, apiToken)).filter((ns) => isMultiAgent(ns.name) || isMultiAgent(ns.script));
+  const kvNs = (await listKvNamespaces(accountId, apiToken)).filter((kv) => isMultiAgent(kv.title));
+  const containers = (await listContainerApps(accountId, apiToken)).filter((app) => isMultiAgent(app.name));
+
+  console.log(`Workers:              ${workers.length}`);
+  for (const w of workers) console.log(`  • ${w.id}`);
+
+  console.log(`\nDurable Object NS:    ${doNs.length}`);
+  for (const ns of doNs) console.log(`  • ${ns.name} (script: ${ns.script}, class: ${ns.class})`);
+
+  console.log(`\nKV namespaces:        ${kvNs.length}`);
+  for (const kv of kvNs) console.log(`  • ${kv.title} (${kv.id})`);
+
+  console.log(`\nContainer apps:       ${containers.length}`);
+  for (const c of containers) console.log(`  • ${c.name} (${c.id})`);
+
+  const total = workers.length + doNs.length + kvNs.length + containers.length;
+  if (total === 0) {
+    console.log("\n✅ Nothing found — your account is clean.");
+    return;
+  }
+
+  console.log(`\n⚠️  Found ${total} leftover primitive(s).`);
+
+  // Auto-delete without prompting since user explicitly asked
+  console.log("\n🗑️  Deleting everything…\n");
+
+  for (const w of workers) {
+    try {
+      await deleteWorker(accountId, apiToken, w.id);
+      console.log(`  ✓ Worker deleted: ${w.id}`);
+    } catch (err) {
+      console.log(`  ✗ Worker delete failed: ${w.id} — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  for (const c of containers) {
+    try {
+      await deleteContainerApp(accountId, apiToken, c.id);
+      console.log(`  ✓ Container app deleted: ${c.name}`);
+    } catch (err) {
+      console.log(`  ✗ Container app delete failed: ${c.name} — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  for (const ns of doNs) {
+    try {
+      await deleteDoNamespace(accountId, apiToken, ns.id);
+      console.log(`  ✓ DO namespace deleted: ${ns.name}`);
+    } catch (err) {
+      console.log(`  ✗ DO namespace delete failed: ${ns.name} — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  for (const kv of kvNs) {
+    try {
+      await deleteKvNamespace(accountId, apiToken, kv.id);
+      console.log(`  ✓ KV namespace deleted: ${kv.title}`);
+    } catch (err) {
+      console.log(`  ✗ KV namespace delete failed: ${kv.title} — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  console.log("\n✅ Cleanup complete.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/redeploy-multi-agent.ts
+++ b/scripts/redeploy-multi-agent.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env tsx
+/**
+ * Headless redeploy of the kimiflare-multi-agent worker.
+ * Runs the same deployCommute() generator the TUI uses, streaming each step
+ * to stdout. Picks up whatever is on kimiflare-commute `main` (clones fresh).
+ *
+ * Usage: npx tsx scripts/redeploy-multi-agent.ts [workerName]
+ */
+import { deployCommute } from "../src/remote/deploy-commute.js";
+
+async function main() {
+  const workerName = process.argv[2];
+  const opts = workerName ? { workerName } : {};
+  console.log(`▶ Redeploying multi-agent worker${workerName ? ` (${workerName})` : " (default: kimiflare-multi-agent)"}…\n`);
+
+  const gen = deployCommute(opts);
+  let result: unknown;
+  while (true) {
+    const { value, done } = await gen.next();
+    if (done) {
+      result = value;
+      break;
+    }
+    const step = value as { message: string; ok?: boolean; error?: boolean };
+    const prefix = step.error ? "✗" : step.ok ? "✓" : "·";
+    console.log(`${prefix} ${step.message}`);
+  }
+  console.log("\n✅ Deploy finished:");
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error("\n✗ Deploy failed:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -191,6 +191,7 @@ export interface Cfg {
   multiAgentEnabled?: boolean;
   workerEndpoint?: string;
   workerApiKey?: string;
+  workerName?: string;
   autoExecute?: boolean;
 }
 function App({
@@ -2273,6 +2274,7 @@ function App({
           multiAgentEnabled: cfg.multiAgentEnabled,
           workerEndpoint: cfg.workerEndpoint,
           workerApiKey: cfg.workerApiKey,
+          workerName: cfg.workerName,
           autoExecute: cfg.autoExecute,
         } : undefined}
         onMultiAgentSave={async (patch) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,8 @@ export interface KimiConfig {
   multiAgentEnabled?: boolean;
   /** Bearer/secret for the worker endpoint (sent as X-Worker-Api-Key). */
   workerApiKey?: string;
+  /** Name of the deployed multi-agent Worker. Used for tear-down. */
+  workerName?: string;
   /** When true, after plan workers synthesize, spawn one executor worker
    *  to implement the synthesized plan and open a PR. Off by default. */
   autoExecute?: boolean;

--- a/src/remote/deploy-commute.ts
+++ b/src/remote/deploy-commute.ts
@@ -26,6 +26,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { loadConfig, saveConfig, type KimiConfig } from "../config.js";
+import { getUserAgent } from "../util/version.js";
 
 export interface DeployStep {
   message: string;
@@ -53,6 +54,114 @@ const PUBLIC_SANDBOX_IMAGE = "ghcr.io/sinameraji/kimiflare-remote-agent:latest";
  *  Also drives the KV namespace title + the tear-down target. */
 const WORKER_NAME = "kimiflare-multi-agent";
 const KV_TITLE = "kimiflare-multi-agent-OAUTH_KV";
+const CF_API = "https://api.cloudflare.com/client/v4";
+
+interface CfEnvelope<T> {
+  success: boolean;
+  result?: T;
+  errors?: Array<{ code?: number; message?: string }>;
+}
+
+interface DurableObjectNamespace {
+  id: string;
+  name: string;
+  script: string;
+  class: string;
+}
+
+interface ContainerApplication {
+  id: string;
+  name: string;
+}
+
+async function cfApiFetch<T>(
+  accountId: string,
+  apiToken: string,
+  path: string,
+  init?: RequestInit,
+): Promise<CfEnvelope<T>> {
+  const url = `${CF_API}/accounts/${encodeURIComponent(accountId)}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+      "User-Agent": getUserAgent(),
+      ...init?.headers,
+    },
+  });
+  const json = (await res.json()) as CfEnvelope<T>;
+  return json;
+}
+
+async function listDurableObjectNamespaces(
+  accountId: string,
+  apiToken: string,
+): Promise<DurableObjectNamespace[]> {
+  const json = await cfApiFetch<DurableObjectNamespace[]>(
+    accountId,
+    apiToken,
+    "/workers/durable_objects/namespaces",
+  );
+  if (!json.success || !json.result) {
+    throw new Error(
+      json.errors?.map((e) => e.message).join(", ") ?? "Failed to list DO namespaces",
+    );
+  }
+  return json.result;
+}
+
+async function deleteDurableObjectNamespace(
+  accountId: string,
+  apiToken: string,
+  namespaceId: string,
+): Promise<void> {
+  const json = await cfApiFetch<unknown>(
+    accountId,
+    apiToken,
+    `/workers/durable_objects/namespaces/${encodeURIComponent(namespaceId)}`,
+    { method: "DELETE" },
+  );
+  if (!json.success) {
+    throw new Error(
+      json.errors?.map((e) => e.message).join(", ") ?? "Failed to delete DO namespace",
+    );
+  }
+}
+
+async function listContainerApplications(
+  accountId: string,
+  apiToken: string,
+): Promise<ContainerApplication[]> {
+  const json = await cfApiFetch<ContainerApplication[]>(
+    accountId,
+    apiToken,
+    "/containers/applications",
+  );
+  if (!json.success || !json.result) {
+    // Containers API may be unavailable or require different permissions.
+    return [];
+  }
+  return json.result;
+}
+
+async function deleteContainerApplication(
+  accountId: string,
+  apiToken: string,
+  appId: string,
+): Promise<void> {
+  const json = await cfApiFetch<unknown>(
+    accountId,
+    apiToken,
+    `/containers/applications/${encodeURIComponent(appId)}`,
+    { method: "DELETE" },
+  );
+  if (!json.success) {
+    throw new Error(
+      json.errors?.map((e) => e.message).join(", ") ?? "Failed to delete container application",
+    );
+  }
+}
 
 function generateSecret(): string {
   return randomBytes(32).toString("hex");
@@ -481,23 +590,25 @@ export async function* deployCommute(opts: DeployOpts = {}): AsyncGenerator<Depl
   // Strip [[artifacts]] block. Match the header + every following line
   // that isn't blank-then-section, until the next blank line or new [[.
   toml = toml.replace(/\n\[\[artifacts\]\][\s\S]*?(?=\n\[|\n*$)/g, "\n");
-  // Always ensure the migrations block lists ALL current DO classes.
-  // For existing workers, we bump the tag (v1 → v2 → v3) so Wrangler
-  // knows to add any new classes (e.g. WorkerDO) without recreating
-  // existing ones. Wrangler ignores already-created classes.
-  const existingMigrations = toml.match(/\[\[migrations\]\]/);
-  if (existingMigrations) {
-    // Replace the existing migrations block with the current class list
-    toml = toml.replace(
-      /\[\[migrations\]\][\s\S]*?new_sqlite_classes\s*=\s*\[[^\]]*\]/,
-      `[[migrations]]\ntag = "v2"\nnew_sqlite_classes = ["SessionDO", "WorkerDO", "Sandbox"]`,
-    );
-  } else {
-    toml +=
-      `\n# Auto-added by kimiflare /multi-agent → Set up (fresh deploy only)\n` +
-      `[[migrations]]\n` +
-      `tag = "v1"\n` +
-      `new_sqlite_classes = ["SessionDO", "WorkerDO", "Sandbox"]\n`;
+  // Only touch migrations on fresh deploys. Existing workers already have
+  // their DO namespaces created; re-declaring new_sqlite_classes creates
+  // NEW namespaces for those classes, which breaks container applications
+  // that are bound to the old namespace (e.g. "kimiflare-multi-agent-sandbox").
+  if (!workerExists) {
+    const existingMigrations = toml.match(/\[\[migrations\]\]/);
+    if (existingMigrations) {
+      // Replace the existing migrations block with the current class list
+      toml = toml.replace(
+        /\[\[migrations\]\][\s\S]*?new_sqlite_classes\s*=\s*\[[^\]]*\]/,
+        `[[migrations]]\ntag = "v1"\nnew_sqlite_classes = ["SessionDO", "WorkerDO", "Sandbox"]`,
+      );
+    } else {
+      toml +=
+        `\n# Auto-added by kimiflare /multi-agent → Set up (fresh deploy only)\n` +
+        `[[migrations]]\n` +
+        `tag = "v1"\n` +
+        `new_sqlite_classes = ["SessionDO", "WorkerDO", "Sandbox"]\n`;
+    }
   }
   // Enable invocation logs so the multi-agent worker emits structured logs
   // to Cloudflare (visible in Workers & Pages → Logs). Keep the general
@@ -566,6 +677,7 @@ export async function* deployCommute(opts: DeployOpts = {}): AsyncGenerator<Depl
     ...cfg,
     workerEndpoint: workerUrl,
     workerApiKey,
+    workerName,
     multiAgentEnabled: true,
   };
   await saveConfig(next);
@@ -578,18 +690,26 @@ export async function* deployCommute(opts: DeployOpts = {}): AsyncGenerator<Depl
   return { workerEndpoint: workerUrl, workerApiKey };
 }
 
+export interface TeardownOpts {
+  /** Override the Worker name to tear down. Defaults to the name stored in
+   *  config (workerName) or "kimiflare-multi-agent". */
+  workerName?: string;
+}
+
 /**
  * Tear down the user's multi-agent infrastructure: delete the Worker,
- * delete OAUTH_KV namespace(s) titled by the binding, clear cfg.
+ * delete Durable Object namespaces, delete container applications,
+ * delete OAUTH_KV namespace(s), clear cfg.
  *
  * Streams progress like deployCommute.
  */
-export async function* teardownCommute(): AsyncGenerator<DeployStep, void, void> {
+export async function* teardownCommute(opts: TeardownOpts = {}): AsyncGenerator<DeployStep, void, void> {
   const cfg = await loadConfig();
   if (!cfg?.accountId || !cfg?.apiToken) {
     yield { message: "Cloudflare credentials missing — nothing to tear down.", error: true };
     throw new Error("missing CF creds");
   }
+  const workerName = opts.workerName ?? cfg.workerName ?? WORKER_NAME;
   const cfEnv: Record<string, string> = {
     CLOUDFLARE_ACCOUNT_ID: cfg.accountId,
     CLOUDFLARE_API_TOKEN: cfg.apiToken,
@@ -602,29 +722,81 @@ export async function* teardownCommute(): AsyncGenerator<DeployStep, void, void>
 
   // 1. Delete the Worker. Pipe "y" to auto-confirm wrangler's interactive
   //    "Are you sure?" prompt.
-  yield { message: `Deleting Worker "${WORKER_NAME}"…` };
-  const del = await runCmd("wrangler", ["delete", "--name", WORKER_NAME], {
+  yield { message: `Deleting Worker "${workerName}"…` };
+  const del = await runCmd("wrangler", ["delete", "--name", workerName], {
     env: cfEnv,
     input: "y\n",
     timeoutMs: 60_000,
   });
   if (del.code === 0) {
-    yield { message: `Worker "${WORKER_NAME}" deleted`, ok: true };
+    yield { message: `Worker "${workerName}" deleted`, ok: true };
   } else {
     const combined = (del.stdout + del.stderr).toLowerCase();
     if (combined.includes("not found") || combined.includes("does not exist") || combined.includes("10007")) {
       yield { message: "Worker not found (already deleted or never created)", ok: true };
     } else {
       yield {
-        message: explainWranglerFailure(`wrangler delete --name ${WORKER_NAME}`, del.stdout, del.stderr),
+        message: explainWranglerFailure(`wrangler delete --name ${workerName}`, del.stdout, del.stderr),
         error: true,
       };
-      // Don't throw — continue to KV + config cleanup so partial state can
-      // still be cleared. The error is surfaced above.
+      // Don't throw — continue to KV + DO + config cleanup so partial state
+      // can still be cleared. The error is surfaced above.
     }
   }
 
-  // 2. Find + delete OAUTH_KV namespace(s). User may have multiple from
+  // 2. Delete Durable Object namespaces belonging to this worker.
+  yield { message: `Looking up Durable Object namespaces for "${workerName}"…` };
+  try {
+    const namespaces = await listDurableObjectNamespaces(cfg.accountId, cfg.apiToken);
+    const targets = namespaces.filter(
+      (ns) => ns.script === workerName || ns.name.startsWith(`${workerName}_`),
+    );
+    if (targets.length === 0) {
+      yield { message: "No Durable Object namespaces found (nothing to delete)", ok: true };
+    } else {
+      for (const ns of targets) {
+        try {
+          await deleteDurableObjectNamespace(cfg.accountId, cfg.apiToken, ns.id);
+          yield { message: `DO namespace ${ns.name} deleted (${ns.id.slice(0, 8)}…)`, ok: true };
+        } catch (err) {
+          yield {
+            message: `DO namespace ${ns.name} delete warning: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      }
+    }
+  } catch (err) {
+    yield {
+      message: `DO namespace lookup warning: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // 3. Delete container applications tied to this worker's DOs.
+  //    Container app names are typically "{worker-name}-{class-lowercase}".
+  yield { message: `Looking up container applications for "${workerName}"…` };
+  try {
+    const apps = await listContainerApplications(cfg.accountId, cfg.apiToken);
+    const appPrefix = `${workerName}-`.toLowerCase();
+    const targets = apps.filter((app) => app.name.toLowerCase().startsWith(appPrefix));
+    if (targets.length === 0) {
+      yield { message: "No container applications found (nothing to delete)", ok: true };
+    } else {
+      for (const app of targets) {
+        try {
+          await deleteContainerApplication(cfg.accountId, cfg.apiToken, app.id);
+          yield { message: `Container application ${app.name} deleted (${app.id.slice(0, 8)}…)`, ok: true };
+        } catch (err) {
+          yield {
+            message: `Container application ${app.name} delete warning: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      }
+    }
+  } catch {
+    yield { message: "(could not list container applications — skipping container cleanup)" };
+  }
+
+  // 4. Find + delete OAUTH_KV namespace(s). User may have multiple from
   //    prior failed deploys; delete all titled OAUTH_KV-ish.
   yield { message: "Listing KV namespaces to find OAUTH_KV…" };
   const kvList = await runCmd("wrangler", ["kv", "namespace", "list"], { env: cfEnv, timeoutMs: 30_000 });
@@ -656,11 +828,12 @@ export async function* teardownCommute(): AsyncGenerator<DeployStep, void, void>
     yield { message: "(could not list KV namespaces — skipping KV cleanup)" };
   }
 
-  // 3. Clear multi-agent fields from cfg.
+  // 5. Clear multi-agent fields from cfg.
   const next: KimiConfig = {
     ...cfg,
     workerEndpoint: undefined,
     workerApiKey: undefined,
+    workerName: undefined,
     multiAgentEnabled: false,
     autoExecute: false,
   };

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -373,7 +373,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
         cam.send("AssistantStreamStarted", { stream_id: sid });
         cam.send("AssistantTokenDelta", { stream_id: sid, token: "# Tearing down multi-agent\n\n" });
         try {
-          for await (const step of teardownCommute()) {
+          for await (const step of teardownCommute({ workerName: cfg.workerName })) {
             const prefix = step.error ? "✗ " : (step.done || step.ok) ? "✓ " : "· ";
             cam.send("AssistantTokenDelta", { stream_id: sid, token: `${prefix}${step.message}\n` });
             if (step.error) break;

--- a/src/ui/multi-agent-modal.tsx
+++ b/src/ui/multi-agent-modal.tsx
@@ -14,6 +14,7 @@ export interface MultiAgentSettings {
   multiAgentEnabled?: boolean;
   workerEndpoint?: string;
   workerApiKey?: string;
+  workerName?: string;
   autoExecute?: boolean;
   cliRef?: string;
 }
@@ -131,13 +132,14 @@ export function MultiAgentModal({ initial, onSave, onDone, remoteWorkerUrl, remo
     setDeploying(true);
     setDeployLog(["Starting tear-down…"]);
     try {
-      for await (const step of teardownCommute()) {
+      for await (const step of teardownCommute({ workerName: state.workerName })) {
         const prefix = step.error ? "✗ " : (step.done || step.ok) ? "✓ " : "· ";
         setDeployLog((l) => [...l, `${prefix}${step.message}`]);
         if (step.done) {
           persist({
             workerEndpoint: undefined,
             workerApiKey: undefined,
+            workerName: undefined,
             multiAgentEnabled: false,
             autoExecute: false,
           });
@@ -149,7 +151,7 @@ export function MultiAgentModal({ initial, onSave, onDone, remoteWorkerUrl, remo
     } finally {
       setDeploying(false);
     }
-  }, [persist]);
+  }, [persist, state.workerName]);
 
   const beginEdit = useCallback((f: Field) => {
     if (f === "deploy") {


### PR DESCRIPTION
Follow-up to #511.

## What's new

### Teardown ()
- New `teardownCommute()` generator in `src/remote/deploy-commute.ts` that cleanly disables multi-agent and deletes all associated Cloudflare resources:
  - Worker script
  - Durable Object namespace
  - KV namespace (OAUTH_KV)
  - Container applications (if any)
- `workerName` is now tracked in config so teardown knows exactly which Worker to delete.

### Dev/ops scripts
- `scripts/cleanup-multi-agent.ts` — standalone audit + cleanup tool. Reads credentials from `~/.config/kimiflare/config.json`, lists all multi-agent-related resources, and optionally deletes them. Useful for cleaning up stale resources after experiments.
- `scripts/redeploy-multi-agent.ts` — headless redeploy. Runs the same `deployCommute()` generator the TUI uses, streaming each step to stdout. Accepts an optional worker name argument.

### Config changes
- `KimiConfig` gains `workerName?: string` (persisted alongside endpoint/apiKey).
- `app.tsx` and `multi-agent-modal.tsx` wired to pass `workerName` through.

## Files changed
- `src/remote/deploy-commute.ts` — add teardown, container app cleanup
- `src/config.ts` — add `workerName`
- `src/app.tsx` — pass `workerName` through config
- `src/ui/multi-agent-modal.tsx` — clear `workerName` on teardown
- `src/ui-mode.ts` — minor type fix
- `scripts/cleanup-multi-agent.ts` — new
- `scripts/redeploy-multi-agent.ts` — new