### PR TITLE
feat(ui): auto-prompt /fresh when plan mode completes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -97,6 +97,7 @@ import { SlashPicker } from "./ui/slash-picker.js";
 import { usePickerController } from "./ui/use-picker-controller.js";
 import { useModalHost } from "./ui/use-modal-host.js";
 import { ModalHost, ModalOverlay } from "./ui/modal-host.js";
+import type { PlanCompleteChoice } from "./ui/plan-complete-picker.js";
 import { useSessionManager } from "./ui/use-session-manager.js";
 import { useTurnController } from "./ui/use-turn-controller.js";
 import {
@@ -109,6 +110,8 @@ import { runInit as runInitImpl } from "./init/run-init.js";
 import { runStartupTasks } from "./ui/run-startup-tasks.js";
 import { initLsp as initLspImpl, initMcp as initMcpImpl } from "./ui/manager-init.js";
 import { runCompact as runCompactImpl } from "./agent/run-compact.js";
+import { distillSessionPlan } from "./agent/distill.js";
+import { writeToClipboard } from "./util/clipboard.js";
 import {
   handleCommandDelete as handleCommandDeleteImpl,
   handleCommandSave as handleCommandSaveImpl,
@@ -301,6 +304,7 @@ function App({
     showGatewayPicker, setShowGatewayPicker,
     showSkillsPicker, setShowSkillsPicker,
     showShellPicker, setShowShellPicker,
+    showPlanCompletePicker, setShowPlanCompletePicker,
     hasFullscreenModal,
     hasAnyModal,
   } = modals;
@@ -1187,6 +1191,73 @@ function App({
       ]);
     },
     [mkKey, setShowUiPicker],
+  );
+
+  const handlePlanCompletePick = useCallback(
+    (picked: PlanCompleteChoice | null) => {
+      setShowPlanCompletePicker(false);
+      if (!picked || picked === "continue") return;
+
+      // Replicate /fresh logic
+      const plan = distillSessionPlan(messagesRef.current);
+      if (!plan) {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: "No plan found to start fresh with." },
+        ]);
+        setMode(picked);
+        return;
+      }
+
+      const clipResult = writeToClipboard(plan);
+
+      // Reset session (reuse /clear logic)
+      if (cacheStableRef.current && messagesRef.current.length >= 2) {
+        messagesRef.current = [messagesRef.current[0]!, messagesRef.current[1]!];
+      } else {
+        messagesRef.current = [messagesRef.current[0]!];
+      }
+      resetSession();
+      executorRef.current.clearArtifacts();
+      if (flushTimeoutRef.current) {
+        clearTimeout(flushTimeoutRef.current);
+        flushTimeoutRef.current = null;
+      }
+      pendingTextRef.current.clear();
+      activeAsstIdRef.current = null;
+      pendingToolCallsRef.current.clear();
+      usageRef.current = null;
+      turnCounterRef.current = 0;
+      setEvents([]);
+      setUsage(null);
+      setSessionUsage(null);
+      gatewayMetaRef.current = null;
+      setGatewayMeta(null);
+      clearTaskTracking();
+      compactSuggestedRef.current = false;
+      updateNudgedRef.current = false;
+
+      // Seed with plan
+      messagesRef.current.push({ role: "user", content: plan });
+
+      setEvents((e) => [
+        ...e,
+        {
+          kind: "info",
+          key: mkKey(),
+          text: clipResult.success
+            ? `Plan copied to clipboard. Starting fresh session in ${picked} mode with plan only…`
+            : `Clipboard unavailable. Starting fresh session in ${picked} mode with plan only…`,
+        },
+      ]);
+
+      if (!clipResult.success) {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "--- Plan ---\n" + plan }]);
+      }
+
+      setMode(picked);
+    },
+    [mkKey, setShowPlanCompletePicker, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta, clearTaskTracking, resetSession],
   );
 
   const handleModelPick = useCallback(
@@ -2155,6 +2226,15 @@ function App({
             })();
 
             cleanupTurn();
+
+            // If the turn completed in plan mode and produced a substantive plan,
+            // prompt the user to choose the next step (auto, edit, or continue).
+            if (modeRef.current === "plan") {
+              const plan = distillSessionPlan(messagesRef.current);
+              if (plan) {
+                setShowPlanCompletePicker(true);
+              }
+            }
           },
           onError: async (e) => {
             if (e.name === "AbortError") {
@@ -2196,7 +2276,7 @@ function App({
         },
       );
     },
-    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe, updateGatewayMeta],
+    [cfg, handleSlash, updateAssistant, updateTool, saveSessionSafe, updateGatewayMeta, setShowPlanCompletePicker],
   );
 
   useEffect(() => {
@@ -2443,6 +2523,7 @@ function App({
           setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `Type /skills ${action} <name> to ${action} a skill.` }]);
         }}
         onSkillsDone={() => setShowSkillsPicker(false)}
+        onPlanCompletePick={handlePlanCompletePick}
       />
     );
   }

--- a/src/ui/modal-host.tsx
+++ b/src/ui/modal-host.tsx
@@ -24,6 +24,7 @@ import { InboxModal } from "./inbox-modal.js";
 import { MultiAgentModal, type MultiAgentSettings } from "./multi-agent-modal.js";
 import { HooksDashboard } from "./hooks-dashboard.js";
 import { HelpMenu } from "./help-menu.js";
+import { PlanCompletePicker, type PlanCompleteChoice } from "./plan-complete-picker.js";
 import type { Theme } from "./theme.js";
 import type { ModalHostController } from "./use-modal-host.js";
 import type { CustomCommand } from "../commands/types.js";
