### PR TITLE
fix(ui): make PlanCompletePicker an inline overlay and auto-submit plan

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -97,6 +97,7 @@ import { SlashPicker } from "./ui/slash-picker.js";
 import { usePickerController } from "./ui/use-picker-controller.js";
 import { useModalHost } from "./ui/use-modal-host.js";
 import { ModalHost, ModalOverlay } from "./ui/modal-host.js";
+import { PlanCompletePicker } from "./ui/plan-complete-picker.js";
 import type { PlanCompleteChoice } from "./ui/plan-complete-picker.js";
 import { useSessionManager } from "./ui/use-session-manager.js";
 import { useTurnController } from "./ui/use-turn-controller.js";
@@ -1237,9 +1238,6 @@ function App({
       compactSuggestedRef.current = false;
       updateNudgedRef.current = false;
 
-      // Seed with plan
-      messagesRef.current.push({ role: "user", content: plan });
-
       setEvents((e) => [
         ...e,
         {
@@ -1256,8 +1254,10 @@ function App({
       }
 
       setMode(picked);
+      modeRef.current = picked;
+      submitRef.current(plan);
     },
-    [mkKey, setShowPlanCompletePicker, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta, clearTaskTracking, resetSession],
+    [mkKey, setShowPlanCompletePicker, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta, clearTaskTracking, resetSession, submitRef],
   );
 
   const handleModelPick = useCallback(
@@ -2523,7 +2523,6 @@ function App({
           setEvents((e) => [...e, { kind: "info", key: mkKey(), text: `Type /skills ${action} <name> to ${action} a skill.` }]);
         }}
         onSkillsDone={() => setShowSkillsPicker(false)}
-        onPlanCompletePick={handlePlanCompletePick}
       />
     );
   }
@@ -2553,6 +2552,8 @@ function App({
             onLimitResolved={() => { limitResolveRef.current = null; }}
             onLoopResolved={() => { loopResolveRef.current = null; }}
           />
+        ) : showPlanCompletePicker ? (
+          <PlanCompletePicker onPick={handlePlanCompletePick} />
         ) : (
           <Box flexDirection="column" marginTop={1}>
             {(activeWorkers.length > 0 || coordinatorNarration) && (

--- a/src/ui/modal-host.tsx
+++ b/src/ui/modal-host.tsx
@@ -24,7 +24,7 @@ import { InboxModal } from "./inbox-modal.js";
 import { MultiAgentModal, type MultiAgentSettings } from "./multi-agent-modal.js";
 import { HooksDashboard } from "./hooks-dashboard.js";
 import { HelpMenu } from "./help-menu.js";
-import { PlanCompletePicker, type PlanCompleteChoice } from "./plan-complete-picker.js";
+
 import type { Theme } from "./theme.js";
 import type { ModalHostController } from "./use-modal-host.js";
 import type { CustomCommand } from "../commands/types.js";
@@ -122,8 +122,6 @@ export interface ModalHostProps {
   // Skills picker
   onSkillsAction: (action: string) => void;
   onSkillsDone: () => void;
-  // Plan complete picker
-  onPlanCompletePick: (choice: PlanCompleteChoice | null) => void;
 }
 
 /**
@@ -436,16 +434,6 @@ export function ModalHost(props: ModalHostProps): React.ReactElement | null {
       <ThemeProvider theme={theme}>
         <Box flexDirection="column">
           <ModePicker current={props.currentMode} onPick={props.onPickMode} multiAgentEnabled={props.multiAgentEnabled} />
-        </Box>
-      </ThemeProvider>
-    );
-  }
-
-  if (modals.showPlanCompletePicker) {
-    return (
-      <ThemeProvider theme={theme}>
-        <Box flexDirection="column">
-          <PlanCompletePicker onPick={props.onPlanCompletePick} />
         </Box>
       </ThemeProvider>
     );

--- a/src/ui/use-modal-host.test.ts
+++ b/src/ui/use-modal-host.test.ts
@@ -86,4 +86,14 @@ describe("computeModalFlags", () => {
       hasAnyModal: true,
     });
   });
+
+  it("flags plan complete picker as overlay, not fullscreen", () => {
+    const f = computeModalFlags({
+      ...EMPTY_MODAL_STATE,
+      showPlanCompletePicker: true,
+    });
+    assert.strictEqual(f.hasOverlayModal, true);
+    assert.strictEqual(f.hasFullscreenModal, false);
+    assert.strictEqual(f.hasAnyModal, true);
+  });
 });

--- a/src/ui/use-modal-host.ts
+++ b/src/ui/use-modal-host.ts
@@ -257,9 +257,9 @@ export function computeModalFlags(s: ModalFlagsInput): ModalFlags {
     s.showMemoryPicker ||
     s.showGatewayPicker ||
     s.showSkillsPicker ||
-    s.showShellPicker ||
-    s.showPlanCompletePicker;
-  const hasOverlayModal = s.limitModal !== null || s.loopModal !== null;
+    s.showShellPicker;
+  const hasOverlayModal =
+    s.limitModal !== null || s.loopModal !== null || s.showPlanCompletePicker;
   return {
     hasFullscreenModal,
     hasOverlayModal,


### PR DESCRIPTION
## Summary

Fixes two issues with the plan-complete picker:

1. **Picker fills the whole screen and hides the chat/plan** — Moved  from a fullscreen modal (rendered inside ) to an inline overlay in the main  render tree. This matches the existing  /  pattern and keeps the chat view visible behind it.

2. **Selecting auto mode does not start execution** — After resetting the session and switching mode,  now calls  to automatically kick off the first agent turn. Previously the plan was silently pushed to  but never submitted, so the user had to type a message manually.

## Changes

-  —  is now an overlay modal instead of fullscreen.
-  — Removed  and its  prop.
-  — Added inline  render branch;  now auto-submits via .
-  — Added test asserting overlay (not fullscreen) flag.