### PR TITLE
feat(agent): increase default tool-call limit from 50 to 200

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -258,7 +258,7 @@ function raceWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T>
 export async function runAgentTurn(opts: AgentTurnOpts): Promise<void> {
   const turnStart = performance.now();
   logger.info("turn:start", { sessionId: opts.sessionId, codeMode: opts.codeMode ?? false });
-  const max = opts.maxToolIterations ?? 50;
+  const max = opts.maxToolIterations ?? 200;
   const codeMode = opts.codeMode ?? false;
 
   // M6.1: fire the Stop hook on any clean exit (turn ended normally,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2019,7 +2019,7 @@ function App({
         onToolLimitReached: () =>
           new Promise<LimitDecision>((resolve) => {
             limitResolveRef.current = resolve;
-            setLimitModal({ limit: 50, resolve });
+            setLimitModal({ limit: 200, resolve });
           }),
         onLoopDetected: () =>
           new Promise<LoopDecision>((resolve) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,7 @@ program
   .option("-m, --model <id>", "model id (defaults to @cf/moonshotai/kimi-k2.6)")
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")
   .option("--reasoning", "include reasoning in stdout (print mode only)")
-  .option("--continue-on-limit", "reset tool-call counter and continue when the 50-call limit is hit (print mode only)")
+  .option("--continue-on-limit", "reset tool-call counter and continue when the 200-call limit is hit (print mode only)")
   .option("--max-input-tokens <n>", "cumulative prompt token budget; exits 42 when exhausted (print mode only)", (v) => parseInt(v, 10))
   .option("--emit-events", "emit Camouflage NDJSON events to stdout; requires -p (for initial prompt)")
   .option("--multi-turn", "with --emit-events: keep reading stdin for UserInputSubmitted follow-ups after the initial turn")

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -887,7 +887,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
           onToolLimitReached: async () => {
             const r = await confirm(cam, {
               id: `lim-${Date.now()}`,
-              prompt: "Tool-call limit reached (50). Continue running?",
+              prompt: "Tool-call limit reached (200). Continue running?",
               yes_label: "Continue",
               no_label: "Stop turn",
               default: "no",

--- a/src/ui/use-modal-host.test.ts
+++ b/src/ui/use-modal-host.test.ts
@@ -15,7 +15,7 @@ describe("computeModalFlags", () => {
   it("flags limit overlay only", () => {
     const f = computeModalFlags({
       ...EMPTY_MODAL_STATE,
-      limitModal: { limit: 50, resolve: () => {} },
+      limitModal: { limit: 200, resolve: () => {} },
     });
     assert.strictEqual(f.hasOverlayModal, true);
     assert.strictEqual(f.hasFullscreenModal, false);
@@ -77,7 +77,7 @@ describe("computeModalFlags", () => {
   it("combines flags when both overlay and fullscreen are open", () => {
     const f = computeModalFlags({
       ...EMPTY_MODAL_STATE,
-      limitModal: { limit: 50, resolve: () => {} },
+      limitModal: { limit: 200, resolve: () => {} },
       showLspWizard: true,
     });
     assert.deepStrictEqual(f, {


### PR DESCRIPTION
The 50-call ceiling was too conservative for modern agent workflows. Bump the default to 200 while keeping the limit-modal safeguard so users can still intervene if a runaway loop occurs.