### PR TITLE
feat(usage): carry over cost baseline on /fresh

### DIFF
--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -20,6 +20,7 @@ import type { GatewayMeta } from "../agent/client.js";
 import type { Mode } from "../mode.js";
 import type { DailyUsage } from "../usage-tracker.js";
 import {
+  carryOverSessionBaseline,
   formatCostReport,
   formatFeatureBreakdown,
   formatGatewaySection,
@@ -235,6 +236,9 @@ const handleFresh: Handler = (ctx) => {
 
   const clipResult = writeToClipboard(plan);
 
+  // Capture old session ID before reset so we can carry its cost forward
+  const oldSessionId = ctx.sessionIdRef.current;
+
   // Reset session (reuse /clear logic)
   if (ctx.cacheStableRef.current && ctx.messagesRef.current.length >= 2) {
     ctx.messagesRef.current = [ctx.messagesRef.current[0]!, ctx.messagesRef.current[1]!];
@@ -263,6 +267,14 @@ const handleFresh: Handler = (ctx) => {
 
   // Seed with plan
   ctx.messagesRef.current.push({ role: "user", content: plan });
+
+  // Force creation of the new session ID and carry over the old cost baseline
+  const newSessionId = ctx.ensureSessionId() as string;
+  if (oldSessionId) {
+    void carryOverSessionBaseline(oldSessionId, newSessionId).then(() => {
+      void getCostReport(newSessionId).then((report) => ctx.setSessionUsage(report.session));
+    });
+  }
 
   setEvents((e) => [
     ...e,

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -67,6 +67,9 @@ export interface SessionUsage {
   gatewayCost?: number;
   gatewayLogs?: GatewayUsageSnapshot[];
   turns?: TurnCost[];
+  /** Carried-over cost from a previous session (e.g. after /fresh). Hidden
+   *  bookkeeping — added to the session display but NOT to daily aggregates. */
+  baselineCost?: number;
   // Cost attribution fields
   category?: string;
   confidence?: number;
@@ -446,7 +449,7 @@ export async function getCostReport(sessionId?: string): Promise<CostReport> {
         promptTokens: rawSession.promptTokens,
         completionTokens: rawSession.completionTokens,
         cachedTokens: rawSession.cachedTokens,
-        cost: rawSession.cost,
+        cost: rawSession.cost + (rawSession.baselineCost ?? 0),
         gatewayRequests: rawSession.gatewayRequests,
         gatewayCachedRequests: rawSession.gatewayCachedRequests,
         gatewayCost: rawSession.gatewayCost,
@@ -498,6 +501,28 @@ export async function getCostReport(sessionId?: string): Promise<CostReport> {
   }
 
   return { session, today: todayUsage, month: monthUsage, allTime };
+}
+
+/** Copy the displayed cost from an old session into a new session as a hidden
+ *  baseline. Used by `/fresh` so the status-bar dollar amount stays continuous
+ *  across session resets. The baseline is added to the session display only —
+ *  it does NOT affect today/month/allTime aggregates. */
+export async function carryOverSessionBaseline(
+  fromSessionId: string,
+  toSessionId: string,
+): Promise<void> {
+  await withLock(async () => {
+    const log = pruneUsageLog(await loadLog());
+    const fromSession = log.sessions.find((s) => s.id === fromSessionId);
+    const baseline = fromSession
+      ? Math.max(0, fromSession.cost + (fromSession.baselineCost ?? 0))
+      : 0;
+
+    const toSession = getOrCreateSession(log, toSessionId, today());
+    toSession.baselineCost = baseline;
+
+    await saveLog(log);
+  });
 }
 
 function hasPendingReconcile(session: SessionUsage): boolean {


### PR DESCRIPTION
When `/fresh` resets the session for plan→implement transitions, the status-bar dollar amount now stays continuous instead of dropping to `$0.00`.

## Changes

- **`src/usage-tracker.ts`**
  - Add `baselineCost` to `SessionUsage` — hidden bookkeeping only, not added to daily aggregates
  - `carryOverSessionBaseline()` snapshots the old session's displayed cost (including any prior baseline) into the new session
  - `getCostReport()` adds baseline to session display but leaves today/month/allTime untouched

- **`src/ui/slash-commands.ts`**
  - Wire `/fresh` handler to capture old session ID before reset
  - Force new session ID creation after pushing the plan message
  - Carry the baseline over immediately and refresh `sessionUsage` state

## Edge cases handled

| Case | Mitigation |
|------|-----------|
| Multiple `/fresh` in a row | Baseline = `cost + baselineCost` (displayed total) |
| Session not yet in `usage.json` | Graceful fallback to 0 |
| New session ID doesn't exist yet | `ensureSessionId()` forces creation |
| Race with `recordUsage` | `withLock` serializes writes |
| Old session later pruned | Baseline is a snapshot — safe |
| Negative baseline | `Math.max(0, ...)` |

## Testing

- `npm run typecheck` ✅
- `src/util/usage-tracker.test.ts` ✅ (7/7)

Co-authored-by: kimiflare <kimiflare@proton.me>