### PR TITLE
fix(ui): cursor position on history nav + lingering spinners on old assistant msgs

### DIFF
--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -70,6 +70,15 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
     if (count >= 3) repeatedSigs.add(sig);
   }
 
+  // Only the most recent assistant message should show a streaming spinner.
+  let lastAssistantIndex = -1;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]!.kind === "assistant") {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
+
   return (
     <Box flexDirection="column">
       {events.map((e, i) => {
@@ -88,7 +97,7 @@ export const ChatView = React.memo(function ChatView({ events, showReasoning, ve
                 </Text>
               </Box>
             )}
-            <EventView evt={e} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} intentTier={intentTier} />
+            <EventView evt={e} showReasoning={showReasoning} verbose={verbose} repeatedSigs={repeatedSigs} intentTier={intentTier} isLastAssistant={i === lastAssistantIndex} />
           </Box>
         );
       })}
@@ -102,12 +111,14 @@ const EventView = React.memo(function EventView({
   verbose,
   repeatedSigs,
   intentTier,
+  isLastAssistant,
 }: {
   evt: ChatEvent;
   showReasoning: boolean;
   verbose?: boolean;
   repeatedSigs?: Set<string>;
   intentTier?: IntentTier;
+  isLastAssistant?: boolean;
 }) {
   const theme = useTheme();
   if (evt.kind === "user") {
@@ -164,7 +175,7 @@ const EventView = React.memo(function EventView({
               </Box>
             ) : null}
             {evt.text ? <MD text={evt.text} /> : null}
-            {evt.streaming && (
+            {evt.streaming && isLastAssistant && (
               <Text color={theme.spinner}>
                 <Spinner type="dots" />
               </Text>

--- a/src/ui/text-input.tsx
+++ b/src/ui/text-input.tsx
@@ -82,9 +82,25 @@ export function CustomTextInput({
   };
   const pastesRef = useRef<Map<string, string>>(new Map());
   const pasteCounterRef = useRef(0);
+  const prevValueRef = useRef(value);
 
   useEffect(() => {
     if (!focus) return;
+    const prevValue = prevValueRef.current;
+    prevValueRef.current = value;
+
+    if (value === prevValue) return;
+
+    // If the cursor was at the end of the previous value, keep it at the end
+    // (handles history navigation and other external value replacements).
+    if (cursorOffset === prevValue.length) {
+      if (cursorOffset !== value.length) {
+        setCursorOffset(value.length);
+      }
+      return;
+    }
+
+    // Otherwise just clamp to valid range.
     const next = cursorOffset > value.length ? value.length : cursorOffset;
     if (next !== cursorOffset) {
       setCursorOffset(next);


### PR DESCRIPTION
## Changes

- **text-input**: when value changes externally (e.g. Up/Down history navigation) and the cursor was at the end of the old text, jump it to the end of the new text instead of leaving it at the old offset.

- **chat**: only render the streaming spinner on the most recent assistant event. Prevents old completed assistant messages from showing a lingering animation.

Fixes #26 (partially — cursor fix).