### PR TITLE
feat(headless): full headless/CI parity with OpenCode

### DIFF
--- a/docs/plans/headless-ci-parity-plan.md
+++ b/docs/plans/headless-ci-parity-plan.md
@@ -1,0 +1,394 @@
+# Headless / CI Mode Parity with OpenCode
+
+> Status: Planning complete — ready for implementation  
+> Author: kimiflare  
+> Date: 2026-06-12  
+> Branch: `feat/headless-ci-parity`
+
+---
+
+## 1. Executive Summary
+
+**This is a very achievable goal.** KimiFlare's existing architecture already covers ~60% of OpenCode's headless/CI surface. We have a solid print mode (`-p`), an NDJSON emit protocol (`--emit-events`), a permission system with auto-approval (`--dangerously-allow-all`), session persistence, and an SDK with an RPC server. The remaining gaps are incremental enhancements and one medium-sized feature (a persistent HTTP server).
+
+**Estimated effort: 2–3 weeks of focused work** for one developer, or one sprint for a small team.
+
+---
+
+## 2. Current State Assessment
+
+### 2.1 What KimiFlare Already Has
+
+| Feature | Location | Notes |
+|---------|----------|-------|
+| **One-shot headless prompt** | `src/index.tsx:21` (`-p, --print <prompt>`) | Streams reply to stdout, exits. Foundation is solid. |
+| **NDJSON event stream** | `src/emit-mode.ts` (`--emit-events`) | Camouflage protocol — more structured than OpenCode's `--format json`. Already supports multi-turn via stdin. |
+| **Auto-approval** | `src/index.tsx:23` (`--dangerously-allow-all`) | Equivalent to OpenCode's `--dangerously-skip-permissions`. |
+| **Model override** | `src/index.tsx:22` (`-m, --model <id>`) | Works in both print and interactive modes. |
+| **Multi-turn stdin** | `src/emit-mode.ts:156` (`--multi-turn`) | Reads `UserInputSubmitted` NDJSON lines from stdin after initial turn. |
+| **Bidirectional permissions** | `src/emit-mode.ts:114` | `PermissionResponse` messages on stdin resolve pending asks. |
+| **Session persistence** | `src/sessions.ts` | Full load/save with checkpoints, artifacts, titles. |
+| **SDK / RPC server** | `src/sdk/rpc.ts` (`--mode rpc`) | Stdio-based JSON-RPC for editor integrations (Zed, etc.). |
+| **Tool hooks** | `src/hooks/manager.ts` | Pre/Post tool-use hooks fire in print mode too (M6.1). |
+| **Output reduction** | `src/tools/reducer.ts` | Large tool outputs are capped automatically. |
+| **Budget exhaustion** | `src/agent/loop.ts` | Exits 42 when `maxInputTokens` is hit. |
+| **Reasoning output** | `src/index.tsx:24` (`--reasoning`) | Streams reasoning blocks to stderr in print mode. |
+| **Continue on limit** | `src/index.tsx:25` (`--continue-on-limit`) | Resets tool-call counter at 200 calls. |
+
+### 2.2 What's Missing vs. OpenCode
+
+| OpenCode Feature | KimiFlare Gap | Complexity |
+|------------------|---------------|------------|
+| `opencode run [message..]` | **Naming only** — we have `-p`. Minor UX difference. | Trivial |
+| `opencode serve` (persistent HTTP server) | **No HTTP server.** RPC is stdio-only. | Medium |
+| `--attach http://...` | **No attach mode.** Cannot connect CLI to a warm server. | Medium (depends on serve) |
+| `--format json` (raw JSON events) | **Only NDJSON via `--emit-events`.** No plain JSONL for print mode. | Low |
+| `--file` / `-f` (file attachments) | **Not supported in print/emit mode.** | Low |
+| `--continue` / `-c` in headless | **`--continue` is interactive-only.** Print mode always starts fresh. | Low |
+| `--session <id>` in headless | **Session ID is ignored in print mode.** | Low |
+| `--dir <path>` | **Always uses `process.cwd()`.** | Low |
+| `--title <title>` | **Sessions auto-titled.** No override in headless. | Low |
+| `--thinking` | **We have `--reasoning`.** Naming mismatch only. | Trivial |
+| `--variant` (model variant) | **No variant support.** | Low |
+| Server-Sent Events (`/event`) | **No SSE endpoint.** | Medium (depends on serve) |
+| OpenAPI spec | **No HTTP API docs.** | Low (depends on serve) |
+| mDNS discovery | **Not implemented.** | Low |
+| `--share` | **No session sharing.** | Medium |
+
+---
+
+## 3. Root Cause: Why the Gaps Exist
+
+### 3.1 Print Mode Was Built as a "Simple Utility"
+
+`runPrintMode` (`src/index.tsx:360`) was designed for quick one-offs:
+- No session loading — always starts with a fresh `[system, user]` message pair.
+- No file attachment parsing — the TUI handles `@file` mentions via `input-handlers.ts`.
+- Permission asker is a binary: `allowAll ? "allow" : "deny"` — no gradation.
+
+### 3.2 Emit Mode Is Tightly Coupled to Camouflage
+
+`runEmitMode` (`src/emit-mode.ts:57`) emits the Camouflage event protocol. It's powerful but opinionated:
+- Event names like `AssistantStreamStarted`, `UserMessageCreated` are Camouflage-specific.
+- There's no "plain JSONL" mode for generic scripting.
+- Multi-turn is stdin-driven, not HTTP-driven.
+
+### 3.3 No HTTP Layer
+
+The RPC server (`src/sdk/rpc.ts:21`) is stdio-based by design — it's for ACP (Agent Client Protocol) editor integration. There's no Hono/Express/Fastify server in the main CLI bundle. The `remote/worker/` sub-project has Hono, but it's a separate deployable artifact, not a local CLI feature.
+
+---
+
+## 4. Implementation Plan
+
+### Phase 1: Enhanced Print Mode (Week 1)
+
+**Goal:** Close the "simple headless" gap without adding a server.
+
+#### 4.1.1 P1.1 — Session Continuation in Print Mode
+
+**Files:** `src/index.tsx`, `src/print-mode.ts` (new)
+
+**Work:**
+- Extract `runPrintMode` from `src/index.tsx` into a new `src/print-mode.ts` module.
+- Add `--continue` and `--session <id>` support to print mode.
+- When continuing, load the session file from `~/.local/share/kimiflare/sessions/`, filter out old system prompts, and append the new user prompt.
+- Preserve the session's artifact store across turns.
+
+**Interface:**
+```bash
+kimiflare -p "fix the bug" --continue          # continue last session in cwd
+kimiflare -p "fix the bug" --session abc123     # continue specific session
+```
+
+#### 4.1.2 P1.2 — File Attachments in Headless Mode
+
+**Files:** `src/print-mode.ts`, `src/emit-mode.ts`
+
+**Work:**
+- Add `--file <path>` / `-f <path>` CLI flag (repeatable).
+- Read file contents and inject them into the user message using the same format as TUI `@file` mentions (`src/ui/input-handlers.ts`).
+- Support glob patterns (`--file "src/**/*.ts"`).
+- In emit mode, emit `FileAttached` events so the TUI renderer can show them.
+
+**Interface:**
+```bash
+kimiflare -p "refactor these" -f src/utils.ts -f src/helpers.ts
+kimiflare -p "review" -f "docs/**/*.md"
+```
+
+#### 4.1.3 P1.3 — `--format json` for Print Mode
+
+**Files:** `src/print-mode.ts`
+
+**Work:**
+- Add `--format <mode>` flag with values: `text` (default), `json`, `stream-json`.
+- `text`: current behavior — assistant text to stdout, tool metadata to stderr.
+- `json`: single JSON object at the end containing `{ text, toolCalls[], usage, duration }`.
+- `stream-json`: NDJSON lines, one per event (assistant delta, tool call, tool result, usage update). This is a simplified, non-Camouflage version of `--emit-events`.
+
+**Interface:**
+```bash
+kimiflare -p "list files" --format json
+kimiflare -p "list files" --format stream-json
+```
+
+#### 4.1.4 P1.4 — `--dir` and `--title` Flags
+
+**Files:** `src/print-mode.ts`, `src/emit-mode.ts`
+
+**Work:**
+- `--dir <path>`: `process.chdir()` before running, or pass `cwd` override to `ToolExecutor` and `buildSystemPrompt`.
+- `--title <title>`: override auto-generated session title when saving.
+
+**Interface:**
+```bash
+kimiflare -p "analyze" --dir ./other-project --title "security-audit"
+```
+
+#### 4.1.5 P1.5 — Rename `--reasoning` to `--thinking` (Alias)
+
+**Files:** `src/index.tsx`
+
+**Work:**
+- Keep `--reasoning` for back-compat.
+- Add `--thinking` as an alias. Update docs.
+
+---
+
+### Phase 2: Persistent HTTP Server (Week 2)
+
+**Goal:** Build `kimiflare serve` — a local HTTP server that avoids cold-start costs and enables multi-client access.
+
+#### 4.2.1 P2.1 — HTTP Server Core
+
+**Files:** `src/server/index.ts` (new), `src/server/routes.ts` (new)
+
+**Work:**
+- Add a new CLI subcommand: `kimiflare serve`.
+- Use **Hono** (already a transitive dep via `remote/worker/`) or Node's built-in `http` module to avoid new dependencies.
+- Bind to `localhost` by default, configurable via `--port` and `--hostname`.
+- Support `KIMIFLARE_SERVER_PASSWORD` for HTTP Basic Auth (username defaults to `kimiflare`).
+
+**Interface:**
+```bash
+kimiflare serve --port 4096 --hostname 127.0.0.1
+```
+
+**Architecture decision:** Use Node's built-in `http` + `createServer` to keep the bundle self-contained. Hono is nice but adds a dep to the main CLI. If we already bundle Hono for remote, check `tsup.config.ts` externals first.
+
+#### 4.2.2 P2.2 — Session Management API
+
+**Files:** `src/server/routes.ts`
+
+**Work:**
+- `POST /prompt` — submit a prompt, get a session ID back.
+- `GET /session/:id` — get session state, messages, usage.
+- `POST /session/:id/prompt` — send a follow-up to an existing session.
+- `DELETE /session/:id` — delete a session.
+- `GET /session` — list all sessions.
+
+**Request/response shape:** JSON, matching the SDK types (`src/sdk/types.ts`).
+
+#### 4.2.3 P2.3 — Server-Sent Events Stream
+
+**Files:** `src/server/sse.ts` (new)
+
+**Work:**
+- `GET /event` — SSE endpoint that streams session events.
+- First event: `server.connected`.
+- Subsequent events: `assistant.delta`, `tool.call`, `tool.result`, `usage.update`, `session.completed`, `error`.
+- Support `Last-Event-ID` for resumable streams.
+
+**This is the most important feature for CI/scripting.** It lets external tools observe agent progress in real time without polling.
+
+#### 4.2.4 P2.4 — Attach Mode for CLI
+
+**Files:** `src/index.tsx`, `src/attach-mode.ts` (new)
+
+**Work:**
+- Add `--attach <url>` flag to print mode.
+- Instead of running `runAgentTurn` locally, POST to `http://<url>/prompt` and stream the SSE response to stdout.
+- This avoids MCP/LSP cold-boot times on every CLI invocation — the server keeps them warm.
+
+**Interface:**
+```bash
+# Terminal 1
+kimiflare serve --port 4096
+
+# Terminal 2
+kimiflare -p "explain this" --attach http://localhost:4096
+kimiflare -p "fix the bug" --attach http://localhost:4096 --format json
+```
+
+#### 4.2.5 P2.5 — OpenAPI Spec
+
+**Files:** `src/server/openapi.ts` (new)
+
+**Work:**
+- Auto-generate an OpenAPI 3.1 spec from the route handlers.
+- Serve it at `GET /doc`.
+- This is low-effort high-value — enables codegen, documentation, and Postman imports.
+
+---
+
+### Phase 3: Advanced Features (Week 3)
+
+#### 4.3.1 P3.1 — Permission Rules Config File
+
+**Files:** `src/config.ts`, `src/tools/executor.ts`
+
+**Work:**
+- Add a `permissions` field to `~/.config/kimiflare/config.json`:
+  ```json
+  {
+    "permissions": {
+      "bash": { "~/trusted/**": "allow", "**": "ask" },
+      "write": { "**": "ask" },
+      "edit": { "**": "ask" }
+    }
+  }
+  ```
+- In headless mode, evaluate these rules before falling back to `--dangerously-allow-all` or deny.
+- This gives OpenCode-style granular control without requiring `--dangerously-allow-all` for every CI run.
+
+#### 4.3.2 P3.2 — Model Variant Support
+
+**Files:** `src/config.ts`, `src/agent/client.ts`
+
+**Work:**
+- Add `--variant <variant>` flag (e.g., `--variant reasoning`).
+- Map variants to provider-specific parameters (e.g., `reasoning_effort` for Anthropic, `thinking` for OpenAI).
+
+#### 4.3.3 P3.3 — Session Sharing
+
+**Files:** `src/server/routes.ts`, `src/sessions.ts`
+
+**Work:**
+- `POST /session/:id/share` — generate a shareable token.
+- `GET /session/shared/:token` — read-only access to a session transcript.
+- Useful for sharing agent runs with teammates or attaching them to PRs.
+
+#### 4.3.4 P3.4 — mDNS Discovery (Optional)
+
+**Files:** `src/server/mdns.ts` (new)
+
+**Work:**
+- Advertise `kimiflare serve` instances on the local network via Bonjour/mDNS.
+- Enables `kimiflare -p "..." --attach http://kimiflare.local` without knowing the IP.
+- Add `--mdns` and `--mdns-domain` flags.
+
+**Note:** This requires a new dependency (`bonjour-service` or similar). Consider making it optional.
+
+---
+
+## 5. Architecture Decisions
+
+### 5.1 Why Not Reuse `remote/worker/`?
+
+The `remote/worker/` sub-project is a Cloudflare Worker (Hono + Wrangler) designed for remote deployment. It has auth, rate limiting, and multi-tenant concerns that are overkill for a local CLI server. The local server should be:
+- Zero-config (no Wrangler, no CF account).
+- Single-tenant (one user, one machine).
+- Lightweight (no bundling, no deploy step).
+
+**Decision:** Build a separate `src/server/` module using Node's built-in `http`. Share types and session logic with the SDK.
+
+### 5.2 Why Not Replace `--emit-events` with `--format json`?
+
+`--emit-events` is the Camouflage wire protocol. It's stable and has a consumer (the Rust TUI). `--format json` is a user-facing scripting convenience. They serve different audiences.
+
+**Decision:** Keep both. `--format json` is a simplified, documented format for scripts. `--emit-events` remains the Camouflage integration point.
+
+### 5.3 Permission Model in Headless Mode
+
+OpenCode's `--dangerously-skip-permissions` auto-approves anything not explicitly denied. KimiFlare's `--dangerously-allow-all` is the same. But OpenCode also supports config-based rules.
+
+**Decision:** Implement config-based rules (P3.1) as the primary headless permission mechanism. `--dangerously-allow-all` becomes the "I know what I'm doing" escape hatch. In `-p` mode without either, default to `deny` with a clear stderr message.
+
+---
+
+## 6. Testing Strategy
+
+### 6.1 Unit Tests
+
+- `print-mode.test.ts`: test session loading, file attachment injection, format output.
+- `server/routes.test.ts`: test HTTP routes with `node:test` and `supertest` (or raw `http` requests).
+- `server/sse.test.ts`: test SSE event streaming and reconnection.
+
+### 6.2 Integration Tests
+
+- Start `kimiflare serve`, run `kimiflare -p "..." --attach`, verify output.
+- Test MCP cold-boot avoidance: measure time with/without `--attach`.
+- Test permission rules: config file with `allow` for `bash` in `~/tmp/**`, run a bash tool in that dir, verify no prompt.
+
+### 6.3 CI/CD
+
+- Add a GitHub Actions job that runs `kimiflare -p "list files" --format json` and validates the JSON schema.
+- Add a job that starts `kimiflare serve`, hits `/doc`, and verifies the OpenAPI spec is valid (using `swagger-parser`).
+
+---
+
+## 7. Migration & Backward Compatibility
+
+| Change | Backward Compatible? | Mitigation |
+|--------|---------------------|------------|
+| Extract `runPrintMode` to `src/print-mode.ts` | ✅ Yes | Re-export from `index.tsx` if needed. |
+| Add `--format`, `--file`, `--dir`, `--title` | ✅ Yes | New flags, no breaking changes. |
+| Add `--thinking` alias | ✅ Yes | `--reasoning` still works. |
+| Add `kimiflare serve` subcommand | ✅ Yes | New entry point, no existing behavior changed. |
+| Config-based permission rules | ✅ Yes | Only evaluated when `permissions` key is present. |
+| `--attach` flag | ✅ Yes | New flag. |
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| HTTP server bloats the bundle | Medium | Medium | Use Node built-in `http`, no Hono/Express. Make server code lazy-loaded (`await import("./server")`). |
+| SSE connections leak on crash | Low | Medium | Use `AbortController` per connection, clean up on `process.on('exit')`. |
+| Session file corruption with concurrent writes | Low | High | Use atomic writes (`writeFile` to temp, then `rename`). Server holds in-memory lock per session ID. |
+| Permission rules are confusing | Medium | Medium | Document with examples. Start with simple glob patterns only. |
+| MCP servers don't work well in server mode | Medium | High | Test MCP lifecycle carefully. Each session may need its own MCP client pool, or share a global one with reference counting. |
+
+---
+
+## 9. Success Criteria
+
+We will consider this plan complete when:
+
+1. [ ] `kimiflare -p "do X" --format json` produces valid, documented JSON.
+2. [ ] `kimiflare -p "do X" -f file.ts` attaches files correctly.
+3. [ ] `kimiflare -p "do X" --continue` resumes the last session.
+4. [ ] `kimiflare serve` starts an HTTP server with SSE events.
+5. [ ] `kimiflare -p "do X" --attach http://localhost:4096` connects to the server and streams output.
+6. [ ] `GET /doc` returns a valid OpenAPI 3.1 spec.
+7. [ ] Config-based permission rules work in headless mode.
+8. [ ] All new code has co-located tests.
+9. [ ] `npm run typecheck` passes.
+
+---
+
+## 10. Appendix: OpenCode → KimiFlare Command Mapping
+
+| OpenCode | KimiFlare (after this plan) | Notes |
+|----------|----------------------------|-------|
+| `opencode run "prompt"` | `kimiflare -p "prompt"` | Same semantics. |
+| `opencode run -m provider/model` | `kimiflare -p "..." -m @cf/moonshotai/kimi-k2.6` | Same. |
+| `opencode run --format json` | `kimiflare -p "..." --format json` | New flag. |
+| `opencode run --dangerously-skip-permissions` | `kimiflare -p "..." --dangerously-allow-all` | Already exists. |
+| `opencode run --file path` | `kimiflare -p "..." -f path` | New flag. |
+| `opencode run --continue` | `kimiflare -p "..." --continue` | New flag. |
+| `opencode run --session id` | `kimiflare -p "..." --session id` | New flag. |
+| `opencode run --dir path` | `kimiflare -p "..." --dir path` | New flag. |
+| `opencode run --title title` | `kimiflare -p "..." --title title` | New flag. |
+| `opencode serve` | `kimiflare serve` | New subcommand. |
+| `opencode run --attach url` | `kimiflare -p "..." --attach url` | New flag. |
+| `opencode serve --port 4096` | `kimiflare serve --port 4096` | Same. |
+| `opencode serve --hostname 0.0.0.0` | `kimiflare serve --hostname 0.0.0.0` | Same. |
+| `GET /event` (SSE) | `GET /event` (SSE) | New endpoint. |
+| `GET /doc` (OpenAPI) | `GET /doc` (OpenAPI) | New endpoint. |
+
+---
+
+*Co-authored-by: kimiflare <kimiflare@proton.me>*

