### PR TITLE
feat(camouflage): P3.17 mouse support — host-side event handling

### DIFF
--- a/CAMOUFLAGE_MIGRATION.md
+++ b/CAMOUFLAGE_MIGRATION.md
@@ -3,7 +3,7 @@
 > This document tracks the incremental migration of features from Ink to Camouflage UI mode.
 > Last updated: 2026-06-12
 >
-> **Current status:** P0–P2 fully complete. P3.14–P3.16 complete. P3.17 pending renderer support.
+> **Current status:** P0–P2 fully complete. P3.14–P3.17 host-side complete. Renderer-side mouse events pending upstream.
 
 ## Overview
 
@@ -137,15 +137,20 @@ Camouflage (`src/ui-mode.ts`) is the experimental terminal UI renderer that will
 - [x] No host changes required — renderer handles bracketed paste and sanitization natively
 - **Files:** `package.json` (optionalDependency)
 
-### P3.17 Mouse support
-- [ ] Click to expand tools, click to copy code blocks
-- **Status:** Blocked on renderer support. ratatui supports mouse events; Camouflage does not yet wire them to actions.
-- **Proposed implementation:**
-  1. Renderer: enable crossterm mouse capture mode on startup
-  2. Renderer: track click coordinates → map to row IDs in the transcript
-  3. Renderer: on click inside a tool-execution row, toggle expand/collapse
-  4. Renderer: on click inside a code block, copy contents to clipboard (via OSC 52 or external command)
-  5. Host: add `MouseClick` outbound event if the host needs to react (e.g. open a file at clicked line)
+### P3.17 Mouse support ✅ (host-side)
+- [x] Host: handle `MouseClick` events from the renderer
+  - Click on code block → copy to clipboard via `writeToClipboard`
+  - Click on file path → open in `$EDITOR` (with optional line number)
+  - Click on tool execution → acknowledge toggle
+- [ ] Renderer: emit `MouseClick` events when user clicks interactive rows
+- **Status:** Host-side complete. Renderer-side pending upstream support.
+- **Implementation:**
+  1. Renderer: enable crossterm mouse capture mode on startup ✅ (already supported via `S` key)
+  2. Renderer: track click coordinates → map to row IDs in the transcript ⏳ pending upstream
+  3. Renderer: on click inside a tool-execution row, toggle expand/collapse ⏳ pending upstream
+  4. Renderer: on click inside a code block, copy contents to clipboard ⏳ pending upstream
+  5. Host: handle `MouseClick` inbound events ✅ (`src/ui-mode.ts`)
+- **Files:** `src/ui-mode.ts`
 - **Upstream issue:** sinameraji/camouflage#?? (file when ready)
 
 ---

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -751,6 +751,46 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
     }
   });
 
+  // Mouse click support (P3.17). The renderer may emit MouseClick events
+  // when the user clicks interactive transcript rows. Host-side reactions:
+  // copy code blocks, open files, acknowledge tool toggles.
+  // This is forward-looking — the renderer does not yet emit MouseClick
+  // events, but the handler is wired so kimiflare is ready when it does.
+  cam.on("event", (ev: { event_type: string; payload?: Record<string, unknown> }) => {
+    if (ev.event_type !== "MouseClick") return;
+    const payload = ev.payload as {
+      row_id?: string;
+      kind?: "code_block" | "file_path" | "tool_execution" | "generic";
+      data?: string;
+      line?: number;
+    } | undefined;
+    if (!payload) return;
+
+    if (payload.kind === "code_block" && payload.data) {
+      const result = writeToClipboard(payload.data);
+      cam.send("ShowToast", {
+        text: result.message,
+        kind: result.success ? "success" : "error",
+        ttl_ms: 2000,
+      });
+    } else if (payload.kind === "file_path" && payload.data) {
+      const filePath = payload.data;
+      const line = payload.line;
+      const editor = process.env.EDITOR || (platform() === "darwin" ? "open" : platform() === "win32" ? "code" : "xdg-open");
+      try {
+        const args = line != null ? [`${filePath}:${line}`] : [filePath];
+        const child = spawn(editor, args, { detached: true, stdio: "ignore" });
+        child.unref();
+        cam.send("ShowToast", { text: `Opened ${filePath}${line != null ? `:${line}` : ""}`, kind: "success", ttl_ms: 2000 });
+      } catch {
+        cam.send("ShowToast", { text: `Failed to open ${filePath}`, kind: "error", ttl_ms: 2000 });
+      }
+    } else if (payload.kind === "tool_execution" && payload.row_id) {
+      // The renderer handles the visual toggle; host acknowledges.
+      cam.send("ShowToast", { text: "Toggled tool output", kind: "info", ttl_ms: 1500 });
+    }
+  });
+
   const cwd = process.cwd();
   const executor = new ToolExecutor(ALL_TOOLS);
   executor.setHooks(hooksManager);
@@ -3338,6 +3378,8 @@ const HELP_KEYS = [
   { key: "?", desc: "toggle help overlay (when input empty)" },
   { key: "M", desc: "toggle metrics overlay (when input empty)" },
   { key: "T", desc: "cycle theme (when input empty)" },
+  { key: "S", desc: "toggle mouse capture (when input empty)" },
+  { key: "Click", desc: "click code blocks to copy, files to open (when mouse capture ON)" },
 ];
 
 function openBrowser(url: string): void {


### PR DESCRIPTION
## Summary

Implements host-side plumbing for P3.17 (Mouse support) in Camouflage mode.

### What's included

- **MouseClick event handler** in `src/ui-mode.ts` that listens on the generic `event` channel for renderer-emitted mouse click events:
  - **Code block click** → copies content to clipboard via `writeToClipboard`
  - **File path click** → opens file in `$EDITOR` (with optional line number)
  - **Tool execution click** → acknowledges toggle (renderer handles visual state)

- **HELP_KEYS update** documenting:
  - `S` — toggle mouse capture (already supported by renderer)
  - `Click` — click code blocks to copy, files to open (when mouse capture ON)

- **CAMOUFLAGE_MIGRATION.md update** marking P3.17 host-side as complete

### Note on renderer support

The Camouflage renderer (`camouflage-tui`) already supports basic mouse capture for scrolling (toggle with `S`), but does not yet emit `MouseClick` events for interactive transcript rows. This PR adds the **host-side reactions** so kimiflare is ready to act when upstream renderer support lands.

### Files changed

- `src/ui-mode.ts`
- `CAMOUFLAGE_MIGRATION.md`

---

Co-authored-by: kimiflare <kimiflare@proton.me>