### PR TITLE
fix(ui): rebuild system prompt when switching from plan to execution mode

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -135,6 +135,7 @@ import {
   mkAssistantId,
   mkKey,
   openBrowser,
+  rebuildSystemPromptForMode,
   trackRecentFile,
 } from "./ui/app-helpers.js";
 
@@ -1303,6 +1304,13 @@ function App({
 
       setMode(picked);
       modeRef.current = picked;
+      rebuildSystemPromptForMode(
+        messagesRef.current,
+        cacheStableRef.current,
+        cfg?.model ?? DEFAULT_MODEL,
+        picked,
+        [...ALL_TOOLS, ...mcpToolsRef.current, ...lspToolsRef.current],
+      );
       submitRef.current(plan);
     },
     [mkKey, setShowPlanCompletePicker, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta, clearTaskTracking, resetSession, submitRef],

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -44,6 +44,7 @@ import { classifyIntent } from "./intent/classify.js";
 import { deployCommute, teardownCommute, findExistingCommuteWorkers } from "./remote/deploy-commute.js";
 import type { AiGatewayOptions } from "./agent/client.js";
 import { buildSystemPrompt } from "./agent/system-prompt.js";
+import { rebuildSystemPromptForMode } from "./ui/app-helpers.js";
 import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
 import type { ChatMessage } from "./agent/messages.js";
 import { KimiApiError, humanizeCloudflareError } from "./util/errors.js";
@@ -1074,6 +1075,15 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
             cam.send("StatusUpdate", {
               segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },
             });
+            // Rebuild system prompt for the current mode so the agent sees
+            // the correct instructions instead of a stale plan-mode prompt.
+            rebuildSystemPromptForMode(
+              messages,
+              false, // Camouflage UI always uses single system message
+              opts.model,
+              currentMode,
+              ALL_TOOLS,
+            );
             // Seed with plan
             messages.push({ role: "user", content: selected.plan });
             cam.send("UserMessageCreated", { text: selected.plan });
@@ -2369,6 +2379,15 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
         cam.send("StatusUpdate", {
           segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },
         });
+        // Rebuild system prompt for the current mode so the agent sees
+        // the correct instructions instead of a stale plan-mode prompt.
+        rebuildSystemPromptForMode(
+          messages,
+          false, // Camouflage UI always uses single system message
+          opts.model,
+          currentMode,
+          ALL_TOOLS,
+        );
         // Seed with plan
         messages.push({ role: "user", content: plan });
         cam.send("ShowToast", {

--- a/src/ui/app-helpers.ts
+++ b/src/ui/app-helpers.ts
@@ -303,6 +303,33 @@ export function makePrefixMessages(
   ];
 }
 
+/**
+ * Rebuild the system prompt message(s) in `messages` to match `mode`.
+ * Must be called synchronously before starting a new turn after a mode
+ * change, because the React effect that updates the system prompt may
+ * not have fired yet.
+ */
+export function rebuildSystemPromptForMode(
+  messages: ChatMessage[],
+  cacheStable: boolean,
+  model: string,
+  mode: Mode,
+  tools: ToolSpec[],
+): void {
+  if (cacheStable) {
+    const rebuilt = buildSystemMessages({ cwd: process.cwd(), tools, model, mode });
+    messages[0] = rebuilt[0]!;
+    if (rebuilt[1]) {
+      messages[1] = rebuilt[1];
+    }
+  } else {
+    messages[0] = {
+      role: "system",
+      content: buildSystemPrompt({ cwd: process.cwd(), tools, model, mode }),
+    };
+  }
+}
+
 // ── Image-path extraction ────────────────────────────────────────────────
 
 export function findImagePaths(text: string): string[] {

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -49,7 +49,7 @@ import {
   serializeArtifactStore,
   type SessionState,
 } from "../agent/session-state.js";
-import type { ToolExecutor } from "../tools/executor.js";
+import { ALL_TOOLS, type ToolExecutor } from "../tools/executor.js";
 import type { ToolSpec } from "../tools/registry.js";
 import type { McpManager } from "../mcp/manager.js";
 import type { LspManager } from "../lsp/manager.js";
@@ -72,6 +72,7 @@ import {
   FEEDBACK_WORKER_URL,
   formatTokens,
   openBrowser,
+  rebuildSystemPromptForMode,
 } from "./app-helpers.js";
 import { startRemoteSession, streamRemoteProgress } from "../remote/worker-client.js";
 import { saveRemoteSession, type RemoteSession } from "../remote/session-store.js";
@@ -247,6 +248,16 @@ export function executeFreshStart(ctx: SlashContext, planText: string): { succes
   ctx.compactSuggestedRef.current = false;
   ctx.updateNudgedRef.current = false;
   ctx.sessionPlanRef.current = null;
+
+  // Rebuild system prompt for the current mode so the agent sees the
+  // correct instructions (e.g. auto mode) instead of a stale plan-mode prompt.
+  rebuildSystemPromptForMode(
+    ctx.messagesRef.current,
+    ctx.cacheStableRef.current,
+    ctx.cfg?.model ?? "@cf/moonshotai/kimi-k2.6",
+    ctx.mode,
+    [...ALL_TOOLS, ...ctx.mcpToolsRef.current, ...ctx.lspToolsRef.current],
+  );
 
   // Seed with plan
   ctx.messagesRef.current.push({ role: "user", content: planText });


### PR DESCRIPTION
## Problem

When a plan-mode session completes and the user chooses to execute (auto/edit) or runs `/fresh`, the agent was receiving a **stale plan-mode system prompt** that says:

> "PLAN MODE is active… Do not call write, edit, or mutating bash commands."

PR #566 fixed plan *text* preservation (`sessionPlanRef`) so follow-up discussion doesn't bury the original plan, but it **did not fix the stale system prompt**.

## Root Cause

The React `useEffect` that rebuilds the system prompt when `mode` changes fires asynchronously. However, `submitRef.current(plan)` starts the agent turn **immediately in the same tick** — before the effect has a chance to update the prompt. The agent sees the old plan-mode instructions and refuses to execute.

## Fix

Add a synchronous `rebuildSystemPromptForMode()` helper in `ui/app-helpers.ts` that rebuilds the system message(s) in `messagesRef.current` for the current mode. Call it in every path where we reset the session and start fresh with a plan:

- `app.tsx` `handlePlanCompletePick` (Ink PlanCompletePicker)
- `ui/slash-commands.ts` `executeFreshStart` (used by `/fresh` and `present_plan_options`)
- `ui-mode.ts` `/fresh` handler (Camouflage UI)
- `ui-mode.ts` plan-options picker (Camouflage UI)

## Files Changed

- `src/ui/app-helpers.ts` — new `rebuildSystemPromptForMode` helper
- `src/app.tsx` — call helper in `handlePlanCompletePick`
- `src/ui/slash-commands.ts` — call helper in `executeFreshStart`
- `src/ui-mode.ts` — call helper in `/fresh` and plan-options picker

Co-authored-by: kimiflare <kimiflare@proton.me>