### PR TITLE
feat: add /fresh command to reset session with distilled plan

### DIFF
--- a/.github/issue-fresh-resume.md
+++ b/.github/issue-fresh-resume.md
@@ -1,0 +1,105 @@
+# Feature: `/fresh` command + Resume Fresh mode
+
+## Background
+
+When users spend significant time in **plan mode**, KimiFlare researches, explores files, and produces a detailed execution plan. By the time the plan is ready, the session has accumulated a large amount of context (tool results, web fetches, reasoning traces, file reads). Switching to `auto` or `edit` mode to execute the plan carries all this baggage forward, which:
+
+1. **Slows the model down** — Kimi-K2.6 degrades in speed and quality with very long contexts
+2. **Wastes tokens** — intermediate research results are rarely needed during execution
+3. **Dilutes attention** — the model may get distracted by old research rather than focusing on the plan
+
+Users currently work around this manually by copying the plan, quitting KimiFlare, reopening it, and pasting the plan into a fresh session.
+
+## Proposed Solution
+
+### Phase 1: `/fresh` command (PR #1)
+
+A single slash command that productizes the manual workaround:
+
+```
+User: /fresh
+KimiFlare: Plan copied to clipboard. Starting fresh session with plan only…
+[session resets, plan appears as first user message, ready to build]
+```
+
+**Behavior:**
+1. Extract the last assistant message (the plan)
+2. Copy it to the system clipboard
+3. Reset the session (clear messages, events, artifacts, usage, turn counter)
+4. Seed the new session with just the plan as the first user message
+5. Surface confirmation to the user
+
+**Edge cases:**
+- No assistant message found → error: "No plan found to start fresh with."
+- Clipboard unavailable → still reset and seed; inform user to paste manually
+- Busy mid-turn → block with same guard as `/clear`
+
+### Phase 2: Resume Fresh mode (PR #2 — future)
+
+Extend the same distillation logic to `/resume`. When a user resumes an old session, offer two choices:
+
+```
+/resume
+├─ Pick session: "Add OAuth flow (#47 msgs, 3 checkpoints)"
+   ├─ [Resume full]      ← current behavior
+   ├─ [Resume fresh]     ← new: distill plan, start clean
+   └─ [Pick checkpoint]  ← existing behavior
+```
+
+**Why this matters even more for resume:**
+- Fresh plan → `/fresh`: ~5-15 turns of research
+- Resume old session: could be 50+ turns, days of work, hundreds of tool calls
+- The token bloat and quality degradation is **significantly worse** for resumed sessions
+
+## Implementation Notes
+
+### Reusable core: `distillSessionPlan()`
+
+PR #1 should extract the distillation logic into a pure, testable function:
+
+```ts
+// src/agent/distill.ts
+export function distillSessionPlan(messages: ChatMessage[]): string | null;
+```
+
+This function:
+- Scans messages in reverse to find the last assistant message with substantive content
+- Strips reasoning traces and tool-call metadata
+- Returns clean plan text, or `null` if no suitable plan found
+
+PR #2 will reuse this exact function in the resume flow.
+
+### Files touched
+
+| File | PR #1 | PR #2 |
+|------|-------|-------|
+| `src/commands/builtins.ts` | Add `"fresh"` | — |
+| `src/util/clipboard.ts` | **New** — cross-platform clipboard writer | — |
+| `src/agent/distill.ts` | **New** — `distillSessionPlan()` | Reused |
+| `src/ui/slash-commands.ts` | Add `handleFresh` | Extend `handleResumePick` |
+| `src/app.tsx` | Wire through `SlashContext` | Add resume-mode picker |
+| `src/mode.ts` | Optional nudge on plan→auto switch | — |
+
+## Acceptance Criteria
+
+### PR #1
+- [ ] `/fresh` appears in `/help` and slash-command picker
+- [ ] Running `/fresh` copies the last assistant message to clipboard
+- [ ] Session is reset (messages cleared, artifacts cleared, usage reset)
+- [ ] New session is seeded with the plan as first user message
+- [ ] Confirmation event is shown to user
+- [ ] Blocked when model is busy (same as `/clear`)
+- [ ] Graceful fallback when clipboard tool is unavailable
+- [ ] Unit tests for `distillSessionPlan()`
+
+### PR #2
+- [ ] `/resume` offers "Resume fresh" option for sessions above message threshold
+- [ ] "Resume fresh" uses `distillSessionPlan()` then resets + seeds
+- [ ] "Resume full" preserves current behavior exactly
+- [ ] Threshold is configurable or sensibly defaulted (e.g., 20 non-system messages)
+
+## Related
+
+- User workflow: plan mode → research → `/fresh` → auto mode → execute
+- Complements `/compact` (which summarizes but still carries history)
+- Distinct from `/clear` (which wipes everything without preserving the plan)

