### PR TITLE
fix(ui): default to React Ink, update K2.6 to K2.7 branding, bump v0.88.1

### DIFF
--- a/KIMI.md
+++ b/KIMI.md
@@ -7,7 +7,7 @@
 
 ## 1. Project
 
-**KimiFlare** is a terminal coding agent powered by multiple models (Kimi-K2.6, Claude, GPT-5, Gemini, Llama, Groq), routed through your own Cloudflare AI Gateway. It provides an interactive TUI (Terminal User Interface) for AI-assisted coding, file editing, shell command execution, and project exploration with a 262k-token context window.
+**KimiFlare** is a terminal coding agent powered by multiple models (Kimi-K2.7, Claude, GPT-5, Gemini, Llama, Groq), routed through your own Cloudflare AI Gateway. It provides an interactive TUI (Terminal User Interface) for AI-assisted coding, file editing, shell command execution, and project exploration with a 262k-token context window.
 
 - **Primary language:** TypeScript 5.7
 - **Runtime:** Node.js ≥ 20 (ESM only)
@@ -215,7 +215,7 @@ node --inspect-brk bin/kimiflare.mjs
 
 ### External Integrations
 - **Cloudflare AI Gateway** — the spine. All traffic is routed through the user's own Gateway by default: this gives us per-request logs, caching, and authoritative cost attribution via `cf-aig-metadata` tagging (`feature`, `sessionId`, `turnIdx`). Gateway logs are the source of truth for `/cost`; local heuristics are demoted to a brief fallback used only until logs catch up. Supports Universal Endpoint for multi-provider routing (Anthropic, OpenAI, Google, etc.). Emergency opt-out: `KIMIFLARE_DISABLE_AI_GATEWAY=1`.