@@ -121,6 +122,8 @@ export interface ModalHostProps {
   // Skills picker
   onSkillsAction: (action: string) => void;
   onSkillsDone: () => void;
+  // Plan complete picker
+  onPlanCompletePick: (choice: PlanCompleteChoice | null) => void;
 }
 
 /**
@@ -433,6 +436,16 @@ export function ModalHost(props: ModalHostProps): React.ReactElement | null {
       <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <ModePicker current={props.currentMode} onPick={props.onPickMode} multiAgentEnabled={props.multiAgentEnabled} />
+        </Box>
+      </ThemeProvider>
+    );
+  }
+
+  if (modals.showPlanCompletePicker) {
+    return (
+      <ThemeProvider theme={theme}>
+        <Box flexDirection="column">
+          <PlanCompletePicker onPick={props.onPlanCompletePick} />
         </Box>
       </ThemeProvider>
     );

--- a/src/ui/plan-complete-picker.tsx
+++ b/src/ui/plan-complete-picker.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import { useTheme } from "./theme-context.js";
+
+export type PlanCompleteChoice = "auto" | "edit" | "continue";
+
+interface Props {
+  onPick: (choice: PlanCompleteChoice | null) => void;
+}
+
+export function PlanCompletePicker({ onPick }: Props) {
+  const theme = useTheme();
+  const items = [
+    { label: "▸ Execute this plan and accept changes (auto mode)", value: "auto" as const, key: "auto" },
+    { label: "▸ Start building and ask for permission (edit mode)", value: "edit" as const, key: "edit" },
+    { label: "▸ Continue planning / ask a question", value: "continue" as const, key: "continue" },
+  ];
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.accent} paddingX={1}>
+      <Text color={theme.accent} bold>
+        Plan complete — what next?
+      </Text>
+      <Text color={theme.info.color} dimColor={false}>
+        Arrow keys to navigate, Enter to select, Esc to cancel.
+      </Text>
+      <Box marginTop={1}>
+        <SelectInput
+          items={items}
+          onSelect={(item) => onPick(item.value)}
+          onHighlight={() => {}}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/use-modal-host.ts
+++ b/src/ui/use-modal-host.ts
@@ -73,6 +73,8 @@ export interface ModalHostController {
   setShowSkillsPicker: (v: boolean) => void;
   showShellPicker: boolean;
   setShowShellPicker: (v: boolean) => void;
+  showPlanCompletePicker: boolean;
+  setShowPlanCompletePicker: (v: boolean) => void;
 
   /** Any fullscreen modal is active (would trigger an early return). */
   hasFullscreenModal: boolean;
@@ -120,6 +122,7 @@ export function useModalHost(): ModalHostController {
   const [showGatewayPicker, setShowGatewayPicker] = useState(false);
   const [showSkillsPicker, setShowSkillsPicker] = useState(false);
   const [showShellPicker, setShowShellPicker] = useState(false);
+  const [showPlanCompletePicker, setShowPlanCompletePicker] = useState(false);
 
   const flags = useMemo(() => {
     const hasFullscreenModal =
@@ -143,7 +146,8 @@ export function useModalHost(): ModalHostController {
       showMemoryPicker ||
       showGatewayPicker ||
       showSkillsPicker ||
-      showShellPicker;
+      showShellPicker ||
+      showPlanCompletePicker;
     const hasOverlayModal = limitModal !== null || loopModal !== null;
     return {
       hasFullscreenModal,
@@ -172,6 +176,7 @@ export function useModalHost(): ModalHostController {
     showGatewayPicker,
     showSkillsPicker,
     showShellPicker,
+    showPlanCompletePicker,
     limitModal,
     loopModal,
   ]);
@@ -200,6 +205,7 @@ export function useModalHost(): ModalHostController {
     showGatewayPicker, setShowGatewayPicker,
     showSkillsPicker, setShowSkillsPicker,
     showShellPicker, setShowShellPicker,
+    showPlanCompletePicker, setShowPlanCompletePicker,
     ...flags,
   };
 }
@@ -225,6 +231,7 @@ export interface ModalFlagsInput {
   showGatewayPicker: boolean;
   showSkillsPicker: boolean;
   showShellPicker: boolean;
+  showPlanCompletePicker: boolean;
 }
 
 export interface ModalFlags {
@@ -250,7 +257,8 @@ export function computeModalFlags(s: ModalFlagsInput): ModalFlags {
     s.showMemoryPicker ||
     s.showGatewayPicker ||
     s.showSkillsPicker ||
-    s.showShellPicker;
+    s.showShellPicker ||
+    s.showPlanCompletePicker;
   const hasOverlayModal = s.limitModal !== null || s.loopModal !== null;
   return {
     hasFullscreenModal,
@@ -278,4 +286,5 @@ export const EMPTY_MODAL_STATE: ModalFlagsInput = {
   showGatewayPicker: false,
   showSkillsPicker: false,
   showShellPicker: false,
+  showPlanCompletePicker: false,
 };


### PR DESCRIPTION
When a plan-mode turn finishes with a substantive plan, show a TUI picker that lets the user choose:

1. **Execute plan (auto mode)** — automatically runs  and switches to auto mode
2. **Start building with permission (edit mode)** — automatically runs  and switches to edit mode  
3. **Continue planning / ask a question** — closes picker, stays in plan mode

## Changes
- **New**  —  component using  with theme accent color
- **Modified**  — added  state
- **Modified**  — wired picker into fullscreen modal renderer
- **Modified**  —
  - Detects plan completion in  callback
  -  replicates  logic (reset session, copy plan to clipboard, seed new session) then switches mode

## Behavior
- Only triggers when  and  finds a substantive plan (>20 chars)
- Build and typecheck pass

Co-authored-by: kimiflare <kimiflare@proton.me>