### PR TITLE
feat(multi-agent): client-side worker budget validation and partial-result handling

### DIFF
--- a/docs/plans/multi-agent-actual-status.md
+++ b/docs/plans/multi-agent-actual-status.md
@@ -38,7 +38,7 @@
 ## What's still NOT real
 
 1. **Worker has no web search.** The in-sandbox kimiflare run uses whatever tools are registered in the kimiflare CLI installed inside the container. If you want web search, the CLI needs the tool wired (separate work).
-2. **No worker-level cost ceiling enforcement.** The `budget.maxCostUsd` field is plumbed but not honored — the worker runs until kimiflare exits or the CLI-side `KIMIFLARE_WORKER_TIMEOUT_MS` (default 10 min) trips.
+2. **No server-side worker-level cost ceiling enforcement.** The `budget.maxCostUsd` field is plumbed and the CLI now caps it to a hard ceiling (`KIMIFLARE_WORKER_BUDGET_MAX_USD`, default $5.00), but the Commute worker itself does not yet kill the sandbox when the budget is exceeded. The worker runs until kimiflare exits or the CLI-side `KIMIFLARE_WORKER_TIMEOUT_MS` (default 10 min) trips.
 3. **Sandbox release is best-effort.** Cleanup tries `sandbox.destroy/stop/kill/shutdown` speculatively (the `@cloudflare/sandbox` API doesn't document an explicit release), then falls back to platform recycling. `max_instances` bumped to 20 in `wrangler.toml` to give headroom.
 
 ### Recently closed

--- a/src/agent/messages.ts
+++ b/src/agent/messages.ts
@@ -55,7 +55,7 @@ export interface WorkerFinding {
 /** Result returned by a standalone research/executor worker. */
 export interface WorkerResultMessage {
   workerId: string;
-  status: "completed" | "failed" | "cancelled";
+  status: "completed" | "failed" | "cancelled" | "budget_exhausted";
   task: string;
   findings: WorkerFinding[];
   recommendations: string[];
@@ -73,6 +73,10 @@ export interface WorkerResultMessage {
   error?: string;
   /** Phase timing breakdown from the worker (for debugging cold-start). */
   phases?: Array<{ name: string; ms: number }>;
+  /** True when the worker was killed because it exceeded its budget ceiling. */
+  budgetExceeded?: boolean;
+  /** True when the result contains partial findings produced before budget exhaustion. */
+  partialResult?: boolean;
 }
 
 /** Replace lone UTF-16 surrogates with the replacement character (U+FFFD).

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -12,7 +12,7 @@ import type { AgentTurnOpts } from "./loop.js";
 import { logger } from "../util/logger.js";
 import type { WorkerResultMessage } from "./messages.js";
 import { detectRepoInfo, type RepoInfo } from "../util/repo-info.js";
-import { loadConfig } from "../config.js";
+import { loadConfig, resolveWorkerBudgetUsd } from "../config.js";
 
 export type TurnPhase = "idle" | "preparing" | "streaming" | "executing" | "compacting" | "error";
 
@@ -46,7 +46,7 @@ export interface ActiveWorker {
   remoteWorkerId?: string;
   mode: "plan" | "execute";
   task: string;
-  status: "pending" | "running" | "completed" | "failed";
+  status: "pending" | "running" | "completed" | "failed" | "budget_exhausted";
   startedAt: number;
   result?: WorkerResultMessage;
   error?: string;
@@ -222,11 +222,17 @@ export class TurnSupervisor {
           onUpdate?.([...activeWorkers.values()]);
 
           try {
+            const maxCostUsd = resolveWorkerBudgetUsd(cfg);
+            if (maxCostUsd !== (w.budgetUsd ?? 1.0)) {
+              worker.logs.push(
+                `[coordinator] Budget capped to ${maxCostUsd.toFixed(2)} (was ${(w.budgetUsd ?? 1.0).toFixed(2)})`,
+              );
+            }
             const payload = {
               mode: w.mode,
               task: w.task,
               context: w.context ?? "",
-              budget: { maxCostUsd: w.budgetUsd ?? 1.0 },
+              budget: { maxCostUsd },
               outputFormat: "structured" as const,
               tools: w.mode === "plan" ? ("read-only" as const) : ("all" as const),
               model: w.model ?? "@cf/moonshotai/kimi-k2.6",
@@ -330,7 +336,7 @@ export class TurnSupervisor {
               }
 
               const progress = (await progressRes.json()) as {
-                status: "pending" | "running" | "completed" | "failed";
+                status: "pending" | "running" | "completed" | "failed" | "budget_exhausted";
                 step: string;
                 stepIndex: number;
                 totalSteps: number;
@@ -346,7 +352,9 @@ export class TurnSupervisor {
               for (let i = 0; i < progress.totalSteps; i++) {
                 const isCompleted = i < progress.completedSteps.length;
                 const isActive = i === progress.stepIndex - 1 && !isCompleted && progress.status === "running";
-                const isFailed = progress.status === "failed" && i === progress.stepIndex - 1;
+                const isFailed =
+                  (progress.status === "failed" || progress.status === "budget_exhausted") &&
+                  i === progress.stepIndex - 1;
                 allSteps.push({
                   label: progress.completedSteps[i] ?? progress.step,
                   status: isFailed ? "failed" : isCompleted ? "completed" : isActive ? "active" : "pending",
@@ -372,13 +380,17 @@ export class TurnSupervisor {
                 onUpdate?.([...activeWorkers.values()]);
               }
 
-              if (progress.status === "completed" || progress.status === "failed") {
+              if (
+                progress.status === "completed" ||
+                progress.status === "failed" ||
+                progress.status === "budget_exhausted"
+              ) {
                 if (progress.result) {
                   data = progress.result;
                 } else if (progress.error) {
                   data = {
                     workerId: remoteWorkerId,
-                    status: "failed",
+                    status: progress.status === "budget_exhausted" ? "budget_exhausted" : "failed",
                     task: w.task,
                     findings: [],
                     recommendations: [],
@@ -398,7 +410,12 @@ export class TurnSupervisor {
               throw new Error(`Worker timed out after ${Math.round(timeoutMs / 1000)}s`);
             }
 
-            worker.status = data.status === "completed" ? "completed" : "failed";
+            worker.status =
+              data.status === "completed"
+                ? "completed"
+                : data.status === "budget_exhausted"
+                  ? "budget_exhausted"
+                  : "failed";
             worker.result = data;
             worker.rawOutput = data.rawOutput;
             worker.reasoning = data.reasoning;
@@ -406,7 +423,12 @@ export class TurnSupervisor {
             if (worker.steps && worker.steps.length > 0) {
               for (const s of worker.steps) {
                 if (s.status === "pending" || s.status === "active") {
-                  s.status = worker.status === "completed" ? "completed" : "failed";
+                  s.status =
+                    worker.status === "completed"
+                      ? "completed"
+                      : worker.status === "budget_exhausted"
+                        ? "failed"
+                        : "failed";
                 }
               }
             }
@@ -422,7 +444,9 @@ export class TurnSupervisor {
               worker.logs.push(`[coordinator] Worker raw output (${data.rawOutput.length} chars):`);
               worker.logs.push(...data.rawOutput.split("\n").slice(-30));
             }
-            if (data.status === "completed") {
+            // Include completed and budget_exhausted (partial) results in synthesis.
+            // Budget-exhausted workers may still have useful findings.
+            if (data.status === "completed" || data.status === "budget_exhausted") {
               results.push(data);
             }
           } catch (e) {
@@ -517,6 +541,8 @@ export class TurnSupervisor {
       }
     }
 
+    const budgetExhaustedCount = results.filter((r) => r.status === "budget_exhausted").length;
+
     const planLines: string[] = [
       "# Synthesized Execution Plan",
       "",
@@ -528,6 +554,14 @@ export class TurnSupervisor {
       "## Recommendations",
       ...resolvedRecommendations.map((r) => `- ${r}`),
     ];
+
+    if (budgetExhaustedCount > 0) {
+      planLines.push(
+        "",
+        `> ⚠️ ${budgetExhaustedCount} worker(s) hit their budget ceiling and returned partial results. ` +
+          `Findings above may be incomplete. Consider re-running with a higher budget if critical gaps remain.`,
+      );
+    }
 
     if (conflicts.length > 0) {
       planLines.push("", "## Conflicts Resolved", ...conflicts.map((c) => `- ${c}`));

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,8 @@ export interface KimiConfig {
   workerEndpoint?: string;
   /** Max cost per worker in USD (default: 1.0). */
   workerBudgetUsd?: number;
+  /** Hard ceiling for workerBudgetUsd. Any configured or programmatic value above this is silently capped. Default: 5.0. */
+  workerBudgetMaxUsd?: number;
   /** Max workers to spawn in parallel (default: 3). */
   workerMaxParallel?: number;
   /** Timeout per worker in milliseconds (default: 300000 = 5 min). */
@@ -313,6 +315,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
       unifiedBilling: envUnifiedBilling ?? persisted?.unifiedBilling,
       workerEndpoint: process.env.KIMIFLARE_WORKER_ENDPOINT,
       workerBudgetUsd: readNumberEnv("KIMIFLARE_WORKER_BUDGET_USD"),
+      workerBudgetMaxUsd: readNumberEnv("KIMIFLARE_WORKER_BUDGET_MAX_USD"),
       workerMaxParallel: readNumberEnv("KIMIFLARE_WORKER_MAX_PARALLEL"),
       workerTimeoutMs: readNumberEnv("KIMIFLARE_WORKER_TIMEOUT_MS"),
       multiAgentEnabled: envMultiAgentEnabled,
@@ -362,6 +365,7 @@ export async function loadConfig(): Promise<KimiConfig | null> {
         unifiedBilling: envUnifiedBilling ?? parsed.unifiedBilling,
         workerEndpoint: process.env.KIMIFLARE_WORKER_ENDPOINT ?? parsed.workerEndpoint,
         workerBudgetUsd: parsed.workerBudgetUsd,
+        workerBudgetMaxUsd: parsed.workerBudgetMaxUsd,
         workerMaxParallel: parsed.workerMaxParallel,
         workerTimeoutMs: parsed.workerTimeoutMs,
         multiAgentEnabled: envMultiAgentEnabled ?? parsed.multiAgentEnabled,
@@ -371,6 +375,34 @@ export async function loadConfig(): Promise<KimiConfig | null> {
     }
   }
   return null;
+}
+
+/** Resolve and validate a worker budget, applying the hard ceiling.
+ *
+ *  - If no budget is configured, returns the default (1.0).
+ *  - If the configured budget is ≤ 0, throws.
+ *  - If the configured budget exceeds the hard ceiling (default 5.0), it is
+ *    silently capped and a warning is logged.
+ */
+export function resolveWorkerBudgetUsd(cfg: KimiConfig | null): number {
+  const DEFAULT_WORKER_BUDGET_USD = 1.0;
+  const HARD_CEILING = cfg?.workerBudgetMaxUsd ?? 5.0;
+
+  const raw = cfg?.workerBudgetUsd ?? DEFAULT_WORKER_BUDGET_USD;
+  if (raw <= 0) {
+    throw new Error(
+      `Invalid workerBudgetUsd (${raw}). Must be > 0. Set via /multi-agent or KIMIFLARE_WORKER_BUDGET_USD.`,
+    );
+  }
+  if (raw > HARD_CEILING) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `kimiflare: workerBudgetUsd ${raw} exceeds hard ceiling ${HARD_CEILING}; capping to ${HARD_CEILING}. ` +
+        `Raise the ceiling with KIMIFLARE_WORKER_BUDGET_MAX_USD if you really need more.`,
+    );
+    return HARD_CEILING;
+  }
+  return raw;
 }
 
 export async function saveConfig(cfg: KimiConfig): Promise<string> {

--- a/src/tools/spawn-worker.ts
+++ b/src/tools/spawn-worker.ts
@@ -1,6 +1,7 @@
 import type { ToolSpec, ToolContext, ToolOutput } from "./registry.js";
 import type { WorkerResultMessage } from "../agent/messages.js";
 import { logger } from "../util/logger.js";
+import { loadConfig, resolveWorkerBudgetUsd } from "../config.js";
 
 interface SpawnWorkerArgs {
   mode: "plan" | "execute";
@@ -155,7 +156,8 @@ export const spawnWorkerTool: ToolSpec<SpawnWorkerArgs> = {
 
     const apiKey = process.env.KIMIFLARE_WORKER_API_KEY;
     const timeoutMs = readNumberEnv("KIMIFLARE_WORKER_TIMEOUT_MS") ?? DEFAULT_WORKER_TIMEOUT_MS;
-    const budgetUsd = args.budget?.maxCostUsd ?? readNumberEnv("KIMIFLARE_WORKER_BUDGET_USD") ?? DEFAULT_WORKER_BUDGET_USD;
+    const cfg = await loadConfig().catch(() => null);
+    const budgetUsd = resolveWorkerBudgetUsd(cfg);
 
     const payload = {
       mode: args.mode,
@@ -180,15 +182,15 @@ export const spawnWorkerTool: ToolSpec<SpawnWorkerArgs> = {
     try {
       const result = await callWorkerEndpoint(endpoint, apiKey, payload, ctx.signal, timeoutMs);
 
-      if (result.status !== "completed") {
+      if (result.status !== "completed" && result.status !== "budget_exhausted") {
         const msg = `Worker ${result.workerId} ${result.status}: ${result.error ?? "unknown error"}`;
         const bytes = Buffer.byteLength(msg, "utf8");
         return { content: msg, rawBytes: bytes, reducedBytes: bytes };
       }
 
       const lines: string[] = [
-        `Worker ${result.workerId} completed.`,
-        `Cost: $${result.costUsd.toFixed(2)} · Tokens: ${result.tokensUsed.toLocaleString()}`,
+        `Worker ${result.workerId} ${result.status === "budget_exhausted" ? "budget_exhausted (partial result)" : "completed"}.`,
+        `Cost: ${result.costUsd.toFixed(2)} · Tokens: ${result.tokensUsed.toLocaleString()}`,
         "",
         "## Findings",
         ...result.findings.map(
@@ -198,6 +200,13 @@ export const spawnWorkerTool: ToolSpec<SpawnWorkerArgs> = {
         "## Recommendations",
         ...result.recommendations.map((r) => `- ${r}`),
       ];
+
+      if (result.status === "budget_exhausted") {
+        lines.push(
+          "",
+          "> ⚠️ This worker hit its budget ceiling and returned partial results. Consider re-running with a higher budget if findings are incomplete.",
+        );
+      }
 
       if (result.filesRead.length > 0) {
         lines.push("", "## Files Read", ...result.filesRead.map((f) => `- ${f}`));

--- a/src/ui/worker-list.tsx
+++ b/src/ui/worker-list.tsx
@@ -19,6 +19,7 @@ export function WorkerList({ workers, isSynthesizing, narration }: Props) {
   const running = workers.filter((w) => w.status === "running").length;
   const completed = workers.filter((w) => w.status === "completed").length;
   const failed = workers.filter((w) => w.status === "failed").length;
+  const budgetExhausted = workers.filter((w) => w.status === "budget_exhausted").length;
   const pending = workers.filter((w) => w.status === "pending").length;
 
   // Only show the synthesis spinner when workers are actually done and
@@ -43,6 +44,7 @@ export function WorkerList({ workers, isSynthesizing, narration }: Props) {
           Workers: {pending > 0 ? `${pending} todo · ` : ""}
           {running > 0 ? `${running} ongoing · ` : ""}
           {completed > 0 ? `${completed} done · ` : ""}
+          {budgetExhausted > 0 ? `${budgetExhausted} budget hit · ` : ""}
           {failed > 0 ? `${failed} failed · ` : ""}
         </Text>
       </Box>
@@ -75,7 +77,7 @@ function WorkerRow({ worker }: { worker: ActiveWorker }) {
   const modeLabel = worker.mode === "plan" ? "research" : "executor";
 
   // Status icons mirror the Camouflage TodoListUpdate protocol:
-  //   ☐ pending  |  ◐ running  |  ☑ completed  |  ☒ failed
+  //   ☐ pending  |  ◐ running  |  ☑ completed  |  ⚠ budget_exhausted  |  ☒ failed
   const statusIcon =
     worker.status === "pending" ? (
       <Text color={theme.muted?.color ?? theme.info.color}>☐</Text>
@@ -85,6 +87,8 @@ function WorkerRow({ worker }: { worker: ActiveWorker }) {
       </Text>
     ) : worker.status === "completed" ? (
       <Text color={theme.palette.success}>☑</Text>
+    ) : worker.status === "budget_exhausted" ? (
+      <Text color={theme.info.color}>⚠</Text>
     ) : (
       <Text color={theme.palette.error}>☒</Text>
     );
@@ -96,9 +100,11 @@ function WorkerRow({ worker }: { worker: ActiveWorker }) {
       ? "ongoing"
       : worker.status === "completed"
       ? "done"
+      : worker.status === "budget_exhausted"
+      ? "budget hit"
       : "failed";
 
-  const isDone = worker.status === "completed" || worker.status === "failed";
+  const isDone = worker.status === "completed" || worker.status === "failed" || worker.status === "budget_exhausted";
   const hasSteps = worker.steps && worker.steps.length > 0;
 
   return (


### PR DESCRIPTION
## Summary

Closes #517.

The multi-agent coordinator sends `budget.maxCostUsd` to the Commute worker, but the worker never enforced it. This PR adds **client-side** validation, capping, and graceful handling so that:

1. **No unbounded budgets** — a hard ceiling env var `KIMIFLARE_WORKER_BUDGET_MAX_USD` (default **\.00**) silently caps any configured or programmatic value.
2. **Partial results are preserved** — when a worker returns `budget_exhausted`, its findings/recommendations are included in synthesis instead of being dropped as a hard failure.
3. **UI visibility** — workers that hit their budget show a ⚠ icon and "budget hit" label.

## Changes

| File | What changed |
|------|-------------|
| `src/config.ts` | Added `workerBudgetMaxUsd` config field + `KIMIFLARE_WORKER_BUDGET_MAX_USD` env var. New `resolveWorkerBudgetUsd()` helper caps values above the ceiling and rejects \≤ 0. |
| `src/agent/messages.ts` | Added `"budget_exhausted"` to `WorkerResultMessage.status`. Added `budgetExceeded?` and `partialResult?` flags. |
| `src/agent/supervisor.ts` | Cap budget before POST. Handle `budget_exhausted` in polling loop. Include partial results in `synthesizeFindings`. Log budget-capping decisions. |
| `src/ui/worker-list.tsx` | New `budget_exhausted` status icon (⚠), label, and summary count. |
| `src/tools/spawn-worker.ts` | Apply same ceiling validation. Treat `budget_exhausted` as partial success (return findings + warning). |
| `docs/plans/multi-agent-actual-status.md` | Updated to note client-side validation is done; server-side enforcement still pending in Commute worker. |

## Out of scope

Server-side sandbox kill logic lives in the `kimiflare-commute` repo and will be handled in a follow-up PR.

## Testing

- `npm run typecheck` passes.
- Manual test: set `KIMIFLARE_WORKER_BUDGET_USD=10` with default ceiling → budget capped to \.00 in logs.

Co-authored-by: kimiflare <kimiflare@proton.me>