--- a/PR1-DEVELOPMENT-PLAN.md
+++ b/PR1-DEVELOPMENT-PLAN.md
@@ -1,0 +1,252 @@
+# PR1 Development Plan: `/fresh` Command
+
+## Goal
+Implement a `/fresh` slash command that extracts the last assistant message (the plan), copies it to clipboard, resets the session, and seeds a new session with just that plan.
+
+## Branch
+`feat/fresh-command` (already created off latest main)
+
+## Step-by-Step Implementation
+
+### Step 1: Create `src/agent/distill.ts`
+**New file.** Pure function to extract the plan from message history.
+
+```ts
+import type { ChatMessage } from "./messages.js";
+
+/**
+ * Extract the last substantive assistant message from a conversation.
+ * Returns clean plan text, or null if no suitable message found.
+ */
+export function distillSessionPlan(messages: ChatMessage[]): string | null {
+  // Scan in reverse for the last assistant message
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== "assistant") continue;
+
+    let text = "";
+    if (typeof m.content === "string") {
+      text = m.content;
+    } else if (Array.isArray(m.content)) {
+      text = m.content
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("\n");
+    }
+
+    text = text.trim();
+    // Require at least some substance (not just "ok" or "done")
+    if (text.length > 20) {
+      return text;
+    }
+  }
+  return null;
+}
+```
+
+**Test file:** `src/agent/distill.test.ts`
+- Test with no assistant messages → returns null
+- Test with short assistant message (<20 chars) → returns null
+- Test with valid plan message → returns text
+- Test with content parts array → returns concatenated text
+
+### Step 2: Create `src/util/clipboard.ts`
+**New file.** Cross-platform clipboard writer with graceful fallback.
+
+```ts
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+
+export interface ClipboardResult {
+  success: boolean;
+  message: string;
+}
+
+export function writeToClipboard(text: string): ClipboardResult {
+  const os = platform();
+  try {
+    if (os === "darwin") {
+      execSync("pbcopy", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    }
+    if (os === "win32") {
+      execSync("clip", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    }
+    // Linux — try xclip first, then xsel
+    try {
+      execSync("xclip -selection clipboard", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    } catch {
+      execSync("xsel --clipboard --input", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    }
+  } catch {
+    return {
+      success: false,
+      message: "Clipboard not available — plan will be shown below",
+    };
+  }
+}
+```
+
+### Step 3: Register `/fresh` in built-in commands
+**File:** `src/commands/builtins.ts`
+
+Add to `BUILTIN_COMMANDS` array:
+```ts
+{ name: "fresh", description: "Reset session and start fresh with the last plan", source: "builtin" },
+```
+
+### Step 4: Implement `handleFresh` in slash command dispatcher
+**File:** `src/ui/slash-commands.ts`
+
+Add to `SlashContext` interface (around line 135):
+```ts
+resetSession: () => void;
+// ... existing
+```
+*(Note: `resetSession` is already in `SlashContext` via `use-session-manager.ts`)*
+
+Add handler function before the `handlers` record:
+```ts
+const handleFresh: Handler = (ctx) => {
+  const { busy, mkKey, setEvents, messagesRef } = ctx;
+  if (busy) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "can't /fresh while model is running — press Esc to interrupt first" },
+    ]);
+    return true;
+  }
+
+  const plan = distillSessionPlan(messagesRef.current);
+  if (!plan) {
+    setEvents((e) => [
+      ...e,
+      { kind: "error", key: mkKey(), text: "No plan found to start fresh with." },
+    ]);
+    return true;
+  }
+
+  const { writeToClipboard } = await import("../util/clipboard.js");
+  const clipResult = writeToClipboard(plan);
+
+  // Reset session (reuse /clear logic)
+  if (ctx.cacheStableRef.current && messagesRef.current.length >= 2) {
+    messagesRef.current = [messagesRef.current[0]!, messagesRef.current[1]!];
+  } else {
+    messagesRef.current = [messagesRef.current[0]!];
+  }
+  ctx.resetSession();
+  ctx.executorRef.current.clearArtifacts();
+  if (ctx.flushTimeoutRef.current) {
+    clearTimeout(ctx.flushTimeoutRef.current);
+    ctx.flushTimeoutRef.current = null;
+  }
+  ctx.pendingTextRef.current.clear();
+  ctx.activeAsstIdRef.current = null;
+  ctx.pendingToolCallsRef.current.clear();
+  ctx.usageRef.current = null;
+  ctx.turnCounterRef.current = 0;
+  setEvents([]);
+  ctx.setUsage(null);
+  ctx.setSessionUsage(null);
+  ctx.gatewayMetaRef.current = null;
+  ctx.setGatewayMeta(null);
+  ctx.clearTaskTracking();
+  ctx.compactSuggestedRef.current = false;
+  ctx.updateNudgedRef.current = false;
+
+  // Seed with plan
+  messagesRef.current.push({ role: "user", content: plan });
+
+  setEvents((e) => [
+    ...e,
+    {
+      kind: "info",
+      key: mkKey(),
+      text: clipResult.success
+        ? "Plan copied to clipboard. Starting fresh session with plan only…"
+        : "Clipboard unavailable. Starting fresh session with plan only…",
+    },
+  ]);
+
+  if (!clipResult.success) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "--- Plan ---\n" + plan },
+    ]);
+  }
+
+  return true;
+};
+```
+
+Register in `handlers` record:
+```ts
+"/fresh": handleFresh,
+```
+
+### Step 5: Wire through app.tsx
+**File:** `src/app.tsx`
+
+Ensure `resetSession` is passed through `buildSlashContext` dependencies (line ~1423). It already is — verify it's in the dependency array.
+
+### Step 6: Optional nudge on mode switch
+**File:** `src/mode.ts` or `src/ui/slash-commands.ts` (`handleMode`)
+
+In `handleMode`, when switching from `plan` to `auto` or `edit`, check message count. If above threshold (e.g., 10 non-system messages), emit a tip:
+```ts
+if (ctx.mode === "plan" && (arg === "auto" || arg === "edit")) {
+  const nonSystemCount = ctx.messagesRef.current.filter((m) => m.role !== "system").length;
+  if (nonSystemCount > 10) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "Tip: you have extensive planning context. Run `/fresh` to start clean with just the plan." },
+    ]);
+  }
+}
+```
+
+### Step 7: Run typecheck and tests
+```bash
+npm run typecheck
+npm test
+```
+
+### Step 8: Update help menu
+**File:** `src/ui/help-menu.tsx`
+
+Add `/fresh` to the command list.
+
+### Step 9: Commit
+```bash
+git add -A
+git commit -m "feat: add /fresh command to reset session with distilled plan
+
+- Add distillSessionPlan() to extract last assistant message
+- Add cross-platform clipboard utility
+- Register /fresh slash command
+- Reset session and seed with plan on execution
+- Show tip when switching from plan to auto/edit with heavy context
+
+Co-authored-by: kimiflare <kimiflare@proton.me>"
+```
+
+## Files Modified / Created
+
+| Status | File |
+|--------|------|
+| **Create** | `src/agent/distill.ts` |
+| **Create** | `src/agent/distill.test.ts` |
+| **Create** | `src/util/clipboard.ts` |
+| **Modify** | `src/commands/builtins.ts` |
+| **Modify** | `src/ui/slash-commands.ts` |
+| **Modify** | `src/ui/help-menu.tsx` |
+| **Verify** | `src/app.tsx` (deps array) |
+
+## Notes
+- Keep `handleFresh` logic DRY with `handleClear` — consider extracting a shared `resetSessionState()` helper if appropriate
+- The clipboard utility should be best-effort; never block the core flow
+- `distillSessionPlan` is intentionally simple now — it will be reused for PR2 (resume fresh)

