### PR TITLE
fix(memory): route embeddings through AI Gateway /compat/embeddings

### DIFF
--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { fetchEmbeddings, cosineSimilarity } from "./embeddings.js";
+
+function assertClose(actual: Float32Array, expected: number[], epsilon = 1e-6): void {
+  assert.strictEqual(actual.length, expected.length);
+  for (let i = 0; i < actual.length; i++) {
+    assert.ok(
+      Math.abs(actual[i]! - expected[i]!) < epsilon,
+      `expected ${actual[i]} to be close to ${expected[i]} at index ${i}`,
+    );
+  }
+}
+
+describe("fetchEmbeddings", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let lastRequest: Request | null = null;
+
+  before(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      lastRequest = new Request(input, init);
+      return new Response(JSON.stringify({ result: { data: [[0.1, 0.2, 0.3]] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses the direct Workers AI path when no gateway is configured", async () => {
+    const vectors = await fetchEmbeddings({
+      accountId: "acct",
+      apiToken: "token",
+      model: "@cf/baai/bge-base-en-v1.5",
+      texts: ["hello world"],
+    });
+    assert.ok(lastRequest);
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/%40cf%2Fbaai%2Fbge-base-en-v1.5",
+    );
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer token");
+    const body = await lastRequest!.clone().json();
+    assert.deepStrictEqual(body, { text: ["hello world"] });
+    assert.strictEqual(vectors.length, 1);
+    assertClose(vectors[0]!, [0.1, 0.2, 0.3]);
+  });
+
+  it("batches multiple texts through the direct Workers AI path", async () => {
+    globalThis.fetch = async (input, init) => {
+      lastRequest = new Request(input, init);
+      return new Response(
+        JSON.stringify({ result: { shape: [2, 3], data: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const vectors = await fetchEmbeddings({
+      accountId: "acct",
+      apiToken: "token",
+      texts: ["first", "second"],
+    });
+    assert.strictEqual(vectors.length, 2);
+    assertClose(vectors[0]!, [0.1, 0.2, 0.3]);
+    assertClose(vectors[1]!, [0.4, 0.5, 0.6]);
+    const body = await lastRequest!.clone().json();
+    assert.deepStrictEqual(body, { text: ["first", "second"] });
+  });
+
+  it("uses AI Gateway /compat/embeddings with a workers-ai/ model prefix", async () => {
+    globalThis.fetch = async (input, init) => {
+      lastRequest = new Request(input, init);
+      return new Response(
+        JSON.stringify({
+          data: [
+            { embedding: [0.1, 0.2, 0.3], index: 0 },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const vectors = await fetchEmbeddings({
+      accountId: "acct",
+      apiToken: "token",
+      model: "@cf/baai/bge-base-en-v1.5",
+      texts: ["hello gateway"],
+      gateway: { id: "my-gateway" },
+    });
+    assert.ok(lastRequest);
+    assert.strictEqual(
+      lastRequest!.url,
+      "https://gateway.ai.cloudflare.com/v1/acct/my-gateway/compat/embeddings",
+    );
+    assert.strictEqual(lastRequest!.headers.get("Authorization"), "Bearer token");
+    const body = await lastRequest!.clone().json();
+    assert.strictEqual(body.model, "workers-ai/@cf/baai/bge-base-en-v1.5");
+    assert.deepStrictEqual(body.input, ["hello gateway"]);
+    assert.strictEqual(vectors.length, 1);
+    assertClose(vectors[0]!, [0.1, 0.2, 0.3]);
+  });
+
+  it("batches multiple texts through AI Gateway and preserves order", async () => {
+    globalThis.fetch = async (input, init) => {
+      lastRequest = new Request(input, init);
+      return new Response(
+        JSON.stringify({
+          data: [
+            { embedding: [0.4, 0.5, 0.6], index: 1 },
+            { embedding: [0.1, 0.2, 0.3], index: 0 },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const vectors = await fetchEmbeddings({
+      accountId: "acct",
+      apiToken: "token",
+      texts: ["first", "second"],
+      gateway: { id: "my-gateway" },
+    });
+    assert.strictEqual(vectors.length, 2);
+    assertClose(vectors[0]!, [0.1, 0.2, 0.3]);
+    assertClose(vectors[1]!, [0.4, 0.5, 0.6]);
+    const body = await lastRequest!.clone().json();
+    assert.deepStrictEqual(body.input, ["first", "second"]);
+  });
+
+  it("forwards gateway cache and metadata headers", async () => {
+    globalThis.fetch = async (input, init) => {
+      lastRequest = new Request(input, init);
+      return new Response(
+        JSON.stringify({ data: [{ embedding: [0.1], index: 0 }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    await fetchEmbeddings({
+      accountId: "acct",
+      apiToken: "token",
+      texts: ["hi"],
+      gateway: {
+        id: "my-gateway",
+        cacheTtl: 3600,
+        skipCache: true,
+        metadata: { team: "cli", test: true },
+      },
+    });
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-cache-ttl"), "3600");
+    assert.strictEqual(lastRequest!.headers.get("cf-aig-skip-cache"), "true");
+    const metadata = lastRequest!.headers.get("cf-aig-metadata");
+    assert.ok(metadata);
+    const parsed = JSON.parse(metadata!);
+    assert.strictEqual(parsed.team, "cli");
+    assert.strictEqual(parsed.test, true);
+    assert.strictEqual(parsed.feature, "embedding");
+  });
+
+  it("returns an empty array for empty input", async () => {
+    const vectors = await fetchEmbeddings({
+      accountId: "acct",
+      apiToken: "token",
+      texts: [],
+    });
+    assert.deepStrictEqual(vectors, []);
+  });
+
+  it("throws when the response contains no vectors", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    await assert.rejects(
+      fetchEmbeddings({
+        accountId: "acct",
+        apiToken: "token",
+        texts: ["hi"],
+        gateway: { id: "my-gateway" },
+      }),
+      /no vectors/,
+    );
+  });
+});
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", () => {
+    const a = new Float32Array([1, 0, 0]);
+    assert.strictEqual(cosineSimilarity(a, a), 1);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    const a = new Float32Array([1, 0, 0]);
+    const b = new Float32Array([0, 1, 0]);
+    assert.strictEqual(cosineSimilarity(a, b), 0);
+  });
+
+  it("returns 0 for mismatched dimensions", () => {
+    const a = new Float32Array([1, 0]);
+    const b = new Float32Array([1, 0, 0]);
+    assert.strictEqual(cosineSimilarity(a, b), 0);
+  });
+});

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -49,18 +49,110 @@ async function fetchWithRetry(
   throw lastError ?? new Error("embeddings request failed after retries");
 }
 
+/**
+ * Parse the OpenAI-compatible embeddings response returned by AI Gateway's
+ * /compat/embeddings endpoint.
+ */
+function parseOpenAiEmbeddingResponse(json: unknown): Float32Array[] {
+  if (!json || typeof json !== "object") {
+    throw new Error("embeddings response was not an object");
+  }
+  const data = (json as Record<string, unknown>).data;
+  if (!Array.isArray(data)) {
+    throw new Error("embeddings response contained no data array");
+  }
+
+  const indexed: { index: number; vector: Float32Array }[] = [];
+  for (const item of data) {
+    if (!item || typeof item !== "object") continue;
+    const embedding = (item as Record<string, unknown>).embedding;
+    const idx = (item as Record<string, unknown>).index;
+    if (!Array.isArray(embedding)) continue;
+    indexed.push({
+      index: typeof idx === "number" ? idx : indexed.length,
+      vector: new Float32Array(embedding as number[]),
+    });
+  }
+
+  if (indexed.length === 0) {
+    throw new Error("embeddings response contained no vectors");
+  }
+
+  indexed.sort((a, b) => a.index - b.index);
+  return indexed.map((item) => {
+    if (item.vector.length === 0) {
+      throw new Error("embeddings response contained empty vector");
+    }
+    return item.vector;
+  });
+}
+
+/**
+ * Parse the native Workers AI embeddings response returned by the direct
+ * api.cloudflare.com endpoint.
+ */
+function parseWorkersAiEmbeddingResponse(json: unknown): Float32Array[] {
+  // Workers AI returns { result: { data: number[][] } } or { result: { shape: [...], data: number[] } }
+  let vectors: number[][] = [];
+  if (json && typeof json === "object") {
+    const result = (json as Record<string, unknown>).result;
+    if (result && typeof result === "object") {
+      const data = (result as Record<string, unknown>).data;
+      if (Array.isArray(data)) {
+        if (Array.isArray(data[0])) {
+          vectors = data as number[][];
+        } else {
+          // Flattened array with shape info
+          const shape = (result as Record<string, unknown>).shape as number[] | undefined;
+          if (shape && shape.length === 2) {
+            const dim = shape[1]!;
+            const flat = data as number[];
+            vectors = [];
+            for (let i = 0; i < flat.length; i += dim) {
+              vectors.push(flat.slice(i, i + dim));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (vectors.length === 0) {
+    throw new Error("embeddings response contained no vectors");
+  }
+
+  return vectors.map((vec) => {
+    const arr = new Float32Array(vec);
+    if (arr.length === 0) {
+      throw new Error("embeddings response contained empty vector");
+    }
+    return arr;
+  });
+}
+
 export async function fetchEmbeddings(opts: EmbedOpts): Promise<Float32Array[]> {
   const model = opts.model ?? DEFAULT_MODEL;
+  const texts = opts.texts.map(truncateForEmbedding);
+
+  if (texts.length === 0) {
+    return [];
+  }
 
   let url: string;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": getUserAgent(),
   };
+  let body: string;
+  let parseResponse: (json: unknown) => Float32Array[];
 
   if (opts.gateway) {
-    // Gateway path: embeddings go through the AI Gateway for observability.
-    url = `https://gateway.ai.cloudflare.com/v1/${opts.accountId}/${opts.gateway.id}/workers-ai/${model}`;
+    // Gateway path: AI Gateway's OpenAI-compatible /compat/embeddings endpoint.
+    // The native /workers-ai/{model} path returns HTTP 401 for embedding models,
+    // so we route through the Universal Endpoint with a workers-ai/ model prefix.
+    url = `https://gateway.ai.cloudflare.com/v1/${encodeURIComponent(
+      opts.accountId,
+    )}/${encodeURIComponent(opts.gateway.id)}/compat/embeddings`;
     headers.Authorization = `Bearer ${opts.apiToken}`;
 
     const merged: Record<string, string | number | boolean> = {
@@ -75,56 +167,26 @@ export async function fetchEmbeddings(opts: EmbedOpts): Promise<Float32Array[]> 
     if (opts.gateway.skipCache !== undefined) {
       headers["cf-aig-skip-cache"] = String(opts.gateway.skipCache);
     }
+
+    body = JSON.stringify({
+      model: `workers-ai/${model}`,
+      input: texts,
+    });
+    parseResponse = parseOpenAiEmbeddingResponse;
   } else {
     // Direct Workers AI path: lower latency, no gateway overhead.
-    url = `https://api.cloudflare.com/client/v4/accounts/${opts.accountId}/ai/run/${model}`;
+    url = `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(
+      opts.accountId,
+    )}/ai/run/${encodeURIComponent(model)}`;
     headers.Authorization = `Bearer ${opts.apiToken}`;
+
+    body = JSON.stringify({ text: texts });
+    parseResponse = parseWorkersAiEmbeddingResponse;
   }
 
-  // Workers AI embeddings endpoint accepts single text or batch
-  const results: Float32Array[] = [];
-  for (const text of opts.texts) {
-    const truncated = truncateForEmbedding(text);
-    const body = JSON.stringify({ text: [truncated] });
-    const res = await fetchWithRetry(url, { method: "POST", headers, body });
-    const json = (await res.json()) as unknown;
-
-    // Workers AI returns { result: { data: number[][] } } or { result: { shape: [...], data: number[] } }
-    let vectors: number[][] = [];
-    if (json && typeof json === "object") {
-      const result = (json as Record<string, unknown>).result;
-      if (result && typeof result === "object") {
-        const data = (result as Record<string, unknown>).data;
-        if (Array.isArray(data)) {
-          if (Array.isArray(data[0])) {
-            vectors = data as number[][];
-          } else {
-            // Flattened array with shape info
-            const shape = (result as Record<string, unknown>).shape as number[] | undefined;
-            if (shape && shape.length === 2) {
-              const dim = shape[1]!;
-              const flat = data as number[];
-              vectors = [];
-              for (let i = 0; i < flat.length; i += dim) {
-                vectors.push(flat.slice(i, i + dim));
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (vectors.length === 0) {
-      throw new Error("embeddings response contained no vectors");
-    }
-    const vec = new Float32Array(vectors[0]!);
-    if (vec.length === 0) {
-      throw new Error("embeddings response contained empty vector");
-    }
-    results.push(vec);
-  }
-
-  return results;
+  const res = await fetchWithRetry(url, { method: "POST", headers, body });
+  const json = (await res.json()) as unknown;
+  return parseResponse(json);
 }
 
 export function cosineSimilarity(a: Float32Array, b: Float32Array): number {


### PR DESCRIPTION
## Problem

After switching from direct Workers AI to AI Gateway, embedding requests for `@cf/baai/bge-base-en-v1.5` fail with HTTP 401 "Authentication error" while chat requests succeed.

The root cause is that `fetchEmbeddings` was using the native `/workers-ai/{model}` path on `gateway.ai.cloudflare.com`, which does not authenticate correctly for embedding models. Chat already uses the AI Gateway Universal Endpoint (`/compat/chat/completions`) successfully.

## Fix

- Route embedding requests through `gateway.ai.cloudflare.com/v1/{account}/{gateway}/compat/embeddings` when a gateway is configured.
- Use the same `workers-ai/{model}` model prefix that chat completions use.
- Parse the OpenAI-compatible `{ data: [{ embedding, index }] }` response.
- Batch all input texts in a single request (both gateway and direct paths) instead of looping one text at a time.
- URL-encode account, gateway, and model identifiers.

## Verification

- Added `src/memory/embeddings.test.ts` covering direct Workers AI and AI Gateway paths, batching, header forwarding, and error handling.
- `npm run typecheck` passes.
- New embeddings tests pass; the only unrelated failures in the full suite are pre-existing (`src/ui/theme-contrast.test.ts`, `src/cost-debug.test.ts`).

Co-authored-by: kimiflare <kimiflare@proton.me>
