### PR TITLE
fix(plan-mode): preserve original plan across follow-up discussion

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -464,6 +464,8 @@ function App({
   }, []);
   const sessionStartRecallRef = useRef<Promise<import("./memory/schema.js").HybridResult[]> | null>(null);
   const kimiMdStaleNudgedRef = useRef(false);
+  /** Stores the plan distilled from a plan-mode session so it survives follow-up discussion. */
+  const sessionPlanRef = useRef<string | null>(null);
 
   const sessionMgr = useSessionManager({
     cfg,
@@ -1243,8 +1245,9 @@ function App({
       setShowPlanCompletePicker(false);
       if (!picked || picked === "continue") return;
 
-      // Replicate /fresh logic
-      const plan = distillSessionPlan(messagesRef.current);
+      // Use the plan captured when the picker was first shown so follow-up
+      // discussion doesn't bury the original plan in message history.
+      const plan = sessionPlanRef.current ?? distillSessionPlan(messagesRef.current);
       if (!plan) {
         setEvents((e) => [
           ...e,
@@ -1281,6 +1284,7 @@ function App({
       clearTaskTracking();
       compactSuggestedRef.current = false;
       updateNudgedRef.current = false;
+      sessionPlanRef.current = null;
 
       setEvents((e) => [
         ...e,
@@ -1526,6 +1530,7 @@ function App({
     compiledContextRef,
     lastApiErrorRef,
     activeScopeRef,
+    sessionPlanRef,
   }), [
     exit, busy, cfg, mode, lspScope, lspProjectPath,
     setCfg, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta,
@@ -2280,6 +2285,7 @@ function App({
             if (modeRef.current === "plan") {
               const plan = distillSessionPlan(messagesRef.current);
               if (plan) {
+                sessionPlanRef.current = plan;
                 setShowPlanCompletePicker(true);
               }
             }

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -205,6 +205,8 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
   let currentThemeName = "everforest-dark";
   const branch = tryGitBranch();
   let currentSessionFilePath: string | null = null;
+  /** Stores the plan distilled from a plan-mode session so it survives follow-up discussion. */
+  let sessionPlan: string | null = null;
 
   // Multi-agent (experimental): the mode is hidden from the cycle unless
   // explicitly enabled. We honor the env var directly in addition to the
@@ -1028,6 +1030,15 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
       cam.send("StatusUpdate", { segments: { elapsed: "" } });
       kimiLog({ dir: "turn", phase: "end" });
 
+      // If the turn completed in plan mode and produced a substantive plan,
+      // capture it so follow-up discussion doesn't bury the original plan.
+      if (currentMode === "plan" && !currentController?.signal.aborted) {
+        const plan = distillSessionPlan(messages);
+        if (plan) {
+          sessionPlan = plan;
+        }
+      }
+
       if (planOptionsRef.current && !currentController?.signal.aborted) {
         const options = planOptionsRef.current;
         planOptionsRef.current = null;
@@ -1058,6 +1069,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
             promptTokens = 0;
             cachedTokens = 0;
             completionTokens = 0;
+            sessionPlan = null;
             cam.send("TranscriptCleared", {});
             cam.send("StatusUpdate", {
               segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },
@@ -1679,6 +1691,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
         promptTokens = 0;
         cachedTokens = 0;
         completionTokens = 0;
+        sessionPlan = null;
         cam.send("TranscriptCleared", {});
         cam.send("StatusUpdate", {
           segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },
@@ -2335,7 +2348,9 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
           cam.send("ShowToast", { text: "can't /fresh while model is running — press Esc to interrupt first", kind: "warn", ttl_ms: 2500 });
           return true;
         }
-        const plan = distillSessionPlan(messages);
+        // Prefer the plan captured when plan-mode completed so follow-up
+        // discussion doesn't bury the original plan in message history.
+        const plan = sessionPlan ?? distillSessionPlan(messages);
         if (!plan) {
           cam.send("ShowToast", { text: "No plan found to start fresh with.", kind: "error", ttl_ms: 2500 });
           return true;
@@ -2349,6 +2364,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
         promptTokens = 0;
         cachedTokens = 0;
         completionTokens = 0;
+        sessionPlan = null;
         cam.send("TranscriptCleared", {});
         cam.send("StatusUpdate", {
           segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -168,6 +168,7 @@ export interface SlashContext {
   compiledContextRef: React.MutableRefObject<boolean>;
   lastApiErrorRef: React.MutableRefObject<{ httpStatus?: number; code?: number; message: string } | null>;
   activeScopeRef: React.MutableRefObject<AbortScope | null>;
+  sessionPlanRef: React.MutableRefObject<string | null>;
 }
 
 type Handler = (ctx: SlashContext, rest: string[], arg: string) => boolean;
@@ -212,6 +213,7 @@ const handleClear: Handler = (ctx) => {
   ctx.clearTaskTracking();
   ctx.compactSuggestedRef.current = false;
   ctx.updateNudgedRef.current = false;
+  ctx.sessionPlanRef.current = null;
   return true;
 };
 
@@ -244,6 +246,7 @@ export function executeFreshStart(ctx: SlashContext, planText: string): { succes
   ctx.clearTaskTracking();
   ctx.compactSuggestedRef.current = false;
   ctx.updateNudgedRef.current = false;
+  ctx.sessionPlanRef.current = null;
 
   // Seed with plan
   ctx.messagesRef.current.push({ role: "user", content: planText });
@@ -269,7 +272,9 @@ const handleFresh: Handler = (ctx) => {
     return true;
   }
 
-  const plan = distillSessionPlan(ctx.messagesRef.current);
+  // Prefer the plan captured when plan-mode completed so follow-up discussion
+  // doesn't bury the original plan in message history.
+  const plan = ctx.sessionPlanRef.current ?? distillSessionPlan(ctx.messagesRef.current);
   if (!plan) {
     setEvents((e) => [
       ...e,


### PR DESCRIPTION
When a plan-mode session completes, we now capture the distilled plan in a dedicated ref/variable instead of re-distilling it from message history every time the user wants to execute.

Previously, if the user chose "continue" in the plan-complete picker and asked follow-up questions, new assistant messages would bury the original plan. Later, when the user switched to execute mode or ran /fresh, `distillSessionPlan()` would return the latest follow-up response instead of the original plan, causing the agent to lose the plan entirely.

## Changes

- **app.tsx**: add `sessionPlanRef`, capture plan when plan-complete picker is first shown, use stored plan in `handlePlanCompletePick` and `/fresh`
- **ui-mode.ts**: add `sessionPlan` variable, capture plan after plan-mode turns, use stored plan in `/fresh`
- **slash-commands.ts**: add `sessionPlanRef` to `SlashContext`, use it in `handleFresh` and clear it in `handleClear` / `executeFreshStart`

Fixes the bug where follow-up discussion in plan mode would cause the original plan to be lost.