### PR TITLE
fix(multi-agent): abort signal, escape cancel, and user-message routing

### DIFF
--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -37,6 +37,8 @@ export interface SpawnWorkerOpts {
 /** Active worker tracking for UI status. */
 export interface ActiveWorker {
   id: string;
+  /** Remote DO workerId returned by the Commute worker (needed for /cancel). */
+  remoteWorkerId?: string;
   mode: "plan" | "execute";
   task: string;
   status: "pending" | "running" | "completed" | "failed";
@@ -132,6 +134,7 @@ export class TurnSupervisor {
   async spawnWorkers(
     workers: SpawnWorkerOpts[],
     onUpdate?: (workers: ActiveWorker[]) => void,
+    signal?: AbortSignal,
   ): Promise<WorkerResultMessage[]> {
     // Read config first; env vars override individual fields for back-compat.
     // We also fall back to the /remote setup endpoint when the dedicated
@@ -245,7 +248,7 @@ export class TurnSupervisor {
                 : {}),
             };
 
-            const timeoutMs = parseInt(process.env.KIMIFLARE_WORKER_TIMEOUT_MS ?? "600000", 10);
+            const timeoutMs = parseInt(process.env.KIMIFLARE_WORKER_TIMEOUT_MS ?? "900000", 10);
 
             worker.logs.push(`[coordinator] Sending payload (${JSON.stringify(payload).length} bytes)`);
             worker.logs.push(`[coordinator] Worker will clone ${repo.owner}/${repo.repo} and run kimiflare inside Cloudflare Sandbox`);
@@ -266,6 +269,7 @@ export class TurnSupervisor {
               throw new Error(`Worker start failed: ${startRes.status} ${text.slice(0, 200)}`);
             }
             const { workerId: remoteWorkerId } = (await startRes.json()) as { workerId: string };
+            worker.remoteWorkerId = remoteWorkerId;
             worker.logs.push(`[coordinator] Worker started (id: ${remoteWorkerId}) — polling for progress…`);
             onUpdate?.([...activeWorkers.values()]);
 
@@ -277,6 +281,19 @@ export class TurnSupervisor {
             let data: WorkerResultMessage | undefined;
 
             while (Date.now() - startTime < timeoutMs) {
+              if (signal?.aborted) {
+                worker.logs.push(`[coordinator] Cancelling worker (id: ${remoteWorkerId})…`);
+                onUpdate?.([...activeWorkers.values()]);
+                try {
+                  await fetch(`${endpoint}/worker/${remoteWorkerId}/cancel`, {
+                    method: "POST",
+                    headers: apiKey ? { "X-Worker-Api-Key": apiKey } : {},
+                  });
+                } catch {
+                  // Best-effort cancel — ignore network errors
+                }
+                throw new Error("Cancelled by user");
+              }
               await new Promise((r) => setTimeout(r, pollInterval));
 
               let progressRes: Response | undefined;
@@ -508,6 +525,7 @@ export class TurnSupervisor {
     context: string,
     onUpdate?: (workers: ActiveWorker[]) => void,
     onPhaseChange?: (phase: "spawning" | "synthesizing" | "complete") => void,
+    signal?: AbortSignal,
   ): Promise<{
     plan: string;
     conflicts: string[];
@@ -515,10 +533,16 @@ export class TurnSupervisor {
     prUrl?: string;
     executor?: { status: "completed" | "failed"; error?: string };
   }> {
+    if (this._activeWorkers.size > 0) {
+      throw new Error(
+        `Multi-agent already active (${this._activeWorkers.size} worker(s) in flight). ` +
+        "Wait for completion or cancel before starting a new heavy task.",
+      );
+    }
     const workers = decomposePrompt(prompt, context);
     onPhaseChange?.("spawning");
     try {
-      const results = await this.spawnWorkers(workers, onUpdate);
+      const results = await this.spawnWorkers(workers, onUpdate, signal);
       onPhaseChange?.("synthesizing");
       const synth = this.synthesizeFindings(results);
 
@@ -544,6 +568,7 @@ export class TurnSupervisor {
         const execResults = await this.spawnWorkers(
           [{ mode: "execute", task: executeTask, context }],
           onUpdate,
+          signal,
         );
         const exec = execResults[0];
         if (!exec) {

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -273,6 +273,7 @@ export class TurnSupervisor {
             const pollInterval = 3000;
             const startTime = Date.now();
             let lastLogCount = 0;
+            let lastStep = "";
             let data: WorkerResultMessage | undefined;
 
             while (Date.now() - startTime < timeoutMs) {
@@ -323,9 +324,16 @@ export class TurnSupervisor {
                 worker.logs.push(`[worker] ${logLine}`);
               }
 
-              // Show current step
-              worker.logs.push(`[coordinator] Step ${progress.stepIndex}/${progress.totalSteps}: ${progress.message}`);
-              onUpdate?.([...activeWorkers.values()]);
+              // Show current step (only when it changes)
+              const stepKey = `${progress.stepIndex}:${progress.step}`;
+              if (stepKey !== lastStep) {
+                lastStep = stepKey;
+                worker.logs.push(`[coordinator] Step ${progress.stepIndex}/${progress.totalSteps}: ${progress.message}`);
+                onUpdate?.([...activeWorkers.values()]);
+              } else if (newLogs.length > 0) {
+                // Still need to refresh if new worker logs arrived
+                onUpdate?.([...activeWorkers.values()]);
+              }
 
               if (progress.status === "completed" || progress.status === "failed") {
                 if (progress.result) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -435,6 +435,9 @@ function App({
   const mcpToolsRef = useRef<ToolSpec[]>([]);
   const mcpInitRef = useRef(false);
   const submitRef = useRef<(full: string, display?: string) => void>(() => {});
+  /** AbortController for the current multi-agent spawn. Used by Escape to
+   *  cancel in-flight workers via the remote /cancel endpoint. */
+  const multiAgentAbortRef = useRef<AbortController | null>(null);
   const lspManagerRef = useRef(new LspManager());
   const lspToolsRef = useRef<ToolSpec[]>([]);
   const lspInitRef = useRef(false);
@@ -890,6 +893,13 @@ function App({
         hasPerm: hasPendingPermission(),
         hasLimit: limitResolveRef.current !== null,
       });
+      // Multi-agent cancel path: abort the dedicated controller so the
+      // polling loop breaks and /cancel fires on each active worker.
+      if (multiAgentAbortRef.current) {
+        multiAgentAbortRef.current.abort();
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cancelling multi-agent workers…" }]);
+        return;
+      }
       const outcome = runInterruptOrExit(interruptDepsRef.current!);
       if (!outcome.didInterruptTurn && !outcome.hadPermission && !outcome.hadLimit && !outcome.hadLoop) {
         logger.info("input:ctrl+c:exiting");
@@ -913,10 +923,21 @@ function App({
         resumeSessions !== null ||
         checkpointSession !== null ||
         showThemePicker;
-      if (!modalOpen && (busyRef.current || supervisorRef.current.isRunning) && activeScopeRef.current && !isAbortingRef.current && now - lastEscapeAtRef.current > 500) {
-        lastEscapeAtRef.current = now;
-        runInterruptTurn(interruptDepsRef.current!);
-        return;
+      if (!modalOpen && !isAbortingRef.current && now - lastEscapeAtRef.current > 500) {
+        // Multi-agent cancel path: workers are in flight but there is no
+        // activeScopeRef (multi-agent bypasses runAgentTurn). Abort the
+        // dedicated controller so the polling loop breaks and /cancel fires.
+        if (multiAgentAbortRef.current) {
+          lastEscapeAtRef.current = now;
+          multiAgentAbortRef.current.abort();
+          setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cancelling multi-agent workers…" }]);
+          return;
+        }
+        if ((busyRef.current || supervisorRef.current.isRunning) && activeScopeRef.current) {
+          lastEscapeAtRef.current = now;
+          runInterruptTurn(interruptDepsRef.current!);
+          return;
+        }
       }
     }
     if (key.ctrl && inputChar === "r") {
@@ -951,6 +972,13 @@ function App({
       hasLimit: limitResolveRef.current !== null,
       hasLoop: loopResolveRef.current !== null,
     });
+    // Multi-agent cancel path: abort the dedicated controller so the
+    // polling loop breaks and /cancel fires on each active worker.
+    if (multiAgentAbortRef.current) {
+      multiAgentAbortRef.current.abort();
+      setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "cancelling multi-agent workers…" }]);
+      return;
+    }
     // SIGINT preserves the pre-refactor asymmetry: it does NOT iterate
     // pendingToolCalls to mark them cancelled (the Ctrl+C path does).
     // Pass `skipPendingToolCleanup: true` so interruptTurn matches.
@@ -1648,23 +1676,32 @@ function App({
       // Two-gate check for multi-agent mode:
       // 1. Mode gate: multi-agent-experimental must be active
       // 2. Tier gate: task must be classified as "heavy"
+      // 3. Activity gate: don't spawn new workers if some are already in flight
       if (modeRef.current === "multi-agent-experimental") {
         if (classification.tier !== "heavy") {
           setEvents((e) => [
             ...e,
             { kind: "info", key: mkKey(), text: `multi-agent mode active, but task is ${classification.tier} — running locally` },
           ]);
+        } else if (activeWorkers.length > 0) {
+          setEvents((e) => [
+            ...e,
+            { kind: "info", key: mkKey(), text: `multi-agent workers already active (${activeWorkers.length}) — routing to coordinator` },
+          ]);
         } else {
           setEvents((e) => [
             ...e,
             { kind: "info", key: mkKey(), text: "multi-agent mode: spawning parallel research workers..." },
           ]);
+          const controller = new AbortController();
+          multiAgentAbortRef.current = controller;
           try {
             const { plan, conflicts, recommendations, prUrl, executor } = await supervisorRef.current!.autoSpawnWorkers(
               trimmed,
               `Current project: ${process.cwd()}`,
               (workers) => setActiveWorkers(workers),
               (phase) => setIsSynthesizing(phase === "synthesizing"),
+              controller.signal,
             );
             setEvents((e) => [
               ...e,
@@ -1697,12 +1734,21 @@ function App({
           } catch (e) {
             setIsSynthesizing(false);
             const err = e as Error;
-            setEvents((e) => [
-              ...e,
-              { kind: "error", key: mkKey(), text: `multi-agent spawn failed: ${err.message}` },
-            ]);
+            if (err.message === "Cancelled by user") {
+              setEvents((e) => [
+                ...e,
+                { kind: "info", key: mkKey(), text: "multi-agent cancelled" },
+              ]);
+            } else {
+              setEvents((e) => [
+                ...e,
+                { kind: "error", key: mkKey(), text: `multi-agent spawn failed: ${err.message}` },
+              ]);
+            }
             endTurn();
             return;
+          } finally {
+            multiAgentAbortRef.current = null;
           }
         }
       }


### PR DESCRIPTION
## Fixes

### Issue 1: User Messages Route to Workers Instead of Coordinator
-  now checks  before calling 
-  also guards against double-spawn via 
- Follow-up messages while workers are active fall through to the normal coordinator turn

### Issue 2: Escape/Ctrl+C Doesn't Cancel Multi-Agent
- Added  to  and 
- Polling loop checks  and POSTs  before breaking
-  creates an  per multi-agent session
- Escape, Ctrl+C, and SIGINT all abort  when workers are in flight

### Issue 3: Worker Timeout During Install
- Bumped coordinator default timeout from 600s → 900s

## Testing
- 
> kimiflare@0.77.0 typecheck
> tsc --noEmit passes
- Branches off latest 

Co-authored-by: kimiflare <kimiflare@proton.me>