--- a/src/agent/distill.test.ts
+++ b/src/agent/distill.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { distillSessionPlan } from "./distill.js";
+import type { ChatMessage } from "./messages.js";
+
+describe("distillSessionPlan", () => {
+  it("returns null when there are no assistant messages", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Hello" },
+    ];
+    assert.strictEqual(distillSessionPlan(messages), null);
+  });
+
+  it("returns null when the assistant message is too short", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "ok" },
+    ];
+    assert.strictEqual(distillSessionPlan(messages), null);
+  });
+
+  it("returns the text of a valid plan message", () => {
+    const plan = "Here is the plan:\n1. First do this\n2. Then do that";
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Plan this out" },
+      { role: "assistant", content: plan },
+    ];
+    assert.strictEqual(distillSessionPlan(messages), plan);
+  });
+
+  it("returns concatenated text from content parts array", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Plan this out" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Part one of the plan." },
+          { type: "text", text: "Part two of the plan." },
+        ],
+      },
+    ];
+    const result = distillSessionPlan(messages);
+    assert.strictEqual(result, "Part one of the plan.\nPart two of the plan.");
+  });
+
+  it("skips non-text content parts", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Plan this out" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is the plan with an image:" },
+          { type: "image_url", image_url: { url: "http://example.com/img.png" } },
+          { type: "text", text: "Continue with more planning details here." },
+        ],
+      },
+    ];
+    const result = distillSessionPlan(messages);
+    assert.strictEqual(
+      result,
+      "Here is the plan with an image:\nContinue with more planning details here.",
+    );
+  });
+
+  it("returns the most recent substantive assistant message", () => {
+    const oldPlan = "Old plan that is long enough to qualify";
+    const newPlan = "New plan that is also long enough to qualify here";
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "First request" },
+      { role: "assistant", content: oldPlan },
+      { role: "user", content: "Second request" },
+      { role: "assistant", content: newPlan },
+    ];
+    assert.strictEqual(distillSessionPlan(messages), newPlan);
+  });
+
+  it("ignores short assistant messages and finds a longer one earlier", () => {
+    const plan = "This is a substantial plan with enough content to be useful";
+    const messages: ChatMessage[] = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: plan },
+      { role: "user", content: "Thanks" },
+      { role: "assistant", content: "ok" },
+    ];
+    assert.strictEqual(distillSessionPlan(messages), plan);
+  });
+
+  it("returns null for empty messages array", () => {
+    assert.strictEqual(distillSessionPlan([]), null);
+  });
+});