-- **Cloudflare Workers AI** — primary LLM backend (Kimi-K2.6). Reached via the Gateway in normal operation; direct path remains in code as fallback.
+- **Cloudflare Workers AI** — primary LLM backend (Kimi-K2.7). Reached via the Gateway in normal operation; direct path remains in code as fallback.
 - **MCP Servers** — external tools via Model Context Protocol.
 - **LSP Servers** — language servers for code intelligence.
 - **GitHub API** — PR/issue/code reading via `src/tools/github.ts`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimiflare",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "description": "A terminal coding agent powered by Kimi K2.7, routed through your own Cloudflare AI Gateway — per-request logs, response caching, authoritative cost. Web search, GitHub, headless browser, LSP, MCP, local memory, 262k context.",
   "keywords": [
     "ai",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1228,6 +1228,21 @@ function App({
     (picked: "ink" | "camouflage" | null) => {
       setShowUiPicker(false);
       if (!picked) return;
+      if (picked === "camouflage") {
+        // Camouflage is strictly opt-in via CLI flag or env var; we do not
+        // persist it to config so it can never become the silent default.
+        setEvents((e) => [
+          ...e,
+          {
+            kind: "error",
+            key: mkKey(),
+            text:
+              "Camouflage is experimental and must be opted into explicitly. " +
+              "Launch with `kimiflare --ui camouflage` or set `KIMIFLARE_UI=camouflage`.",
+          },
+        ]);
+        return;
+      }
       setCfg((c) => {
         if (!c) return c;
         const updated = { ...c, uiEngine: picked };
@@ -1239,11 +1254,7 @@ function App({
         {
           kind: "error",
           key: mkKey(),
-          text:
-            `UI engine set to "${picked}". RESTART kimiflare for it to take effect.` +
-            (picked === "camouflage"
-              ? " (Camouflage is EXPERIMENTAL — `kimiflare --ui ink` or `unset KIMIFLARE_UI` to bail.)"
-              : ""),
+          text: `UI engine set to "${picked}". RESTART kimiflare for it to take effect.`,
         },
       ]);
     },

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -11,7 +11,7 @@ export const BUILTIN_COMMANDS: SlashItem[] = [
   { name: "mode", argHint: "edit|plan|auto|multi-agent-experimental", description: "Switch agent mode", source: "builtin" },
   { name: "multi-agent", argHint: "[enable|disable|status|setup]", description: "Configure multi-agent (endpoint, auto-implement, set up)", source: "builtin" },
   { name: "theme", argHint: "[<name>]", description: "Switch color theme", source: "builtin" },
-  { name: "ui", argHint: "ink|camouflage", description: "Switch UI engine (takes effect on next launch)", source: "builtin" },
+  { name: "ui", argHint: "ink", description: "Switch UI engine to React Ink (takes effect on next launch). Camouflage is opt-in via --ui camouflage.", source: "builtin" },
   { name: "plan", description: "Switch to plan mode", source: "builtin" },
   { name: "auto", description: "Switch to auto mode", source: "builtin" },
   { name: "edit", description: "Switch to edit mode", source: "builtin" },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -312,14 +312,14 @@ async function main() {
   // alt-screen and flash for a fraction of a second.
   const logoText = renderLogo(getAppVersion());
 
-  // UI engine resolution: `--ui` flag wins, then `KIMIFLARE_UI` env var,
-  // then the persisted `uiEngine` field in ~/.config/kimiflare/config.json
-  // (set from inside either TUI via the `/ui` slash command), then the safe
-  // default (`ink`). Camouflage is opt-in experimental until it covers every
-  // surface (queue, hooks, mode switching, MCP UI, etc.) and gets enough
-  // burn-in via dogfooding.
+  // UI engine resolution: React Ink is the default for all users.
+  // Camouflage is strictly opt-in via `--ui camouflage` or the `KIMIFLARE_UI`
+  // env var. We deliberately do NOT let a persisted `uiEngine: "camouflage"`
+  // field in ~/.config/kimiflare/config.json silently switch users to the
+  // experimental engine on the next launch.
+  const explicitUi = opts.ui ?? process.env.KIMIFLARE_UI;
   const uiEngine = (
-    opts.ui ?? process.env.KIMIFLARE_UI ?? cfg?.uiEngine ?? "ink"
+    explicitUi ?? (cfg?.uiEngine === "ink" ? "ink" : undefined) ?? "ink"
   ).toLowerCase();
   if (uiEngine !== "camouflage") {
     console.log(logoText);

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -2147,7 +2147,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
               {
                 value: "camouflage",
                 label: "Camouflage",
-                description: "experimental Rust TUI — bail with `kimiflare --ui ink`",
+                description: "experimental — opt in with `kimiflare --ui camouflage`",
               },
             ],
             default: current,
@@ -2164,6 +2164,18 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
             text: `unknown UI engine "${args}" — choose "ink" or "camouflage"`,
             kind: "warn",
             ttl_ms: 3000,
+          });
+          return true;
+        }
+        if (nextUi === "camouflage") {
+          // Camouflage is strictly opt-in via CLI flag or env var; we do not
+          // persist it so it can never become the silent default for users.
+          cam.send("ShowToast", {
+            text:
+              "Camouflage is experimental and must be opted into explicitly. " +
+              "Launch with `kimiflare --ui camouflage` or set `KIMIFLARE_UI=camouflage`.",
+            kind: "error",
+            ttl_ms: 12000,
           });
           return true;
         }
@@ -2185,9 +2197,7 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
         cam.send("ShowToast", {
           text:
             `UI engine set to "${nextUi}". RESTART kimiflare for it to take effect.` +
-            (nextUi === "ink"
-              ? "  (or `unset KIMIFLARE_UI` if you previously exported it)"
-              : "  (Camouflage is EXPERIMENTAL — `kimiflare --ui ink` to bail.)"),
+            "  (or `unset KIMIFLARE_UI` if you previously exported it)",
           kind: "error",
           ttl_ms: 12000,
         });

--- a/src/ui/logo.ts
+++ b/src/ui/logo.ts
@@ -43,7 +43,7 @@ function buildTextLines(version: string): string[] {
     `  ${bold}${accent}Kimiflare${reset}`,
     "",
     `  ${dim}Terminal coding agent${reset}`,
-    `  ${dim}powered by Kimi-K2.6${reset}`,
+    `  ${dim}powered by Kimi-K2.7${reset}`,
     "",
     `  ${dim}v${version}${reset}`,
     "",

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -811,6 +811,21 @@ const handleUi: Handler = (ctx, _rest, arg) => {
     return true;
   }
   const next = arg as "ink" | "camouflage";
+  if (next === "camouflage") {
+    // Camouflage is strictly opt-in via CLI flag or env var; we do not persist
+    // it so it can never become the silent default for users.
+    setEvents((e) => [
+      ...e,
+      {
+        kind: "error",
+        key: mkKey(),
+        text:
+          "Camouflage is experimental and must be opted into explicitly. " +
+          "Launch with `kimiflare --ui camouflage` or set `KIMIFLARE_UI=camouflage`.",
+      },
+    ]);
+    return true;
+  }
   ctx.setCfg((prev) => {
     if (!prev) return prev;
     const updated = { ...prev, uiEngine: next } as Cfg;
@@ -818,18 +833,13 @@ const handleUi: Handler = (ctx, _rest, arg) => {
     return updated;
   });
   // Loud red "error"-kind event so the user can't miss that they need to
-  // restart. Also reminds them of the env-var escape hatch in case the
-  // new engine is broken on their machine.
+  // restart.
   setEvents((e) => [
     ...e,
     {
       kind: "error",
       key: mkKey(),
-      text:
-        `UI engine set to "${next}". RESTART kimiflare for it to take effect.` +
-        (next === "camouflage"
-          ? " (Camouflage is EXPERIMENTAL — `kimiflare --ui ink` or `unset KIMIFLARE_UI` to bail.)"
-          : ""),
+      text: `UI engine set to "${next}". RESTART kimiflare for it to take effect.`,
     },
   ]);
   return true;

--- a/src/ui/ui-picker.tsx
+++ b/src/ui/ui-picker.tsx
@@ -26,7 +26,7 @@ export function UiPicker({ current, onPick }: Props) {
     {
       label: "Camouflage",
       value: "camouflage",
-      description: "experimental Rust TUI — bail with `kimiflare --ui ink`",
+      description: "experimental — opt in with `kimiflare --ui camouflage`",
     },
     { label: "< Back", value: "__back__", description: "" },
   ];


### PR DESCRIPTION
This release fixes the remaining Kimi-K2.6 branding and makes React Ink the default TUI for all users.

## Changes

- **Logo / branding**: updates the startup logo and `KIMI.md` from `Kimi-K2.6` to `Kimi-K2.7`.
- **Default TUI**: React Ink is now the default for all users. Camouflage is strictly opt-in via `--ui camouflage` or `KIMIFLARE_UI=camouflage`; a persisted `uiEngine: "camouflage"` in `~/.config/kimiflare/config.json` will no longer silently switch users to the experimental engine on the next launch.
- **Version**: bumps `package.json` to `0.88.1`.

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm test` has one pre-existing failure in `src/ui/theme-contrast.test.ts` that is unrelated to these changes.

Closes the v0.88.0 follow-up.