--- a/src/attach-mode.ts
+++ b/src/attach-mode.ts
@@ -1,0 +1,271 @@
+/**
+ * Attach mode: connect to a running kimiflare serve instance
+ * and stream the response to stdout.
+ */
+
+import type { PrintFormat } from "./print-mode.js";
+
+export interface AttachModeOpts {
+  attachUrl: string;
+  prompt: string;
+  model?: string;
+  files?: string[];
+  format?: PrintFormat;
+  allowAll?: boolean;
+  sessionId?: string;
+}
+
+export async function runAttachMode(opts: AttachModeOpts): Promise<void> {
+  const url = opts.attachUrl.replace(/\/$/, "");
+  const format = opts.format ?? "text";
+
+  // If we have a sessionId, send follow-up; otherwise start new session
+  const endpoint = opts.sessionId
+    ? `${url}/session/${opts.sessionId}/prompt`
+    : `${url}/prompt`;
+
+  const body: Record<string, unknown> = {
+    prompt: opts.prompt,
+    allowAll: opts.allowAll ?? false,
+  };
+  if (opts.model) body.model = opts.model;
+  if (opts.files) body.files = opts.files;
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "unknown error");
+    console.error(`kimiflare attach: ${response.status} ${text}`);
+    process.exit(1);
+  }
+
+  const result = (await response.json()) as { sessionId: string; status: string };
+  const sessionId = result.sessionId;
+
+  if (format === "json") {
+    // For JSON format, we need to collect the full output.
+    // Connect to SSE and accumulate.
+    await streamSseJson(url, sessionId);
+  } else {
+    // text or stream-json: stream directly
+    await streamSse(url, sessionId, format);
+  }
+}
+
+async function streamSse(url: string, sessionId: string, format: PrintFormat): Promise<void> {
+  const eventSource = new EventSource(`${url}/event`);
+  let done = false;
+
+  return new Promise((resolve, reject) => {
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.event === "server.connected") return;
+
+        switch (data.event) {
+          case "assistant.delta":
+            if (format === "text") {
+              process.stdout.write(data.delta);
+            } else if (format === "stream-json") {
+              process.stdout.write(JSON.stringify({ event: "text_delta", delta: data.delta }) + "\n");
+            }
+            break;
+          case "tool.call":
+            if (format === "text") {
+              process.stderr.write(`\x1b[2m[tool ${data.name}(${JSON.stringify(data.arguments)})]\x1b[0m\n`);
+            } else if (format === "stream-json") {
+              process.stdout.write(JSON.stringify({ event: "tool_call", id: data.id, name: data.name, arguments: data.arguments }) + "\n");
+            }
+            break;
+          case "tool.result":
+            if (format === "text") {
+              const snippet = data.content.length > 400 ? data.content.slice(0, 400) + "..." : data.content;
+              process.stderr.write(`\x1b[2m[result: ${snippet.replace(/\n/g, " ⏎ ")}]\x1b[0m\n`);
+            } else if (format === "stream-json") {
+              process.stdout.write(JSON.stringify({ event: "tool_result", toolCallId: data.toolCallId, name: data.name, content: data.content, ok: data.ok }) + "\n");
+            }
+            break;
+          case "usage.update":
+            if (format === "stream-json") {
+              process.stdout.write(JSON.stringify({ event: "usage", promptTokens: data.promptTokens, completionTokens: data.completionTokens, totalTokens: data.totalTokens }) + "\n");
+            }
+            break;
+          case "warning":
+            if (format === "text") {
+              process.stderr.write(`\x1b[33mkimiflare: ${data.message}\x1b[0m\n`);
+            } else if (format === "stream-json") {
+              process.stdout.write(JSON.stringify({ event: "warning", message: data.message }) + "\n");
+            }
+            break;
+          case "session.completed":
+            done = true;
+            eventSource.close();
+            if (format === "text") process.stdout.write("\n");
+            resolve(undefined);
+            break;
+          case "error":
+            done = true;
+            eventSource.close();
+            if (format === "text") {
+              process.stderr.write(`\n\x1b[31mError: ${data.message}\x1b[0m\n`);
+            } else if (format === "stream-json") {
+              process.stdout.write(JSON.stringify({ event: "error", message: data.message }) + "\n");
+            }
+            process.exitCode = 1;
+            resolve(undefined);
+            break;
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+
+    eventSource.onerror = () => {
+      if (!done) {
+        eventSource.close();
+        reject(new Error("SSE connection failed"));
+      }
+    };
+
+    // Timeout safety
+    setTimeout(() => {
+      if (!done) {
+        eventSource.close();
+        reject(new Error("SSE stream timed out after 10 minutes"));
+      }
+    }, 600_000);
+  });
+}
+
+async function streamSseJson(url: string, sessionId: string): Promise<void> {
+  // Accumulate events and output final JSON
+  const text: string[] = [];
+  const toolCalls: Array<{ id: string; name: string; arguments: string }> = [];
+  const toolResults: Array<{ toolCallId: string; name: string; content: string; ok: boolean }> = [];
+  let usage: { promptTokens: number; completionTokens: number; totalTokens: number } | undefined;
+
+  const eventSource = new EventSource(`${url}/event`);
+
+  return new Promise((resolve, reject) => {
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.event === "server.connected") return;
+
+        switch (data.event) {
+          case "assistant.delta":
+            text.push(data.delta);
+            break;
+          case "tool.call":
+            toolCalls.push({ id: data.id, name: data.name, arguments: data.arguments });
+            break;
+          case "tool.result":
+            toolResults.push({ toolCallId: data.toolCallId, name: data.name, content: data.content, ok: data.ok });
+            break;
+          case "usage.update":
+            usage = {
+              promptTokens: data.promptTokens,
+              completionTokens: data.completionTokens,
+              totalTokens: data.totalTokens,
+            };
+            break;
+          case "session.completed":
+            eventSource.close();
+            process.stdout.write(
+              JSON.stringify(
+                {
+                  text: text.join(""),
+                  toolCalls,
+                  toolResults,
+                  usage,
+                  sessionId,
+                },
+                null,
+                2,
+              ) + "\n",
+            );
+            resolve(undefined);
+            break;
+          case "error":
+            eventSource.close();
+            process.stdout.write(
+              JSON.stringify({ error: data.message, sessionId }, null, 2) + "\n",
+            );
+            process.exitCode = 1;
+            resolve(undefined);
+            break;
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    eventSource.onerror = () => {
+      eventSource.close();
+      reject(new Error("SSE connection failed"));
+    };
+
+    setTimeout(() => {
+      eventSource.close();
+      reject(new Error("SSE stream timed out after 10 minutes"));
+    }, 600_000);
+  });
+}
+
+// Minimal EventSource polyfill for Node.js
+class EventSource {
+  private url: string;
+  private controller: AbortController;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    this.controller = new AbortController();
+    this.start();
+  }
+
+  private async start(): Promise<void> {
+    try {
+      const response = await fetch(this.url, {
+        signal: this.controller.signal,
+        headers: { Accept: "text/event-stream" },
+      });
+      if (!response.ok || !response.body) {
+        this.onerror?.();
+        return;
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        let currentData = "";
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            currentData = line.slice(6);
+          } else if (line === "" && currentData) {
+            this.onmessage?.({ data: currentData });
+            currentData = "";
+          }
+        }
+      }
+    } catch {
+      this.onerror?.();
+    }
+  }
+
+  close(): void {
+    this.controller.abort();
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,12 @@ export interface LspServerConfig {
   maxRestartAttempts?: number;
 }
 
+/** Permission rule: allow, deny, or ask (default). */
+export type PermissionRule = "allow" | "deny" | "ask";
+
+/** Per-tool permission rules keyed by glob pattern. */
+export type PermissionRules = Record<string, PermissionRule>;
+
 export interface KimiConfig {
   accountId: string;
   apiToken: string;
@@ -174,6 +180,10 @@ export interface KimiConfig {
   /** Max characters of pre-read content to inject per worker batch.
    *  Default: 50_000. */
   workerPreReadMaxChars?: number;
+  /** Permission rules for headless/CI mode. Keys are tool names (e.g. "bash", "write").
+   *  Values are glob-pattern → rule mappings. Patterns are matched against the
+   *  target path (for file tools) or command string (for bash). */
+  permissions?: Record<string, PermissionRules>;
 }
 
 export const DEFAULT_MODEL = "@cf/moonshotai/kimi-k2.6";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,13 @@
 import { Command } from "commander";
 import { loadConfig, DEFAULT_MODEL } from "./config.js";
 import { resolveLspConfig } from "./util/lsp-config.js";
-import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
-import { KimiApiError, humanizeCloudflareError } from "./util/errors.js";
-import type { AiGatewayOptions } from "./agent/client.js";
-import { buildSystemPrompt } from "./agent/system-prompt.js";
-import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
-import type { ChatMessage } from "./agent/messages.js";
 import { checkForUpdate } from "./util/update-check.js";
 import type { UpdateCheckResult } from "./util/update-check.js";
 import { getAppVersion } from "./util/version.js";
 import { createRemoteCommand } from "./remote/cli.js";
 import { renderLogo } from "./ui/logo.js";
+import { runPrintMode } from "./print-mode.js";
+import type { PrintFormat } from "./print-mode.js";
 
 const program = new Command();
 program
@@ -22,13 +18,21 @@ program
   .option("-m, --model <id>", "model id (defaults to @cf/moonshotai/kimi-k2.6)")
   .option("--dangerously-allow-all", "auto-approve every permission prompt (print mode only)")
   .option("--reasoning", "include reasoning in stdout (print mode only)")
+  .option("--thinking", "alias for --reasoning")
   .option("--continue-on-limit", "reset tool-call counter and continue when the 200-call limit is hit (print mode only)")
   .option("--max-input-tokens <n>", "cumulative prompt token budget; exits 42 when exhausted (print mode only)", (v) => parseInt(v, 10))
   .option("--emit-events", "emit Camouflage NDJSON events to stdout; requires -p (for initial prompt)")
   .option("--multi-turn", "with --emit-events: keep reading stdin for UserInputSubmitted follow-ups after the initial turn")
   .option("--ui <name>", "render UI with the given engine: `ink` (default, stable) or `camouflage` (experimental Rust TUI). Can also be set via the KIMIFLARE_UI environment variable.")
   .option("--camouflage-bin <path>", "with --ui camouflage: path to the camouflage-tui binary (defaults to PATH lookup)")
-  .option("--mode <mode>", "run mode: interactive (default), print, rpc");
+  .option("--mode <mode>", "run mode: interactive (default), print, rpc")
+  .option("-c, --continue", "continue the most recent session in the current working directory (print mode only)")
+  .option("-S, --session <id>", "resume a specific session by id (print mode only)")
+  .option("-f, --file <path>", "attach file(s) to the prompt; repeatable, supports globs (print mode only)", (v, prev: string[] | undefined) => (prev ?? []).concat(v))
+  .option("--format <mode>", "output format for print mode: text (default), json, stream-json")
+  .option("--dir <path>", "run in the specified directory instead of the current one (print mode only)")
+  .option("--title <title>", "override the auto-generated session title (print mode only)")
+  .option("--attach <url>", "attach to a running kimiflare serve instance (print mode only)");
 
 program
   .command("cost")
@@ -128,6 +132,25 @@ program
   )
   ;
 
+program
+  .command("serve")
+  .description("Start a headless HTTP server for API access and CI integration")
+  .option("--port <n>", "port to listen on", (v) => parseInt(v, 10), 4096)
+  .option("--hostname <host>", "hostname to listen on", "127.0.0.1")
+  .action(async (cmdOpts) => {
+    const cfg = await loadConfig();
+    if (!cfg) {
+      console.error("kimiflare serve: missing credentials.");
+      process.exit(2);
+    }
+    const { startServer } = await import("./server/index.js");
+    await startServer({
+      port: cmdOpts.port,
+      hostname: cmdOpts.hostname,
+      config: cfg,
+    });
+  });
+
 program.action(async () => {
   await main();
 });
@@ -138,6 +161,7 @@ const opts = program.opts<{
   model?: string;
   dangerouslyAllowAll?: boolean;
   reasoning?: boolean;
+  thinking?: boolean;
   continueOnLimit?: boolean;
   maxInputTokens?: number;
   emitEvents?: boolean;
@@ -145,6 +169,13 @@ const opts = program.opts<{
   ui?: string;
   camouflageBin?: string;
   mode?: string;
+  continue?: boolean;
+  session?: string;
+  file?: string[];
+  format?: string;
+  dir?: string;
+  title?: string;
+  attach?: string;
 }>();
 
 async function main() {
@@ -225,16 +256,44 @@ async function main() {
       process.exit(2);
     }
     const model = opts.model ?? cfg.model ?? DEFAULT_MODEL;
+    const format = (opts.format ?? "text") as PrintFormat;
+    if (format !== "text" && format !== "json" && format !== "stream-json") {
+      console.error(`kimiflare: invalid --format "${format}". Use: text, json, stream-json`);
+      process.exit(2);
+    }
+
+    // Attach mode: connect to a running server
+    if (opts.attach) {
+      const { runAttachMode } = await import("./attach-mode.js");
+      await runAttachMode({
+        attachUrl: opts.attach,
+        prompt: opts.print,
+        model,
+        files: opts.file,
+        format,
+        allowAll: !!opts.dangerouslyAllowAll,
+        sessionId: opts.session,
+      });
+      return;
+    }
+
     await runPrintMode({
       ...cfg,
       model,
       prompt: opts.print,
       allowAll: !!opts.dangerouslyAllowAll,
-      showReasoning: !!opts.reasoning,
+      showReasoning: !!(opts.reasoning || opts.thinking),
       codeMode: cfg.codeMode,
       continueOnLimit: !!opts.continueOnLimit,
       maxInputTokens: opts.maxInputTokens,
       updateResult,
+      continueSession: !!opts.continue,
+      sessionId: opts.session,
+      files: opts.file,
+      format,
+      dir: opts.dir,
+      title: opts.title,
+      permissions: cfg.permissions,
     });
     return;
   }
@@ -325,140 +384,6 @@ async function main() {
   }
 }
 
-interface PrintOpts {
-  accountId: string;
-  apiToken: string;
-  model: string;
-  prompt: string;
-  allowAll: boolean;
-  showReasoning: boolean;
-  coauthor?: boolean;
-  coauthorName?: string;
-  coauthorEmail?: string;
-  aiGatewayId?: string;
-  aiGatewayCacheTtl?: number;
-  aiGatewaySkipCache?: boolean;
-  aiGatewayCollectLogPayload?: boolean;
-  aiGatewayMetadata?: Record<string, string | number | boolean>;
-  updateResult: UpdateCheckResult;
-  codeMode?: boolean;
-  continueOnLimit?: boolean;
-  maxInputTokens?: number;
-}
 
-function gatewayFromPrintOpts(opts: PrintOpts): AiGatewayOptions | undefined {
-  if (!opts.aiGatewayId) return undefined;
-  return {
-    id: opts.aiGatewayId,
-    cacheTtl: opts.aiGatewayCacheTtl,
-    skipCache: opts.aiGatewaySkipCache,
-    collectLogPayload: opts.aiGatewayCollectLogPayload,
-    metadata: opts.aiGatewayMetadata,
-  };
-}
-
-async function runPrintMode(opts: PrintOpts): Promise<void> {
-  if (opts.updateResult.hasUpdate) {
-    process.stderr.write(
-      `\x1b[33mkimiflare update available: ${opts.updateResult.localVersion} → ${opts.updateResult.latestVersion}\x1b[0m\n` +
-        `\x1b[33m  npm update -g kimiflare  then restart\x1b[0m\n\n`,
-    );
-  }
-
-  const cwd = process.cwd();
-  // M6.1: print mode loads the same hooks as the TUI. Audit / guard /
-  // notification hooks fire in CI runs too — that's the case where
-  // they matter most.
-  const { HooksManager } = await import("./hooks/manager.js");
-  const hooks = new HooksManager(cwd);
-  const executor = new ToolExecutor(ALL_TOOLS, { hooks });
-  const messages: ChatMessage[] = [
-    { role: "system", content: buildSystemPrompt({ cwd, tools: ALL_TOOLS, model: opts.model }) },
-    { role: "user", content: opts.prompt },
-  ];
-
-  const controller = new AbortController();
-  process.on("SIGINT", () => controller.abort());
-
-  let printedReasoningHeader = false;
-  let printedAnswerHeader = false;
-
-  try {
-    await runAgentTurn({
-      accountId: opts.accountId,
-      apiToken: opts.apiToken,
-      model: opts.model,
-      gateway: gatewayFromPrintOpts(opts),
-      messages,
-      tools: ALL_TOOLS,
-      executor,
-      hooks, // M6.1: Stop fires at end of print-mode turn too.
-      cwd,
-      signal: controller.signal,
-      codeMode: opts.codeMode,
-      continueOnLimit: opts.continueOnLimit,
-      maxInputTokens: opts.maxInputTokens,
-      coauthor:
-        opts.coauthor !== false
-          ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "kimiflare@proton.me" }
-          : undefined,
-      callbacks: {
-        onReasoningDelta: opts.showReasoning
-          ? (delta) => {
-              if (!printedReasoningHeader) {
-                process.stderr.write("\x1b[2m--- reasoning ---\n");
-                printedReasoningHeader = true;
-              }
-              process.stderr.write(delta);
-            }
-          : undefined,
-        onTextDelta: (delta) => {
-          if (opts.showReasoning && printedReasoningHeader && !printedAnswerHeader) {
-            process.stderr.write("\n--- answer ---\x1b[0m\n");
-            printedAnswerHeader = true;
-          }
-          process.stdout.write(delta);
-        },
-        onToolCallFinalized: (call) => {
-          process.stderr.write(`\x1b[2m[tool ${call.function.name}(${call.function.arguments})]\x1b[0m\n`);
-        },
-        onToolResult: (result) => {
-          const snippet =
-            result.content.length > 400 ? result.content.slice(0, 400) + "..." : result.content;
-          process.stderr.write(`\x1b[2m[result: ${snippet.replace(/\n/g, " ⏎ ")}]\x1b[0m\n`);
-        },
-        onWarning: (msg) => {
-          process.stderr.write(`\x1b[33mkimiflare: ${msg}\x1b[0m\n`);
-        },
-        askPermission: async ({ tool, args }) => {
-          if (opts.allowAll) return "allow";
-          process.stderr.write(
-            `\x1b[31m[permission denied: ${tool.name}(${JSON.stringify(args)}) — pass --dangerously-allow-all to approve in print mode]\x1b[0m\n`,
-          );
-          return "deny";
-        },
-      },
-    });
-  } catch (err) {
-    if (err instanceof BudgetExhaustedError) {
-      process.stderr.write("\n\x1b[33m[Budget exhausted — exiting with code 42]\x1b[0m\n");
-      process.exitCode = 42;
-      return;
-    }
-    if (err instanceof AgentLoopError) {
-      process.stderr.write("\n\x1b[33m[Agent loop detected — exiting with code 43]\x1b[0m\n");
-      process.exitCode = 43;
-      return;
-    }
-    if (err instanceof KimiApiError) {
-      process.stderr.write(`\n\x1b[31mError: ${humanizeCloudflareError(err)}\x1b[0m\n`);
-      process.exitCode = 1;
-      return;
-    }
-    throw err;
-  }
-
-  process.stdout.write("\n");
-}
 
 