--- a/src/agent/distill.ts
+++ b/src/agent/distill.ts
@@ -1,0 +1,30 @@
+import type { ChatMessage } from "./messages.js";
+
+/**
+ * Extract the last substantive assistant message from a conversation.
+ * Returns clean plan text, or null if no suitable message found.
+ */
+export function distillSessionPlan(messages: ChatMessage[]): string | null {
+  // Scan in reverse for the last assistant message
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== "assistant") continue;
+
+    let text = "";
+    if (typeof m.content === "string") {
+      text = m.content;
+    } else if (Array.isArray(m.content)) {
+      text = m.content
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("\n");
+    }
+
+    text = text.trim();
+    // Require at least some substance (not just "ok" or "done")
+    if (text.length > 20) {
+      return text;
+    }
+  }
+  return null;
+}

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -29,6 +29,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "checkpoints", description: "List checkpoints in current session", source: "builtin" },
   { name: "compact", description: "Summarize old turns to free context", source: "builtin" },
   { name: "clear", description: "Clear current conversation", source: "builtin" },
+  { name: "fresh", description: "Reset session and start fresh with the last plan", source: "builtin" },
   { name: "init", description: "Scan repo and write KIMI.md", source: "builtin" },
   { name: "remote", argHint: "<prompt>", description: "Run a remote session on Cloudflare", source: "builtin" },
   { name: "update", description: "Check for updates", source: "builtin" },

