### PR TITLE
fix(ui): prevent blank screen when PlanCompletePicker opens after plan mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2066,6 +2066,7 @@ function App({
         clearPermissionResolveRef();
         limitResolveRef.current = null;
         loopResolveRef.current = null;
+        setLimitModal(null);
         setLoopModal(null);
         pendingToolCallsRef.current.clear();
 

--- a/src/ui/use-modal-host.ts
+++ b/src/ui/use-modal-host.ts
@@ -146,9 +146,8 @@ export function useModalHost(): ModalHostController {
       showMemoryPicker ||
       showGatewayPicker ||
       showSkillsPicker ||
-      showShellPicker ||
-      showPlanCompletePicker;
-    const hasOverlayModal = limitModal !== null || loopModal !== null;
+      showShellPicker;
+    const hasOverlayModal = limitModal !== null || loopModal !== null || showPlanCompletePicker;
     return {
       hasFullscreenModal,
       hasOverlayModal,


### PR DESCRIPTION
## Problem

Commit `7724f13` moved PlanCompletePicker from a fullscreen ModalHost modal to an inline overlay in app.tsx, but the useModalHost() hook's inline flags calculation was never updated. showPlanCompletePicker is still included in hasFullscreenModal, so when plan mode finishes:

1. setShowPlanCompletePicker(true) fires
2. hasFullscreenModal becomes true
3. app.tsx returns <ModalHost … /> early
4. ModalHost no longer renders PlanCompletePicker (it was removed there)
5. ModalHost falls through and returns null
6. User sees a completely blank screen

Additionally, cleanupTurn() clears limitResolveRef.current but never calls setLimitModal(null). If the agent hit the 50-tool limit during plan mode, the stale limitModal blocks the picker with ModalOverlay instead.

## Changes

- src/ui/use-modal-host.ts: Move showPlanCompletePicker from hasFullscreenModal to hasOverlayModal in the inline flags calculation, matching the already-correct computeModalFlags helper.
- src/app.tsx: Add setLimitModal(null) inside cleanupTurn() so limit modals don't leak across turns.

## Testing

- npm run typecheck passes.
- src/ui/use-modal-host.test.ts already asserts showPlanCompletePicker → hasOverlayModal: true, hasFullscreenModal: false.