### PR TITLE
feat(multi-agent): coordinator narration, step visualization, and auto-present findings

### DIFF
--- a/src/agent/supervisor.test.ts
+++ b/src/agent/supervisor.test.ts
@@ -93,22 +93,42 @@ describe("TurnSupervisor.spawnWorkers (regression: instance-field access)", () =
   // but _activeWorkers is an instance field, not on the prototype.
   it("runs without reaching for instance fields via the prototype", async () => {
     let calls = 0;
-    globalThis.fetch = (async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
       calls++;
+      const url = typeof input === "string" ? input : input.toString();
+      const isStart = url.endsWith("/worker") && !url.includes("/progress");
+      if (isStart) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ workerId: `w${calls}` }),
+          text: async () => "",
+        } as unknown as Response;
+      }
+      // Progress poll
       return {
         ok: true,
         status: 200,
         json: async () => ({
-          workerId: `w${calls}`,
           status: "completed",
-          task: "t",
-          findings: [],
-          recommendations: [],
-          filesRead: [],
-          webSources: [],
-          costUsd: 0,
-          tokensUsed: 0,
-          reasoning: "",
+          step: "done",
+          stepIndex: 1,
+          totalSteps: 1,
+          message: "finished",
+          logs: [],
+          completedSteps: ["done"],
+          result: {
+            workerId: `w${calls}`,
+            status: "completed",
+            task: "t",
+            findings: [],
+            recommendations: [],
+            filesRead: [],
+            webSources: [],
+            costUsd: 0,
+            tokensUsed: 0,
+            reasoning: "",
+          },
         }),
         text: async () => "",
       } as unknown as Response;
@@ -120,7 +140,8 @@ describe("TurnSupervisor.spawnWorkers (regression: instance-field access)", () =
       { mode: "plan", task: "beta" },
     ]);
 
-    assert.strictEqual(calls, 2);
+    // 2 start calls + 2 progress polls = 4 calls
+    assert.strictEqual(calls, 4);
     assert.strictEqual(results.length, 2);
     assert.ok(sup.activeWorkers.every((w) => w.status === "completed"));
   });

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -34,6 +34,11 @@ export interface SpawnWorkerOpts {
   prBody?: string;
 }
 