--- a/src/ui/help-menu.tsx
+++ b/src/ui/help-menu.tsx
@@ -60,6 +60,7 @@ const CATEGORIES: Category[] = [
       { command: "/resume", description: "pick a past conversation" },
       { command: "/compact", description: "summarize old turns to free context" },
       { command: "/clear", description: "clear current conversation" },
+      { command: "/fresh", description: "reset session and start fresh with the last plan" },
     ],
   },
   {

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -76,6 +76,8 @@ import { startRemoteSession, streamRemoteProgress } from "../remote/worker-clien
 import { saveRemoteSession, type RemoteSession } from "../remote/session-store.js";
 import { deployForTui } from "../remote/deploy.js";
 import { authGitHubForTui } from "../remote/tui-auth.js";
+import { distillSessionPlan } from "../agent/distill.js";
+import { writeToClipboard } from "../util/clipboard.js";
 
 type SetEvents = React.Dispatch<React.SetStateAction<ChatEvent[]>>;
 
@@ -209,6 +211,77 @@ const handleClear: Handler = (ctx) => {
   ctx.clearTaskTracking();
   ctx.compactSuggestedRef.current = false;
   ctx.updateNudgedRef.current = false;
+  return true;
+};
+
+const handleFresh: Handler = (ctx) => {
+  const { busy, mkKey, setEvents } = ctx;
+  if (busy) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "can't /fresh while model is running — press Esc to interrupt first" },
+    ]);
+    return true;
+  }
+
+  const plan = distillSessionPlan(ctx.messagesRef.current);
+  if (!plan) {
+    setEvents((e) => [
+      ...e,
+      { kind: "error", key: mkKey(), text: "No plan found to start fresh with." },
+    ]);
+    return true;
+  }
+
+  const clipResult = writeToClipboard(plan);
+
+  // Reset session (reuse /clear logic)
+  if (ctx.cacheStableRef.current && ctx.messagesRef.current.length >= 2) {
+    ctx.messagesRef.current = [ctx.messagesRef.current[0]!, ctx.messagesRef.current[1]!];
+  } else {
+    ctx.messagesRef.current = [ctx.messagesRef.current[0]!];
+  }
+  ctx.resetSession();
+  ctx.executorRef.current.clearArtifacts();
+  if (ctx.flushTimeoutRef.current) {
+    clearTimeout(ctx.flushTimeoutRef.current);
+    ctx.flushTimeoutRef.current = null;
+  }
+  ctx.pendingTextRef.current.clear();
+  ctx.activeAsstIdRef.current = null;
+  ctx.pendingToolCallsRef.current.clear();
+  ctx.usageRef.current = null;
+  ctx.turnCounterRef.current = 0;
+  setEvents([]);
+  ctx.setUsage(null);
+  ctx.setSessionUsage(null);
+  ctx.gatewayMetaRef.current = null;
+  ctx.setGatewayMeta(null);
+  ctx.clearTaskTracking();
+  ctx.compactSuggestedRef.current = false;
+  ctx.updateNudgedRef.current = false;
+
+  // Seed with plan
+  ctx.messagesRef.current.push({ role: "user", content: plan });
+
+  setEvents((e) => [
+    ...e,
+    {
+      kind: "info",
+      key: mkKey(),
+      text: clipResult.success
+        ? "Plan copied to clipboard. Starting fresh session with plan only…"
+        : "Clipboard unavailable. Starting fresh session with plan only…",
+    },
+  ]);
+
+  if (!clipResult.success) {
+    setEvents((e) => [
+      ...e,
+      { kind: "info", key: mkKey(), text: "--- Plan ---\n" + plan },
+    ]);
+  }
+
   return true;
 };
 