--- a/src/permissions-evaluator.test.ts
+++ b/src/permissions-evaluator.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { evaluatePermissionRules } from "./permissions-evaluator.js";
+import type { PermissionRules } from "./config.js";
+
+describe("evaluatePermissionRules", () => {
+  const cwd = "/home/user/project";
+
+  it("returns ask when no rules are defined", () => {
+    const result = evaluatePermissionRules(
+      { tool: "bash", args: { command: "ls" }, cwd },
+      {},
+    );
+    assert.strictEqual(result, "ask");
+  });
+
+  it("returns ask when tool has no rules", () => {
+    const result = evaluatePermissionRules(
+      { tool: "bash", args: { command: "ls" }, cwd },
+      { write: { "**": "deny" } },
+    );
+    assert.strictEqual(result, "ask");
+  });
+
+  it("allows bash commands matching allow pattern", () => {
+    const rules: Record<string, PermissionRules> = {
+      bash: { "npm test": "allow", "**": "ask" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "bash", args: { command: "npm test" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "allow");
+  });
+
+  it("denies bash commands matching deny pattern", () => {
+    const rules: Record<string, PermissionRules> = {
+      bash: { "rm -rf": "deny", "**": "allow" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "bash", args: { command: "rm -rf /" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "deny");
+  });
+
+  it("allows file writes to allowed paths", () => {
+    const rules: Record<string, PermissionRules> = {
+      write: { "**/tmp/**": "allow", "**": "deny" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "write", args: { path: "/home/user/project/tmp/file.txt" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "allow");
+  });
+
+  it("denies file writes to non-allowed paths", () => {
+    const rules: Record<string, PermissionRules> = {
+      write: { "**/tmp/**": "allow", "**": "deny" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "write", args: { path: "/home/user/project/src/main.ts" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "deny");
+  });
+
+  it("matches more specific patterns first", () => {
+    const rules: Record<string, PermissionRules> = {
+      write: {
+        "**/src/**": "allow",
+        "**": "deny",
+      },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "write", args: { path: "src/app.tsx" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "allow");
+  });
+
+  it("falls back to ask when no pattern matches", () => {
+    const rules: Record<string, PermissionRules> = {
+      write: { "**/src/**": "allow" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "write", args: { path: "docs/readme.md" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "ask");
+  });
+
+  it("handles glob patterns with wildcards", () => {
+    const rules: Record<string, PermissionRules> = {
+      read: { "**/*.md": "allow", "**": "deny" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "read", args: { path: "README.md" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "allow");
+  });
+
+  it("handles home directory expansion", () => {
+    const rules: Record<string, PermissionRules> = {
+      read: { "~/projects/**": "allow", "**": "deny" },
+    };
+    const result = evaluatePermissionRules(
+      { tool: "read", args: { path: "~/projects/myapp/package.json" }, cwd },
+      rules,
+    );
+    assert.strictEqual(result, "allow");
+  });
+});

--- a/src/permissions-evaluator.ts
+++ b/src/permissions-evaluator.ts
@@ -1,0 +1,133 @@
+/**
+ * Config-based permission rule evaluator for headless/CI mode.
+ *
+ * Rules are defined in ~/.config/kimiflare/config.json as:
+ * {
+ *   "permissions": {
+ *     "bash": { "**\/test\/\*\*": "allow", "**": "ask" },
+ *     "write": { "**": "deny" },
+ *     "edit": { "~/trusted/**": "allow", "**": "ask" }
+ *   }
+ * }
+ *
+ * Evaluation order:
+ * 1. Match the most specific pattern first.
+ * 2. If no rule matches, return "ask" (fallback to interactive behavior).
+ * 3. In headless mode, "ask" becomes "deny" unless --dangerously-allow-all is set.
+ */
+
+import { resolve, relative } from "node:path";
+import { homedir } from "node:os";
+import type { PermissionRule, PermissionRules } from "./config.js";
+
+export interface PermissionEvalRequest {
+  tool: string;
+  args: Record<string, unknown>;
+  cwd: string;
+}
+
+/**
+ * Evaluate permission rules for a tool call.
+ * Returns the decision: "allow", "deny", or "ask".
+ */
+export function evaluatePermissionRules(
+  req: PermissionEvalRequest,
+  rules: Record<string, PermissionRules>,
+): PermissionRule {
+  const toolRules = rules[req.tool];
+  if (!toolRules) return "ask";
+
+  // Extract the target path or command from args
+  const target = extractTarget(req.tool, req.args, req.cwd);
+  if (!target) return "ask";
+
+  // Find matching rules, sorted by specificity (longest pattern first)
+  const entries = Object.entries(toolRules).sort((a, b) => b[0].length - a[0].length);
+
+  for (const [pattern, rule] of entries) {
+    if (matchPattern(target, pattern, req.cwd)) {
+      return rule;
+    }
+  }
+
+  return "ask";
+}
+
+function expandHome(path: string): string {
+  if (path.startsWith("~/")) {
+    return resolve(homedir(), path.slice(2));
+  }
+  return path;
+}
+
+function extractTarget(tool: string, args: Record<string, unknown>, cwd: string): string | null {
+  switch (tool) {
+    case "write":
+    case "edit":
+    case "read":
+    case "glob":
+    case "grep":
+      return typeof args.path === "string" ? resolve(cwd, expandHome(args.path)) : null;
+    case "bash":
+      return typeof args.command === "string" ? args.command : null;
+    case "browser_fetch":
+    case "web_fetch":
+      return typeof args.url === "string" ? args.url : null;
+    case "search_web":
+      return typeof args.query === "string" ? args.query : null;
+    default:
+      // For unknown tools, try common arg names
+      return (
+        (typeof args.path === "string" ? resolve(cwd, expandHome(args.path)) : null) ??
+        (typeof args.url === "string" ? args.url : null) ??
+        (typeof args.command === "string" ? args.command : null)
+      );
+  }
+}
+
+function matchPattern(target: string, pattern: string, cwd: string): boolean {
+  // Expand home directory
+  let expandedPattern = pattern;
+  if (pattern.startsWith("~/")) {
+    expandedPattern = resolve(homedir(), pattern.slice(2));
+  }
+
+  // Absolute path match
+  if (target.startsWith(expandedPattern)) {
+    return true;
+  }
+
+  // Glob-style matching using simple rules
+  const regex = globToRegex(expandedPattern);
+  if (regex.test(target)) {
+    return true;
+  }
+
+  // Try relative to cwd
+  try {
+    const relTarget = relative(cwd, target);
+    if (regex.test(relTarget)) {
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+
+  return false;
+}
+
+function globToRegex(pattern: string): RegExp {
+  // Simple glob to regex conversion
+  let regex = pattern
+    .replace(/\*\*/g, "<<<DOUBLESTAR>>>")
+    .replace(/\*/g, "[^/]*")
+    .replace(/<<<DOUBLESTAR>>>/g, ".*")
+    .replace(/\?/g, ".");
+
+  // If pattern doesn't start with / or ., make it match anywhere
+  if (!regex.startsWith("/") && !regex.startsWith(".*")) {
+    regex = ".*/" + regex;
+  }
+
+  return new RegExp(`^${regex}$`);
+}

--- a/src/print-mode.ts
+++ b/src/print-mode.ts
@@ -1,0 +1,421 @@
+/**
+ * Enhanced print (headless) mode for KimiFlare.
+ *
+ * Supports one-shot prompts with optional session continuation,
+ * file attachments, structured output formats, and cwd override.
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve, basename } from "node:path";
+import { runAgentTurn, BudgetExhaustedError, AgentLoopError } from "./agent/loop.js";
+import type { AgentCallbacks } from "./agent/loop.js";
+import type { AiGatewayOptions } from "./agent/client.js";
+import { buildSystemPrompt } from "./agent/system-prompt.js";
+import { ToolExecutor, ALL_TOOLS } from "./tools/executor.js";
+import type { ChatMessage, ContentPart } from "./agent/messages.js";
+import { KimiApiError, humanizeCloudflareError } from "./util/errors.js";
+import { saveSession, loadSession, listSessions, sessionsDir, type SessionFile } from "./sessions.js";
+import { encodeImageFile, isImagePath } from "./util/image.js";
+import type { UpdateCheckResult } from "./util/update-check.js";
+import { glob } from "./util/glob.js";
+import { evaluatePermissionRules } from "./permissions-evaluator.js";
+import type { PermissionRules } from "./config.js";
+
+export type PrintFormat = "text" | "json" | "stream-json";
+
+export interface PrintModeOpts {
+  accountId: string;
+  apiToken: string;
+  model: string;
+  prompt: string;
+  allowAll: boolean;
+  showReasoning: boolean;
+  coauthor?: boolean;
+  coauthorName?: string;
+  coauthorEmail?: string;
+  aiGatewayId?: string;
+  aiGatewayCacheTtl?: number;
+  aiGatewaySkipCache?: boolean;
+  aiGatewayCollectLogPayload?: boolean;
+  aiGatewayMetadata?: Record<string, string | number | boolean>;
+  updateResult: UpdateCheckResult;
+  codeMode?: boolean;
+  continueOnLimit?: boolean;
+  maxInputTokens?: number;
+  /** Session continuation */
+  continueSession?: boolean;
+  sessionId?: string;
+  /** File attachments (paths or globs) */
+  files?: string[];
+  /** Output format */
+  format?: PrintFormat;
+  /** Working directory override */
+  dir?: string;
+  /** Session title override */
+  title?: string;
+  /** Config-based permission rules */
+  permissions?: Record<string, PermissionRules>;
+}
+
+interface JsonToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+interface JsonToolResult {
+  toolCallId: string;
+  name: string;
+  content: string;
+  ok: boolean;
+}
+
+interface JsonOutput {
+  text: string;
+  toolCalls: JsonToolCall[];
+  toolResults: JsonToolResult[];
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+  durationMs: number;
+  sessionId: string;
+}
+
+function gatewayFromPrintOpts(opts: PrintModeOpts): AiGatewayOptions | undefined {
+  if (!opts.aiGatewayId) return undefined;
+  return {
+    id: opts.aiGatewayId,
+    cacheTtl: opts.aiGatewayCacheTtl,
+    skipCache: opts.aiGatewaySkipCache,
+    collectLogPayload: opts.aiGatewayCollectLogPayload,
+    metadata: opts.aiGatewayMetadata,
+  };
+}
+
+async function resolveSession(opts: PrintModeOpts): Promise<{ sessionFile: SessionFile; isNew: boolean }> {
+  if (opts.sessionId) {
+    const filePath = resolve(sessionsDir(), `${opts.sessionId}.json`);
+    try {
+      const file = await loadSession(filePath);
+      return { sessionFile: file, isNew: false };
+    } catch {
+      // Fall through to create new
+    }
+  }
+
+  if (opts.continueSession) {
+    const cwd = opts.dir ? resolve(opts.dir) : process.cwd();
+    const sessions = await listSessions(1, cwd);
+    if (sessions.length > 0) {
+      const filePath = sessions[0]!.filePath;
+      const file = await loadSession(filePath);
+      return { sessionFile: file, isNew: false };
+    }
+  }
+
+  // Create new session
+  const { makeSessionId } = await import("./sessions.js");
+  const id = makeSessionId(opts.prompt);
+  return {
+    sessionFile: {
+      id,
+      cwd: opts.dir ? resolve(opts.dir) : process.cwd(),
+      model: opts.model,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      title: opts.title,
+    },
+    isNew: true,
+  };
+}
+
+async function resolveFiles(filePatterns: string[], cwd: string): Promise<string[]> {
+  const resolved = new Set<string>();
+  for (const pattern of filePatterns) {
+    // If it's a literal existing file, use it directly
+    try {
+      const stat = await import("node:fs/promises").then((m) => m.stat(resolve(cwd, pattern)));
+      if (stat.isFile()) {
+        resolved.add(resolve(cwd, pattern));
+        continue;
+      }
+    } catch {
+      // Not a literal file, try glob
+    }
+    // Try glob
+    const matches = await glob(pattern, { cwd, absolute: true });
+    for (const m of matches) {
+      resolved.add(m);
+    }
+  }
+  return [...resolved];
+}
+
+async function buildUserMessage(prompt: string, files: string[], cwd: string): Promise<{ content: string | ContentPart[]; display: string }> {
+  let text = prompt;
+  const imageParts: ContentPart[] = [];
+  const fileContents: string[] = [];
+
+  for (const filePath of files) {
+    if (isImagePath(filePath)) {
+      try {
+        const img = await encodeImageFile(filePath);
+        imageParts.push({ type: "image_url", image_url: { url: img.dataUrl } });
+      } catch (e) {
+        fileContents.push(`\n<!-- failed to attach image ${basename(filePath)}: ${(e as Error).message} -->\n`);
+      }
+    } else {
+      try {
+        const content = await readFile(filePath, "utf8");
+        const relPath = filePath.startsWith(cwd) ? filePath.slice(cwd.length + 1) : filePath;
+        fileContents.push(`\n--- ${relPath} ---\n${content}\n--- end ${relPath} ---\n`);
+      } catch (e) {
+        fileContents.push(`\n<!-- failed to read ${basename(filePath)}: ${(e as Error).message} -->\n`);
+      }
+    }
+  }
+
+  if (fileContents.length > 0) {
+    text += "\n\n" + fileContents.join("\n");
+  }
+
+  const display = prompt; // Original prompt without file contents for display
+
+  if (imageParts.length > 0) {
+    const parts: ContentPart[] = [{ type: "text", text }];
+    parts.push(...imageParts);
+    return { content: parts, display };
+  }
+
+  return { content: text, display };
+}
+
+export async function runPrintMode(opts: PrintModeOpts): Promise<void> {
+  const startMs = Date.now();
+
+  if (opts.updateResult.hasUpdate) {
+    process.stderr.write(
+      `\x1b[33mkimiflare update available: ${opts.updateResult.localVersion} → ${opts.updateResult.latestVersion}\x1b[0m\n` +
+        `\x1b[33m  npm update -g kimiflare  then restart\x1b[0m\n\n`,
+    );
+  }
+
+  const cwd = opts.dir ? resolve(opts.dir) : process.cwd();
+
+  // M6.1: print mode loads the same hooks as the TUI.
+  const { HooksManager } = await import("./hooks/manager.js");
+  const hooks = new HooksManager(cwd);
+  const executor = new ToolExecutor(ALL_TOOLS, { hooks });
+
+  // Resolve session
+  const { sessionFile, isNew } = await resolveSession(opts);
+  if (opts.title && isNew) {
+    sessionFile.title = opts.title;
+  }
+
+  // Build messages
+  const messages: ChatMessage[] = [];
+  if (isNew || sessionFile.messages.length === 0) {
+    messages.push({ role: "system", content: buildSystemPrompt({ cwd, tools: ALL_TOOLS, model: opts.model }) });
+  } else {
+    // Continue: load existing messages, filter out old system prompts, keep context
+    const nonSystem = sessionFile.messages.filter((m) => m.role !== "system");
+    messages.push({ role: "system", content: buildSystemPrompt({ cwd, tools: ALL_TOOLS, model: opts.model }) });
+    messages.push(...nonSystem);
+  }
+
+  // Build user message with file attachments
+  const files = opts.files ? await resolveFiles(opts.files, cwd) : [];
+  const { content: userContent } = await buildUserMessage(opts.prompt, files, cwd);
+  messages.push({ role: "user", content: userContent });
+
+  const controller = new AbortController();
+  process.on("SIGINT", () => controller.abort());
+
+  // Output state
+  const format = opts.format ?? "text";
+  let printedReasoningHeader = false;
+  let printedAnswerHeader = false;
+  const jsonOutput: JsonOutput = {
+    text: "",
+    toolCalls: [],
+    toolResults: [],
+    durationMs: 0,
+    sessionId: sessionFile.id,
+  };
+
+  function emitStreamJson(eventType: string, payload: Record<string, unknown>): void {
+    if (format === "stream-json") {
+      process.stdout.write(JSON.stringify({ event: eventType, ...payload }) + "\n");
+    }
+  }
+
+  const callbacks: AgentCallbacks = {
+    onReasoningDelta: opts.showReasoning
+      ? (delta) => {
+          if (format === "text") {
+            if (!printedReasoningHeader) {
+              process.stderr.write("\x1b[2m--- reasoning ---\n");
+              printedReasoningHeader = true;
+            }
+            process.stderr.write(delta);
+          }
+        }
+      : undefined,
+    onTextDelta: (delta) => {
+      if (format === "text") {
+        if (opts.showReasoning && printedReasoningHeader && !printedAnswerHeader) {
+          process.stderr.write("\n--- answer ---\x1b[0m\n");
+          printedAnswerHeader = true;
+        }
+        process.stdout.write(delta);
+      } else if (format === "json") {
+        jsonOutput.text += delta;
+      } else if (format === "stream-json") {
+        emitStreamJson("text_delta", { delta });
+      }
+    },
+    onToolCallFinalized: (call) => {
+      if (format === "text") {
+        process.stderr.write(`\x1b[2m[tool ${call.function.name}(${call.function.arguments})]\x1b[0m\n`);
+      } else if (format === "json") {
+        let args: Record<string, unknown> = {};
+        try {
+          args = JSON.parse(call.function.arguments);
+        } catch {
+          /* ignore */
+        }
+        jsonOutput.toolCalls.push({ id: call.id, name: call.function.name, arguments: args });
+      } else if (format === "stream-json") {
+        emitStreamJson("tool_call", { id: call.id, name: call.function.name, arguments: call.function.arguments });
+      }
+    },
+    onToolResult: (result) => {
+      if (format === "text") {
+        const snippet = result.content.length > 400 ? result.content.slice(0, 400) + "..." : result.content;
+        process.stderr.write(`\x1b[2m[result: ${snippet.replace(/\n/g, " ⏎ ")}]\x1b[0m\n`);
+      } else if (format === "json") {
+        jsonOutput.toolResults.push({
+          toolCallId: result.tool_call_id,
+          name: result.name,
+          content: result.content,
+          ok: result.ok,
+        });
+      } else if (format === "stream-json") {
+        emitStreamJson("tool_result", {
+          toolCallId: result.tool_call_id,
+          name: result.name,
+          content: result.content,
+          ok: result.ok,
+        });
+      }
+    },
+    onUsage: (usage) => {
+      if (format === "json") {
+        jsonOutput.usage = {
+          promptTokens: usage.prompt_tokens ?? 0,
+          completionTokens: usage.completion_tokens ?? 0,
+          totalTokens: usage.total_tokens ?? 0,
+        };
+      } else if (format === "stream-json") {
+        emitStreamJson("usage", {
+          promptTokens: usage.prompt_tokens ?? 0,
+          completionTokens: usage.completion_tokens ?? 0,
+          totalTokens: usage.total_tokens ?? 0,
+        });
+      }
+    },
+    onWarning: (msg) => {
+      if (format === "text") {
+        process.stderr.write(`\x1b[33mkimiflare: ${msg}\x1b[0m\n`);
+      } else if (format === "stream-json") {
+        emitStreamJson("warning", { message: msg });
+      }
+    },
+    askPermission: async ({ tool, args }) => {
+      if (opts.allowAll) return "allow";
+
+      // Evaluate config-based permission rules
+      if (opts.permissions) {
+        const rule = evaluatePermissionRules({ tool: tool.name, args, cwd }, opts.permissions);
+        if (rule === "allow") return "allow";
+        if (rule === "deny") {
+          const msg = `[permission denied by config rule: ${tool.name}(${JSON.stringify(args)})]`;
+          if (format === "text") process.stderr.write(`\x1b[31m${msg}\x1b[0m\n`);
+          else if (format === "stream-json") emitStreamJson("permission_denied", { tool: tool.name, args, reason: "config_rule" });
+          return "deny";
+        }
+        // "ask" falls through to default deny in headless mode
+      }
+
+      const msg = `[permission denied: ${tool.name}(${JSON.stringify(args)}) — pass --dangerously-allow-all to approve in print mode, or configure permissions in config.json]`;
+      if (format === "text") {
+        process.stderr.write(`\x1b[31m${msg}\x1b[0m\n`);
+      } else if (format === "stream-json") {
+        emitStreamJson("permission_denied", { tool: tool.name, args });
+      }
+      return "deny";
+    },
+  };
+
+  try {
+    await runAgentTurn({
+      accountId: opts.accountId,
+      apiToken: opts.apiToken,
+      model: opts.model,
+      gateway: gatewayFromPrintOpts(opts),
+      messages,
+      tools: ALL_TOOLS,
+      executor,
+      hooks,
+      cwd,
+      signal: controller.signal,
+      codeMode: opts.codeMode,
+      continueOnLimit: opts.continueOnLimit,
+      maxInputTokens: opts.maxInputTokens,
+      coauthor:
+        opts.coauthor !== false
+          ? { name: opts.coauthorName || "kimiflare", email: opts.coauthorEmail || "kimiflare@proton.me" }
+          : undefined,
+      callbacks,
+    });
+  } catch (err) {
+    if (err instanceof BudgetExhaustedError) {
+      const msg = "[Budget exhausted — exiting with code 42]";
+      if (format === "text") process.stderr.write(`\n\x1b[33m${msg}\x1b[0m\n`);
+      else if (format === "stream-json") emitStreamJson("error", { message: msg, code: 42 });
+      process.exitCode = 42;
+      return;
+    }
+    if (err instanceof AgentLoopError) {
+      const msg = "[Agent loop detected — exiting with code 43]";
+      if (format === "text") process.stderr.write(`\n\x1b[33m${msg}\x1b[0m\n`);
+      else if (format === "stream-json") emitStreamJson("error", { message: msg, code: 43 });
+      process.exitCode = 43;
+      return;
+    }
+    if (err instanceof KimiApiError) {
+      const msg = `Error: ${humanizeCloudflareError(err)}`;
+      if (format === "text") process.stderr.write(`\n\x1b[31m${msg}\x1b[0m\n`);
+      else if (format === "stream-json") emitStreamJson("error", { message: msg, code: 1 });
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+
+  // Save session
+  sessionFile.messages = messages;
+  sessionFile.updatedAt = new Date().toISOString();
+  await saveSession(sessionFile);
+
+  // Final output
+  jsonOutput.durationMs = Date.now() - startMs;
+
+  if (format === "text") {
+    process.stdout.write("\n");
+  } else if (format === "json") {
+    process.stdout.write(JSON.stringify(jsonOutput, null, 2) + "\n");
+  } else if (format === "stream-json") {
+    emitStreamJson("done", { sessionId: sessionFile.id, durationMs: jsonOutput.durationMs });
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,81 @@
+/**
+ * KimiFlare headless HTTP server.
+ *
+ * Provides a local REST API + SSE event stream for CI integration,
+ * editor plugins, and scripting. Built on Node's built-in `http` module
+ * to avoid extra dependencies.
+ */
+
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { URL } from "node:url";
+import type { KimiConfig } from "../config.js";
+import { logger } from "../util/logger.js";
+import { setupRoutes } from "./routes.js";
+
+export interface ServerOpts {
+  port: number;
+  hostname: string;
+  config: KimiConfig;
+}
+
+export async function startServer(opts: ServerOpts): Promise<Server> {
+  const { handleRequest, cleanup } = setupRoutes(opts.config);
+
+  const server = createServer((req, res) => {
+    // CORS
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, Last-Event-ID");
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // Basic auth if password is configured
+    const password = process.env.KIMIFLARE_SERVER_PASSWORD;
+    if (password) {
+      const auth = req.headers.authorization ?? "";
+      const expected = "Basic " + Buffer.from(`kimiflare:${password}`).toString("base64");
+      if (auth !== expected) {
+        res.writeHead(401, { "WWW-Authenticate": 'Basic realm="kimiflare"' });
+        res.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+    }
+
+    void handleRequest(req, res);
+  });
+
+  server.on("close", () => {
+    cleanup();
+  });
+
+  // Graceful shutdown
+  const shutdown = () => {
+    logger.info("server: shutting down gracefully");
+    server.close(() => {
+      cleanup();
+      process.exit(0);
+    });
+    // Force close after 10s
+    setTimeout(() => {
+      logger.warn("server: forced shutdown");
+      process.exit(1);
+    }, 10000);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  return new Promise((resolve, reject) => {
+    server.listen(opts.port, opts.hostname, () => {
+      logger.info("server: listening", { hostname: opts.hostname, port: opts.port });
+      console.log(`kimiflare serve: http://${opts.hostname}:${opts.port}`);
+      console.log(`  API docs: http://${opts.hostname}:${opts.port}/doc`);
+      console.log(`  SSE stream: http://${opts.hostname}:${opts.port}/event`);
+      resolve(server);
+    });
+    server.on("error", reject);
+  });
+}

--- a/src/server/openapi.ts
+++ b/src/server/openapi.ts
@@ -1,0 +1,256 @@
+/**
+ * OpenAPI 3.1 specification for the KimiFlare headless server.
+ */
+
+export function getOpenApiSpec(): string {
+  const spec = {
+    openapi: "3.1.0",
+    info: {
+      title: "KimiFlare Headless Server API",
+      version: "1.0.0",
+      description: "HTTP API for running KimiFlare agent sessions headlessly.",
+    },
+    servers: [{ url: "/", description: "Local server" }],
+    paths: {
+      "/": {
+        get: {
+          summary: "Health check",
+          responses: {
+            "200": {
+              description: "Server is running",
+              content: {
+                "application/json": {
+                  schema: { type: "object", properties: { status: { type: "string" }, version: { type: "string" } } },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/prompt": {
+        post: {
+          summary: "Start a new agent session with a prompt",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["prompt"],
+                  properties: {
+                    prompt: { type: "string", description: "The user prompt" },
+                    model: { type: "string", description: "Model ID to use" },
+                    cwd: { type: "string", description: "Working directory" },
+                    title: { type: "string", description: "Session title" },
+                    files: { type: "array", items: { type: "string" }, description: "File paths or globs to attach" },
+                    allowAll: { type: "boolean", description: "Auto-approve all tool calls" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "202": {
+              description: "Session started",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      sessionId: { type: "string" },
+                      status: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/session": {
+        get: {
+          summary: "List sessions",
+          parameters: [
+            {
+              name: "cwd",
+              in: "query",
+              schema: { type: "string" },
+              description: "Filter by working directory",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "List of sessions",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      sessions: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            id: { type: "string" },
+                            cwd: { type: "string" },
+                            firstPrompt: { type: "string" },
+                            title: { type: "string" },
+                            messageCount: { type: "number" },
+                            updatedAt: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/session/{id}": {
+        get: {
+          summary: "Get session state",
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Session state",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string" },
+                      cwd: { type: "string" },
+                      model: { type: "string" },
+                      messages: { type: "array" },
+                      title: { type: "string" },
+                      updatedAt: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "404": { description: "Session not found" },
+          },
+        },
+        delete: {
+          summary: "Delete a session",
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Session deleted",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: { deleted: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/session/{id}/prompt": {
+        post: {
+          summary: "Send a follow-up prompt to a session",
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["prompt"],
+                  properties: {
+                    prompt: { type: "string" },
+                    files: { type: "array", items: { type: "string" } },
+                    allowAll: { type: "boolean" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "202": {
+              description: "Follow-up started",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      sessionId: { type: "string" },
+                      status: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "404": { description: "Session not found" },
+          },
+        },
+      },
+      "/event": {
+        get: {
+          summary: "Server-Sent Events stream",
+          responses: {
+            "200": {
+              description: "SSE stream of session events",
+              content: {
+                "text/event-stream": {
+                  schema: {
+                    type: "object",
+                    description: "Stream of events: server.connected, assistant.delta, tool.call, tool.result, usage.update, session.completed, error",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>KimiFlare Headless Server API</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; }
+    pre { background: #f5f5f5; padding: 16px; border-radius: 8px; overflow-x: auto; }
+    h1 { border-bottom: 2px solid #333; padding-bottom: 8px; }
+    h2 { margin-top: 32px; }
+    code { background: #f0f0f0; padding: 2px 6px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>KimiFlare Headless Server API</h1>
+  <p>OpenAPI 3.1 specification for the local HTTP server.</p>
+  <h2>Spec</h2>
+  <pre>${JSON.stringify(spec, null, 2)}</pre>
+</body>
+</html>`;
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,0 +1,399 @@
+/**
+ * HTTP route handlers for the KimiFlare headless server.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { URL } from "node:url";
+import type { KimiConfig } from "../config.js";
+import { runAgentTurn } from "../agent/loop.js";
+import type { AgentCallbacks } from "../agent/loop.js";
+import { buildSystemPrompt } from "../agent/system-prompt.js";
+import { ToolExecutor, ALL_TOOLS } from "../tools/executor.js";
+import type { ChatMessage, ContentPart } from "../agent/messages.js";
+import { saveSession, loadSession, listSessions, sessionsDir, type SessionFile } from "../sessions.js";
+import { logger } from "../util/logger.js";
+import { createSseStream, type SseClient } from "./sse.js";
+import { getOpenApiSpec } from "./openapi.js";
+import { evaluatePermissionRules } from "../permissions-evaluator.js";
+import { readFile } from "node:fs/promises";
+import { resolve, basename } from "node:path";
+import { encodeImageFile, isImagePath } from "../util/image.js";
+import { glob } from "../util/glob.js";
+
+interface ActiveSession {
+  sessionFile: SessionFile;
+  messages: ChatMessage[];
+  executor: ToolExecutor;
+  sseClients: Set<SseClient>;
+}
+
+const activeSessions = new Map<string, ActiveSession>();
+
+function json(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+function badRequest(res: ServerResponse, message: string): void {
+  json(res, 400, { error: message });
+}
+
+function notFound(res: ServerResponse, message: string): void {
+  json(res, 404, { error: message });
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const text = Buffer.concat(chunks).toString("utf8");
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function resolveFiles(filePatterns: string[], cwd: string): Promise<string[]> {
+  const resolved = new Set<string>();
+  for (const pattern of filePatterns) {
+    try {
+      const stat = await import("node:fs/promises").then((m) => m.stat(resolve(cwd, pattern)));
+      if (stat.isFile()) {
+        resolved.add(resolve(cwd, pattern));
+        continue;
+      }
+    } catch {
+      // Not a literal file, try glob
+    }
+    const matches = await glob(pattern, { cwd, absolute: true });
+    for (const m of matches) {
+      resolved.add(m);
+    }
+  }
+  return [...resolved];
+}
+
+async function buildUserMessage(prompt: string, files: string[], cwd: string): Promise<string | ContentPart[]> {
+  let text = prompt;
+  const imageParts: ContentPart[] = [];
+  const fileContents: string[] = [];
+
+  for (const filePath of files) {
+    if (isImagePath(filePath)) {
+      try {
+        const img = await encodeImageFile(filePath);
+        imageParts.push({ type: "image_url", image_url: { url: img.dataUrl } });
+      } catch (e) {
+        fileContents.push(`\n<!-- failed to attach image ${basename(filePath)}: ${(e as Error).message} -->\n`);
+      }
+    } else {
+      try {
+        const content = await readFile(filePath, "utf8");
+        const relPath = filePath.startsWith(cwd) ? filePath.slice(cwd.length + 1) : filePath;
+        fileContents.push(`\n--- ${relPath} ---\n${content}\n--- end ${relPath} ---\n`);
+      } catch (e) {
+        fileContents.push(`\n<!-- failed to read ${basename(filePath)}: ${(e as Error).message} -->\n`);
+      }
+    }
+  }
+
+  if (fileContents.length > 0) {
+    text += "\n\n" + fileContents.join("\n");
+  }
+
+  if (imageParts.length > 0) {
+    const parts: ContentPart[] = [{ type: "text", text }];
+    parts.push(...imageParts);
+    return parts;
+  }
+
+  return text;
+}
+
+export function setupRoutes(config: KimiConfig) {
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+    const method = req.method ?? "GET";
+    const pathname = url.pathname;
+
+    try {
+      // Health check
+      if (pathname === "/" && method === "GET") {
+        json(res, 200, { status: "ok", version: process.env.npm_package_version ?? "dev" });
+        return;
+      }
+
+      // OpenAPI docs
+      if (pathname === "/doc" && method === "GET") {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(getOpenApiSpec());
+        return;
+      }
+
+      // SSE event stream
+      if (pathname === "/event" && method === "GET") {
+        const client = createSseStream(res);
+        client.send("server.connected", { timestamp: Date.now() });
+        // Client is kept alive; cleanup happens on disconnect
+        return;
+      }
+
+      // List sessions
+      if (pathname === "/session" && method === "GET") {
+        const cwd = url.searchParams.get("cwd") ?? undefined;
+        const sessions = await listSessions(30, cwd);
+        json(res, 200, { sessions });
+        return;
+      }
+
+      // Get session
+      const sessionMatch = pathname.match(/^\/session\/([^/]+)$/);
+      if (sessionMatch && method === "GET") {
+        const sessionId = sessionMatch[1]!;
+        const active = activeSessions.get(sessionId);
+        if (active) {
+          json(res, 200, {
+            id: active.sessionFile.id,
+            cwd: active.sessionFile.cwd,
+            model: active.sessionFile.model,
+            messages: active.messages,
+            title: active.sessionFile.title,
+            updatedAt: active.sessionFile.updatedAt,
+          });
+          return;
+        }
+        try {
+          const file = await loadSession(resolve(sessionsDir(), `${sessionId}.json`));
+          json(res, 200, {
+            id: file.id,
+            cwd: file.cwd,
+            model: file.model,
+            messages: file.messages,
+            title: file.title,
+            updatedAt: file.updatedAt,
+          });
+          return;
+        } catch {
+          notFound(res, `session ${sessionId} not found`);
+          return;
+        }
+      }
+
+      // Delete session
+      if (sessionMatch && method === "DELETE") {
+        const sessionId = sessionMatch[1]!;
+        activeSessions.delete(sessionId);
+        try {
+          const { unlink } = await import("node:fs/promises");
+          await unlink(resolve(sessionsDir(), `${sessionId}.json`));
+        } catch {
+          // ignore
+        }
+        json(res, 200, { deleted: sessionId });
+        return;
+      }
+
+      // Prompt (new session)
+      if (pathname === "/prompt" && method === "POST") {
+        const body = (await readBody(req)) as Record<string, unknown>;
+        const prompt = typeof body.prompt === "string" ? body.prompt : "";
+        const model = typeof body.model === "string" ? body.model : (config.model ?? "@cf/moonshotai/kimi-k2.6");
+        const cwd = typeof body.cwd === "string" ? body.cwd : process.cwd();
+        const title = typeof body.title === "string" ? body.title : undefined;
+        const files = Array.isArray(body.files) ? body.files.filter((f): f is string => typeof f === "string") : [];
+        const allowAll = body.allowAll === true;
+
+        if (!prompt) {
+          badRequest(res, "prompt is required");
+          return;
+        }
+
+        const { makeSessionId } = await import("../sessions.js");
+        const sessionId = makeSessionId(prompt);
+        const sessionFile: SessionFile = {
+          id: sessionId,
+          cwd,
+          model,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          messages: [],
+          title,
+        };
+
+        const executor = new ToolExecutor(ALL_TOOLS);
+        const messages: ChatMessage[] = [
+          { role: "system", content: buildSystemPrompt({ cwd, tools: ALL_TOOLS, model }) },
+        ];
+
+        const resolvedFiles = await resolveFiles(files, cwd);
+        const userContent = await buildUserMessage(prompt, resolvedFiles, cwd);
+        messages.push({ role: "user", content: userContent });
+
+        const active: ActiveSession = {
+          sessionFile,
+          messages,
+          executor,
+          sseClients: new Set(),
+        };
+        activeSessions.set(sessionId, active);
+
+        // Start agent turn in background
+        runAgentTurnForSession(active, config, allowAll);
+
+        json(res, 202, { sessionId, status: "started" });
+        return;
+      }
+
+      // Follow-up prompt to existing session
+      if (pathname === "/session/:id/prompt" && method === "POST") {
+        // Actually the regex below handles this
+      }
+
+      const sessionPromptMatch = pathname.match(/^\/session\/([^/]+)\/prompt$/);
+      if (sessionPromptMatch && method === "POST") {
+        const sessionId = sessionPromptMatch[1]!;
+        const active = activeSessions.get(sessionId);
+        if (!active) {
+          notFound(res, `session ${sessionId} not found or expired`);
+          return;
+        }
+
+        const body = (await readBody(req)) as Record<string, unknown>;
+        const prompt = typeof body.prompt === "string" ? body.prompt : "";
+        const files = Array.isArray(body.files) ? body.files.filter((f): f is string => typeof f === "string") : [];
+        const allowAll = body.allowAll === true;
+
+        if (!prompt) {
+          badRequest(res, "prompt is required");
+          return;
+        }
+
+        const resolvedFiles = await resolveFiles(files, active.sessionFile.cwd);
+        const userContent = await buildUserMessage(prompt, resolvedFiles, active.sessionFile.cwd);
+        active.messages.push({ role: "user", content: userContent });
+
+        runAgentTurnForSession(active, config, allowAll);
+
+        json(res, 202, { sessionId, status: "started" });
+        return;
+      }
+
+      // Not found
+      notFound(res, `unknown endpoint: ${method} ${pathname}`);
+    } catch (err) {
+      logger.error("server: request error", { error: (err as Error).message, path: pathname });
+      json(res, 500, { error: (err as Error).message });
+    }
+  }
+
+  function cleanup(): void {
+    for (const [, active] of activeSessions) {
+      for (const client of active.sseClients) {
+        client.close();
+      }
+    }
+    activeSessions.clear();
+  }
+
+  return { handleRequest, cleanup };
+}
+
+async function runAgentTurnForSession(active: ActiveSession, config: KimiConfig, allowAll: boolean): Promise<void> {
+  const controller = new AbortController();
+  const { sessionFile, messages, executor } = active;
+
+  const callbacks: AgentCallbacks = {
+    onTextDelta: (delta) => {
+      for (const client of active.sseClients) {
+        client.send("assistant.delta", { delta });
+      }
+    },
+    onToolCallFinalized: (call) => {
+      for (const client of active.sseClients) {
+        client.send("tool.call", {
+          id: call.id,
+          name: call.function.name,
+          arguments: call.function.arguments,
+        });
+      }
+    },
+    onToolResult: (result) => {
+      for (const client of active.sseClients) {
+        client.send("tool.result", {
+          toolCallId: result.tool_call_id,
+          name: result.name,
+          content: result.content,
+          ok: result.ok,
+        });
+      }
+    },
+    onUsage: (usage) => {
+      for (const client of active.sseClients) {
+        client.send("usage.update", {
+          promptTokens: usage.prompt_tokens,
+          completionTokens: usage.completion_tokens,
+          totalTokens: usage.total_tokens,
+        });
+      }
+    },
+    onWarning: (msg) => {
+      for (const client of active.sseClients) {
+        client.send("warning", { message: msg });
+      }
+    },
+    askPermission: async ({ tool, args }) => {
+      if (allowAll) return "allow";
+
+      // Evaluate config-based permission rules
+      if (config.permissions) {
+        const rule = evaluatePermissionRules({ tool: tool.name, args, cwd: sessionFile.cwd }, config.permissions);
+        if (rule === "allow") return "allow";
+        if (rule === "deny") {
+          for (const client of active.sseClients) {
+            client.send("permission.denied", { tool: tool.name, args, reason: "config_rule" });
+          }
+          return "deny";
+        }
+      }
+
+      for (const client of active.sseClients) {
+        client.send("permission.request", { tool: tool.name, args });
+      }
+      // In server mode without allowAll, we auto-deny after a brief wait
+      // since there's no interactive user. Future: support async permission
+      // approval via a separate endpoint.
+      return "deny";
+    },
+  };
+
+  try {
+    await runAgentTurn({
+      accountId: config.accountId,
+      apiToken: config.apiToken,
+      model: sessionFile.model,
+      messages,
+      tools: ALL_TOOLS,
+      executor,
+      cwd: sessionFile.cwd,
+      signal: controller.signal,
+      codeMode: config.codeMode,
+      callbacks,
+    });
+
+    sessionFile.messages = messages;
+    sessionFile.updatedAt = new Date().toISOString();
+    await saveSession(sessionFile);
+
+    for (const client of active.sseClients) {
+      client.send("session.completed", { sessionId: sessionFile.id });
+    }
+  } catch (err) {
+    const message = (err as Error).message;
+    logger.error("server: agent turn failed", { sessionId: sessionFile.id, error: message });
+    for (const client of active.sseClients) {
+      client.send("error", { message, sessionId: sessionFile.id });
+    }
+  }
+}

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -1,0 +1,39 @@
+/**
+ * Server-Sent Events (SSE) stream handler.
+ */
+
+import type { ServerResponse } from "node:http";
+
+export interface SseClient {
+  send(event: string, data: Record<string, unknown>): void;
+  close(): void;
+}
+
+export function createSseStream(res: ServerResponse): SseClient {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+
+  // Heartbeat to keep connection alive
+  const heartbeat = setInterval(() => {
+    res.write(":heartbeat\n\n");
+  }, 30000);
+
+  res.on("close", () => {
+    clearInterval(heartbeat);
+  });
+
+  return {
+    send(event: string, data: Record<string, unknown>) {
+      const payload = JSON.stringify(data);
+      res.write(`event: ${event}\n`);
+      res.write(`data: ${payload}\n\n`);
+    },
+    close() {
+      clearInterval(heartbeat);
+      res.end();
+    },
+  };
+}


### PR DESCRIPTION
# Headless / CI Mode Parity with OpenCode

> Status: Planning complete — ready for implementation  
> Author: kimiflare  
> Date: 2026-06-12  
> Branch: `feat/headless-ci-parity`

---

## 1. Executive Summary

**This is a very achievable goal.** KimiFlare's existing architecture already covers ~60% of OpenCode's headless/CI surface. We have a solid print mode (`-p`), an NDJSON emit protocol (`--emit-events`), a permission system with auto-approval (`--dangerously-allow-all`), session persistence, and an SDK with an RPC server. The remaining gaps are incremental enhancements and one medium-sized feature (a persistent HTTP server).

**Estimated effort: 2–3 weeks of focused work** for one developer, or one sprint for a small team.

---

## 2. Current State Assessment

### 2.1 What KimiFlare Already Has

| Feature | Location | Notes |
|---------|----------|-------|
| **One-shot headless prompt** | `src/index.tsx:21` (`-p, --print <prompt>`) | Streams reply to stdout, exits. Foundation is solid. |
| **NDJSON event stream** | `src/emit-mode.ts` (`--emit-events`) | Camouflage protocol — more structured than OpenCode's `--format json`. Already supports multi-turn via stdin. |
| **Auto-approval** | `src/index.tsx:23` (`--dangerously-allow-all`) | Equivalent to OpenCode's `--dangerously-skip-permissions`. |
| **Model override** | `src/index.tsx:22` (`-m, --model <id>`) | Works in both print and interactive modes. |
| **Multi-turn stdin** | `src/emit-mode.ts:156` (`--multi-turn`) | Reads `UserInputSubmitted` NDJSON lines from stdin after initial turn. |
| **Bidirectional permissions** | `src/emit-mode.ts:114` | `PermissionResponse` messages on stdin resolve pending asks. |
| **Session persistence** | `src/sessions.ts` | Full load/save with checkpoints, artifacts, titles. |
| **SDK / RPC server** | `src/sdk/rpc.ts` (`--mode rpc`) | Stdio-based JSON-RPC for editor integrations (Zed, etc.). |
| **Tool hooks** | `src/hooks/manager.ts` | Pre/Post tool-use hooks fire in print mode too (M6.1). |
| **Output reduction** | `src/tools/reducer.ts` | Large tool outputs are capped automatically. |
| **Budget exhaustion** | `src/agent/loop.ts` | Exits 42 when `maxInputTokens` is hit. |
| **Reasoning output** | `src/index.tsx:24` (`--reasoning`) | Streams reasoning blocks to stderr in print mode. |
| **Continue on limit** | `src/index.tsx:25` (`--continue-on-limit`) | Resets tool-call counter at 200 calls. |

### 2.2 What's Missing vs. OpenCode

| OpenCode Feature | KimiFlare Gap | Complexity |
|------------------|---------------|------------|
| `opencode run [message..]` | **Naming only** — we have `-p`. Minor UX difference. | Trivial |
| `opencode serve` (persistent HTTP server) | **No HTTP server.** RPC is stdio-only. | Medium |
| `--attach http://...` | **No attach mode.** Cannot connect CLI to a warm server. | Medium (depends on serve) |
| `--format json` (raw JSON events) | **Only NDJSON via `--emit-events`.** No plain JSONL for print mode. | Low |
| `--file` / `-f` (file attachments) | **Not supported in print/emit mode.** | Low |
| `--continue` / `-c` in headless | **`--continue` is interactive-only.** Print mode always starts fresh. | Low |
| `--session <id>` in headless | **Session ID is ignored in print mode.** | Low |
| `--dir <path>` | **Always uses `process.cwd()`.** | Low |
| `--title <title>` | **Sessions auto-titled.** No override in headless. | Low |
| `--thinking` | **We have `--reasoning`.** Naming mismatch only. | Trivial |
| `--variant` (model variant) | **No variant support.** | Low |
| Server-Sent Events (`/event`) | **No SSE endpoint.** | Medium (depends on serve) |
| OpenAPI spec | **No HTTP API docs.** | Low (depends on serve) |
| mDNS discovery | **Not implemented.** | Low |
| `--share` | **No session sharing.** | Medium |

---

## 3. Root Cause: Why the Gaps Exist

### 3.1 Print Mode Was Built as a "Simple Utility"

`runPrintMode` (`src/index.tsx:360`) was designed for quick one-offs:
- No session loading — always starts with a fresh `[system, user]` message pair.
- No file attachment parsing — the TUI handles `@file` mentions via `input-handlers.ts`.
- Permission asker is a binary: `allowAll ? "allow" : "deny"` — no gradation.

### 3.2 Emit Mode Is Tightly Coupled to Camouflage

`runEmitMode` (`src/emit-mode.ts:57`) emits the Camouflage event protocol. It's powerful but opinionated:
- Event names like `AssistantStreamStarted`, `UserMessageCreated` are Camouflage-specific.
- There's no "plain JSONL" mode for generic scripting.
- Multi-turn is stdin-driven, not HTTP-driven.

### 3.3 No HTTP Layer

The RPC server (`src/sdk/rpc.ts:21`) is stdio-based by design — it's for ACP (Agent Client Protocol) editor integration. There's no Hono/Express/Fastify server in the main CLI bundle. The `remote/worker/` sub-project has Hono, but it's a separate deployable artifact, not a local CLI feature.

---

## 4. Implementation Plan

### Phase 1: Enhanced Print Mode (Week 1)

**Goal:** Close the "simple headless" gap without adding a server.

#### 4.1.1 P1.1 — Session Continuation in Print Mode

**Files:** `src/index.tsx`, `src/print-mode.ts` (new)

**Work:**
- Extract `runPrintMode` from `src/index.tsx` into a new `src/print-mode.ts` module.
- Add `--continue` and `--session <id>` support to print mode.
- When continuing, load the session file from `~/.local/share/kimiflare/sessions/`, filter out old system prompts, and append the new user prompt.
- Preserve the session's artifact store across turns.

**Interface:**
```bash
kimiflare -p "fix the bug" --continue          # continue last session in cwd
kimiflare -p "fix the bug" --session abc123     # continue specific session
```

#### 4.1.2 P1.2 — File Attachments in Headless Mode

**Files:** `src/print-mode.ts`, `src/emit-mode.ts`

**Work:**
- Add `--file <path>` / `-f <path>` CLI flag (repeatable).
- Read file contents and inject them into the user message using the same format as TUI `@file` mentions (`src/ui/input-handlers.ts`).
- Support glob patterns (`--file "src/**/*.ts"`).
- In emit mode, emit `FileAttached` events so the TUI renderer can show them.

**Interface:**
```bash
kimiflare -p "refactor these" -f src/utils.ts -f src/helpers.ts
kimiflare -p "review" -f "docs/**/*.md"
```

#### 4.1.3 P1.3 — `--format json` for Print Mode

**Files:** `src/print-mode.ts`

**Work:**
- Add `--format <mode>` flag with values: `text` (default), `json`, `stream-json`.
- `text`: current behavior — assistant text to stdout, tool metadata to stderr.
- `json`: single JSON object at the end containing `{ text, toolCalls[], usage, duration }`.
- `stream-json`: NDJSON lines, one per event (assistant delta, tool call, tool result, usage update). This is a simplified, non-Camouflage version of `--emit-events`.

**Interface:**
```bash
kimiflare -p "list files" --format json
kimiflare -p "list files" --format stream-json
```

#### 4.1.4 P1.4 — `--dir` and `--title` Flags

**Files:** `src/print-mode.ts`, `src/emit-mode.ts`

**Work:**
- `--dir <path>`: `process.chdir()` before running, or pass `cwd` override to `ToolExecutor` and `buildSystemPrompt`.
- `--title <title>`: override auto-generated session title when saving.

**Interface:**
```bash
kimiflare -p "analyze" --dir ./other-project --title "security-audit"
```

#### 4.1.5 P1.5 — Rename `--reasoning` to `--thinking` (Alias)

**Files:** `src/index.tsx`

**Work:**
- Keep `--reasoning` for back-compat.
- Add `--thinking` as an alias. Update docs.

---

### Phase 2: Persistent HTTP Server (Week 2)

**Goal:** Build `kimiflare serve` — a local HTTP server that avoids cold-start costs and enables multi-client access.

#### 4.2.1 P2.1 — HTTP Server Core

**Files:** `src/server/index.ts` (new), `src/server/routes.ts` (new)

**Work:**
- Add a new CLI subcommand: `kimiflare serve`.
- Use **Hono** (already a transitive dep via `remote/worker/`) or Node's built-in `http` module to avoid new dependencies.
- Bind to `localhost` by default, configurable via `--port` and `--hostname`.
- Support `KIMIFLARE_SERVER_PASSWORD` for HTTP Basic Auth (username defaults to `kimiflare`).

**Interface:**
```bash
kimiflare serve --port 4096 --hostname 127.0.0.1
```

**Architecture decision:** Use Node's built-in `http` + `createServer` to keep the bundle self-contained. Hono is nice but adds a dep to the main CLI. If we already bundle Hono for remote, check `tsup.config.ts` externals first.

#### 4.2.2 P2.2 — Session Management API

**Files:** `src/server/routes.ts`

**Work:**
- `POST /prompt` — submit a prompt, get a session ID back.
- `GET /session/:id` — get session state, messages, usage.
- `POST /session/:id/prompt` — send a follow-up to an existing session.
- `DELETE /session/:id` — delete a session.
- `GET /session` — list all sessions.

**Request/response shape:** JSON, matching the SDK types (`src/sdk/types.ts`).

#### 4.2.3 P2.3 — Server-Sent Events Stream

**Files:** `src/server/sse.ts` (new)

**Work:**
- `GET /event` — SSE endpoint that streams session events.
- First event: `server.connected`.
- Subsequent events: `assistant.delta`, `tool.call`, `tool.result`, `usage.update`, `session.completed`, `error`.
- Support `Last-Event-ID` for resumable streams.

**This is the most important feature for CI/scripting.** It lets external tools observe agent progress in real time without polling.

#### 4.2.4 P2.4 — Attach Mode for CLI

**Files:** `src/index.tsx`, `src/attach-mode.ts` (new)

**Work:**
- Add `--attach <url>` flag to print mode.
- Instead of running `runAgentTurn` locally, POST to `http://<url>/prompt` and stream the SSE response to stdout.
- This avoids MCP/LSP cold-boot times on every CLI invocation — the server keeps them warm.

**Interface:**
```bash
# Terminal 1
kimiflare serve --port 4096

# Terminal 2
kimiflare -p "explain this" --attach http://localhost:4096
kimiflare -p "fix the bug" --attach http://localhost:4096 --format json
```

#### 4.2.5 P2.5 — OpenAPI Spec

**Files:** `src/server/openapi.ts` (new)

**Work:**
- Auto-generate an OpenAPI 3.1 spec from the route handlers.
- Serve it at `GET /doc`.
- This is low-effort high-value — enables codegen, documentation, and Postman imports.

---

### Phase 3: Advanced Features (Week 3)

#### 4.3.1 P3.1 — Permission Rules Config File

**Files:** `src/config.ts`, `src/tools/executor.ts`

**Work:**
- Add a `permissions` field to `~/.config/kimiflare/config.json`:
  ```json
  {
    "permissions": {
      "bash": { "~/trusted/**": "allow", "**": "ask" },
      "write": { "**": "ask" },
      "edit": { "**": "ask" }
    }
  }
  ```
- In headless mode, evaluate these rules before falling back to `--dangerously-allow-all` or deny.
- This gives OpenCode-style granular control without requiring `--dangerously-allow-all` for every CI run.

#### 4.3.2 P3.2 — Model Variant Support

**Files:** `src/config.ts`, `src/agent/client.ts`

**Work:**
- Add `--variant <variant>` flag (e.g., `--variant reasoning`).
- Map variants to provider-specific parameters (e.g., `reasoning_effort` for Anthropic, `thinking` for OpenAI).

#### 4.3.3 P3.3 — Session Sharing

**Files:** `src/server/routes.ts`, `src/sessions.ts`

**Work:**
- `POST /session/:id/share` — generate a shareable token.
- `GET /session/shared/:token` — read-only access to a session transcript.
- Useful for sharing agent runs with teammates or attaching them to PRs.

#### 4.3.4 P3.4 — mDNS Discovery (Optional)

**Files:** `src/server/mdns.ts` (new)

**Work:**
- Advertise `kimiflare serve` instances on the local network via Bonjour/mDNS.
- Enables `kimiflare -p "..." --attach http://kimiflare.local` without knowing the IP.
- Add `--mdns` and `--mdns-domain` flags.

**Note:** This requires a new dependency (`bonjour-service` or similar). Consider making it optional.

---

## 5. Architecture Decisions

### 5.1 Why Not Reuse `remote/worker/`?

The `remote/worker/` sub-project is a Cloudflare Worker (Hono + Wrangler) designed for remote deployment. It has auth, rate limiting, and multi-tenant concerns that are overkill for a local CLI server. The local server should be:
- Zero-config (no Wrangler, no CF account).
- Single-tenant (one user, one machine).
- Lightweight (no bundling, no deploy step).

**Decision:** Build a separate `src/server/` module using Node's built-in `http`. Share types and session logic with the SDK.

### 5.2 Why Not Replace `--emit-events` with `--format json`?

`--emit-events` is the Camouflage wire protocol. It's stable and has a consumer (the Rust TUI). `--format json` is a user-facing scripting convenience. They serve different audiences.

**Decision:** Keep both. `--format json` is a simplified, documented format for scripts. `--emit-events` remains the Camouflage integration point.

### 5.3 Permission Model in Headless Mode

OpenCode's `--dangerously-skip-permissions` auto-approves anything not explicitly denied. KimiFlare's `--dangerously-allow-all` is the same. But OpenCode also supports config-based rules.

**Decision:** Implement config-based rules (P3.1) as the primary headless permission mechanism. `--dangerously-allow-all` becomes the "I know what I'm doing" escape hatch. In `-p` mode without either, default to `deny` with a clear stderr message.

---

## 6. Testing Strategy

### 6.1 Unit Tests

- `print-mode.test.ts`: test session loading, file attachment injection, format output.
- `server/routes.test.ts`: test HTTP routes with `node:test` and `supertest` (or raw `http` requests).
- `server/sse.test.ts`: test SSE event streaming and reconnection.

### 6.2 Integration Tests

- Start `kimiflare serve`, run `kimiflare -p "..." --attach`, verify output.
- Test MCP cold-boot avoidance: measure time with/without `--attach`.
- Test permission rules: config file with `allow` for `bash` in `~/tmp/**`, run a bash tool in that dir, verify no prompt.

### 6.3 CI/CD

- Add a GitHub Actions job that runs `kimiflare -p "list files" --format json` and validates the JSON schema.
- Add a job that starts `kimiflare serve`, hits `/doc`, and verifies the OpenAPI spec is valid (using `swagger-parser`).

---

## 7. Migration & Backward Compatibility

| Change | Backward Compatible? | Mitigation |
|--------|---------------------|------------|
| Extract `runPrintMode` to `src/print-mode.ts` | ✅ Yes | Re-export from `index.tsx` if needed. |
| Add `--format`, `--file`, `--dir`, `--title` | ✅ Yes | New flags, no breaking changes. |
| Add `--thinking` alias | ✅ Yes | `--reasoning` still works. |
| Add `kimiflare serve` subcommand | ✅ Yes | New entry point, no existing behavior changed. |
| Config-based permission rules | ✅ Yes | Only evaluated when `permissions` key is present. |
| `--attach` flag | ✅ Yes | New flag. |

---

## 8. Risks & Mitigations

| Risk | Likelihood | Impact | Mitigation |
|------|-----------|--------|------------|
| HTTP server bloats the bundle | Medium | Medium | Use Node built-in `http`, no Hono/Express. Make server code lazy-loaded (`await import("./server")`). |
| SSE connections leak on crash | Low | Medium | Use `AbortController` per connection, clean up on `process.on('exit')`. |
| Session file corruption with concurrent writes | Low | High | Use atomic writes (`writeFile` to temp, then `rename`). Server holds in-memory lock per session ID. |
| Permission rules are confusing | Medium | Medium | Document with examples. Start with simple glob patterns only. |
| MCP servers don't work well in server mode | Medium | High | Test MCP lifecycle carefully. Each session may need its own MCP client pool, or share a global one with reference counting. |

---

## 9. Success Criteria

We will consider this plan complete when:

1. [ ] `kimiflare -p "do X" --format json` produces valid, documented JSON.
2. [ ] `kimiflare -p "do X" -f file.ts` attaches files correctly.
3. [ ] `kimiflare -p "do X" --continue` resumes the last session.
4. [ ] `kimiflare serve` starts an HTTP server with SSE events.
5. [ ] `kimiflare -p "do X" --attach http://localhost:4096` connects to the server and streams output.
6. [ ] `GET /doc` returns a valid OpenAPI 3.1 spec.
7. [ ] Config-based permission rules work in headless mode.
8. [ ] All new code has co-located tests.
9. [ ] `npm run typecheck` passes.

---

## 10. Appendix: OpenCode → KimiFlare Command Mapping

| OpenCode | KimiFlare (after this plan) | Notes |
|----------|----------------------------|-------|
| `opencode run "prompt"` | `kimiflare -p "prompt"` | Same semantics. |
| `opencode run -m provider/model` | `kimiflare -p "..." -m @cf/moonshotai/kimi-k2.6` | Same. |
| `opencode run --format json` | `kimiflare -p "..." --format json` | New flag. |
| `opencode run --dangerously-skip-permissions` | `kimiflare -p "..." --dangerously-allow-all` | Already exists. |
| `opencode run --file path` | `kimiflare -p "..." -f path` | New flag. |
| `opencode run --continue` | `kimiflare -p "..." --continue` | New flag. |
| `opencode run --session id` | `kimiflare -p "..." --session id` | New flag. |
| `opencode run --dir path` | `kimiflare -p "..." --dir path` | New flag. |
| `opencode run --title title` | `kimiflare -p "..." --title title` | New flag. |
| `opencode serve` | `kimiflare serve` | New subcommand. |
| `opencode run --attach url` | `kimiflare -p "..." --attach url` | New flag. |
| `opencode serve --port 4096` | `kimiflare serve --port 4096` | Same. |
| `opencode serve --hostname 0.0.0.0` | `kimiflare serve --hostname 0.0.0.0` | Same. |
| `GET /event` (SSE) | `GET /event` (SSE) | New endpoint. |
| `GET /doc` (OpenAPI) | `GET /doc` (OpenAPI) | New endpoint. |

---

*Co-authored-by: kimiflare <kimiflare@proton.me>*
