### PR TITLE
fix(multi-agent): respect config timeout, extend on progress, and clear worker list after synthesis

### DIFF
--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -431,7 +431,8 @@ export class TurnSupervisor {
                 : {}),
             };
 
-            const timeoutMs = parseInt(process.env.KIMIFLARE_WORKER_TIMEOUT_MS ?? "900000", 10);
+            const timeoutMs = cfg?.workerTimeoutMs
+              ?? parseInt(process.env.KIMIFLARE_WORKER_TIMEOUT_MS ?? "900000", 10);
 
             worker.logs.push(`[coordinator] Sending payload (${JSON.stringify(payload).length} bytes)`);
             worker.logs.push(`[coordinator] Worker will clone ${repo.owner}/${repo.repo} and run kimiflare inside Cloudflare Sandbox`);
@@ -464,12 +465,12 @@ export class TurnSupervisor {
 
             // ── Poll progress every 3s until done or timeout ──
             const pollInterval = 3000;
-            const startTime = Date.now();
+            let lastProgressAt = Date.now();
             let lastLogCount = 0;
             let lastStep = "";
             let data: WorkerResultMessage | undefined;
 
-            while (Date.now() - startTime < timeoutMs) {
+            while (Date.now() - lastProgressAt < timeoutMs) {
               if (signal?.aborted) {
                 worker.logs.push(`[coordinator] Cancelling worker (id: ${remoteWorkerId})…`);
                 onUpdate?.([...activeWorkers.values()]);
@@ -549,9 +550,11 @@ export class TurnSupervisor {
               const stepKey = `${progress.stepIndex}:${progress.step}`;
               if (stepKey !== lastStep) {
                 lastStep = stepKey;
+                lastProgressAt = Date.now();
                 worker.logs.push(`[coordinator] Step ${progress.stepIndex}/${progress.totalSteps}: ${progress.message}`);
                 onUpdate?.([...activeWorkers.values()]);
               } else if (newLogs.length > 0) {
+                lastProgressAt = Date.now();
                 // Still need to refresh if new worker logs arrived
                 onUpdate?.([...activeWorkers.values()]);
               }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1731,6 +1731,8 @@ function App({
               },
             ]);
             messagesRef.current.push({ role: "assistant", content: plan });
+            setActiveWorkers([]);
+            supervisorRef.current!.clearWorkers();
             if (conflicts.length > 0) {
               setEvents((e) => [
                 ...e,
@@ -1769,6 +1771,8 @@ function App({
                 { kind: "error", key: mkKey(), text: `multi-agent spawn failed: ${err.message}` },
               ]);
             }
+            setActiveWorkers([]);
+            supervisorRef.current!.clearWorkers();
             endTurn();
             return;
           } finally {

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -740,6 +740,8 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
             if (!(err instanceof Error && err.name === "AbortError")) {
               cam.send("ShowToast", { text: `multi-agent spawn failed: ${err instanceof Error ? err.message : String(err)}`, kind: "error", ttl_ms: 4000 });
             }
+          } finally {
+            multiAgentSupervisor.clearWorkers();
           }
           return;
         }


### PR DESCRIPTION
## Summary

Fixes two bugs in KimiFlare multi-agent mode:

1. **Worker timeout is hard-coded and does not extend on progress**
   -  now respects  before falling back to the env var.
   - The polling loop tracks  and resets it whenever new logs arrive or the step changes. The timeout now fires only when there has been **no progress** for , rather than a fixed wall-clock limit.

2. **WorkerList persists after synthesis, pushing results above it**
   - After successful synthesis and in the catch block,  and  are called so the stale WorkerList disappears and synthesis is the final visible output.

3. **Camouflage supervisor state leaks across turns**
   - Added  in a  block after  in .

## Testing

- Set  in  to a low value (e.g. 30000) and verify it is respected.
- Spawn a multi-agent task, wait for synthesis, and confirm the WorkerList disappears and the synthesis is the final visible output.
- Verify Camouflage UI does not leak worker state across turns.

Co-authored-by: kimiflare <kimiflare@proton.me>