### PR TITLE
fix(agent): strengthen tasks_set prompt and add heuristic auto-advance

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -453,6 +453,19 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   let budgetExhausted = false;
   let loopExhausted = false;
 
+  // Task auto-advance heuristic: track tasks state and mutating tools since
+  // the last tasks_set so we can nudge the UI forward when the model forgets.
+  let currentTasks: Task[] = [];
+  let mutatingToolsSinceLastTasksSet = 0;
+  const MUTATING_TOOLS = new Set(["write", "edit", "bash"]);
+  const AUTO_ADVANCE_THRESHOLD = 3;
+  const originalOnTasks = opts.callbacks.onTasks;
+  const wrappedOnTasks = (tasks: Task[]) => {
+    currentTasks = tasks;
+    mutatingToolsSinceLastTasksSet = 0;
+    originalOnTasks?.(tasks);
+  };
+
   while (true) {
     // Budget enforcement: before starting a new turn, if we've already hit the
     // limit, run one final synthesis turn and then signal budget exhaustion.
@@ -719,7 +732,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
     }
 
     let blockedCount = 0;
-    for (const tc of toolCalls) {
+    for (const [i, tc] of toolCalls.entries()) {
       if (opts.signal.aborted) throw new DOMException("aborted", "AbortError");
 
       // Anti-loop guardrail
@@ -838,7 +851,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           tools: opts.tools,
           executor: opts.executor,
           askPermission: opts.callbacks.askPermission,
-          ctx: { cwd: opts.cwd, signal: opts.signal, onTasks: opts.callbacks.onTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId, githubToken: opts.githubToken },
+          ctx: { cwd: opts.cwd, signal: opts.signal, onTasks: wrappedOnTasks, coauthor: opts.coauthor, memoryManager: opts.memoryManager, sessionId: opts.sessionId, githubToken: opts.githubToken },
           timeoutMs: 30000,
           memoryLimitMB: 128,
         });
@@ -912,7 +925,7 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
           {
             cwd: opts.cwd,
             signal: opts.signal,
-            onTasks: opts.callbacks.onTasks,
+            onTasks: wrappedOnTasks,
             coauthor: opts.coauthor,
             memoryManager: opts.memoryManager,
             sessionId: opts.sessionId,
@@ -1081,6 +1094,29 @@ export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
 
         recentToolCalls.push(loopSignature);
         if (recentToolCalls.length > LOOP_WINDOW) recentToolCalls.shift();
+      }
+
+      // Heuristic auto-advance: if the model has executed multiple mutating
+      // tools without calling tasks_set, nudge the task list forward so the
+      // UI stays honest. We only do this when tasks_set is not coming later
+      // in the same batch of tool calls.
+      if (MUTATING_TOOLS.has(tc.function.name)) {
+        mutatingToolsSinceLastTasksSet++;
+        const hasTasksSetComing = toolCalls.slice(i + 1).some((t) => t.function.name === "tasks_set");
+        if (!hasTasksSetComing && mutatingToolsSinceLastTasksSet >= AUTO_ADVANCE_THRESHOLD) {
+          const inProgressIdx = currentTasks.findIndex((t) => t.status === "in_progress");
+          const nextPendingIdx = currentTasks.findIndex((t) => t.status === "pending");
+          if (inProgressIdx !== -1 && nextPendingIdx !== -1) {
+            const updated = currentTasks.map((t, idx) => {
+              if (idx === inProgressIdx) return { ...t, status: "completed" as const };
+              if (idx === nextPendingIdx) return { ...t, status: "in_progress" as const };
+              return t;
+            });
+            currentTasks = updated;
+            mutatingToolsSinceLastTasksSet = 0;
+            wrappedOnTasks(updated);
+          }
+        }
       }
     }
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -64,7 +64,7 @@ How to work:
 - Prefer calling tools over guessing. Read files before editing them. Use \`glob\` and \`grep\` to explore code before assuming structure.
 - Before any mutating tool call (write, edit, bash), state in one short sentence what you're about to do, then call the tool. The user will be asked to approve each mutating call.
 - When the user asks for a change, make the change. Do not paste code in chat that you could apply with \`edit\` or \`write\`.
-- For multi-step work, call \`tasks_set\` at the start with a short task list (one task "in_progress", the rest "pending"), then call it again after each step completes (flip that one to "completed" and the next to "in_progress"). Skip it for trivial single-step requests.
+- When working through a multi-step task list, you MUST call \`tasks_set\` **immediately before starting each new step** and **immediately after completing each step**. Do not execute mutating tools (\`write\`, \`edit\`, \`bash\`) without updating task progress first. Skip \`tasks_set\` for trivial single-step requests.
 - Keep responses terse. The user sees tool calls and their results inline — do not re-summarize them unless asked.
 - If a tool returns an error, read it carefully and adjust; do not retry the same call blindly.
 - Read as much of a file as needed rather than guessing; your context window is large enough to absorb whole files.


### PR DESCRIPTION
## Problem

The task-update UI lag is purely a model-behavior issue: the LLM doesn't call `tasks_set` frequently enough. It emits batches of mutating tool calls without updating progress, then forgets until much later.

## Changes

### Option 1: Stronger system prompt
Changed the soft instruction in `src/agent/system-prompt.ts` to imperative language:
> When working through a multi-step task list, you MUST call `tasks_set` **immediately before starting each new step** and **immediately after completing each step**. Do not execute mutating tools (`write`, `edit`, `bash`) without updating task progress first.

### Option 2: Heuristic auto-advance
Added a lightweight fallback in `src/agent/loop.ts`:
- Tracks mutating tools since the last `tasks_set`
- After **3** mutating tools without a `tasks_set`, automatically flips the current `in_progress` task to `completed` and the next `pending` to `in_progress`
- Only fires when no `tasks_set` is coming later in the same batch
- This keeps the UI honest even when the model forgets to update progress

## Verification
- `npm run typecheck` passes
- `npm test -- src/agent/system-prompt.test.ts src/agent/loop.test.ts` passes