### PR TITLE
feat(agent): mode-aware /fresh with continuation summaries

### DIFF
--- a/src/agent/continuation-summary.ts
+++ b/src/agent/continuation-summary.ts
@@ -1,0 +1,197 @@
+import { execSync } from "node:child_process";
+import { runKimi } from "./client.js";
+import type { AiGatewayOptions } from "./client.js";
+import type { ChatMessage } from "./messages.js";
+import type { Mode } from "../mode.js";
+import type { MemoryManager } from "../memory/manager.js";
+import { distillSessionPlan } from "./distill.js";
+
+export interface ContinuationSummaryOpts {
+  messages: ChatMessage[];
+  mode: Mode;
+  accountId: string;
+  apiToken: string;
+  model: string;
+  gateway?: AiGatewayOptions;
+  memoryManager?: MemoryManager | null;
+  memoryEnabled?: boolean;
+  signal?: AbortSignal;
+}
+
+const HANDOFF_SYSTEM = `You are a session-continuation engine. Given evidence from a coding session, produce a dense handoff document so a new agent can pick up exactly where this one left off.
+
+Output format (use these exact headings):
+Goal: what the user originally asked for.
+Completed: files modified, tests added, key decisions, commits made.
+Remaining: what still needs to be done.
+Current state: any open errors, incomplete refactors, or pending work.
+Context: relevant file paths or architectural notes.
+
+Rules:
+- Be terse but complete. A new agent with zero prior context must be able to continue.
+- Do not include chat-style pleasantries.
+- Do not speculate beyond the evidence provided.
+- Aim for ~300-600 tokens.`;
+
+function extractFirstUserGoal(messages: ChatMessage[]): string {
+  const texts: string[] = [];
+  for (const m of messages) {
+    if (m.role !== "user") continue;
+    let text = "";
+    if (typeof m.content === "string") {
+      text = m.content;
+    } else if (Array.isArray(m.content)) {
+      text = m.content
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("\n");
+    }
+    text = text.trim();
+    if (text.length > 5) {
+      texts.push(text);
+      if (texts.length >= 3) break;
+    }
+  }
+  return texts.join("\n---\n");
+}
+
+function extractRecentAssistantMessages(messages: ChatMessage[], count = 3): string {
+  const texts: string[] = [];
+  for (let i = messages.length - 1; i >= 0 && texts.length < count; i--) {
+    const m = messages[i];
+    if (m?.role !== "assistant") continue;
+    let text = "";
+    if (typeof m.content === "string") {
+      text = m.content;
+    } else if (Array.isArray(m.content)) {
+      text = m.content
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("\n");
+    }
+    text = text.trim();
+    if (text.length > 10) {
+      texts.unshift(text);
+    }
+  }
+  return texts.join("\n---\n");
+}
+
+function gatherGitEvidence(): string {
+  const pieces: string[] = [];
+  try {
+    const branch = execSync("git branch --show-current", { cwd: process.cwd(), encoding: "utf8" }).trim();
+    if (branch) pieces.push(`Branch: ${branch}`);
+  } catch {
+    // ignore
+  }
+  try {
+    const log = execSync("git log --oneline -5", { cwd: process.cwd(), encoding: "utf8" }).trim();
+    if (log) pieces.push(`Recent commits:\n${log}`);
+  } catch {
+    // ignore
+  }
+  try {
+    const status = execSync("git status --short", { cwd: process.cwd(), encoding: "utf8" }).trim();
+    if (status) pieces.push(`Working tree changes:\n${status}`);
+  } catch {
+    // ignore
+  }
+  return pieces.join("\n\n");
+}
+
+async function gatherMemoryEvidence(
+  manager: MemoryManager,
+  enabled: boolean,
+  signal?: AbortSignal,
+): Promise<string> {
+  if (!enabled) return "";
+  try {
+    const cwd = process.cwd();
+    const results = await manager.recall({ text: cwd, repoPath: cwd, limit: 10 });
+    const highSignal = results.filter((r) =>
+      ["edit_event", "task", "instruction"].includes(r.memory.category),
+    );
+    if (highSignal.length === 0) return "";
+    const synthesized = await manager.synthesizeRecalled(highSignal, signal);
+    return synthesized ? `Recorded work log:\n${synthesized}` : "";
+  } catch {
+    return "";
+  }
+}
+
+async function runKimiText(opts: {
+  accountId: string;
+  apiToken: string;
+  model: string;
+  gateway?: AiGatewayOptions;
+  messages: ChatMessage[];
+  signal?: AbortSignal;
+}): Promise<string> {
+  const events = runKimi({
+    accountId: opts.accountId,
+    apiToken: opts.apiToken,
+    model: opts.model,
+    messages: opts.messages,
+    temperature: 0.1,
+    reasoningEffort: "low",
+    gateway: opts.gateway,
+    signal: opts.signal,
+  });
+  let text = "";
+  for await (const ev of events) {
+    if (ev.type === "text") text += ev.delta;
+  }
+  return text.trim();
+}
+
+/**
+ * Generate a mode-aware continuation summary for `/fresh`.
+ *
+ * - `plan` mode: returns the distilled plan text (fast, no LLM call).
+ * - `auto` / `edit` / `multi-agent-experimental`: gathers evidence and makes
+ *   one lightweight LLM call to produce a handoff document.
+ */
+export async function generateContinuationSummary(
+  opts: ContinuationSummaryOpts,
+): Promise<string | null> {
+  const { messages, mode } = opts;
+
+  if (mode === "plan") {
+    return distillSessionPlan(messages);
+  }
+
+  // For auto / edit / multi-agent-experimental, build a handoff document
+  const goal = extractFirstUserGoal(messages);
+  const recentAssistant = extractRecentAssistantMessages(messages);
+  const gitEvidence = gatherGitEvidence();
+  const memoryEvidence = opts.memoryManager
+    ? await gatherMemoryEvidence(opts.memoryManager, opts.memoryEnabled ?? false, opts.signal)
+    : "";
+
+  const evidenceParts: string[] = [];
+  if (goal) evidenceParts.push(`## Original goal(s)\n${goal}`);
+  if (recentAssistant) evidenceParts.push(`## Recent assistant messages\n${recentAssistant}`);
+  if (gitEvidence) evidenceParts.push(`## Git state\n${gitEvidence}`);
+  if (memoryEvidence) evidenceParts.push(`## ${memoryEvidence}`);
+
+  if (evidenceParts.length === 0) {
+    return null;
+  }
+
+  const userPrompt = evidenceParts.join("\n\n");
+
+  const summary = await runKimiText({
+    accountId: opts.accountId,
+    apiToken: opts.apiToken,
+    model: opts.model,
+    gateway: opts.gateway,
+    signal: opts.signal,
+    messages: [
+      { role: "system", content: HANDOFF_SYSTEM },
+      { role: "user", content: userPrompt },
+    ],
+  });
+
+  return summary || null;
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -108,6 +108,7 @@ import {
   type InterruptDeps,
 } from "./ui/input-handlers.js";
 import { dispatchSlashCommand, type SlashContext, executeFreshStart } from "./ui/slash-commands.js";
+import { generateContinuationSummary } from "./agent/continuation-summary.js";
 import { runInit as runInitImpl } from "./init/run-init.js";
 import { runStartupTasks } from "./ui/run-startup-tasks.js";
 import { initLsp as initLspImpl, initMcp as initMcpImpl } from "./ui/manager-init.js";
@@ -126,6 +127,7 @@ import {
   capEvents,
   compactEventsVisual,
   CONTEXT_LIMIT,
+  DEFAULT_AUTO_FRESH_SUGGESTION_TURNS,
   detectGitBranch,
   findImagePaths,
   gatewayFromConfig,
@@ -199,6 +201,8 @@ export interface Cfg {
   workerApiKey?: string;
   workerName?: string;
   autoExecute?: boolean;
+  autoFreshSuggestionTurns?: number;
+  autoFreshEnabled?: boolean;
 }
 function App({
   initialCfg,
@@ -441,6 +445,7 @@ function App({
   const compiledContextRef = useRef(initialCfg?.compiledContext === true);
   const updateNudgedRef = useRef(false);
   const compactSuggestedRef = useRef(false);
+  const freshSuggestedRef = useRef(false);
   const mcpManagerRef = useRef(new McpManager());
   const mcpToolsRef = useRef<ToolSpec[]>([]);
   const mcpInitRef = useRef(false);
@@ -470,6 +475,7 @@ function App({
 
   const sessionMgr = useSessionManager({
     cfg,
+    mode,
     messagesRef,
     sessionStateRef,
     artifactStoreRef,
@@ -1241,81 +1247,6 @@ function App({
     [mkKey, setShowUiPicker],
   );
 
-  const handlePlanCompletePick = useCallback(
-    (picked: PlanCompleteChoice | null) => {
-      setShowPlanCompletePicker(false);
-      if (!picked || picked === "continue") return;
-
-      // Use the plan captured when the picker was first shown so follow-up
-      // discussion doesn't bury the original plan in message history.
-      const plan = sessionPlanRef.current ?? distillSessionPlan(messagesRef.current);
-      if (!plan) {
-        setEvents((e) => [
-          ...e,
-          { kind: "error", key: mkKey(), text: "No plan found to start fresh with." },
-        ]);
-        setMode(picked);
-        return;
-      }
-
-      const clipResult = writeToClipboard(plan);
-
-      // Reset session (reuse /clear logic)
-      if (cacheStableRef.current && messagesRef.current.length >= 2) {
-        messagesRef.current = [messagesRef.current[0]!, messagesRef.current[1]!];
-      } else {
-        messagesRef.current = [messagesRef.current[0]!];
-      }
-      resetSession();
-      executorRef.current.clearArtifacts();
-      if (flushTimeoutRef.current) {
-        clearTimeout(flushTimeoutRef.current);
-        flushTimeoutRef.current = null;
-      }
-      pendingTextRef.current.clear();
-      activeAsstIdRef.current = null;
-      pendingToolCallsRef.current.clear();
-      usageRef.current = null;
-      turnCounterRef.current = 0;
-      setEvents([]);
-      setUsage(null);
-      setSessionUsage(null);
-      gatewayMetaRef.current = null;
-      setGatewayMeta(null);
-      clearTaskTracking();
-      compactSuggestedRef.current = false;
-      updateNudgedRef.current = false;
-      sessionPlanRef.current = null;
-
-      setEvents((e) => [
-        ...e,
-        {
-          kind: "info",
-          key: mkKey(),
-          text: clipResult.success
-            ? `Plan copied to clipboard. Starting fresh session in ${picked} mode with plan only…`
-            : `Clipboard unavailable. Starting fresh session in ${picked} mode with plan only…`,
-        },
-      ]);
-
-      if (!clipResult.success) {
-        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "--- Plan ---\n" + plan }]);
-      }
-
-      setMode(picked);
-      modeRef.current = picked;
-      rebuildSystemPromptForMode(
-        messagesRef.current,
-        cacheStableRef.current,
-        cfg?.model ?? DEFAULT_MODEL,
-        picked,
-        [...ALL_TOOLS, ...mcpToolsRef.current, ...lspToolsRef.current],
-      );
-      submitRef.current(plan);
-    },
-    [mkKey, setShowPlanCompletePicker, setMode, setEvents, setUsage, setSessionUsage, setGatewayMeta, clearTaskTracking, resetSession, submitRef],
-  );
-
   const handleModelPick = useCallback(
     (picked: ModelEntry | null) => {
       setShowModelPicker(false);
@@ -1532,6 +1463,7 @@ function App({
     sessionIdRef,
     compactSuggestedRef,
     updateNudgedRef,
+    freshSuggestedRef,
     memoryManagerRef,
     artifactStoreRef,
     sessionStateRef,
@@ -1552,8 +1484,49 @@ function App({
     initMcp, initLsp, ensureSessionId,
   ]);
 
+  const handlePlanCompletePick = useCallback(
+    (picked: PlanCompleteChoice | null) => {
+      setShowPlanCompletePicker(false);
+      if (!picked || picked === "continue") return;
+
+      // Use the plan captured when the picker was first shown so follow-up
+      // discussion doesn't bury the original plan in message history.
+      const plan = sessionPlanRef.current ?? distillSessionPlan(messagesRef.current);
+      if (!plan) {
+        setEvents((e) => [
+          ...e,
+          { kind: "error", key: mkKey(), text: "No plan found to start fresh with." },
+        ]);
+        setMode(picked);
+        return;
+      }
+
+      const clipResult = executeFreshStart(buildSlashContext(), plan, picked);
+
+      setEvents((e) => [
+        ...e,
+        {
+          kind: "info",
+          key: mkKey(),
+          text: clipResult.success
+            ? `Plan copied to clipboard. Starting fresh session in ${picked} mode with plan only…`
+            : `Clipboard unavailable. Starting fresh session in ${picked} mode with plan only…`,
+        },
+      ]);
+
+      if (!clipResult.success) {
+        setEvents((e) => [...e, { kind: "info", key: mkKey(), text: "--- Plan ---\n" + plan }]);
+      }
+
+      setMode(picked);
+      modeRef.current = picked;
+      submitRef.current(plan);
+    },
+    [mkKey, setShowPlanCompletePicker, setMode, setEvents, submitRef, buildSlashContext],
+  );
+
   const handleSlash = useCallback(
-    (cmd: string): boolean => dispatchSlashCommand(buildSlashContext(), cmd),
+    async (cmd: string): Promise<boolean> => dispatchSlashCommand(buildSlashContext(), cmd),
     [buildSlashContext],
   );
 
@@ -1624,7 +1597,7 @@ function App({
       if (trimmed.startsWith("/")) {
         const head = trimmed.split(/\s+/)[0]!.toLowerCase();
         const selfManaged = ["/compact", "/init"].includes(head);
-        if (handleSlash(trimmed)) {
+        if (await handleSlash(trimmed)) {
           if (!selfManaged) {
             endTurn();
           }
@@ -1779,6 +1752,70 @@ function App({
           ...e,
           { kind: "info", key: mkKey(), text: "Tip: Rerunning /init occasionally helps KimiFlare stay accurate as your project evolves." },
         ]);
+      }
+
+      // Auto-fresh suggestion for long auto/edit sessions
+      const autoFreshThreshold = cfg?.autoFreshSuggestionTurns ?? DEFAULT_AUTO_FRESH_SUGGESTION_TURNS;
+      if (
+        autoFreshThreshold > 0 &&
+        turnCounterRef.current >= autoFreshThreshold &&
+        (modeRef.current === "auto" || modeRef.current === "edit" || modeRef.current === "multi-agent-experimental") &&
+        !freshSuggestedRef.current
+      ) {
+        freshSuggestedRef.current = true;
+        if (cfg?.autoFreshEnabled) {
+          // Auto-execute /fresh after a silent checkpoint
+          void (async () => {
+            try {
+              const turnIndex = messagesRef.current.length;
+              if (turnIndex > 0) {
+                const cp: Checkpoint = {
+                  id: `cp_prefresh_${Date.now()}`,
+                  label: "pre-fresh auto-save",
+                  turnIndex,
+                  timestamp: new Date().toISOString(),
+                  sessionState: compiledContextRef.current ? sessionStateRef.current : undefined,
+                  artifactStore: serializeArtifactStore(artifactStoreRef.current),
+                };
+                ensureSessionId();
+                const { sessionsDir } = await import("./sessions.js");
+                const filePath = join(sessionsDir(), `${sessionIdRef.current}.json`);
+                await addCheckpoint(filePath, cp);
+              }
+              const summary = await generateContinuationSummary({
+                messages: messagesRef.current,
+                mode: modeRef.current,
+                accountId: cfg.accountId,
+                apiToken: cfg.apiToken,
+                model: cfg.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+                gateway: gatewayFromConfig(cfg),
+                memoryManager: memoryManagerRef.current,
+                memoryEnabled: cfg.memoryEnabled,
+              });
+              if (summary) {
+                executeFreshStart(buildSlashContext(), summary);
+                setEvents((e) => [
+                  ...e,
+                  { kind: "info", key: mkKey(), text: "Auto-fresh triggered: starting new session with continuation context…" },
+                ]);
+              }
+            } catch (e) {
+              setEvents((es) => [
+                ...es,
+                { kind: "error", key: mkKey(), text: `Auto-fresh failed: ${(e as Error).message}` },
+              ]);
+            }
+          })();
+        } else {
+          setEvents((e) => [
+            ...e,
+            {
+              kind: "info",
+              key: mkKey(),
+              text: `Session has run for ${turnCounterRef.current} turns. The model may slow down with accumulated context. Run /fresh to continue with a summarized state, or /compact to compress history.`,
+            },
+          ]);
+        }
       }
 
       gatewayMetaRef.current = null;

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -29,7 +29,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "checkpoints", description: "List checkpoints in current session", source: "builtin" },
   { name: "compact", description: "Summarize old turns to free context", source: "builtin" },
   { name: "clear", description: "Clear current conversation", source: "builtin" },
-  { name: "fresh", description: "Reset session and start fresh with the last plan", source: "builtin" },
+  { name: "fresh", description: "Start a fresh session with a summarized plan or continuation context", source: "builtin" },
   { name: "init", description: "Scan repo and write KIMI.md", source: "builtin" },
   { name: "remote", argHint: "<prompt>", description: "Run a remote session on Cloudflare", source: "builtin" },
   { name: "update", description: "Check for updates", source: "builtin" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,10 @@ export interface KimiConfig {
   workerTimeoutMs?: number;
   /** Enable multi-agent-experimental mode in the mode cycle. Default: false. */
   multiAgentEnabled?: boolean;
+  /** Turn count at which KimiFlare suggests /fresh in auto/edit mode. 0 = disabled. Default: 30. */
+  autoFreshSuggestionTurns?: number;
+  /** If true, automatically execute /fresh when the threshold is hit instead of just suggesting it. Default: false. */
+  autoFreshEnabled?: boolean;
   /** Bearer/secret for the worker endpoint (sent as X-Worker-Api-Key). */
   workerApiKey?: string;
   /** Name of the deployed multi-agent Worker. Used for tear-down. */

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -83,6 +83,7 @@ async function loadCamouflage() {
 import { listSessions, loadSession, addCheckpoint, loadSessionFromCheckpoint } from "./sessions.js";
 import { summarizeMessagesViaLlm } from "./agent/llm-summarize.js";
 import { distillSessionPlan } from "./agent/distill.js";
+import { generateContinuationSummary } from "./agent/continuation-summary.js";
 import { buildWelcome } from "./ui/greetings.js";
 import { themeList, resolveTheme } from "./ui/theme.js";
 import { checkForUpdate, checkOptionalDependency } from "./util/update-check.js";
@@ -116,6 +117,8 @@ export interface UiModeOpts {
   continueOnLimit?: boolean;
   maxInputTokens?: number;
   aiGatewayId?: string;
+  /** Model for internal plumbing tasks (memory verification, hypothetical queries, continuation summaries). Default: @cf/moonshotai/kimi-k2.5. */
+  plumbingModel?: string;
   /** Optional path to the camouflage-tui binary. Defaults to PATH lookup. */
   camouflageBin?: string;
   /** Optional multi-line ANSI text (e.g. the CLI logo) to pin above the
@@ -2358,48 +2361,57 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
           cam.send("ShowToast", { text: "can't /fresh while model is running — press Esc to interrupt first", kind: "warn", ttl_ms: 2500 });
           return true;
         }
-        // Prefer the plan captured when plan-mode completed so follow-up
-        // discussion doesn't bury the original plan in message history.
-        const plan = sessionPlan ?? distillSessionPlan(messages);
-        if (!plan) {
-          cam.send("ShowToast", { text: "No plan found to start fresh with.", kind: "error", ttl_ms: 2500 });
-          return true;
-        }
-        const clipResult = writeToClipboard(plan);
-        // Reset session (reuse /clear logic)
-        const systemMessages = messages.filter((m) => m.role === "system");
-        messages.length = 0;
-        messages.push(...systemMessages);
-        sessionCostUsd = 0;
-        promptTokens = 0;
-        cachedTokens = 0;
-        completionTokens = 0;
-        sessionPlan = null;
-        cam.send("TranscriptCleared", {});
-        cam.send("StatusUpdate", {
-          segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },
-        });
-        // Rebuild system prompt for the current mode so the agent sees
-        // the correct instructions instead of a stale plan-mode prompt.
-        rebuildSystemPromptForMode(
-          messages,
-          false, // Camouflage UI always uses single system message
-          opts.model,
-          currentMode,
-          ALL_TOOLS,
-        );
-        // Seed with plan
-        messages.push({ role: "user", content: plan });
-        cam.send("ShowToast", {
-          text: clipResult.success
-            ? "Plan copied to clipboard. Starting fresh session with plan only…"
-            : "Clipboard unavailable. Starting fresh session with plan only…",
-          kind: "info",
-          ttl_ms: 3000,
-        });
-        if (!clipResult.success) {
-          cam.send("UserMessageCreated", { text: "--- Plan ---\n" + plan });
-        }
+        // Mode-aware summary: plan mode uses the distilled plan;
+        // auto/edit/multi-agent produce a handoff document via LLM.
+        void (async () => {
+          const summary = await generateContinuationSummary({
+            messages,
+            mode: currentMode,
+            accountId: opts.accountId,
+            apiToken: opts.apiToken,
+            model: opts.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+            gateway: gatewayFromOpts(opts),
+          });
+          if (!summary) {
+            cam.send("ShowToast", { text: "No plan or summary found to start fresh with.", kind: "error", ttl_ms: 2500 });
+            return;
+          }
+          const clipResult = writeToClipboard(summary);
+          // Reset session (reuse /clear logic)
+          const systemMessages = messages.filter((m) => m.role === "system");
+          messages.length = 0;
+          messages.push(...systemMessages);
+          sessionCostUsd = 0;
+          promptTokens = 0;
+          cachedTokens = 0;
+          completionTokens = 0;
+          sessionPlan = null;
+          cam.send("TranscriptCleared", {});
+          cam.send("StatusUpdate", {
+            segments: { tokens: "in 0", cost: "$0.00", elapsed: "" },
+          });
+          // Rebuild system prompt for the current mode so the agent sees
+          // the correct instructions instead of a stale plan-mode prompt.
+          rebuildSystemPromptForMode(
+            messages,
+            false, // Camouflage UI always uses single system message
+            opts.model,
+            currentMode,
+            ALL_TOOLS,
+          );
+          // Seed with summary
+          messages.push({ role: "user", content: summary });
+          cam.send("ShowToast", {
+            text: clipResult.success
+              ? "Summary copied to clipboard. Starting fresh session with continuation context…"
+              : "Clipboard unavailable. Starting fresh session with continuation context…",
+            kind: "info",
+            ttl_ms: 3000,
+          });
+          if (!clipResult.success) {
+            cam.send("UserMessageCreated", { text: "--- Continuation Context ---\n" + summary });
+          }
+        })();
         return true;
       }
       case "logout": {

--- a/src/ui/app-helpers.ts
+++ b/src/ui/app-helpers.ts
@@ -28,6 +28,7 @@ const MAX_GITIGNORE_SIZE = 1 * 1024 * 1024; // 1 MB
 export const CONTEXT_LIMIT = 262_000;
 export const AUTO_COMPACT_THRESHOLD = 0.8;
 export const MAX_EVENTS = 500;
+export const DEFAULT_AUTO_FRESH_SUGGESTION_TURNS = 30;
 export const MAX_IMAGES_PER_MESSAGE = 10;
 export const FEEDBACK_WORKER_URL = "https://hello.kimiflare.com";
 

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -79,6 +79,7 @@ import { saveRemoteSession, type RemoteSession } from "../remote/session-store.j
 import { deployForTui } from "../remote/deploy.js";
 import { authGitHubForTui } from "../remote/tui-auth.js";
 import { distillSessionPlan } from "../agent/distill.js";
+import { generateContinuationSummary } from "../agent/continuation-summary.js";
 import { writeToClipboard } from "../util/clipboard.js";
 
 type SetEvents = React.Dispatch<React.SetStateAction<ChatEvent[]>>;
@@ -163,6 +164,7 @@ export interface SlashContext {
   sessionIdRef: React.MutableRefObject<string | null>;
   compactSuggestedRef: React.MutableRefObject<boolean>;
   updateNudgedRef: React.MutableRefObject<boolean>;
+  freshSuggestedRef: React.MutableRefObject<boolean>;
   memoryManagerRef: React.MutableRefObject<MemoryManager | null>;
   artifactStoreRef: React.MutableRefObject<ArtifactStore>;
   sessionStateRef: React.MutableRefObject<SessionState>;
@@ -172,7 +174,7 @@ export interface SlashContext {
   sessionPlanRef: React.MutableRefObject<string | null>;
 }
 
-type Handler = (ctx: SlashContext, rest: string[], arg: string) => boolean;
+type Handler = (ctx: SlashContext, rest: string[], arg: string) => boolean | Promise<boolean>;
 
 // ── Handlers ─────────────────────────────────────────────────────────────
 
@@ -214,11 +216,12 @@ const handleClear: Handler = (ctx) => {
   ctx.clearTaskTracking();
   ctx.compactSuggestedRef.current = false;
   ctx.updateNudgedRef.current = false;
+  ctx.freshSuggestedRef.current = false;
   ctx.sessionPlanRef.current = null;
   return true;
 };
 
-export function executeFreshStart(ctx: SlashContext, planText: string): { success: boolean } {
+export function executeFreshStart(ctx: SlashContext, planText: string, overrideMode?: Mode): { success: boolean } {
   // Capture old session ID before reset so we can carry its cost forward
   const oldSessionId = ctx.sessionIdRef.current;
 
@@ -247,6 +250,7 @@ export function executeFreshStart(ctx: SlashContext, planText: string): { succes
   ctx.clearTaskTracking();
   ctx.compactSuggestedRef.current = false;
   ctx.updateNudgedRef.current = false;
+  ctx.freshSuggestedRef.current = false;
   ctx.sessionPlanRef.current = null;
 
   // Rebuild system prompt for the current mode so the agent sees the
@@ -255,7 +259,7 @@ export function executeFreshStart(ctx: SlashContext, planText: string): { succes
     ctx.messagesRef.current,
     ctx.cacheStableRef.current,
     ctx.cfg?.model ?? "@cf/moonshotai/kimi-k2.6",
-    ctx.mode,
+    overrideMode ?? ctx.mode,
     [...ALL_TOOLS, ...ctx.mcpToolsRef.current, ...ctx.lspToolsRef.current],
   );
 
@@ -273,8 +277,8 @@ export function executeFreshStart(ctx: SlashContext, planText: string): { succes
   return writeToClipboard(planText);
 }
 
-const handleFresh: Handler = (ctx) => {
-  const { busy, mkKey, setEvents } = ctx;
+const handleFresh: Handler = async (ctx) => {
+  const { busy, mkKey, setEvents, cfg } = ctx;
   if (busy) {
     setEvents((e) => [
       ...e,
@@ -283,18 +287,36 @@ const handleFresh: Handler = (ctx) => {
     return true;
   }
 
-  // Prefer the plan captured when plan-mode completed so follow-up discussion
-  // doesn't bury the original plan in message history.
-  const plan = ctx.sessionPlanRef.current ?? distillSessionPlan(ctx.messagesRef.current);
-  if (!plan) {
+  // Mode-aware summary: plan mode uses the distilled plan;
+  // auto/edit/multi-agent produce a handoff document via LLM.
+  const summary = await generateContinuationSummary({
+    messages: ctx.messagesRef.current,
+    mode: ctx.mode,
+    accountId: cfg?.accountId ?? "",
+    apiToken: cfg?.apiToken ?? "",
+    model: cfg?.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+    gateway: cfg?.aiGatewayId
+      ? {
+          id: cfg.aiGatewayId,
+          cacheTtl: cfg.aiGatewayCacheTtl,
+          skipCache: cfg.aiGatewaySkipCache,
+          collectLogPayload: cfg.aiGatewayCollectLogPayload,
+          metadata: cfg.aiGatewayMetadata,
+        }
+      : undefined,
+    memoryManager: ctx.memoryManagerRef.current,
+    memoryEnabled: cfg?.memoryEnabled,
+  });
+
+  if (!summary) {
     setEvents((e) => [
       ...e,
-      { kind: "error", key: mkKey(), text: "No plan found to start fresh with." },
+      { kind: "error", key: mkKey(), text: "No plan or summary found to start fresh with." },
     ]);
     return true;
   }
 
-  const clipResult = executeFreshStart(ctx, plan);
+  const clipResult = executeFreshStart(ctx, summary);
 
   setEvents((e) => [
     ...e,
@@ -302,15 +324,15 @@ const handleFresh: Handler = (ctx) => {
       kind: "info",
       key: mkKey(),
       text: clipResult.success
-        ? "Plan copied to clipboard. Starting fresh session with plan only…"
-        : "Clipboard unavailable. Starting fresh session with plan only…",
+        ? "Summary copied to clipboard. Starting fresh session with continuation context…"
+        : "Clipboard unavailable. Starting fresh session with continuation context…",
     },
   ]);
 
   if (!clipResult.success) {
     setEvents((e) => [
       ...e,
-      { kind: "info", key: mkKey(), text: "--- Plan ---\n" + plan },
+      { kind: "info", key: mkKey(), text: "--- Continuation Context ---\n" + summary },
     ]);
   }
 
@@ -1672,7 +1694,7 @@ const handlers: Record<string, Handler> = {
  * command, false if `cmd` is unrecognized (so the caller can fall through
  * to custom-command lookup).
  */
-export function dispatchSlashCommand(ctx: SlashContext, cmd: string): boolean {
+export function dispatchSlashCommand(ctx: SlashContext, cmd: string): boolean | Promise<boolean> {
   const raw = cmd.trim();
   const [head, ...rest] = raw.split(/\s+/);
   const c = (head ?? "").toLowerCase();

--- a/src/ui/use-session-manager.ts
+++ b/src/ui/use-session-manager.ts
@@ -22,6 +22,8 @@ import { getCostReport } from "../usage-tracker.js";
 import type { DailyUsage } from "../usage-tracker.js";
 import type { ChatEvent } from "./chat.js";
 import { setLogSessionId } from "../util/log-sink.js";
+import type { Mode } from "../mode.js";
+import { DEFAULT_AUTO_FRESH_SUGGESTION_TURNS } from "./app-helpers.js";
 
 /**
  * Pull the first chunk of user text out of a message list — used to
@@ -44,7 +46,9 @@ export function extractFirstUserText(messages: ChatMessage[]): string {
 
 export interface SessionManagerDeps {
   /** Model name + other config needed at save time. Null while booting. */
-  cfg: { model: string } | null;
+  cfg: { model: string; autoFreshSuggestionTurns?: number } | null;
+  /** Current agent mode. */
+  mode: Mode;
   // Refs the hook needs to read/write at save and resume time. These
   // belong to the wider app (the agent loop mutates them too), so they're
   // injected rather than owned.
@@ -182,10 +186,31 @@ export function useSessionManager(deps: SessionManagerDeps): SessionManager {
           }
         }
 
+        const nonSystemCount = file.messages.filter((m) => m.role !== "system").length;
         const msg = checkpointId
           ? `resumed session ${file.id} from checkpoint`
-          : `resumed session ${file.id} (${file.messages.filter((m) => m.role !== "system").length} msgs)`;
+          : `resumed session ${file.id} (${nonSystemCount} msgs)`;
         d.setEvents([{ kind: "info", key: d.mkKey(), text: msg }]);
+
+        // Suggest /fresh for long auto/edit sessions resumed without a checkpoint
+        if (!checkpointId) {
+          const threshold = d.cfg?.autoFreshSuggestionTurns ?? DEFAULT_AUTO_FRESH_SUGGESTION_TURNS;
+          if (
+            threshold > 0 &&
+            nonSystemCount >= threshold &&
+            (d.mode === "auto" || d.mode === "edit" || d.mode === "multi-agent-experimental")
+          ) {
+            d.setEvents((es) => [
+              ...es,
+              {
+                kind: "info",
+                key: d.mkKey(),
+                text: `This session has ${nonSystemCount} turns. The model may slow down with accumulated context. Run /fresh to continue with a summarized state, or /compact to compress history.`,
+              },
+            ]);
+          }
+        }
+
         const userMsgs = file.messages
           .filter((m) => m.role === "user" && m.content)
           .map((m) => {


### PR DESCRIPTION
## Summary

This PR makes the `/fresh` command mode-aware and adds auto-fresh capabilities for long-running auto/edit sessions.

### What's new

- **Continuation summaries**: New `generateContinuationSummary()` produces dense handoff documents tailored to the current mode (auto/edit/plan/multi-agent). It gathers evidence from git state, memory, and recent messages to build a context-rich handoff.
- **Mode-aware /fresh**: When the user runs `/fresh`, the system now rebuilds the system prompt for the *current* mode and seeds the new session with a mode-appropriate summary instead of a generic plan.
- **Auto-fresh**: In auto, edit, and multi-agent modes, after a configurable number of turns (default: 30), the system can automatically suggest or execute `/fresh`. A silent checkpoint is saved before resetting.
- **Cost continuity**: Session cost baselines are carried over across fresh boundaries so `/cost` remains accurate.
- **New config options**:
  - `autoFreshEnabled` — whether to auto-execute fresh (default: false)
  - `autoFreshSuggestionTurns` — turn threshold for suggestion/auto-execution (default: 30)

### Files changed

- `src/agent/continuation-summary.ts` — new
- `src/app.tsx` — auto-fresh trigger, handoff integration
- `src/ui/slash-commands.ts` — mode-aware executeFreshStart
- `src/ui-mode.ts`, `src/ui/use-session-manager.ts`, `src/ui/app-helpers.ts` — mode plumbing
- `src/config.ts` — new config fields
- `src/commands/builtins.ts` — register new config fields

### Testing

- [ ] Run `npm run typecheck`
- [ ] Manual test: start auto mode, run 30+ turns, verify suggestion appears
- [ ] Manual test: run `/fresh` in each mode, verify correct system prompt and summary

---

Co-authored-by: kimiflare <kimiflare@proton.me>