@@ -537,14 +610,25 @@ const handleGateway: Handler = (ctx, rest) => {
 };
 
 const handleMode: Handler = (ctx, _rest, arg) => {
-  const { setEvents, mkKey } = ctx;
+  const { setEvents, mkKey, mode } = ctx;
   if (!arg) {
     ctx.setShowModePicker(true);
     return true;
   }
   if (arg === "edit" || arg === "plan" || arg === "auto" || arg === "multi-agent-experimental") {
+    const prevMode = mode;
     ctx.setMode(arg);
     setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `mode: ${arg}` }]);
+    // Nudge about /fresh when switching from plan to auto/edit with heavy context
+    if (prevMode === "plan" && (arg === "auto" || arg === "edit")) {
+      const nonSystemCount = ctx.messagesRef.current.filter((m) => m.role !== "system").length;
+      if (nonSystemCount > 10) {
+        setEvents((e) => [
+          ...e,
+          { kind: "info", key: mkKey(), text: "Tip: you have extensive planning context. Run `/fresh` to start clean with just the plan." },
+        ]);
+      }
+    }
     return true;
   }
   setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "usage: /mode edit|plan|auto|multi-agent-experimental" }]);
@@ -1500,6 +1584,7 @@ const handleHelp: Handler = (ctx) => {
 const handlers: Record<string, Handler> = {
   "/exit": handleExit,
   "/clear": handleClear,
+  "/fresh": handleFresh,
   "/reasoning": handleReasoning,
   "/cost": handleCost,
   "/shell": handleShell,

--- a/src/util/clipboard.ts
+++ b/src/util/clipboard.ts
@@ -1,0 +1,34 @@
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+
+export interface ClipboardResult {
+  success: boolean;
+  message: string;
+}
+
+export function writeToClipboard(text: string): ClipboardResult {
+  const os = platform();
+  try {
+    if (os === "darwin") {
+      execSync("pbcopy", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    }
+    if (os === "win32") {
+      execSync("clip", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    }
+    // Linux — try xclip first, then xsel
+    try {
+      execSync("xclip -selection clipboard", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    } catch {
+      execSync("xsel --clipboard --input", { input: text, timeout: 5000 });
+      return { success: true, message: "Copied to clipboard" };
+    }
+  } catch {
+    return {
+      success: false,
+      message: "Clipboard not available — plan will be shown below",
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Implements a `/fresh` slash command that extracts the last assistant message (the plan), copies it to clipboard, resets the session, and seeds a new session with just that plan.

## Changes

- **`src/agent/distill.ts`** — New pure function `distillSessionPlan()` to extract the last substantive assistant message from conversation history.
- **`src/agent/distill.test.ts`** — 8 tests covering: no assistant messages, short messages, valid plan, content parts array, non-text parts, most-recent selection, empty array.
- **`src/util/clipboard.ts`** — Cross-platform clipboard writer (macOS `pbcopy`, Windows `clip`, Linux `xclip`/`xsel`) with graceful fallback.
- **`src/commands/builtins.ts`** — Registered `/fresh` in built-in commands.
- **`src/ui/slash-commands.ts`** — Added `handleFresh` handler that:
  - Copies the distilled plan to clipboard
  - Resets session state (reuses `/clear` logic)
  - Seeds the new session with the plan as a user message
  - Shows the plan inline if clipboard is unavailable
  - Added optional nudge when switching from `plan` → `auto`/`edit` with >10 non-system messages
- **`src/ui/help-menu.tsx`** — Added `/fresh` to the Session category.

## Testing

- `npm run typecheck` passes
- `src/agent/distill.test.ts` passes (8/8)

## Notes

- Clipboard utility is best-effort; never blocks the core flow.
- `distillSessionPlan` is intentionally simple and will be reused for PR2 (resume fresh).

---

Co-authored-by: kimiflare <kimiflare@proton.me>