### PR TITLE
feat(agent): LLM-based task decomposition for multi-agent

### DIFF
--- a/src/agent/supervisor.test.ts
+++ b/src/agent/supervisor.test.ts
@@ -159,8 +159,8 @@ describe("TurnSupervisor.spawnWorkers (regression: instance-field access)", () =
 });
 
 describe("decomposePrompt", () => {
-  it("splits an explicit numbered list into one worker per item", () => {
-    const workers = decomposePrompt(
+  it("splits an explicit numbered list into one worker per item", async () => {
+    const workers = await decomposePrompt(
       "Research the following:\n1. caching strategies\n2. testing approaches\n3. migration paths",
       "ctx",
     );
@@ -170,27 +170,171 @@ describe("decomposePrompt", () => {
     assert.ok(workers[2]?.task.includes("migration"));
   });
 
-  it("splits an explicit bulleted list", () => {
-    const workers = decomposePrompt("Look at:\n- auth\n- routing\n- billing", "ctx");
+  it("splits an explicit bulleted list", async () => {
+    const workers = await decomposePrompt("Look at:\n- auth\n- routing\n- billing", "ctx");
     assert.strictEqual(workers.length, 3);
   });
 
   // Regression: previously chopped this prose prompt into 3 nonsense fragments
   // by splitting on every "and". The user's "and" is grammatical conjunction,
   // not a list separator — workers must see the whole prompt.
-  it("does NOT split a cohesive prose prompt on conjunctions", () => {
+  it("does NOT split a cohesive prose prompt on conjunctions", async () => {
     const prompt =
       "do heavy exploration and research in this project and identify 1 high leverage large idea";
-    const workers = decomposePrompt(prompt, "ctx");
+    const workers = await decomposePrompt(prompt, "ctx");
     assert.strictEqual(workers.length, 2);
     for (const w of workers) {
       assert.ok(w.task.includes(prompt), `expected full prompt preserved: ${w.task}`);
     }
   });
 
-  it("falls back to 2 angled workers when there is no clear list", () => {
-    const workers = decomposePrompt("make the app faster", "ctx");
+  it("falls back to 2 angled workers when there is no clear list", async () => {
+    const workers = await decomposePrompt("make the app faster", "ctx");
     assert.strictEqual(workers.length, 2);
     assert.ok(workers.every((w) => w.mode === "plan"));
+  });
+
+  it("uses LLM decomposition for prose when strategy is llm and cfg is provided", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/event-stream"]]),
+        body: new ReadableStream({
+          start(controller) {
+            const payload = JSON.stringify({
+              choices: [{ delta: { content: '{"tasks":["Analyze auth.ts","Check middleware.ts"],"reasoning":"split by file"}' } }],
+              usage: null,
+            });
+            controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+            controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        text: async () => "",
+        json: async () => ({}),
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    const workers = await decomposePrompt("analyze our auth system", "ctx", {
+      cwd: process.cwd(),
+      cfg: {
+        accountId: "test",
+        apiToken: "test",
+        model: "@cf/moonshotai/kimi-k2.6",
+        decompositionStrategy: "llm",
+      },
+    });
+    globalThis.fetch = realFetch;
+
+    assert.strictEqual(workers.length, 2);
+    assert.ok(workers[0]!.task.includes("auth"));
+    assert.ok(workers[1]!.task.includes("middleware"));
+  });
+
+  it("falls back to regex when LLM returns invalid JSON", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/event-stream"]]),
+        body: new ReadableStream({
+          start(controller) {
+            const payload = JSON.stringify({
+              choices: [{ delta: { content: "not json at all" } }],
+              usage: null,
+            });
+            controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+            controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        text: async () => "",
+        json: async () => ({}),
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    // Use a unique prompt so we don't hit the cache from the previous LLM test.
+    const workers = await decomposePrompt("analyze our auth system (invalid json case)", "ctx", {
+      cwd: process.cwd(),
+      cfg: {
+        accountId: "test",
+        apiToken: "test",
+        model: "@cf/moonshotai/kimi-k2.6",
+        decompositionStrategy: "llm",
+      },
+    });
+    globalThis.fetch = realFetch;
+
+    assert.strictEqual(workers.length, 2);
+    assert.ok(
+      workers[0]!.task.includes("Research overview"),
+      `expected fallback task, got: ${workers[0]!.task}`,
+    );
+  });
+
+  it("uses regex fallback when strategy is regex", async () => {
+    const workers = await decomposePrompt("analyze our auth system", "ctx", {
+      cwd: process.cwd(),
+      cfg: {
+        accountId: "test",
+        apiToken: "test",
+        model: "@cf/moonshotai/kimi-k2.6",
+        decompositionStrategy: "regex",
+      },
+    });
+    assert.strictEqual(workers.length, 2);
+    assert.ok(workers[0]!.task.includes("Research overview"));
+  });
+
+  it("caches decomposition results", async () => {
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([["content-type", "text/event-stream"]]),
+        body: new ReadableStream({
+          start(controller) {
+            const payload = JSON.stringify({
+              choices: [{ delta: { content: '{"tasks":["Task A","Task B"],"reasoning":"ok"}' } }],
+              usage: null,
+            });
+            controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
+            controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        text: async () => "",
+        json: async () => ({}),
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    const cfg = {
+      accountId: "test",
+      apiToken: "test",
+      model: "@cf/moonshotai/kimi-k2.6",
+      decompositionStrategy: "llm" as const,
+    };
+
+    const workers1 = await decomposePrompt("same prompt", "same ctx", { cwd: process.cwd(), cfg });
+    const workers2 = await decomposePrompt("same prompt", "same ctx", { cwd: process.cwd(), cfg });
+    globalThis.fetch = realFetch;
+
+    assert.strictEqual(calls, 1);
+    assert.deepStrictEqual(workers1, workers2);
+  });
+});
+
+describe("getFileTreeSnapshot", () => {
+  it("returns a non-empty string for the current directory", async () => {
+    const { getFileTreeSnapshot } = await import("./supervisor.js");
+    const tree = await getFileTreeSnapshot(process.cwd());
+    assert.ok(typeof tree === "string");
+    assert.ok(tree.length > 0);
   });
 });

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -10,9 +10,12 @@
 import { runAgentTurn } from "./loop.js";
 import type { AgentTurnOpts } from "./loop.js";
 import { logger } from "../util/logger.js";
-import type { WorkerResultMessage } from "./messages.js";
+import { runKimi } from "./client.js";
+import type { WorkerResultMessage, ChatMessage } from "./messages.js";
 import { detectRepoInfo, type RepoInfo } from "../util/repo-info.js";
-import { loadConfig } from "../config.js";
+import { loadConfig, type KimiConfig } from "../config.js";
+import { readdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
 
 export type TurnPhase = "idle" | "preparing" | "streaming" | "executing" | "compacting" | "error";
 
@@ -568,7 +571,8 @@ export class TurnSupervisor {
         "Wait for completion or cancel before starting a new heavy task.",
       );
     }
-    const workers = decomposePrompt(prompt, context);
+    const cfg = await loadConfig().catch(() => null);
+    const workers = await decomposePrompt(prompt, context, { cwd: process.cwd(), cfg: cfg ?? undefined });
 
     // Narrate the decomposition plan so the user knows what each agent will do
     const narrationLines: string[] = [
@@ -629,28 +633,74 @@ export class TurnSupervisor {
   }
 }
 
-/** Conservative heuristic to decompose a heavy prompt into parallel research tasks.
- *
- * Only splits the prompt when the user gave EXPLICIT list structure — numbered
- * (`1. … 2. … 3. …`) or bulleted (`- …`/`* …`) — because that's the only
- * cheap signal that's reliably a list. Earlier this also split on any
- * conjunction or comma, which chopped cohesive sentences like "do heavy
- * exploration AND research IN this project AND identify…" into nonsense
- * fragments.
- *
- * For prose prompts (no explicit list), spawn 2 workers with the FULL prompt
- * preserved and different angles. The synthesizer dedups overlapping findings,
- * so two well-formed angles beat N fragmented ones.
- */
-export function decomposePrompt(prompt: string, context: string): SpawnWorkerOpts[] {
-  const items = extractListItems(prompt);
-  if (items.length >= 2) {
-    return items.slice(0, 4).map((task) => ({ mode: "plan" as const, task, context }));
+/** In-memory cache for decomposition results keyed by prompt+context hash. */
+const decompositionCache = new Map<string, SpawnWorkerOpts[]>();
+
+const MAX_CACHE_ENTRIES = 50;
+
+function cacheKey(prompt: string, context: string, strategy: string): string {
+  return createHash("sha256").update(`${prompt}\0${context}\0${strategy}`).digest("hex");
+}
+
+function getCached(key: string): SpawnWorkerOpts[] | undefined {
+  return decompositionCache.get(key);
+}
+
+function setCached(key: string, value: SpawnWorkerOpts[]): void {
+  if (decompositionCache.size >= MAX_CACHE_ENTRIES) {
+    const first = decompositionCache.keys().next().value;
+    if (first !== undefined) decompositionCache.delete(first);
   }
-  return [
-    { mode: "plan", task: `Research overview and best practices for: ${prompt}`, context },
-    { mode: "plan", task: `Investigate implementation details, trade-offs, and risks for: ${prompt}`, context },
-  ];
+  decompositionCache.set(key, value);
+}
+
+/** Build a lightweight file-tree snapshot for the current working directory.
+ *  Returns top-level dirs + key files, capped at ~40 lines, excluding
+ *  build artifacts and dependency folders. */
+export async function getFileTreeSnapshot(cwd: string): Promise<string> {
+  const IGNORED = new Set([
+    "node_modules",
+    ".git",
+    "dist",
+    "build",
+    "out",
+    "target",
+    ".next",
+    ".nuxt",
+    ".astro",
+    "coverage",
+    ".coverage",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    ".idea",
+    ".vscode",
+    ".DS_Store",
+  ]);
+  try {
+    const entries = await readdir(cwd, { withFileTypes: true });
+    const dirs: string[] = [];
+    const files: string[] = [];
+    for (const e of entries) {
+      if (e.name.startsWith(".") && !e.name.startsWith(".github") && !e.name.startsWith(".config")) {
+        if (!e.isDirectory()) continue;
+      }
+      if (IGNORED.has(e.name)) continue;
+      if (e.isDirectory()) dirs.push(`${e.name}/`);
+      else files.push(e.name);
+    }
+    dirs.sort();
+    files.sort();
+    const lines = [...dirs, ...files];
+    if (lines.length === 0) return "(empty directory)";
+    if (lines.length > 40) {
+      return lines.slice(0, 40).join("\n") + "\n… (truncated)";
+    }
+    return lines.join("\n");
+  } catch {
+    return "(unable to read directory)";
+  }
 }
 
 /** Pull explicit list items from a prompt: numbered (`1. …`, `1) …`) or
@@ -662,4 +712,159 @@ function extractListItems(prompt: string): string[] {
   const bulleted = [...prompt.matchAll(/(?:^|\n)\s*[-*•]\s+([^\n]+)/g)].map((m) => m[1]?.trim() ?? "");
   if (bulleted.length >= 2) return bulleted.filter((s) => s.length > 0);
   return [];
+}
+
+const DECOMPOSITION_SYSTEM = `You are a task-decomposition assistant. Given a user's coding request and a snapshot of their project directory, produce 2–4 well-scoped, non-overlapping research tasks that can be executed in parallel by independent agents.
+
+Rules:
+- Each task must be self-contained and actionable.
+- Tasks must NOT overlap in scope. If two tasks would investigate the same file or concept, merge them.
+- Respect file/directory boundaries mentioned in the prompt or visible in the file tree.
+- Scale task count with perceived complexity: 2 tasks for simple questions, 3–4 for broad audits or multi-file changes.
+- Return ONLY a JSON object with this exact shape (no markdown fences, no extra text):
+  {"tasks":["task 1","task 2",...],"reasoning":"brief explanation of why you split this way"}`;
+
+async function decomposeWithLlm(
+  prompt: string,
+  context: string,
+  fileTree: string,
+  cfg: KimiConfig,
+): Promise<SpawnWorkerOpts[] | null> {
+  const model = cfg.decompositionModel ?? "@cf/moonshotai/kimi-k2.5";
+  const accountId = cfg.accountId;
+  const apiToken = cfg.apiToken;
+  if (!accountId || !apiToken) {
+    logger.warn("decompose:missing_creds", { reason: "no accountId or apiToken" });
+    return null;
+  }
+
+  const gateway = cfg.aiGatewayId
+    ? {
+        id: cfg.aiGatewayId,
+        cacheTtl: cfg.aiGatewayCacheTtl,
+        skipCache: cfg.aiGatewaySkipCache,
+        metadata: { feature: "decomposition", ...(cfg.aiGatewayMetadata ?? {}) },
+      }
+    : undefined;
+
+  const userContent = [
+    `User request: ${prompt}`,
+    context ? `Additional context: ${context}` : "",
+    `Project file tree (top-level):\n${fileTree}`,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const messages: ChatMessage[] = [
+    { role: "system", content: DECOMPOSITION_SYSTEM },
+    { role: "user", content: userContent },
+  ];
+
+  try {
+    let text = "";
+    const events = runKimi({
+      accountId,
+      apiToken,
+      model,
+      messages,
+      temperature: 0.1,
+      maxCompletionTokens: 2048,
+      reasoningEffort: "low",
+      gateway,
+    });
+    for await (const ev of events) {
+      if (ev.type === "text") text += ev.delta;
+    }
+
+    // Strip markdown fences if the model wrapped JSON in them
+    const cleaned = text.replace(/```(?:json)?\s*/gi, "").replace(/```\s*$/gi, "").trim();
+    const parsed = JSON.parse(cleaned) as { tasks?: unknown; reasoning?: string };
+    const rawTasks = parsed.tasks;
+    if (!Array.isArray(rawTasks) || rawTasks.length === 0) {
+      logger.warn("decompose:invalid_tasks", { rawTasks });
+      return null;
+    }
+
+    const tasks = rawTasks
+      .map((t) => (typeof t === "string" ? t.trim() : ""))
+      .filter((t) => t.length > 0);
+
+    if (tasks.length < 2) {
+      logger.warn("decompose:too_few_tasks", { count: tasks.length });
+      return null;
+    }
+
+    // Deduplicate near-identical tasks
+    const unique: string[] = [];
+    for (const t of tasks) {
+      const lower = t.toLowerCase();
+      if (!unique.some((u) => u.toLowerCase() === lower || lower.includes(u.toLowerCase()) || u.toLowerCase().includes(lower))) {
+        unique.push(t);
+      }
+    }
+
+    const capped = unique.slice(0, 4);
+    logger.debug("decompose:llm_success", { taskCount: capped.length, reasoning: parsed.reasoning });
+    return capped.map((task) => ({ mode: "plan" as const, task, context }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("decompose:llm_failed", { error: msg });
+    return null;
+  }
+}
+
+/** Fallback decomposition for prose prompts without explicit list structure. */
+function fallbackDecomposition(prompt: string, context: string): SpawnWorkerOpts[] {
+  return [
+    { mode: "plan", task: `Research overview and best practices for: ${prompt}`, context },
+    { mode: "plan", task: `Investigate implementation details, trade-offs, and risks for: ${prompt}`, context },
+  ];
+}
+
+/** Decompose a heavy prompt into parallel research tasks.
+ *
+ * 1. Explicit list items (numbered/bulleted) → immediate return.
+ * 2. Check in-memory cache.
+ * 3. If strategy is "regex" → fallback to 2-angle split.
+ * 4. Otherwise → attempt LLM decomposition with file-tree awareness.
+ * 5. On any failure → log warning and fallback to 2-angle split.
+ */
+export async function decomposePrompt(
+  prompt: string,
+  context: string,
+  opts?: { cwd?: string; cfg?: KimiConfig },
+): Promise<SpawnWorkerOpts[]> {
+  const items = extractListItems(prompt);
+  if (items.length >= 2) {
+    return items.slice(0, 4).map((task) => ({ mode: "plan" as const, task, context }));
+  }
+
+  const strategy = opts?.cfg?.decompositionStrategy ?? "llm";
+  const key = cacheKey(prompt, context, strategy);
+  const cached = getCached(key);
+  if (cached) {
+    logger.debug("decompose:cache_hit");
+    return cached;
+  }
+
+  if (strategy === "regex") {
+    const result = fallbackDecomposition(prompt, context);
+    setCached(key, result);
+    return result;
+  }
+
+  // "llm" or "hybrid" — try LLM decomposition
+  if (opts?.cfg) {
+    const cwd = opts.cwd ?? process.cwd();
+    const fileTree = await getFileTreeSnapshot(cwd);
+    const llmResult = await decomposeWithLlm(prompt, context, fileTree, opts.cfg);
+    if (llmResult) {
+      setCached(key, llmResult);
+      return llmResult;
+    }
+  }
+
+  const result = fallbackDecomposition(prompt, context);
+  setCached(key, result);
+  return result;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,6 +133,14 @@ export interface KimiConfig {
   /** When true, after plan workers synthesize, spawn one executor worker
    *  to implement the synthesized plan and open a PR. Off by default. */
   autoExecute?: boolean;
+  /** Model used for LLM-based task decomposition in multi-agent mode.
+   *  Default: @cf/moonshotai/kimi-k2.5 (fast and cheap). */
+  decompositionModel?: string;
+  /** Strategy for decomposing heavy prompts into parallel research tasks.
+   *  - "llm": use a lightweight LLM call (default)
+   *  - "regex": pure regex heuristic (no LLM, fastest)
+   *  - "hybrid": regex for explicit lists, LLM for prose */
+  decompositionStrategy?: "llm" | "regex" | "hybrid";
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";


### PR DESCRIPTION
## Summary

Replaces the pure regex heuristic in `decomposePrompt()` with an LLM-aware decomposition pipeline that considers prompt intent, codebase structure, and configurable strategy.

## Changes

### src/config.ts
- Added `decompositionModel?: string` — defaults to `@cf/moonshotai/kimi-k2.5` (fast & cheap)
- Added `decompositionStrategy?: 'llm' | 'regex' | 'hybrid'` — defaults to `'llm'`

### src/agent/supervisor.ts
- **`decomposePrompt()`** is now `async` and supports three strategies:
  - **Explicit lists** (numbered/bulleted): regex split, unchanged behavior
  - **`'llm'\'**: single lightweight LLM call with a file-tree snapshot to produce 2–4 non-overlapping tasks
  - **`'regex'\'**: skips LLM, uses the original 2-angle fallback
  - **`'hybrid'\'**: same as `'llm'\'` (regex for lists, LLM for prose)
- **`getFileTreeSnapshot()`** — lightweight top-level directory scan, capped at ~40 lines, excludes build artifacts
- **`decomposeWithLlm()`** — calls `runKimi` with a structured JSON-extraction prompt, validates task count, deduplicates near-identical tasks
- **In-memory LRU cache** — 50 entries, keyed by `prompt + context + strategy` hash to avoid redundant LLM calls
- **Graceful fallback** — on any LLM failure (network, bad JSON, invalid tasks), falls back to the original 2-angle split

### src/agent/supervisor.test.ts
- Added tests for LLM decomposition, invalid-JSON fallback, regex strategy, caching, and file tree snapshot

## Cost

A single cheap LLM call (~500–1000 input tokens, ~200 output tokens) costs ~$0.001 max. Caching prevents redundant calls.

## Fixes

Fixes #518