### PR TITLE
feat(agent): LLM-based synthesis for multi-agent findings

### DIFF
--- a/src/agent/supervisor.test.ts
+++ b/src/agent/supervisor.test.ts
@@ -34,9 +34,15 @@ function finding(
 }
 
 describe("TurnSupervisor.synthesizeFindings", () => {
-  it("keeps all findings when topics do not overlap", () => {
+  let runKimiCalls: Array<{ model: string; messages: unknown[]; temperature?: number }> = [];
+
+  afterEach(() => {
+    runKimiCalls = [];
+  });
+
+  it("keeps all findings when topics do not overlap", async () => {
     const s = new TurnSupervisor();
-    const out = s.synthesizeFindings([
+    const out = await s.synthesizeFindings([
       result("w1", [finding("OAuth", "high")]),
       result("w2", [finding("Testing", "medium")]),
     ]);
@@ -45,9 +51,9 @@ describe("TurnSupervisor.synthesizeFindings", () => {
     assert.strictEqual(out.conflicts.length, 0);
   });
 
-  it("deduplicates by topic, keeping the higher-confidence finding", () => {
+  it("deduplicates by topic, keeping the higher-confidence finding", async () => {
     const s = new TurnSupervisor();
-    const out = s.synthesizeFindings([
+    const out = await s.synthesizeFindings([
       result("w1", [finding("OAuth", "low", "low-summary")]),
       result("w2", [finding("oauth", "high", "high-summary")]),
     ]);
@@ -55,9 +61,9 @@ describe("TurnSupervisor.synthesizeFindings", () => {
     assert.ok(!out.plan.includes("low-summary"));
   });
 
-  it("detects conflicting recommendations and prefers the higher-confidence one", () => {
+  it("detects conflicting recommendations and prefers the higher-confidence one", async () => {
     const s = new TurnSupervisor();
-    const out = s.synthesizeFindings([
+    const out = await s.synthesizeFindings([
       result("w1", [finding("OAuth", "low")], ["use OAuth library A"]),
       result("w2", [finding("OAuth", "high")], ["use OAuth library B"]),
     ]);
@@ -68,12 +74,140 @@ describe("TurnSupervisor.synthesizeFindings", () => {
     assert.ok(Array.isArray(out.recommendations));
   });
 
-  it("handles an empty results array without crashing", () => {
+  it("handles an empty results array without crashing", async () => {
     const s = new TurnSupervisor();
-    const out = s.synthesizeFindings([]);
+    const out = await s.synthesizeFindings([]);
     assert.strictEqual(out.conflicts.length, 0);
     assert.strictEqual(out.recommendations.length, 0);
     assert.ok(out.plan.includes("Synthesized Execution Plan"));
+  });
+
+  it("uses heuristic path when strategy is heuristic", async () => {
+    const s = new TurnSupervisor();
+    const out = await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high")])],
+      { strategy: "heuristic", accountId: "a", apiToken: "t" },
+    );
+    assert.ok(out.plan.includes("OAuth"));
+  });
+
+  it("uses heuristic path when credentials are missing", async () => {
+    const s = new TurnSupervisor();
+    const out = await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high")])],
+      { strategy: "llm" },
+    );
+    assert.ok(out.plan.includes("OAuth"));
+  });
+
+  it("uses LLM path when credentials are present and strategy is llm", async () => {
+    const s = new TurnSupervisor();
+    (s as unknown as Record<string, unknown>)._runKimi = async function* (opts: { model: string; messages: unknown[]; temperature?: number }) {
+      runKimiCalls.push(opts);
+      yield { type: "text" as const, delta: JSON.stringify({
+        plan: "# Unified Plan\n\nUse OAuth.",
+        conflicts: [],
+        recommendations: ["Use OAuth 2.0"],
+      }) };
+      yield { type: "done" as const, finishReason: "stop", usage: null };
+    };
+
+    const out = await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high", "summary")], ["Use OAuth 2.0"])],
+      { strategy: "llm", accountId: "a", apiToken: "t", model: "@cf/moonshotai/kimi-k2.5" },
+    );
+    assert.strictEqual(runKimiCalls.length, 1);
+    assert.strictEqual(runKimiCalls[0]?.model, "@cf/moonshotai/kimi-k2.5");
+    assert.strictEqual(runKimiCalls[0]?.temperature, 0.2);
+    assert.ok(out.plan.includes("Unified Plan"));
+    assert.deepStrictEqual(out.recommendations, ["Use OAuth 2.0"]);
+  });
+
+  it("falls back to heuristic when LLM returns bad JSON and strategy is hybrid", async () => {
+    const s = new TurnSupervisor();
+    (s as unknown as Record<string, unknown>)._runKimi = async function* () {
+      yield { type: "text" as const, delta: "not json" };
+      yield { type: "done" as const, finishReason: "stop", usage: null };
+    };
+
+    const out = await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high")])],
+      { strategy: "hybrid", accountId: "a", apiToken: "t" },
+    );
+    assert.ok(out.plan.includes("Synthesized Execution Plan"));
+    assert.ok(out.plan.includes("OAuth"));
+  });
+
+  it("falls back to heuristic when LLM throws and strategy is hybrid", async () => {
+    const s = new TurnSupervisor();
+    (s as unknown as Record<string, unknown>)._runKimi = async function* () {
+      throw new Error("network error");
+    };
+
+    const out = await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high")])],
+      { strategy: "hybrid", accountId: "a", apiToken: "t" },
+    );
+    assert.ok(out.plan.includes("OAuth"));
+  });
+
+  it("propagates LLM error when strategy is llm and LLM fails", async () => {
+    const s = new TurnSupervisor();
+    (s as unknown as Record<string, unknown>)._runKimi = async function* () {
+      throw new Error("network error");
+    };
+
+    await assert.rejects(
+      s.synthesizeFindings(
+        [result("w1", [finding("OAuth", "high")])],
+        { strategy: "llm", accountId: "a", apiToken: "t" },
+      ),
+      /network error/,
+    );
+  });
+
+  it("includes worker IDs in the LLM prompt for citation tracking", async () => {
+    const s = new TurnSupervisor();
+    let capturedUserContent = "";
+    (s as unknown as Record<string, unknown>)._runKimi = async function* (opts: { messages: Array<{ role: string; content: string }> }) {
+      const userMsg = opts.messages.find((m) => m.role === "user");
+      capturedUserContent = userMsg?.content ?? "";
+      yield { type: "text" as const, delta: JSON.stringify({
+        plan: "# Plan\n\n[worker: w1] Use OAuth.",
+        conflicts: [],
+        recommendations: ["Use OAuth"],
+      }) };
+      yield { type: "done" as const, finishReason: "stop", usage: null };
+    };
+
+    await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high")], ["Use OAuth"])],
+      { strategy: "llm", accountId: "a", apiToken: "t", prompt: "Implement auth" },
+    );
+    assert.ok(capturedUserContent.includes("Worker w1"));
+    assert.ok(capturedUserContent.includes("Implement auth"));
+  });
+
+  it("streams deltas through onDelta callback", async () => {
+    const s = new TurnSupervisor();
+    (s as unknown as Record<string, unknown>)._runKimi = async function* () {
+      yield { type: "text" as const, delta: '{"plan":"# P' };
+      yield { type: "text" as const, delta: 'lan","conflicts":[],"recommendations":[]}' };
+      yield { type: "done" as const, finishReason: "stop", usage: null };
+    };
+
+    const deltas: string[] = [];
+    const out = await s.synthesizeFindings(
+      [result("w1", [finding("OAuth", "high")])],
+      {
+        strategy: "llm",
+        accountId: "a",
+        apiToken: "t",
+        onDelta: (d) => deltas.push(d),
+      },
+    );
+    assert.deepStrictEqual(deltas, ['{"plan":"# P', 'lan","conflicts":[],"recommendations":[]}' ]);
+    assert.ok(out.plan.includes("Plan"));
   });
 });
 

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -10,7 +10,8 @@
 import { runAgentTurn } from "./loop.js";
 import type { AgentTurnOpts } from "./loop.js";
 import { logger } from "../util/logger.js";
-import { runKimi } from "./client.js";
+import * as client from "./client.js";
+import type { AiGatewayOptions } from "./client.js";
 import type { WorkerResultMessage, ChatMessage } from "./messages.js";
 import { detectRepoInfo, type RepoInfo } from "../util/repo-info.js";
 import { loadConfig, resolveWorkerBudgetUsd, type KimiConfig } from "../config.js";
@@ -145,6 +146,8 @@ export class TurnSupervisor {
   private _phase: TurnPhase = "idle";
   private _killRequested = false;
   private _activeWorkers: Map<string, ActiveWorker> = new Map();
+  /** Injectable LLM client for synthesis (overridable in tests). */
+  private _runKimi = client.runKimi;
 
   /** Coordinator-side MemoryManager for proxying memories to workers */
   memoryManager: MemoryManager | null = null;
@@ -655,17 +658,8 @@ export class TurnSupervisor {
     return results;
   }
 
-  /** Synthesize findings from multiple workers into a unified execution plan.
-   *
-   * Steps:
-   * 1. Deduplicate findings by topic (case-insensitive), keeping the highest-confidence version.
-   * 2. Detect conflicts — same topic with different recommendations.
-   * 3. Tie-breaker: when conflicting recommendations exist, prefer the one from
-   *    the worker with higher average confidence.
-   * 4. Produce a markdown execution plan the coordinator can present to the user
-   *    or feed into an executor worker.
-   */
-  synthesizeFindings(results: WorkerResultMessage[]): {
+  /** Heuristic synthesis — exact legacy behavior, preserved as fallback. */
+  private synthesizeFindingsHeuristic(results: WorkerResultMessage[]): {
     plan: string;
     conflicts: string[];
     recommendations: string[];
@@ -754,6 +748,160 @@ export class TurnSupervisor {
     };
   }
 
+  /** LLM-based synthesis with graceful fallback to heuristic. */
+  private async synthesizeFindingsLlm(
+    results: WorkerResultMessage[],
+    opts: {
+      prompt?: string;
+      accountId: string;
+      apiToken: string;
+      model: string;
+      gateway?: AiGatewayOptions;
+      signal?: AbortSignal;
+      onDelta?: (delta: string) => void;
+    },
+  ): Promise<{ plan: string; conflicts: string[]; recommendations: string[] }> {
+    const MAX_RAW_OUTPUT = 2000;
+    const MAX_REASONING = 2000;
+
+    const workerBlocks = results.map((r, i) => {
+      const findings = r.findings
+        .map(
+          (f) =>
+            `  - Topic: ${f.topic}\n    Summary: ${f.summary}\n    Confidence: ${f.confidence}\n    Relevance: ${f.relevance}\n    Sources: ${f.sources.join(", ") || "none"}`,
+        )
+        .join("\n");
+      const recs = r.recommendations.map((rec) => `  - ${rec}`).join("\n") || "  (none)";
+      const reasoning = r.reasoning ? r.reasoning.slice(0, MAX_REASONING) : "(none)";
+      const rawOutput = r.rawOutput ? r.rawOutput.slice(0, MAX_RAW_OUTPUT) : "(none)";
+      return [
+        `--- Worker ${r.workerId || `w${i + 1}`} ---`,
+        `Task: ${r.task}`,
+        `Status: ${r.status}`,
+        `Findings:\n${findings || "  (none)"}`,
+        `Recommendations:\n${recs}`,
+        `Reasoning:\n${reasoning}`,
+        `Raw Output (truncated):\n${rawOutput}`,
+      ].join("\n");
+    });
+
+    const userContent = [
+      opts.prompt ? `Original user request:\n${opts.prompt}` : "",
+      "",
+      "Worker outputs:",
+      workerBlocks.join("\n\n"),
+      "",
+      "Instructions:",
+      "1. Synthesize the worker findings into a coherent execution plan.",
+      "2. Detect and resolve any conflicts between workers.",
+      "3. Cite sources inline using [worker: <id>] notation.",
+      "4. Return ONLY valid JSON in this exact shape (no markdown fences):",
+      '{"plan":"markdown plan","conflicts":["string"],"recommendations":["string"],"reasoning":"optional string"}',
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content:
+          "You are a synthesis engine. Combine findings from multiple research workers into a single coherent execution plan. Be concise. Return only valid JSON.",
+      },
+      { role: "user", content: userContent },
+    ];
+
+    let text = "";
+    const events = this._runKimi({
+      accountId: opts.accountId,
+      apiToken: opts.apiToken,
+      model: opts.model,
+      messages,
+      temperature: 0.2,
+      maxCompletionTokens: 4096,
+      reasoningEffort: "low",
+      gateway: opts.gateway,
+      signal: opts.signal,
+    });
+    for await (const ev of events) {
+      if (ev.type === "text") {
+        text += ev.delta;
+        opts.onDelta?.(ev.delta);
+      }
+    }
+
+    const cleaned = text.replace(/```(?:json)?\s*/gi, "").replace(/```\s*$/gi, "").trim();
+    const parsed = JSON.parse(cleaned) as {
+      plan?: string;
+      conflicts?: string[];
+      recommendations?: string[];
+      reasoning?: string;
+    };
+
+    if (!parsed.plan || !Array.isArray(parsed.conflicts) || !Array.isArray(parsed.recommendations)) {
+      throw new Error("LLM synthesis returned malformed JSON");
+    }
+
+    return {
+      plan: parsed.plan,
+      conflicts: parsed.conflicts,
+      recommendations: parsed.recommendations,
+    };
+  }
+
+  /** Synthesize findings from multiple workers into a unified execution plan.
+   *
+   * Uses LLM-based synthesis by default (configurable via synthesisStrategy).
+   * Falls back to the heuristic path when credentials are missing, the strategy
+   * demands it, or the LLM call fails.
+   */
+  async synthesizeFindings(
+    results: WorkerResultMessage[],
+    opts?: {
+      prompt?: string;
+      accountId?: string;
+      apiToken?: string;
+      model?: string;
+      gateway?: AiGatewayOptions;
+      signal?: AbortSignal;
+      onDelta?: (delta: string) => void;
+      strategy?: "llm" | "heuristic" | "hybrid";
+      disableLlmSynthesis?: boolean;
+    },
+  ): Promise<{
+    plan: string;
+    conflicts: string[];
+    recommendations: string[];
+  }> {
+    const strategy = opts?.strategy ?? "llm";
+    const disableLlm = opts?.disableLlmSynthesis ?? false;
+    const hasCreds = !!opts?.accountId && !!opts?.apiToken;
+
+    const useHeuristic = !hasCreds || strategy === "heuristic" || disableLlm;
+    if (useHeuristic) {
+      return this.synthesizeFindingsHeuristic(results);
+    }
+
+    try {
+      const llmResult = await this.synthesizeFindingsLlm(results, {
+        prompt: opts?.prompt,
+        accountId: opts.accountId!,
+        apiToken: opts.apiToken!,
+        model: opts?.model ?? "@cf/moonshotai/kimi-k2.5",
+        gateway: opts?.gateway,
+        signal: opts?.signal,
+        onDelta: opts?.onDelta,
+      });
+      return llmResult;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn("supervisor:synthesis_llm_failed", { error: msg });
+      if (strategy === "hybrid") {
+        return this.synthesizeFindingsHeuristic(results);
+      }
+      throw err;
+    }
+  }
+
   /** Automatically spawn research workers for a heavy prompt.
    *
    * Decomposes the prompt into 2-4 parallel research tasks using a simple
@@ -796,14 +944,33 @@ export class TurnSupervisor {
     try {
       const results = await this.spawnWorkers(workers, onUpdate, signal);
       onPhaseChange?.("synthesizing");
-      const synth = this.synthesizeFindings(results);
+
+      const gateway = cfg?.aiGatewayId
+        ? {
+            id: cfg.aiGatewayId,
+            cacheTtl: cfg.aiGatewayCacheTtl,
+            skipCache: cfg.aiGatewaySkipCache,
+            metadata: { feature: "synthesis", ...(cfg.aiGatewayMetadata ?? {}) },
+          }
+        : undefined;
+
+      const synth = await this.synthesizeFindings(results, {
+        prompt,
+        accountId: cfg?.accountId,
+        apiToken: cfg?.apiToken,
+        model: cfg?.synthesisModel,
+        gateway,
+        signal,
+        strategy: cfg?.synthesisStrategy,
+        disableLlmSynthesis: cfg?.disableLlmSynthesis,
+      });
 
       // Auto plan→execute chain ("the 4th agent"). Off by default for safety;
       // opt in via /multi-agent in the TUI or KIMIFLARE_AUTO_EXECUTE=1. Only
       // fires when synthesis produced actionable recommendations.
-      const cfg = await loadConfig().catch(() => null);
+      const cfg2 = await loadConfig().catch(() => null);
       const autoExecute =
-        cfg?.autoExecute ?? /^(1|true|yes|on)$/i.test(process.env.KIMIFLARE_AUTO_EXECUTE ?? "");
+        cfg2?.autoExecute ?? /^(1|true|yes|on)$/i.test(process.env.KIMIFLARE_AUTO_EXECUTE ?? "");
       if (!autoExecute || synth.recommendations.length === 0) {
         return synth;
       }
@@ -973,7 +1140,7 @@ async function decomposeWithLlm(
 
   try {
     let text = "";
-    const events = runKimi({
+    const events = client.runKimi({
       accountId,
       apiToken,
       model,

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,6 +153,16 @@ export interface KimiConfig {
    *  - "regex": pure regex heuristic (no LLM, fastest)
    *  - "hybrid": regex for explicit lists, LLM for prose */
   decompositionStrategy?: "llm" | "regex" | "hybrid";
+  /** Model for synthesizing multi-agent findings.
+   *  Default: @cf/moonshotai/kimi-k2.5 (fast and cheap). */
+  synthesisModel?: string;
+  /** Strategy for synthesizing worker findings.
+   *  - "llm": use a lightweight LLM call (default)
+   *  - "heuristic": pure heuristic (no LLM, fastest)
+   *  - "hybrid": try LLM, fall back to heuristic on failure */
+  synthesisStrategy?: "llm" | "heuristic" | "hybrid";
+  /** Explicit opt-out for LLM-based synthesis. When true, always uses heuristic. */
+  disableLlmSynthesis?: boolean;
   /** Files to pre-read on the coordinator and inject into every worker's
    *  context. Saves redundant `read` tool calls across workers. Paths are
    *  relative to the repo root. */


### PR DESCRIPTION
## Summary

Replaces the pure-heuristic  with an LLM-powered synthesis path that preserves nuance from worker  and , while keeping the legacy heuristic as a graceful fallback.

## Changes

### 1.  — new synthesis config options
-  — model for synthesis (default: )
-  — default ;  forces old path;  tries LLM then falls back
-  — explicit opt-out

### 2.  — rewritten 
- Extracted current body into private  (preserves exact behavior)
- Added private async :
  - Builds a prompt with original user prompt, worker findings, recommendations, reasoning, and truncated raw outputs (~2K chars each)
  - Calls  with configured , low temperature (), and  gateway tag
  - Expects JSON: 
  - On any error, logs warning and falls back to heuristic (when strategy is )
- Made  **async** with new optional :
  - , , , , , , , , 
- Updated  to load config and pass credentials + original  into synthesis
- Added injectable  field on  for testability

### 3.  — updated tests
- Existing heuristic tests made async
- New LLM path tests:
  - Success: valid JSON → parsed output
  - Fallback: bad JSON / throw → heuristic fallback (hybrid mode)
  - Error propagation: throw in  mode surfaces error
  - Citation tracking: worker IDs appear in prompt
  - Streaming:  callback receives tokens

## Design decisions
- **Backward compatibility**:  becomes async but  already is, so all call sites compile without changes
- **Graceful degradation**: Any LLM failure silently falls back to heuristic; user still gets a plan
- **Context window safety**:  and  truncated to ~2K chars each
- **Citation tracking**: Worker IDs included in prompt; LLM instructed to cite inline
- **Streaming ready**:  callback designed in but not wired to TUI yet

## Testing
- 
> kimiflare@0.80.0 typecheck
> tsc --noEmit ✅
- ▶ TurnSupervisor.synthesizeFindings
  ✔ keeps all findings when topics do not overlap (0.948333ms)
  ✔ deduplicates by topic, keeping the higher-confidence finding (0.167333ms)
  ✔ detects conflicting recommendations and prefers the higher-confidence one (0.176083ms)
  ✔ handles an empty results array without crashing (0.1175ms)
  ✔ uses heuristic path when strategy is heuristic (0.171042ms)
  ✔ uses heuristic path when credentials are missing (0.154125ms)
  ✔ uses LLM path when credentials are present and strategy is llm (0.879166ms)
  ✔ falls back to heuristic when LLM returns bad JSON and strategy is hybrid (1.360417ms)
  ✔ falls back to heuristic when LLM throws and strategy is hybrid (0.22625ms)
  ✔ propagates LLM error when strategy is llm and LLM fails (0.421583ms)
  ✔ includes worker IDs in the LLM prompt for citation tracking (0.172708ms)
  ✔ streams deltas through onDelta callback (0.16225ms)
✔ TurnSupervisor.synthesizeFindings (5.788459ms)
▶ TurnSupervisor.spawnWorkers (regression: instance-field access)
  ✔ runs without reaching for instance fields via the prototype (3180.2835ms)
  ✔ marks the worker failed when the endpoint errors (97.282ms)
  ✔ includes batchId, shallowClone, and repoCache in the payload (3091.583708ms)
  ✔ forwards memoryContext, lspContext, and mcpContext in the payload (3090.739292ms)
✔ TurnSupervisor.spawnWorkers (regression: instance-field access) (9460.170208ms)
▶ decomposePrompt
  ✔ splits an explicit numbered list into one worker per item (0.376333ms)
  ✔ splits an explicit bulleted list (0.124667ms)
  ✔ does NOT split a cohesive prose prompt on conjunctions (0.319459ms)
  ✔ falls back to 2 angled workers when there is no clear list (0.082667ms)
  ✔ uses LLM decomposition for prose when strategy is llm and cfg is provided (5.995ms)
  ✔ falls back to regex when LLM returns invalid JSON (0.780375ms)
  ✔ uses regex fallback when strategy is regex (0.105542ms)
  ✔ caches decomposition results (0.62775ms)
✔ decomposePrompt (8.594916ms)
▶ getFileTreeSnapshot
  ✔ returns a non-empty string for the current directory (0.97125ms)
✔ getFileTreeSnapshot (1.033ms)
▶ preReadFilesForWorkers
  ✔ reads files and formats them with separators (3.121666ms)
  ✔ respects maxChars and truncates (1.495166ms)
  ✔ skips missing files gracefully (1.422459ms)
  ✔ returns empty result when no files are readable (0.580375ms)
  ✔ stops reading once maxChars is reached (1.276708ms)
✔ preReadFilesForWorkers (8.087791ms)
▶ getPreReadFilesFromMemory
  ✔ returns empty array when memory is disabled (0.642625ms)
  ✔ returns empty array when memory DB does not exist (11.100875ms)
  ✔ derives top files from memory relatedFiles (5.172125ms)
✔ getPreReadFilesFromMemory (17.049625ms)
ℹ tests 33
ℹ suites 6
ℹ pass 33
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 9726.414458 ✅ (all 33 tests pass)

Co-authored-by: kimiflare <kimiflare@proton.me>