+export interface WorkerStep {
+  label: string;
+  status: "pending" | "active" | "completed" | "failed";
+}
+
 /** Active worker tracking for UI status. */
 export interface ActiveWorker {
   id: string;
@@ -49,6 +54,8 @@ export interface ActiveWorker {
   rawOutput?: string;
   /** Worker reasoning summary (available once the worker finishes). */
   reasoning?: string;
+  /** Structured steps reported by the remote worker (stepIndex/totalSteps/completedSteps). */
+  steps?: WorkerStep[];
   /** Coordinator-side log of what happened during this worker's lifecycle. */
   logs: string[];
 }
@@ -334,6 +341,19 @@ export class TurnSupervisor {
                 result?: WorkerResultMessage;
               };
 
+              // Build structured steps from progress data
+              const allSteps: WorkerStep[] = [];
+              for (let i = 0; i < progress.totalSteps; i++) {
+                const isCompleted = i < progress.completedSteps.length;
+                const isActive = i === progress.stepIndex - 1 && !isCompleted && progress.status === "running";
+                const isFailed = progress.status === "failed" && i === progress.stepIndex - 1;
+                allSteps.push({
+                  label: progress.completedSteps[i] ?? progress.step,
+                  status: isFailed ? "failed" : isCompleted ? "completed" : isActive ? "active" : "pending",
+                });
+              }
+              worker.steps = allSteps;
+
               // Append new logs (only the ones we haven't seen)
               const newLogs = progress.logs.slice(lastLogCount);
               lastLogCount = progress.logs.length;
@@ -382,6 +402,14 @@ export class TurnSupervisor {
             worker.result = data;
             worker.rawOutput = data.rawOutput;
             worker.reasoning = data.reasoning;
+            // Mark all steps completed (or failed) on finish
+            if (worker.steps && worker.steps.length > 0) {
+              for (const s of worker.steps) {
+                if (s.status === "pending" || s.status === "active") {
+                  s.status = worker.status === "completed" ? "completed" : "failed";
+                }
+              }
+            }
             worker.logs.push(`[coordinator] Worker finished with status: ${data.status}`);
             if (data.phases && data.phases.length > 0) {
               const timeline = data.phases.map((p) => `${p.name}: ${Math.round(p.ms / 1000)}s`).join(" · ");
@@ -526,6 +554,7 @@ export class TurnSupervisor {
     onUpdate?: (workers: ActiveWorker[]) => void,
     onPhaseChange?: (phase: "spawning" | "synthesizing" | "complete") => void,
     signal?: AbortSignal,
+    onNarration?: (text: string) => void,
   ): Promise<{
     plan: string;
     conflicts: string[];
@@ -540,6 +569,14 @@ export class TurnSupervisor {
       );
     }
     const workers = decomposePrompt(prompt, context);
+
+    // Narrate the decomposition plan so the user knows what each agent will do
+    const narrationLines: string[] = [
+      `Decomposing your request into ${workers.length} parallel research task${workers.length > 1 ? "s" : ""}:`,
+      ...workers.map((w, i) => `  ${i + 1}. ${w.task.slice(0, 200)}${w.task.length > 200 ? "…" : ""}`),
+    ];
+    onNarration?.(narrationLines.join("\n"));
+
     onPhaseChange?.("spawning");
     try {
       const results = await this.spawnWorkers(workers, onUpdate, signal);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -344,6 +344,7 @@ function App({
   const [lastSessionTopic, setLastSessionTopic] = useState<string | null>(null);
   const [activeWorkers, setActiveWorkers] = useState<import("./agent/supervisor.js").ActiveWorker[]>([]);
   const [isSynthesizing, setIsSynthesizing] = useState(false);
+  const [coordinatorNarration, setCoordinatorNarration] = useState<string>("");
 
   useEffect(() => {
     setGitBranch(detectGitBranch());
@@ -1693,6 +1694,7 @@ function App({
             ...e,
             { kind: "info", key: mkKey(), text: "multi-agent mode: spawning parallel research workers..." },
           ]);
+          setCoordinatorNarration("");
           const controller = new AbortController();
           multiAgentAbortRef.current = controller;
           try {
@@ -1702,12 +1704,28 @@ function App({
               (workers) => setActiveWorkers(workers),
               (phase) => setIsSynthesizing(phase === "synthesizing"),
               controller.signal,
+              (text) => setCoordinatorNarration(text),
             );
+            setCoordinatorNarration("");
             setEvents((e) => [
               ...e,
               { kind: "info", key: mkKey(), text: "workers completed — synthesizing findings" },
             ]);
-            messagesRef.current.push({ role: "system", content: plan });
+            // Present the synthesized plan as a visible assistant message
+            // so the user can actually read what the workers discovered.
+            const asstId = mkAssistantId();
+            setEvents((e) => [
+              ...e,
+              {
+                kind: "assistant",
+                key: `asst_${asstId}`,
+                id: asstId,
+                text: plan,
+                reasoning: "",
+                streaming: false,
+              },
+            ]);
+            messagesRef.current.push({ role: "assistant", content: plan });
             if (conflicts.length > 0) {
               setEvents((e) => [
                 ...e,
@@ -1733,6 +1751,7 @@ function App({
             return;
           } catch (e) {
             setIsSynthesizing(false);
+            setCoordinatorNarration("");
             const err = e as Error;
             if (err.message === "Cancelled by user") {
               setEvents((e) => [
@@ -2446,8 +2465,8 @@ function App({
           />
         ) : (
           <Box flexDirection="column" marginTop={1}>
-            {activeWorkers.length > 0 && (
-              <WorkerList workers={activeWorkers} isSynthesizing={isSynthesizing} />
+            {(activeWorkers.length > 0 || coordinatorNarration) && (
+              <WorkerList workers={activeWorkers} isSynthesizing={isSynthesizing} narration={coordinatorNarration} />
             )}
             {tasks.length > 0 && (
               <TaskList

--- a/src/ui/worker-list.tsx
+++ b/src/ui/worker-list.tsx
@@ -3,17 +3,18 @@ import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import { useTheme } from "./theme-context.js";
 import type { Theme } from "./theme.js";
-import type { ActiveWorker } from "../agent/supervisor.js";
+import type { ActiveWorker, WorkerStep } from "../agent/supervisor.js";
 
 interface Props {
   workers: ActiveWorker[];
   isSynthesizing?: boolean;
+  narration?: string;
 }
 
-export function WorkerList({ workers, isSynthesizing }: Props) {
+export function WorkerList({ workers, isSynthesizing, narration }: Props) {
   const theme = useTheme();
 
-  if (workers.length === 0) return null;
+  if (workers.length === 0 && !narration) return null;
 
   const running = workers.filter((w) => w.status === "running").length;
   const completed = workers.filter((w) => w.status === "completed").length;
@@ -28,6 +29,15 @@ export function WorkerList({ workers, isSynthesizing }: Props) {
 
   return (
     <Box flexDirection="column" marginBottom={1}>
+      {narration && (
+        <Box marginBottom={1}>
+          <Text color={theme.info.color} italic>
+            {narration.split("\n").map((line, i) => (
+              <Text key={`narration-${i}`}>{line}{"\n"}</Text>
+            ))}
+          </Text>
+        </Box>
+      )}
       <Box>
         <Text color={theme.accent} bold>
           Workers: {pending > 0 ? `${pending} todo · ` : ""}
@@ -89,15 +99,7 @@ function WorkerRow({ worker }: { worker: ActiveWorker }) {
       : "failed";
 
   const isDone = worker.status === "completed" || worker.status === "failed";
-
-  // Show the last 5 log lines for running workers so users can see
-  // heartbeat progress and any errors as they unfold; last 8 for done/failed.
-  const visibleLogs =
-    worker.status === "running"
-      ? worker.logs.slice(-5)
-      : worker.status === "pending"
-      ? []
-      : worker.logs.slice(-8);
+  const hasSteps = worker.steps && worker.steps.length > 0;
 
   return (
     <Box flexDirection="column" marginLeft={2}>
@@ -127,9 +129,20 @@ function WorkerRow({ worker }: { worker: ActiveWorker }) {
           ) : null}
         </Text>
       </Box>
-      {visibleLogs.length > 0 && (
+
+      {/* Structured steps — primary visibility */}
+      {hasSteps && (
         <Box flexDirection="column" marginLeft={4}>
-          {visibleLogs.map((line, i) => (
+          {worker.steps!.map((step, i) => (
+            <StepRow key={`${worker.id}-step-${i}`} step={step} theme={theme} />
+          ))}
+        </Box>
+      )}
+
+      {/* Raw logs — collapsed by default, last 3 lines shown as secondary info */}
+      {worker.logs.length > 0 && (
+        <Box flexDirection="column" marginLeft={4}>
+          {worker.logs.slice(-3).map((line, i) => (
             <Text key={`${worker.id}-log-${i}`} color={theme.muted?.color ?? theme.info.color} dimColor>
               {line.slice(0, 120)}
             </Text>
@@ -137,6 +150,35 @@ function WorkerRow({ worker }: { worker: ActiveWorker }) {
         </Box>
       )}
     </Box>
+  );
+}
+
+function StepRow({ step, theme }: { step: WorkerStep; theme: Theme }) {
+  if (step.status === "completed") {
+    return (
+      <Text color={theme.palette.success}>
+        {"  "}✓ <Text strikethrough>{step.label}</Text>
+      </Text>
+    );
+  }
+  if (step.status === "active") {
+    return (
+      <Text color={theme.accent} bold>
+        {"  "}<Spinner type="line" /> {step.label}
+      </Text>
+    );
+  }
+  if (step.status === "failed") {
+    return (
+      <Text color={theme.palette.error}>
+        {"  "}☒ {step.label}
+      </Text>
+    );
+  }
+  return (
+    <Text color={theme.muted?.color ?? theme.info.color} dimColor>
+      {"  "}☐ {step.label}
+    </Text>
   );
 }
 


### PR DESCRIPTION
This PR improves the multi-agent UX in three ways:

1. **Coordinator narration**: When decomposing a heavy prompt into parallel research tasks, the coordinator now narrates its plan so users can see which task is delegated to each agent before work begins.

2. **Per-step status visualization**: Worker progress now renders structured steps (pending ☐ / active ◐ / completed ✓ / failed ☒) with the same color scheme used by TaskList, instead of a flat gray log dump. Raw logs are demoted to the last 3 lines per worker.

3. **Auto-present synthesized findings**: The synthesized execution plan is now emitted as a visible assistant message in the chat, so users no longer need to manually ask "what did the agents find?"

Also fixes a pre-existing broken test in supervisor.test.ts where the mock fetch returned an incorrect progress response shape.

Co-authored-by: kimiflare <kimiflare@proton.me>