### PR TITLE
fix(agent): preserve original plan across /fresh in plan mode

### DIFF
--- a/src/agent/plan-resolver.test.ts
+++ b/src/agent/plan-resolver.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolvePlanForFresh, PLAN_MEMORY_TOPIC_KEY } from "./plan-resolver.js";
+import { MemoryManager } from "../memory/manager.js";
+import type { ChatMessage } from "./messages.js";
+
+describe("resolvePlanForFresh", () => {
+  let tmpDir: string;
+  let manager: MemoryManager;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "kimiflare-plan-resolver-test-"));
+    manager = new MemoryManager({
+      dbPath: join(tmpDir, "memory.db"),
+      accountId: "test-account",
+      apiToken: "test-token",
+      model: "@cf/moonshotai/kimi-k2.7-code",
+      plumbingModel: "@cf/moonshotai/kimi-k2.5",
+      embeddingModel: "@cf/baai/bge-base-en-v1.5",
+    });
+    manager.open();
+  });
+
+  afterEach(async () => {
+    manager.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null for non-plan modes", () => {
+    const messages: ChatMessage[] = [];
+    const result = resolvePlanForFresh({
+      mode: "edit",
+      messages,
+      sessionPlan: "A plan",
+      memoryManager: manager,
+      memoryEnabled: true,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, null);
+  });
+
+  it("prefers the in-session plan for plan mode", () => {
+    const messages: ChatMessage[] = [
+      { role: "assistant", content: "This is the follow-up reply, not the plan." },
+    ];
+    const result = resolvePlanForFresh({
+      mode: "plan",
+      messages,
+      sessionPlan: "Original dev plan",
+      memoryManager: manager,
+      memoryEnabled: true,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, "Original dev plan");
+  });
+
+  it("falls back to the durable memory topic key when sessionPlan is empty", async () => {
+    await manager.rememberPlan("Stored plan", "/repo", "session-1");
+
+    const messages: ChatMessage[] = [];
+    const result = resolvePlanForFresh({
+      mode: "plan",
+      messages,
+      sessionPlan: null,
+      memoryManager: manager,
+      memoryEnabled: true,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, "Stored plan");
+  });
+
+  it("falls back to distilling messages when no session or memory plan exists", () => {
+    const messages: ChatMessage[] = [
+      { role: "assistant", content: "This is the original development plan with enough detail." },
+    ];
+    const result = resolvePlanForFresh({
+      mode: "plan",
+      messages,
+      sessionPlan: null,
+      memoryManager: manager,
+      memoryEnabled: true,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, "This is the original development plan with enough detail.");
+  });
+
+  it("returns null for plan mode when nothing is available", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: "hi" },
+    ];
+    const result = resolvePlanForFresh({
+      mode: "plan",
+      messages,
+      sessionPlan: null,
+      memoryManager: manager,
+      memoryEnabled: true,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, null);
+  });
+
+  it("skips memory lookup when memory is disabled", () => {
+    const messages: ChatMessage[] = [
+      { role: "assistant", content: "Distilled plan from message history." },
+    ];
+    const result = resolvePlanForFresh({
+      mode: "plan",
+      messages,
+      sessionPlan: null,
+      memoryManager: manager,
+      memoryEnabled: false,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, "Distilled plan from message history.");
+  });
+
+  it("uses the exact topic key constant", async () => {
+    await manager.rememberPlan("Plan under exact key", "/repo", "session-1", PLAN_MEMORY_TOPIC_KEY);
+
+    const result = resolvePlanForFresh({
+      mode: "plan",
+      messages: [],
+      sessionPlan: null,
+      memoryManager: manager,
+      memoryEnabled: true,
+      repoPath: "/repo",
+    });
+    assert.strictEqual(result, "Plan under exact key");
+  });
+});

--- a/src/agent/plan-resolver.ts
+++ b/src/agent/plan-resolver.ts
@@ -1,0 +1,48 @@
+import type { MemoryManager } from "../memory/manager.js";
+import type { ChatMessage } from "./messages.js";
+import type { Mode } from "../mode.js";
+import { distillSessionPlan } from "./distill.js";
+
+export const PLAN_MEMORY_TOPIC_KEY = "current_dev_plan";
+
+export interface ResolvePlanForFreshOpts {
+  mode: Mode;
+  messages: ChatMessage[];
+  sessionPlan: string | null;
+  memoryManager: MemoryManager | null;
+  memoryEnabled: boolean | undefined;
+  repoPath: string;
+}
+
+/**
+ * Resolve the plan text to seed a `/fresh` session.
+ *
+ * For plan mode the resolution order is:
+ *   1. In-session captured plan (fast path).
+ *   2. Durable memory lookup by exact topic key.
+ *   3. Fallback: distill from message history.
+ *   4. null.
+ *
+ * For non-plan modes this returns null so callers continue to use
+ * generateContinuationSummary() for handoff documents.
+ */
+export function resolvePlanForFresh(opts: ResolvePlanForFreshOpts): string | null {
+  const { mode, messages, sessionPlan, memoryManager, memoryEnabled, repoPath } = opts;
+
+  if (mode !== "plan") {
+    return null;
+  }
+
+  if (sessionPlan) {
+    return sessionPlan;
+  }
+
+  if (memoryEnabled && memoryManager) {
+    const stored = memoryManager.getByTopicKey(repoPath, PLAN_MEMORY_TOPIC_KEY);
+    if (stored?.content) {
+      return stored.content;
+    }
+  }
+
+  return distillSessionPlan(messages);
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -114,6 +114,7 @@ import { runStartupTasks } from "./ui/run-startup-tasks.js";
 import { initLsp as initLspImpl, initMcp as initMcpImpl } from "./ui/manager-init.js";
 import { runCompact as runCompactImpl } from "./agent/run-compact.js";
 import { distillSessionPlan } from "./agent/distill.js";
+import { resolvePlanForFresh } from "./agent/plan-resolver.js";
 import { writeToClipboard } from "./util/clipboard.js";
 import {
   handleCommandDelete as handleCommandDeleteImpl,
@@ -1510,7 +1511,14 @@ function App({
 
       // Use the plan captured when the picker was first shown so follow-up
       // discussion doesn't bury the original plan in message history.
-      const plan = sessionPlanRef.current ?? distillSessionPlan(messagesRef.current);
+      const plan = resolvePlanForFresh({
+        mode: "plan",
+        messages: messagesRef.current,
+        sessionPlan: sessionPlanRef.current,
+        memoryManager: memoryManagerRef.current,
+        memoryEnabled: cfg?.memoryEnabled,
+        repoPath: process.cwd(),
+      });
       if (!plan) {
         setEvents((e) => [
           ...e,
@@ -2353,6 +2361,13 @@ function App({
               const plan = distillSessionPlan(messagesRef.current);
               if (plan) {
                 sessionPlanRef.current = plan;
+                // Durable backup: store the plan under a deterministic topic key
+                // so it survives /clear, executeFreshStart, or ref resets.
+                if (cfg?.memoryEnabled && memoryManagerRef.current && sessionIdRef.current) {
+                  void memoryManagerRef.current.rememberPlan(plan, process.cwd(), sessionIdRef.current).catch(() => {
+                    // Non-fatal: the in-session ref is the primary fast path.
+                  });
+                }
                 setShowPlanCompletePicker(true);
               }
             }

--- a/src/memory/manager.test.ts
+++ b/src/memory/manager.test.ts
@@ -1,6 +1,9 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { deterministicTopicKey, pickTopicKey } from "./manager.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { deterministicTopicKey, pickTopicKey, MemoryManager } from "./manager.js";
 
 describe("deterministicTopicKey", () => {
   it("lowercases and snake_cases a simple phrase", () => {
@@ -57,5 +60,68 @@ describe("pickTopicKey", () => {
   it("picks the first matching existing key", () => {
     const result = pickTopicKey("project uses tsup", ["project", "project_uses_tsup"]);
     assert.strictEqual(result, "project");
+  });
+});
+
+describe("MemoryManager plan storage", () => {
+  let tmpDir: string;
+  let manager: MemoryManager;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "kimiflare-memory-test-"));
+    manager = new MemoryManager({
+      dbPath: join(tmpDir, "memory.db"),
+      accountId: "test-account",
+      apiToken: "test-token",
+      model: "@cf/moonshotai/kimi-k2.7-code",
+      plumbingModel: "@cf/moonshotai/kimi-k2.5",
+      embeddingModel: "@cf/baai/bge-base-en-v1.5",
+    });
+    manager.open();
+  });
+
+  afterEach(async () => {
+    manager.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rememberPlan stores a plan under the default topic key", async () => {
+    const result = await manager.rememberPlan("Build a login page", "/repo", "session-1");
+    assert.ok(result.id);
+
+    const stored = manager.getByTopicKey("/repo", "current_dev_plan");
+    assert.strictEqual(stored?.content, "Build a login page");
+    assert.strictEqual(stored?.topicKey, "current_dev_plan");
+    assert.strictEqual(stored?.category, "task");
+  });
+
+  it("rememberPlan supersedes the previous plan under the same key", async () => {
+    await manager.rememberPlan("Old plan", "/repo", "session-1");
+    const result = await manager.rememberPlan("New plan", "/repo", "session-2");
+
+    const stored = manager.getByTopicKey("/repo", "current_dev_plan");
+    assert.strictEqual(stored?.content, "New plan");
+    assert.ok(result.superseded);
+    assert.strictEqual(result.superseded?.length, 1);
+  });
+
+  it("rememberPlan supports a custom topic key", async () => {
+    await manager.rememberPlan("Custom plan", "/repo", "session-1", "my_topic");
+    const stored = manager.getByTopicKey("/repo", "my_topic");
+    assert.strictEqual(stored?.content, "Custom plan");
+  });
+
+  it("getByTopicKey returns null when no memory exists", () => {
+    const stored = manager.getByTopicKey("/repo", "current_dev_plan");
+    assert.strictEqual(stored, null);
+  });
+
+  it("getByTopicKey returns the latest memory for the key", async () => {
+    await manager.rememberPlan("First", "/repo", "session-1");
+    await manager.rememberPlan("Second", "/repo", "session-2");
+    await manager.rememberPlan("Third", "/repo", "session-3");
+
+    const stored = manager.getByTopicKey("/repo", "current_dev_plan");
+    assert.strictEqual(stored?.content, "Third");
   });
 });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import type { AiGatewayOptions } from "../agent/client.js";
 import { runKimi } from "../agent/client.js";
 import type { ChatMessage } from "../agent/messages.js";
-import type { MemoryInput, MemoryQuery, HybridResult, MemoryStats, MemoryCategory } from "./schema.js";
+import type { Memory, MemoryInput, MemoryQuery, HybridResult, MemoryStats, MemoryCategory } from "./schema.js";
 import { DEFAULT_EMBEDDING_DIM } from "./schema.js";
 import {
   openMemoryDb,
@@ -270,6 +270,66 @@ export class MemoryManager {
     }
 
     return { id: memory.id, superseded: supersededIds.length > 0 ? supersededIds : undefined };
+  }
+
+  /**
+   * Store a plan directly under a deterministic topic key.
+   * Skips embedding, verification, and hypothetical queries so it is fast and
+   * deterministic. Supersedes any previous plan stored under the same key.
+   */
+  async rememberPlan(
+    plan: string,
+    repoPath: string,
+    sessionId: string,
+    topicKey = "current_dev_plan",
+  ): Promise<{ id: string; superseded?: string[] }> {
+    if (!this.db) throw new Error("Memory DB not open");
+
+    const safeContent = this.shouldRedact() ? redactSecrets(plan) : plan;
+    if (!safeContent.trim()) {
+      throw new Error("Plan content is empty after redaction");
+    }
+
+    const normalizedKey = topicKey.trim();
+    if (!normalizedKey) {
+      throw new Error("Plan topic key cannot be empty");
+    }
+
+    // Supersede any previous plan under the same key.
+    const supersededIds: string[] = [];
+    const existing = findMemoriesByTopicKey(this.db, repoPath, normalizedKey);
+    for (const old of existing) {
+      supersedeMemory(this.db, old.id, "pending");
+      supersededIds.push(old.id);
+    }
+
+    // Zero embedding: this memory is only ever recalled by exact topic key.
+    const zeroEmbedding = new Float32Array(DEFAULT_EMBEDDING_DIM);
+
+    const memory = insertMemory(this.db, {
+      content: safeContent,
+      category: "task",
+      sourceSessionId: sessionId,
+      repoPath,
+      importance: 4,
+      topicKey: normalizedKey,
+    }, zeroEmbedding);
+
+    for (const oldId of supersededIds) {
+      supersedeMemory(this.db, oldId, memory.id);
+    }
+
+    return { id: memory.id, superseded: supersededIds.length > 0 ? supersededIds : undefined };
+  }
+
+  /**
+   * Recall the latest memory for an exact topic key.
+   * Does not use embeddings; returns null if no matching memory exists.
+   */
+  getByTopicKey(repoPath: string, topicKey: string): Memory | null {
+    if (!this.db) return null;
+    const rows = findMemoriesByTopicKey(this.db, repoPath, topicKey);
+    return rows[0] ?? null;
   }
 
   /**

--- a/src/ui-mode.ts
+++ b/src/ui-mode.ts
@@ -95,6 +95,7 @@ async function loadCamouflage() {
 import { listSessions, loadSession, addCheckpoint, loadSessionFromCheckpoint } from "./sessions.js";
 import { summarizeMessagesViaLlm } from "./agent/llm-summarize.js";
 import { distillSessionPlan } from "./agent/distill.js";
+import { resolvePlanForFresh } from "./agent/plan-resolver.js";
 import { generateContinuationSummary } from "./agent/continuation-summary.js";
 import { buildWelcome } from "./ui/greetings.js";
 import { themeList, resolveTheme } from "./ui/theme.js";
@@ -1278,6 +1279,13 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
         const plan = distillSessionPlan(messages);
         if (plan) {
           sessionPlan = plan;
+          // Durable backup: store the plan under a deterministic topic key
+          // so it survives /clear or ref resets.
+          if (startupCfg?.memoryEnabled && memoryManager) {
+            void memoryManager.rememberPlan(plan, process.cwd(), randomUUID()).catch(() => {
+              // Non-fatal: the in-session variable is the primary fast path.
+            });
+          }
         }
       }
 
@@ -3119,17 +3127,28 @@ export async function runUiMode(opts: UiModeOpts): Promise<void> {
           cam.send("ShowToast", { text: "can't /fresh while model is running — press Esc to interrupt first", kind: "warn", ttl_ms: 2500 });
           return true;
         }
-        // Mode-aware summary: plan mode uses the distilled plan;
-        // auto/edit/multi-agent produce a handoff document via LLM.
+        // Mode-aware summary: plan mode uses the captured plan (in-session
+        // variable or durable memory topic key); auto/edit/multi-agent produce a
+        // handoff document via LLM.
         void (async () => {
-          const summary = await generateContinuationSummary({
-            messages,
-            mode: currentMode,
-            accountId: opts.accountId,
-            apiToken: opts.apiToken,
-            model: opts.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
-            gateway: gatewayFromOpts(opts),
-          });
+          const summary =
+            currentMode === "plan"
+              ? resolvePlanForFresh({
+                  mode: currentMode,
+                  messages,
+                  sessionPlan,
+                  memoryManager,
+                  memoryEnabled: startupCfg?.memoryEnabled,
+                  repoPath: process.cwd(),
+                })
+              : await generateContinuationSummary({
+                  messages,
+                  mode: currentMode,
+                  accountId: opts.accountId,
+                  apiToken: opts.apiToken,
+                  model: opts.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+                  gateway: gatewayFromOpts(opts),
+                });
           if (!summary) {
             cam.send("ShowToast", { text: "No plan or summary found to start fresh with.", kind: "error", ttl_ms: 2500 });
             return;

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -79,7 +79,7 @@ import { startRemoteSession, streamRemoteProgress } from "../remote/worker-clien
 import { saveRemoteSession, type RemoteSession } from "../remote/session-store.js";
 import { deployForTui } from "../remote/deploy.js";
 import { authGitHubForTui } from "../remote/tui-auth.js";
-import { distillSessionPlan } from "../agent/distill.js";
+import { resolvePlanForFresh } from "../agent/plan-resolver.js";
 import { generateContinuationSummary } from "../agent/continuation-summary.js";
 import { writeToClipboard } from "../util/clipboard.js";
 import type { Task } from "../tools/registry.js";
@@ -295,26 +295,37 @@ const handleFresh: Handler = async (ctx) => {
     return true;
   }
 
-  // Mode-aware summary: plan mode uses the distilled plan;
-  // auto/edit/multi-agent produce a handoff document via LLM.
-  const summary = await generateContinuationSummary({
-    messages: ctx.messagesRef.current,
-    mode: ctx.mode,
-    accountId: cfg?.accountId ?? "",
-    apiToken: cfg?.apiToken ?? "",
-    model: cfg?.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
-    gateway: cfg?.aiGatewayId
-      ? {
-          id: cfg.aiGatewayId,
-          cacheTtl: cfg.aiGatewayCacheTtl,
-          skipCache: cfg.aiGatewaySkipCache,
-          collectLogPayload: cfg.aiGatewayCollectLogPayload,
-          metadata: cfg.aiGatewayMetadata,
-        }
-      : undefined,
-    memoryManager: ctx.memoryManagerRef.current,
-    memoryEnabled: cfg?.memoryEnabled,
-  });
+  // Mode-aware summary: plan mode uses the captured plan (in-session ref or
+  // durable memory topic key); auto/edit/multi-agent produce a handoff document
+  // via LLM.
+  const summary =
+    ctx.mode === "plan"
+      ? resolvePlanForFresh({
+          mode: ctx.mode,
+          messages: ctx.messagesRef.current,
+          sessionPlan: ctx.sessionPlanRef.current,
+          memoryManager: ctx.memoryManagerRef.current,
+          memoryEnabled: cfg?.memoryEnabled,
+          repoPath: process.cwd(),
+        })
+      : await generateContinuationSummary({
+          messages: ctx.messagesRef.current,
+          mode: ctx.mode,
+          accountId: cfg?.accountId ?? "",
+          apiToken: cfg?.apiToken ?? "",
+          model: cfg?.plumbingModel ?? "@cf/moonshotai/kimi-k2.5",
+          gateway: cfg?.aiGatewayId
+            ? {
+                id: cfg.aiGatewayId,
+                cacheTtl: cfg.aiGatewayCacheTtl,
+                skipCache: cfg.aiGatewaySkipCache,
+                collectLogPayload: cfg.aiGatewayCollectLogPayload,
+                metadata: cfg.aiGatewayMetadata,
+              }
+            : undefined,
+          memoryManager: ctx.memoryManagerRef.current,
+          memoryEnabled: cfg?.memoryEnabled,
+        });
 
   if (!summary) {
     setEvents((e) => [


### PR DESCRIPTION
## Problem

In plan mode, `/fresh` was re-deriving the plan via `distillSessionPlan(messages)`, which simply returns the **last assistant message longer than 20 chars**. After the user picks "continue" and discusses the plan, the last assistant message is the discussion reply, not the original dev plan, so `/fresh` seeds a fresh session with the wrong text (or nothing useful).

## Solution

Make plan preservation deterministic with a two-layer store:

1. **In-session fast path**: keep using `sessionPlanRef` / `sessionPlan`.
2. **Durable agent-memory backup**: persist the captured plan under the deterministic topic key `current_dev_plan` so it survives `/clear`, `executeFreshStart`, or any other ref reset.

## Changes

- `src/memory/manager.ts`: add `getByTopicKey()` and `rememberPlan()` for direct, zero-embedding, superseding plan storage.
- `src/agent/plan-resolver.ts` (new): `resolvePlanForFresh()` with resolution priority: session plan → memory topic key → `distillSessionPlan()` → `null`.
- `src/ui/slash-commands.ts`, `src/app.tsx`, `src/ui-mode.ts`: use `resolvePlanForFresh` in plan mode; persist captured plans to memory as a fire-and-forget backup.
- `src/memory/manager.test.ts`, `src/agent/plan-resolver.test.ts` (new): unit tests for the new memory methods and resolver priority order.

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅
- New and related tests pass ✅

Co-authored-by: kimiflare <kimiflare@proton.me>